### PR TITLE
ci: restrict full matrix to daily schedule, not PRs

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,16 +1,8 @@
 name: CI Full Matrix
 
 on:
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - ".claude/agents/**"
-      - ".claude/commands/**"
-      - ".claude/context/**"
-      - ".claude/epics/**"
-      - ".claude/prds/**"
-      - ".claude/rules/**"
-      - ".claude/README.md"
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC — full matrix
   workflow_dispatch:
 
 concurrency:
@@ -33,10 +25,5 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Run tests
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pytest tests/ -m "not regression" --override-ini="addopts="
-          else
-            pytest tests/ --override-ini="addopts="
-          fi
+        run: pytest tests/ --override-ini="addopts="
 


### PR DESCRIPTION
## Summary

- Removes `pull_request` trigger from `ci-full.yml` — full 4-version matrix no longer runs on every PR
- Adds `schedule: cron: '0 6 * * *'` — full matrix runs daily instead
- Simplifies the `Run tests` step (drops the now-unnecessary PR-specific conditional)

**Before**: every PR ran 6 jobs (lint + 3.9 + 3.12 from `ci.yml`, plus 3.9/3.10/3.11/3.12 from `ci-full.yml`)  
**After**: every PR runs 3 jobs (lint + 3.9 + 3.12); full matrix fires daily and on manual dispatch

Closes #374

## Test plan

- [ ] PR CI shows only `CI` workflow jobs (lint + 3.9 + 3.12) — no `CI Full Matrix` jobs
- [ ] `CI Full Matrix` visible in Actions scheduled runs at 06:00 UTC
- [ ] `workflow_dispatch` on `ci-full.yml` still works manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)