### PR TITLE
Issue #360: Atomic manifest write — tempfile + os.replace()

### DIFF
--- a/src/file_organizer/services/deduplication/backup.py
+++ b/src/file_organizer/services/deduplication/backup.py
@@ -318,6 +318,7 @@ class BackupManager:
         Args:
             manifest: Dictionary containing manifest data
         """
+        tmp_path = None
         try:
             tmp_dir = self.manifest_path.parent
             with tempfile.NamedTemporaryFile(
@@ -333,4 +334,9 @@ class BackupManager:
                 tmp_path = tmp.name
             os.replace(tmp_path, self.manifest_path)
         except OSError as e:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
             raise OSError(f"Failed to save manifest: {e}") from e


### PR DESCRIPTION
## Summary
Replace `fcntl`-based locking in `_save_manifest()` with a write-to-temp + `os.replace()` atomic rename pattern.

**Problem:** The previous approach used `fcntl.flock` for write protection on Unix, but `HAS_FCNTL = False` on Windows — leaving manifest writes completely unprotected. A process crash mid-write could corrupt the manifest file.

**Fix:** Write to a `NamedTemporaryFile` in the same directory (same filesystem), `fsync` to flush, then `os.replace()` for an atomic rename. This is cross-platform and crash-safe on both Unix and Windows.

Read locking in `_load_manifest` via `fcntl` is retained as an additional defense on Unix.

## Test plan
- [x] `ruff check` passes
- [x] 50 backup/dedup tests pass

Closes #360
Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)