### PR TITLE
test(ci): remove stale technical-debt reference from build artifact tests

### DIFF
--- a/tests/test_build_artifacts.py
+++ b/tests/test_build_artifacts.py
@@ -39,14 +39,6 @@ def test_build_macos_has_universal_flags() -> None:
     assert "--x86" in content
 
 
-def test_building_doc_mentions_windows_installer() -> None:
-    doc = PROJECT_ROOT / "technical-debt" / "file_organizer_v2" / "legacy_docs" / "BUILDING.md"
-    assert doc.exists()
-    content = doc.read_text(encoding="utf-8")
-    assert "Windows Installer" in content
-    assert "build_windows.ps1" in content
-
-
 def test_build_linux_script_exists_and_mentions_appimage() -> None:
     script = PROJECT_ROOT / "scripts" / "build_linux.sh"
     assert script.exists()


### PR DESCRIPTION
## Summary

- Removes `test_building_doc_mentions_windows_installer` from `tests/test_build_artifacts.py`
- This test asserted that `technical-debt/file_organizer_v2/legacy_docs/BUILDING.md` exists — a path that only exists locally; CI runners never have the `technical-debt/` archive
- The `build_windows.ps1` content it was checking is already covered by `test_build_windows_ps1_exists_and_has_iscc_path` and `test_build_windows_iss_supports_version_override`

## Audit

Full scan of `tests/` and `.github/workflows/` for `technical-debt`, `legacy_docs`, `file_organizer_v2`:
- **`tests/test_build_artifacts.py:43`** — this test (removed)
- **`pyproject.toml:182`** — ruff exclude for `technical-debt/` (kept; correct hygiene)
- **`.github/workflows/`** — zero references

## Test plan
- [x] `pytest tests/test_build_artifacts.py -v` → 4 passed (was 5, one stale test removed)
- [x] `ruff check tests/test_build_artifacts.py` → clean
- [x] No remaining source references to `technical-debt/` or `legacy_docs` in `tests/` or `.github/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)