### PR TITLE
feat(ci): add local test matrix script and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+# Contributing to File Organizer
+
+## Development Environment Setup
+
+### Prerequisites
+
+- **Python 3.9+** (we test against 3.9, 3.10, 3.11, 3.12)
+- **Node.js 18+** (for frontend tests)
+- **Ollama** (for AI model inference)
+
+### Python Version Management (pyenv)
+
+Our CI tests against Python 3.9, 3.10, 3.11, and 3.12. To catch version-specific issues
+locally before pushing, install all target versions via [pyenv](https://github.com/pyenv/pyenv):
+
+```bash
+# Install pyenv
+brew install pyenv          # macOS
+curl https://pyenv.run | bash  # Linux
+
+# Install CI-targeted Python versions
+pyenv install 3.9.21
+pyenv install 3.10.16
+pyenv install 3.11.11
+pyenv install 3.12.8
+```
+
+### Node Version Management (optional)
+
+Frontend tests run against Node 18.x in CI. If your system Node is newer, consider
+[nvm](https://github.com/nvm-sh/nvm) to switch versions:
+
+```bash
+nvm install 18
+nvm use 18
+```
+
+### Install the Package
+
+```bash
+# Create a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install with development dependencies
+pip install -e ".[dev]"
+
+# Verify
+file-organizer --version
+```
+
+---
+
+## Pre-Push Checklist
+
+Before pushing changes, run these checks to avoid wasting CI minutes and Copilot Review quota:
+
+### Quick Check (recommended before every push)
+
+```bash
+# Fastest — tests on Python 3.12 + frontend only (~2 min)
+./scripts/test-local-matrix.sh --quick
+```
+
+### Full Matrix (recommended before opening a PR)
+
+```bash
+# Full CI mirror — Python 3.9/3.10/3.11/3.12 + frontend (~10 min)
+./scripts/test-local-matrix.sh
+```
+
+### Individual Checks
+
+```bash
+# Python matrix only
+./scripts/test-local-matrix.sh --python
+
+# Frontend only
+./scripts/test-local-matrix.sh --node
+
+# Lint only
+ruff check src/
+
+# Type check
+mypy src/file_organizer/ --strict
+```
+
+---
+
+## What the CI Runs
+
+Our CI has two workflows triggered on PRs to `main`:
+
+| Workflow | File | What it runs |
+|----------|------|-------------|
+| **CI** | `.github/workflows/ci.yml` | Lint + Python 3.9/3.12 tests |
+| **CI Full Matrix** | `.github/workflows/ci-full.yml` | Python 3.9/3.10/3.11/3.12 + Node 18.x frontend |
+
+`scripts/test-local-matrix.sh` mirrors the Full Matrix workflow locally.
+
+---
+
+## Common Pitfalls
+
+These are the most frequent causes of CI failures that pass locally:
+
+| Pitfall | Why it happens | How to avoid |
+|---------|---------------|--------------|
+| `datetime.utcnow()` | Deprecated in 3.12, removed in 3.14 | Use `datetime.now(timezone.utc)` |
+| `os.stat().st_birthtime` | macOS-only; Linux raises `AttributeError` | Use platform-aware fallback (see `heuristics.py`) |
+| `match` statements | Python 3.10+ only | Use `if/elif` for 3.9 compatibility |
+| `X \| Y` union types | Python 3.10+ only | Use `Union[X, Y]` or `Optional[X]` |
+| `tomllib` | Python 3.11+ only | Use `tomli` backport or conditional import |
+| Jest config referencing deleted files | No local `npm test -- --ci` | Run `./scripts/test-local-matrix.sh --node` |
+
+---
+
+## Code Style
+
+- **Formatter**: Black (line length 100)
+- **Import sorting**: isort
+- **Linter**: Ruff (strict)
+- **Type checking**: mypy strict mode
+- **Docstrings**: Google style
+
+### Commit Messages
+
+```
+<type>(<scope>): <subject>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+Example: `fix(history): replace deprecated datetime.utcnow() with timezone-aware alternative`
+
+---
+
+## Testing
+
+```bash
+# Run all tests
+pytest
+
+# Run with coverage
+pytest --cov=file_organizer --cov-report=html
+
+# Run specific markers
+pytest -m unit          # Unit tests only
+pytest -m "not slow"    # Skip slow tests
+pytest -m "not regression"  # Skip regression (matches CI PR behaviour)
+```
+
+### Test Markers
+
+| Marker | Purpose |
+|--------|---------|
+| `@pytest.mark.unit` | Fast unit tests |
+| `@pytest.mark.integration` | Integration tests |
+| `@pytest.mark.slow` | Long-running tests |
+| `@pytest.mark.regression` | Full regression (skipped on CI PRs) |
+| `@pytest.mark.ci` | CI pipeline validation |
+
+---
+
+## Pull Requests
+
+1. Create a feature branch from `main`: `git checkout -b feature/description`
+2. Make changes with tests
+3. Run `./scripts/test-local-matrix.sh --quick` (minimum) or full matrix
+4. Run `ruff check src/` for linting
+5. Commit with descriptive message
+6. Push and open a PR against `main`
+
+PRs trigger both CI workflows automatically. Copilot Review runs on every PR (premium feature),
+so catching issues locally saves real money.

--- a/scripts/test-local-matrix.sh
+++ b/scripts/test-local-matrix.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────
+# test-local-matrix.sh — Mirror ci-full.yml locally
+#
+# Runs the same Python version matrix + Node frontend tests that CI
+# runs, using pyenv for Python version management.
+#
+# Prerequisites:
+#   brew install pyenv           # macOS
+#   pyenv install 3.9.21 3.10.16 3.11.11 3.12.8
+#
+# Usage:
+#   ./scripts/test-local-matrix.sh           # Full matrix
+#   ./scripts/test-local-matrix.sh --python  # Python matrix only
+#   ./scripts/test-local-matrix.sh --node    # Frontend only
+#   ./scripts/test-local-matrix.sh --quick   # Fastest Python (3.12) + frontend
+# ──────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PYTHON_VERSIONS=("3.9" "3.10" "3.11" "3.12")
+FAILED=()
+RUN_PYTHON=true
+RUN_NODE=true
+QUICK=false
+
+# ── Parse arguments ──
+for arg in "$@"; do
+  case "$arg" in
+    --python) RUN_NODE=false ;;
+    --node)   RUN_PYTHON=false ;;
+    --quick)  QUICK=true ;;
+    --help|-h)
+      echo "Usage: $0 [--python|--node|--quick]"
+      echo ""
+      echo "  --python   Run Python matrix only (skip frontend)"
+      echo "  --node     Run frontend tests only (skip Python)"
+      echo "  --quick    Run Python 3.12 + frontend only (fastest check)"
+      echo ""
+      echo "Prerequisites:"
+      echo "  pyenv with Python 3.9, 3.10, 3.11, 3.12 installed"
+      echo "  npm (for frontend tests)"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg (try --help)"
+      exit 1
+      ;;
+  esac
+done
+
+if $QUICK; then
+  PYTHON_VERSIONS=("3.12")
+fi
+
+echo "Local CI Matrix — mirroring ci-full.yml"
+echo "════════════════════════════════════════════════"
+echo ""
+
+# ── Check pyenv ──
+if $RUN_PYTHON && ! command -v pyenv >/dev/null 2>&1; then
+  echo "❌ pyenv not found. Install it first:"
+  echo "   brew install pyenv    # macOS"
+  echo "   curl https://pyenv.run | bash  # Linux"
+  exit 1
+fi
+
+# ── Python matrix ──
+if $RUN_PYTHON; then
+  for version in "${PYTHON_VERSIONS[@]}"; do
+    echo "══════════════════════════════════════"
+    echo "  Python ${version}"
+    echo "══════════════════════════════════════"
+
+    # Resolve the pyenv Python binary for this version
+    PYBIN="$(PYENV_VERSION="${version}" pyenv which python 2>/dev/null || true)"
+
+    if [ -z "$PYBIN" ] || [ ! -x "$PYBIN" ]; then
+      echo "⚠️  Python ${version} not installed — skipping"
+      echo "   Install: pyenv install ${version}"
+      echo ""
+      FAILED+=("Python ${version}: not installed")
+      continue
+    fi
+
+    VENV="/tmp/fo-test-py${version//./}"
+    rm -rf "$VENV"
+
+    echo "  Creating venv from $PYBIN..."
+    "$PYBIN" -m venv "$VENV"
+    # shellcheck disable=SC1091
+    source "$VENV/bin/activate"
+
+    echo "  Installing dependencies..."
+    pip install -e ".[dev]" -q 2>&1 | tail -1
+
+    echo "  Running pytest..."
+    if pytest "$REPO_ROOT/tests/" -m "not regression" --override-ini="addopts=" -q; then
+      echo ""
+      echo "  ✅ Python ${version} — PASSED"
+    else
+      echo ""
+      echo "  ❌ Python ${version} — FAILED"
+      FAILED+=("Python ${version}: test failures")
+    fi
+
+    deactivate
+    rm -rf "$VENV"
+    echo ""
+  done
+fi
+
+# ── Node frontend ──
+if $RUN_NODE; then
+  echo "══════════════════════════════════════"
+  echo "  Frontend (npm test -- --ci)"
+  echo "══════════════════════════════════════"
+  cd "$REPO_ROOT"
+
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "⚠️  npm not found — skipping frontend tests"
+    FAILED+=("Frontend: npm not found")
+  else
+    echo "  Installing npm deps..."
+    npm install --silent 2>&1 | tail -1
+
+    echo "  Running Jest..."
+    if npm test -- --ci 2>&1; then
+      echo ""
+      echo "  ✅ Frontend — PASSED"
+    else
+      echo ""
+      echo "  ❌ Frontend — FAILED"
+      FAILED+=("Frontend: test failures")
+    fi
+  fi
+  echo ""
+fi
+
+# ── Summary ──
+echo "══════════════════════════════════════"
+echo "  Summary"
+echo "══════════════════════════════════════"
+
+if [ ${#FAILED[@]} -eq 0 ]; then
+  echo "✅ All checks passed — safe to push"
+  exit 0
+else
+  echo "❌ ${#FAILED[@]} failure(s):"
+  for f in "${FAILED[@]}"; do
+    echo "   • $f"
+  done
+  echo ""
+  echo "Fix these before pushing to avoid CI failures."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/test-local-matrix.sh` — mirrors `ci-full.yml` locally using pyenv (Python 3.9/3.10/3.11/3.12) + npm frontend tests
- Add `CONTRIBUTING.md` — developer pre-push checklist, pyenv/nvm setup instructions, common pitfalls table, CI workflow reference

## Why
Every PR triggers CI + Copilot Review (premium). A significant fraction of failures are preventable — they only surface because local dev (Python 3.14 on macOS) diverges from CI (Python 3.9–3.12 on ubuntu-latest + Node 18.x). See issue #367 for full context.

## Script Usage

```bash
./scripts/test-local-matrix.sh           # Full matrix (~10 min)
./scripts/test-local-matrix.sh --quick   # Python 3.12 + frontend (~2 min)
./scripts/test-local-matrix.sh --python  # Python matrix only
./scripts/test-local-matrix.sh --node    # Frontend only
```

## Test plan
- [ ] Verify `scripts/test-local-matrix.sh --help` shows usage
- [ ] Verify script is executable (`ls -la scripts/test-local-matrix.sh`)
- [ ] Run `--quick` mode on local machine
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)