### PR TITLE
ci: add daily schedule to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ on:
       - ".claude/prds/**"
       - ".claude/rules/**"
       - ".claude/README.md"
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `schedule: cron: '0 6 * * *'` to `ci.yml`
- CI now runs daily at 06:00 UTC in addition to push/PR triggers
- Scheduled runs use the full suite path (same as push, not the PR `-m "not regression"` shortcut)

## Motivation

Catches dependency drift between pushes — a transitive dep update could silently break tests without any code change. Repo is public so cost is $0.

## Test plan

- [ ] Workflow file parses correctly (no YAML errors)
- [ ] Next scheduled run appears at 06:00 UTC tomorrow in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)