### PR TITLE
fix(ci): remove stale setupFilesAfterEnv reference in jest.config.cjs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,5 @@
 module.exports = {
   testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>/tests/frontend/setup.js"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/file_organizer/web/static/$1",
   },


### PR DESCRIPTION
## Summary

- `tests/frontend/setup.js` was deleted in PR #349 (legacy artifact cleanup)
- `jest.config.cjs` still referenced it via `setupFilesAfterEnv`
- This caused the **Frontend Node 18.x Compatibility** job to fail on every CI Full Matrix run with a Jest validation error
- Fix: remove the stale `setupFilesAfterEnv` line (1-line deletion)

## Root Cause

PR #349 deleted `tests/frontend/` as an "empty JS test shell" but did not update `jest.config.cjs` to remove the now-missing setup file reference.

## Test plan

- [ ] CI Full Matrix: Frontend Node 18.x Compatibility job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)