### PR TITLE
test(docs): Add test_code_examples.py for code example validation

### DIFF
--- a/.claude/epics/phase-6-web-interface/245-analysis.md
+++ b/.claude/epics/phase-6-web-interface/245-analysis.md
@@ -1,0 +1,137 @@
+---
+name: write-frontend-ui-tests-analysis
+issue: 245
+epic: phase-6-web-interface
+created: 2026-02-16T22:51:58Z
+updated: 2026-02-16T22:51:58Z
+status: active
+---
+
+# Issue #245 Analysis: Write Frontend UI Tests
+
+## Overview
+
+Implement comprehensive frontend test suite with component tests, E2E tests, browser compatibility testing, and mobile responsiveness tests. Large task requiring ~14-18 hours estimated effort.
+
+## Parallel Streams
+
+### Stream A: Test Infrastructure & Framework Setup (2-3 hours)
+**Files**: `tests/frontend/`, `package.json`, `jest.config.js`, `playwright.config.js`
+
+**Tasks**:
+- Set up Jest/Vitest for component testing
+- Install and configure Playwright or Cypress for E2E testing
+- Configure Testing Library for DOM queries
+- Set up Axe for accessibility testing
+- Create test directory structure and fixtures
+- Configure coverage reporting (>70% goal)
+- Set up CI/CD test pipeline integration
+
+**Status**: Ready to start immediately
+**Dependencies**: None
+
+### Stream B: Component Tests (5-6 hours)
+**Files**: `tests/frontend/component/`
+
+**Tasks**:
+- Write tests for file upload component (drag-drop, file selection)
+- Write tests for progress bars and status indicators
+- Write tests for search interface (filters, sorting)
+- Write tests for settings and configuration panels
+- Write tests for organization preview/results display
+- Write tests for error message display
+- Write tests for WebSocket event handling (UI updates)
+- Ensure >70% coverage for component code
+
+**Status**: Can start after Stream A begins
+**Dependencies**: Stream A (test infrastructure)
+
+### Stream C: E2E Test Scenarios (6-8 hours)
+**Files**: `tests/frontend/e2e/`
+
+**Tasks**:
+- Create organize workflow E2E test (Upload → Methodology → Organize → Results)
+- Create batch operations test (Multi-upload → Batch organize → Progress tracking)
+- Create methodology selection test (Switch methodologies → Verify categorization)
+- Create search and filter test (Search → Filter → Results → Download)
+- Create settings management test (Update → Verify persist → Reset)
+- Create error handling test (Invalid upload → API error → User display)
+- Test HTMX interactions (hx-get, hx-post, hx-swap, hx-trigger, hx-target)
+- Ensure all E2E tests pass consistently
+
+**Status**: Can start after Stream A begins
+**Dependencies**: Stream A (test infrastructure)
+
+### Stream D: Browser & Responsiveness Testing (2-3 hours)
+**Files**: `tests/frontend/responsive/`, test configuration
+
+**Tasks**:
+- Set up browser compatibility testing (Chrome, Firefox, Safari, Edge)
+- Create responsive tests for mobile (320px - 480px)
+- Create responsive tests for tablet (481px - 768px)
+- Create responsive tests for desktop (769px+)
+- Test touch interactions on mobile
+- Verify keyboard navigation support
+- Document browser/device compatibility matrix
+
+**Status**: Can start after Stream A & C progress
+**Dependencies**: Stream A (framework), Stream C (E2E tests)
+
+### Stream E: Documentation & CI/CD Integration (1-2 hours)
+**Files**: `tests/frontend/README.md`, CI/CD config, documentation
+
+**Tasks**:
+- Document test structure and how to run tests
+- Document test patterns and best practices
+- Document browser compatibility matrix
+- Document responsiveness test procedures
+- Integrate tests into CI/CD pipeline
+- Create visual regression baseline (if using Percy/BackstopJS)
+- Document optional features (visual regression, accessibility)
+
+**Status**: Can start after Stream B & C progress
+**Dependencies**: Streams B & C (tests to document)
+
+## Parallel Execution Plan
+
+**Phase 1 (Start Immediately)**:
+- Stream A: Test infrastructure setup
+
+**Phase 2 (After A progresses)**:
+- Stream B: Component tests
+- Stream C: E2E scenarios
+- Stream D: Browser compatibility (can overlap with B & C)
+
+**Phase 3 (After B & C complete)**:
+- Stream E: Documentation and CI/CD integration
+
+## Key Considerations
+
+1. **HTMX Testing**: Critical to verify hx-get, hx-post, hx-swap interactions work correctly
+2. **Coverage Target**: Maintain >70% frontend code coverage
+3. **Consistency**: E2E tests must pass reliably across runs
+4. **Mobile Testing**: Responsiveness verification essential for modern web app
+5. **Browser Matrix**: Target Chrome, Firefox, Safari, Edge (latest versions)
+6. **Visual Regression**: Optional but valuable for catching UI regressions
+
+## Risk Factors
+
+- **Heavy Testing Load**: 14-18 hours is substantial; may need scope reduction if timeline is tight
+- **Browser Testing Complexity**: Multiple browser/device combinations increase test permutations
+- **Flaky Tests**: E2E tests can be flaky; need solid wait strategies and error handling
+- **Mobile Emulation**: Real device testing preferred over emulation for accurate results
+
+## Success Criteria
+
+- All acceptance criteria met (see task file)
+- Component test coverage >70%
+- All E2E tests pass across target browsers
+- Mobile responsiveness verified
+- HTMX interactions fully tested
+- Tests integrated into CI/CD
+- Documentation complete
+- Code reviewed and merged
+
+---
+
+**Last Updated**: 2026-02-16T22:51:58Z

--- a/.claude/epics/phase-6-web-interface/245.md
+++ b/.claude/epics/phase-6-web-interface/245.md
@@ -1,8 +1,8 @@
 ---
 name: write-frontend-ui-tests
-status: open
+status: in-progress
 created: 2026-01-26T02:53:00Z
-updated: 2026-01-26T03:14:07Z
+updated: 2026-02-16T22:51:58Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/245
 depends_on: [006, 007, 008, 009, 010]
 parallel: true

--- a/file_organizer_v2/tests/docs/test_code_examples.py
+++ b/file_organizer_v2/tests/docs/test_code_examples.py
@@ -1,0 +1,278 @@
+"""Test that code examples in documentation are syntactically valid and use real paths.
+
+Validates:
+- Python code blocks parse without syntax errors
+- cURL examples reference real API endpoints (not phantom routes)
+- Import paths in examples reference real modules
+- No deprecated or wrong endpoint patterns in code blocks
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.docs.conftest import DOCS_DIR, SRC_DIR, extract_code_blocks
+
+
+# Known-real endpoint paths (derived from code inspection of api/routers/)
+REAL_API_ENDPOINTS = {
+    "/api/v1/health",
+    "/api/v1/auth/token",
+    "/api/v1/files",
+    "/api/v1/organize/scan",
+    "/api/v1/organize/preview",
+    "/api/v1/organize/execute",
+    "/api/v1/organize/status",
+    "/api/v1/dedupe/scan",
+    "/api/v1/dedupe/preview",
+    "/api/v1/dedupe/execute",
+    "/api/v1/ws",  # WebSocket base
+    "/api/v1/ws/{client_id}",
+    "/api/v1/system",
+    "/api/v1/marketplace",
+    "/api/v1/integrations",
+}
+
+# Phantom endpoints that do NOT exist
+PHANTOM_ENDPOINTS = [
+    "/api/v1/files/upload",  # No upload route — files router handles differently
+    "/api/v1/organize",      # No single POST /organize — uses sub-paths
+    "/api/v1/analyze",       # No /analyze prefix
+    "/api/v1/analyze/duplicates",  # Wrong — should be /dedupe/*
+    "/api/v1/search",        # Not implemented as documented
+]
+
+# Real importable modules under src/file_organizer/
+REAL_MODULES_CHECK = [
+    "file_organizer",
+    "file_organizer.api",
+    "file_organizer.web",
+]
+
+
+class TestPythonCodeExamples:
+    """Validate Python code blocks in documentation parse without syntax errors."""
+
+    def test_python_examples_parse(self, all_doc_files: list[Path]) -> None:
+        """All Python code blocks in docs must be valid Python syntax."""
+        syntax_errors = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            python_blocks = extract_code_blocks(content, "python")
+
+            for i, block in enumerate(python_blocks):
+                # Skip blocks that are clearly fragments/comments only
+                stripped = block.strip()
+                if not stripped:
+                    continue
+                # Skip blocks that start with #! (shebang) or are just comments
+                lines = [l for l in stripped.splitlines() if l.strip() and not l.strip().startswith("#")]
+                if not lines:
+                    continue
+
+                try:
+                    ast.parse(stripped)
+                except SyntaxError as e:
+                    rel = md_file.relative_to(DOCS_DIR)
+                    syntax_errors.append(
+                        f"  {rel} (block {i + 1}): {e.msg} at line {e.lineno}\n"
+                        f"    Snippet: {stripped[:100]!r}"
+                    )
+
+        assert not syntax_errors, (
+            f"Found {len(syntax_errors)} Python syntax error(s) in docs:\n"
+            + "\n".join(syntax_errors[:10])
+            + ("\n  ... (truncated)" if len(syntax_errors) > 10 else "")
+        )
+
+    def test_no_phantom_upload_endpoint_in_examples(self, all_doc_files: list[Path]) -> None:
+        """Python code blocks must not reference the non-existent /files/upload endpoint."""
+        violations = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            python_blocks = extract_code_blocks(content, "python")
+
+            for block in python_blocks:
+                if "/files/upload" in block:
+                    rel = md_file.relative_to(DOCS_DIR)
+                    violations.append(
+                        f"  {rel}: Python example references non-existent "
+                        f"'/files/upload' endpoint. Use '/api/v1/files' (POST with multipart)."
+                    )
+
+        assert not violations, (
+            "Python code examples reference phantom /files/upload endpoint:\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_wrong_organize_endpoint_in_examples(self, all_doc_files: list[Path]) -> None:
+        """Python examples must use real organize sub-paths, not POST /organize."""
+        violations = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            python_blocks = extract_code_blocks(content, "python")
+
+            for block in python_blocks:
+                # Flag POST to /api/v1/organize directly (without sub-path)
+                if re.search(r"['\"]POST['\"].*['\"].*?/organize['\"](?!\s*/)", block):
+                    rel = md_file.relative_to(DOCS_DIR)
+                    violations.append(
+                        f"  {rel}: Python example POSTs to '/organize' directly. "
+                        f"Use '/organize/scan', '/organize/preview', or '/organize/execute'."
+                    )
+
+        assert not violations, (
+            "Python code examples use wrong organize endpoint:\n"
+            + "\n".join(violations)
+        )
+
+
+class TestCurlExamples:
+    """Validate cURL examples in documentation reference real API endpoints."""
+
+    def _extract_curl_paths(self, block: str) -> list[str]:
+        """Extract URL paths from cURL commands."""
+        # Match curl http://host:port/path or curl -X METHOD http://host:port/path
+        paths = re.findall(
+            r"curl[^\n]*https?://[^/\s]+(/api/v\d+/[^\s'\"\\]+)",
+            block
+        )
+        return paths
+
+    def test_curl_examples_use_real_endpoints(self, all_doc_files: list[Path]) -> None:
+        """cURL examples must not reference phantom endpoints."""
+        violations = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            bash_blocks = extract_code_blocks(content, "bash")
+            # Also check unlabeled blocks for curl commands
+            all_blocks = extract_code_blocks(content, "")
+
+            all_curl_blocks = [b for b in (bash_blocks + all_blocks) if "curl " in b]
+
+            for block in all_curl_blocks:
+                for phantom in PHANTOM_ENDPOINTS:
+                    if phantom in block:
+                        rel = md_file.relative_to(DOCS_DIR)
+                        violations.append(
+                            f"  {rel}: cURL example uses phantom endpoint '{phantom}'"
+                        )
+
+        assert not violations, (
+            "cURL examples reference non-existent endpoints:\n"
+            + "\n".join(violations)
+            + "\n\nCheck REAL_API_ENDPOINTS for valid paths."
+        )
+
+    def test_curl_auth_uses_x_api_key_header(self, all_doc_files: list[Path]) -> None:
+        """cURL examples must use X-API-Key header, not Authorization: Bearer."""
+        violations = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            bash_blocks = extract_code_blocks(content, "bash")
+            all_blocks = extract_code_blocks(content, "")
+
+            all_curl_blocks = [b for b in (bash_blocks + all_blocks) if "curl " in b]
+
+            for block in all_curl_blocks:
+                # cURL with API path should not use Authorization: Bearer
+                if "/api/v" in block and "Authorization: Bearer" in block:
+                    rel = md_file.relative_to(DOCS_DIR)
+                    violations.append(
+                        f"  {rel}: cURL example uses 'Authorization: Bearer' — "
+                        f"should use 'X-API-Key: <key>'"
+                    )
+
+        assert not violations, (
+            "cURL examples use wrong auth header:\n"
+            + "\n".join(violations)
+        )
+
+
+class TestImportPathsInExamples:
+    """Validate that import statements in examples reference real modules."""
+
+    def test_file_organizer_imports_use_real_packages(
+        self, all_doc_files: list[Path]
+    ) -> None:
+        """Python imports from file_organizer.* must reference existing top-level modules."""
+        # Get real top-level subpackages under src/file_organizer/
+        fo_src = SRC_DIR / "file_organizer"
+        real_subpackages = set()
+        if fo_src.exists():
+            for p in fo_src.iterdir():
+                if p.is_dir() and (p / "__init__.py").exists():
+                    real_subpackages.add(p.name)
+                elif p.is_file() and p.suffix == ".py" and p.name != "__init__.py":
+                    real_subpackages.add(p.stem)
+
+        if not real_subpackages:
+            pytest.skip("Cannot find file_organizer source directory")
+
+        violations = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            python_blocks = extract_code_blocks(content, "python")
+
+            for block in python_blocks:
+                # Find: from file_organizer.X import Y  or  import file_organizer.X
+                imports = re.findall(
+                    r"(?:from|import)\s+file_organizer\.(\w+)",
+                    block
+                )
+                for subpkg in imports:
+                    if subpkg not in real_subpackages:
+                        rel = md_file.relative_to(DOCS_DIR)
+                        violations.append(
+                            f"  {rel}: imports from 'file_organizer.{subpkg}' "
+                            f"but that subpackage doesn't exist. "
+                            f"Real subpackages: {sorted(real_subpackages)}"
+                        )
+
+        assert not violations, (
+            "Documentation examples import from non-existent modules:\n"
+            + "\n".join(violations[:10])
+            + ("\n  ... (truncated)" if len(violations) > 10 else "")
+        )
+
+
+class TestApiKeyFormatInExamples:
+    """Validate API key format used in examples matches real format."""
+
+    def test_no_fk_live_api_key_format_in_examples(
+        self, all_doc_files: list[Path]
+    ) -> None:
+        """Code examples must not show 'fk_live_*' API key format (that's the wrong format)."""
+        violations = []
+
+        for md_file in all_doc_files:
+            content = md_file.read_text(encoding="utf-8")
+            # Check all code blocks (any language)
+            all_blocks = extract_code_blocks(content, "")
+            python_blocks = extract_code_blocks(content, "python")
+            bash_blocks = extract_code_blocks(content, "bash")
+
+            for block in all_blocks + python_blocks + bash_blocks:
+                if "fk_live_" in block:
+                    rel = md_file.relative_to(DOCS_DIR)
+                    violations.append(
+                        f"  {rel}: code example uses 'fk_live_*' API key format. "
+                        f"Correct format is 'fo_<id>_<token>'."
+                    )
+
+        # Deduplicate
+        violations = list(dict.fromkeys(violations))
+
+        assert not violations, (
+            "Code examples use wrong API key format:\n"
+            + "\n".join(violations)
+        )


### PR DESCRIPTION
## Summary

- Adds `tests/docs/test_code_examples.py` — the 5th module of the documentation accuracy test suite (Issue #326)
- Validates Python code blocks parse without syntax errors
- Validates cURL examples reference real API endpoints (no phantom routes)
- Validates import paths in examples reference real modules
- Updates issue #245 CCPM tracking to `in-progress`
- Adds issue #245 analysis document with parallel stream breakdown

## Context

This completes the documentation accuracy test suite started in PR #328. The 5 modules together cover:
1. `test_api_reference_sync.py` — API endpoint accuracy
2. `test_websocket_sync.py` — WebSocket path and auth validation  
3. `test_link_integrity.py` — Internal link and mkdocs nav integrity
4. `test_code_examples.py` — Python syntax, cURL phantom endpoints, import paths **(this PR)**
5. `test_web_ui_paths.py` — Web UI mount path (`/ui/`), API docs paths

## Test Plan

- [x] `test_code_examples.py` validates Python code block syntax
- [x] `test_code_examples.py` catches phantom endpoint references in cURL examples
- [x] `test_code_examples.py` validates import paths reference real modules
- [x] CCPM tracking updated for issue #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)