### PR TITLE
Record Phase 2 CCPM + macOS build updates

### DIFF
--- a/.claude/epics/phase-2-enhanced-ux/13.md
+++ b/.claude/epics/phase-2-enhanced-ux/13.md
@@ -98,10 +98,10 @@ Phase 2 is the user-facing layer on top of the powerful Phase 3-5 backend. Docum
 
 ## Current Status (2026-02-09)
 Docs exist but acceptance criteria are not fully verified:
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/USER_GUIDE.md
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/CLI_REFERENCE.md
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/CONFIGURATION.md
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/TROUBLESHOOTING.md
+- file_organizer_v2/docs/USER_GUIDE.md
+- file_organizer_v2/docs/CLI_REFERENCE.md
+- file_organizer_v2/docs/CONFIGURATION.md
+- file_organizer_v2/docs/TROUBLESHOOTING.md
 
 ## Success Criteria
 - [ ] README updated with all Phase 2-5 features

--- a/.claude/epics/phase-2-enhanced-ux/14.md
+++ b/.claude/epics/phase-2-enhanced-ux/14.md
@@ -52,6 +52,6 @@ Build universal macOS binaries that work on both Intel and Apple Silicon archite
 - Installation and usage documentation
 
 ## Implementation Evidence (2026-02-09)
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/scripts/build_macos.sh
-- /Users/rahul/Projects/Local-File-Organizer/.github/workflows/build-macos.yml
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/BUILDING.md
+- file_organizer_v2/scripts/build_macos.sh
+- .github/workflows/build-macos.yml
+- file_organizer_v2/docs/BUILDING.md

--- a/.claude/epics/phase-2-enhanced-ux/23.md
+++ b/.claude/epics/phase-2-enhanced-ux/23.md
@@ -57,8 +57,8 @@ Design and implement a secure auto-update system that checks for new versions, d
 
 ## Current Status (2026-02-09)
 - Implemented: update checker/installer/manager + CLI
-  - /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/updater/
-  - /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/cli/update.py
+  - file_organizer_v2/src/file_organizer/updater/
+  - file_organizer_v2/src/file_organizer/cli/update.py
 - Missing: platform build artifacts and signed release assets (blocked by #28/#14/#16/#20).
 
 ## Deliverables

--- a/.claude/epics/phase-2-enhanced-ux/26.md
+++ b/.claude/epics/phase-2-enhanced-ux/26.md
@@ -57,7 +57,7 @@ Create an interactive chat interface that allows users to organize files using n
 - [ ] Integration tests passing with sample conversations
 
 ## Implementation Evidence (2026-02-09)
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/services/copilot/engine.py
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/cli/copilot.py
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/tui/copilot_view.py
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/tests/test_copilot_engine.py
+- file_organizer_v2/src/file_organizer/services/copilot/engine.py
+- file_organizer_v2/src/file_organizer/cli/copilot.py
+- file_organizer_v2/src/file_organizer/tui/copilot_view.py
+- file_organizer_v2/tests/test_copilot_engine.py

--- a/.claude/epics/phase-2-enhanced-ux/28.md
+++ b/.claude/epics/phase-2-enhanced-ux/28.md
@@ -48,8 +48,8 @@ Configure PyInstaller for the project to enable building standalone executables 
 - Dependency management strategy
 
 ## Implementation Evidence (2026-02-09)
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/scripts/build.py
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/scripts/build_config.py
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/file_organizer.spec
-- /Users/rahul/Projects/Local-File-Organizer/.github/workflows/build.yml
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/BUILDING.md
+- file_organizer_v2/scripts/build.py
+- file_organizer_v2/scripts/build_config.py
+- file_organizer_v2/file_organizer.spec
+- .github/workflows/build.yml
+- file_organizer_v2/docs/BUILDING.md

--- a/.claude/epics/phase-2-enhanced-ux/29.md
+++ b/.claude/epics/phase-2-enhanced-ux/29.md
@@ -59,6 +59,6 @@ Add the ability to save, load, and validate custom organization rules within the
 - [ ] Integration tests with various rule patterns
 
 ## Implementation Evidence (2026-02-09)
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/services/copilot/rules/
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/src/file_organizer/cli/rules.py
-- /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/tests/test_copilot_rules.py
+- file_organizer_v2/src/file_organizer/services/copilot/rules/
+- file_organizer_v2/src/file_organizer/cli/rules.py
+- file_organizer_v2/tests/test_copilot_rules.py

--- a/.claude/epics/phase-2-enhanced-ux/execution-status.md
+++ b/.claude/epics/phase-2-enhanced-ux/execution-status.md
@@ -1,7 +1,7 @@
 ---
 started: 2026-02-09T03:41:48Z
 updated: 2026-02-09T17:16:14Z
-worktree: /Users/rahul/Projects/Local-File-Organizer
+worktree: .
 branch: main
 ---
 

--- a/.claude/epics/phase-2-enhanced-ux/updates/2026-02-09-phase2-ccpm-macos.md
+++ b/.claude/epics/phase-2-enhanced-ux/updates/2026-02-09-phase2-ccpm-macos.md
@@ -12,7 +12,7 @@ This update records the Phase 2 CCPM re-baseline and the macOS build pipeline
 improvements (including universal DMG support and CI workflow updates).
 
 Key artifacts and references:
-- Phase 2 CCPM execution status: `/Users/rahul/Projects/Local-File-Organizer/.claude/epics/phase-2-enhanced-ux/execution-status.md`
-- macOS build script updates: `/Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/scripts/build_macos.sh`
-- macOS CI workflow: `/Users/rahul/Projects/Local-File-Organizer/.github/workflows/build-macos.yml`
-- Build docs: `/Users/rahul/Projects/Local-File-Organizer/file_organizer_v2/docs/BUILDING.md`
+- Phase 2 CCPM execution status: `.claude/epics/phase-2-enhanced-ux/execution-status.md`
+- macOS build script updates: `file_organizer_v2/scripts/build_macos.sh`
+- macOS CI workflow: `.github/workflows/build-macos.yml`
+- Build docs: `file_organizer_v2/docs/BUILDING.md`

--- a/PR_90_DOCUMENTATION_INDEX.md
+++ b/PR_90_DOCUMENTATION_INDEX.md
@@ -239,7 +239,7 @@ START HERE
 
 ### Check Current Status
 ```bash
-cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+cd file_organizer_v2
 ruff check . --statistics
 ```
 
@@ -360,7 +360,7 @@ All documents are in Markdown format and render beautifully on GitHub. Click on 
 ### Reading Locally
 Open in any Markdown viewer or text editor:
 ```bash
-cd /Users/rahul/Projects/Local-File-Organizer
+cd Local-File-Organizer
 open EXECUTIVE_SUMMARY.md  # macOS
 # or
 cat EXECUTIVE_SUMMARY.md | less  # Terminal

--- a/PR_90_REVIEW_ACTION_PLAN.md
+++ b/PR_90_REVIEW_ACTION_PLAN.md
@@ -257,7 +257,7 @@ def mixed_type(val: int | str) -> bool:  # Instead of Union[int, str]
 
 3. **Auto-fix with ruff:**
    ```bash
-   cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+   cd file_organizer_v2
    ruff check . --select UP035 --fix
    ```
 
@@ -342,7 +342,7 @@ ruff check . --select UP006 --fix
 
 **Comprehensive Auto-fix:**
 ```bash
-cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+cd file_organizer_v2
 ruff check . --select UP006,UP007,UP045 --fix
 ```
 
@@ -602,7 +602,7 @@ ruff check . --select UP015 --fix
 
 4. **Run tests**
    ```bash
-   cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+   cd file_organizer_v2
    pytest tests/ -v
    ```
 
@@ -630,7 +630,7 @@ ruff check . --select UP015 --fix
 
 2. **Run all type annotation auto-fixes (H2)**
    ```bash
-   cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+   cd file_organizer_v2
    ruff check . --select UP006,UP007,UP045 --fix
    ```
 
@@ -745,7 +745,7 @@ ruff check . --select UP015 --fix
 
 1. **Run full test suite**
    ```bash
-   cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+   cd file_organizer_v2
    pytest tests/ -v --cov=file_organizer --cov-report=term-missing
    ```
 
@@ -777,7 +777,7 @@ ruff check . --select UP015 --fix
 
 ### Auto-fix All Safe Issues (Recommended)
 ```bash
-cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+cd file_organizer_v2
 
 # Fix all auto-fixable issues in one go
 ruff check . --select UP006,UP007,UP045,UP015,F401,W292,RUF022 --fix

--- a/QUICK_FIX_GUIDE.md
+++ b/QUICK_FIX_GUIDE.md
@@ -64,7 +64,7 @@ except Exception as e:
 ### One Command to Fix Most Issues
 
 ```bash
-cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+cd file_organizer_v2
 
 # Fix 110+ type annotation issues automatically
 ruff check . --select UP006,UP007,UP045 --fix

--- a/REVIEW_STATUS_SUMMARY.md
+++ b/REVIEW_STATUS_SUMMARY.md
@@ -142,7 +142,7 @@ Manual:        ░░░░░░░░░░░░░░░░░░░░   0%
 ### 2. Auto-fix High Priority (5 minutes)
 
 ```bash
-cd /Users/rahul/Projects/Local-File-Organizer/file_organizer_v2
+cd file_organizer_v2
 ruff check . --select UP006,UP007,UP045 --fix
 pytest tests/ -v
 ```

--- a/file_organizer_v2/docs/BUILDING.md
+++ b/file_organizer_v2/docs/BUILDING.md
@@ -83,7 +83,7 @@ python scripts/build.py --one-dir
 ## CI Build Pipeline
 
 GitHub Actions builds are defined in:
-- `/Users/rahul/Projects/Local-File-Organizer/.github/workflows/build.yml`
+- `.github/workflows/build.yml`
 
 The CI pipeline installs dependencies, runs tests, and invokes:
 


### PR DESCRIPTION
Record-keeping PR: adds a Phase 2 update note referencing the CCPM re-baseline and macOS build pipeline improvements (already merged on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 2 record documenting CCPM re-baseline and macOS build pipeline updates with artifact references.
  * Normalized example and evidence paths across documentation from absolute system paths to project-relative paths for clearer, portable instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->