### PR TITLE
Issue #358: Standardize quote style and modernize Optional type hint

### DIFF
--- a/src/file_organizer/services/deduplication/backup.py
+++ b/src/file_organizer/services/deduplication/backup.py
@@ -15,7 +15,6 @@ import json
 import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
 
 # fcntl is Unix-only, not available on Windows
 try:
@@ -194,7 +193,7 @@ class BackupManager:
 
         return removed_backups
 
-    def get_backup_info(self, backup_path: Path) -> Optional[dict]:
+    def get_backup_info(self, backup_path: Path) -> dict | None:
         """
         Get metadata for a specific backup.
 
@@ -291,7 +290,7 @@ class BackupManager:
             return {}
 
         try:
-            with open(self.manifest_path, encoding='utf-8') as f:
+            with open(self.manifest_path, encoding="utf-8") as f:
                 # Acquire shared lock for reading (Unix only)
                 if HAS_FCNTL:
                     fcntl.flock(f.fileno(), fcntl.LOCK_SH)
@@ -315,8 +314,8 @@ class BackupManager:
         """
         try:
             # Open in read+ mode to avoid truncating before lock
-            mode = 'r+' if self.manifest_path.exists() else 'w'
-            with open(self.manifest_path, mode, encoding='utf-8') as f:
+            mode = "r+" if self.manifest_path.exists() else "w"
+            with open(self.manifest_path, mode, encoding="utf-8") as f:
                 # Acquire exclusive lock for writing (Unix only)
                 if HAS_FCNTL:
                     fcntl.flock(f.fileno(), fcntl.LOCK_EX)

--- a/src/file_organizer/services/text_processor.py
+++ b/src/file_organizer/services/text_processor.py
@@ -314,7 +314,7 @@ CATEGORY:"""
             import re
             folder_name = re.sub(r'[^\w_]', '_', folder_name)
             folder_name = re.sub(r'_+', '_', folder_name).strip('_')
-            result = folder_name[:50] if folder_name else 'documents'
+            result = folder_name[:50] if folder_name else "documents"
             logger.info("Folder name generated ({} chars)", len(result))
             return result
 
@@ -390,7 +390,7 @@ FILENAME:"""
             import re
             filename = re.sub(r'[^\w_]', '_', filename)
             filename = re.sub(r'_+', '_', filename).strip('_')
-            result = filename[:50] if filename else 'document'
+            result = filename[:50] if filename else "document"
             logger.info("Filename generated ({} chars)", len(result))
             return result
 


### PR DESCRIPTION
## Summary
- `backup.py`: remove `from typing import Optional`, update `get_backup_info` return type to `dict | None`, standardize single-quoted encoding/mode strings to double quotes
- `text_processor.py`: change single-quoted fallback strings `'documents'` / `'document'` to double quotes

## Test plan
- [x] `ruff check` passes on both files
- [x] Full test suite: 3771 passed, 32 skipped

Closes #358
Closes #354
Closes #353 (duplicate of #354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)