### PR TITLE
fix: address PR #426 review comments

### DIFF
--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -231,7 +231,10 @@ class FileOrganizer:
         # Handle unsupported files (audio and video are now processed above)
         if other_files:
             result.skipped_files = len(other_files)
-            self._show_skipped_files([], [], [])
+            self.console.print("\n[bold yellow]Skipped Files:[/bold yellow]")
+            for f in other_files:
+                self.console.print(f"  [yellow]•[/yellow] {f.name} (unsupported type)")
+            self.console.print("\n  [dim]These file types are not yet supported[/dim]")
 
         # Cleanup
         if self.text_processor:
@@ -442,7 +445,7 @@ class FileOrganizer:
 
                 # dest_path includes the extension (e.g. "Music/Artist/Album/01 - Track.mp3")
                 # Split into folder_name and filename stem for ProcessedFile compatibility
-                folder_name = str(dest_path.parent)
+                folder_name = dest_path.parent.as_posix()
                 filename_stem = dest_path.stem
 
                 # Build human-readable description

--- a/src/file_organizer/services/video/metadata_extractor.py
+++ b/src/file_organizer/services/video/metadata_extractor.py
@@ -207,8 +207,8 @@ class VideoMetadataExtractor:
         except ImportError:
             return False
 
+        cap = cv2.VideoCapture(str(video_path))
         try:
-            cap = cv2.VideoCapture(str(video_path))
             if not cap.isOpened():
                 return False
 
@@ -220,11 +220,12 @@ class VideoMetadataExtractor:
             if metadata.fps and frame_count and metadata.fps > 0:
                 metadata.duration = frame_count / metadata.fps
 
-            cap.release()
             return True
         except Exception:
             logger.debug(f"OpenCV extraction failed for {video_path.name}", exc_info=True)
             return False
+        finally:
+            cap.release()
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +261,19 @@ def _parse_datetime(value: str) -> datetime | None:
     - Date only: 2024-01-15
     - With timezone offset: 2024-01-15T14:30:45+00:00
     """
+    stripped = value.strip()
+
+    # Try datetime.fromisoformat first — handles Z and ±HH:MM offsets (Python 3.11+)
+    try:
+        dt = datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+        # Return naive datetime (strip tzinfo) for consistency with rest of codebase
+        return dt.replace(tzinfo=None)
+    except ValueError:
+        pass
+
+    # Fallback: strptime for formats fromisoformat can't handle
     formats = [
-        "%Y-%m-%dT%H:%M:%S.%fZ",
-        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
         "%Y-%m-%dT%H:%M:%S",
         "%Y-%m-%d %H:%M:%S",
         "%Y-%m-%d",
@@ -270,7 +281,7 @@ def _parse_datetime(value: str) -> datetime | None:
     ]
     for fmt in formats:
         try:
-            return datetime.strptime(value.strip(), fmt)
+            return datetime.strptime(stripped, fmt)
         except ValueError:
             continue
     return None

--- a/src/file_organizer/services/video/organizer.py
+++ b/src/file_organizer/services/video/organizer.py
@@ -165,7 +165,7 @@ class VideoOrganizer:
 
         # Try to extract year from filename (e.g. "2025-01-15" or "20250115")
         stem = metadata.file_path.stem
-        match = re.search(r"(20[12]\d)-?\d{2}-?\d{2}", stem)
+        match = re.search(r"(20\d{2})-?\d{2}-?\d{2}", stem)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
Fixes 5 issues flagged by Copilot review on #426 that were not addressed before merge.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `core/organizer.py:234` | `_show_skipped_files([], [], [])` printed a generic message without listing the actual unsupported files | Inline the unsupported-file listing, showing each filename explicitly |
| `core/organizer.py:445` | `str(dest_path.parent)` uses OS path separators (backslash on Windows) | Changed to `dest_path.parent.as_posix()` for consistent POSIX separators |
| `services/video/metadata_extractor.py:214` | `cap.release()` not called when `cap.isOpened()` returns False — file handle leak | Moved `VideoCapture` creation before `try`, added `finally: cap.release()` |
| `services/video/metadata_extractor.py:262` | `_parse_datetime` had no `%z`-aware formats, so timezone offsets (e.g. `+00:00`) always returned `None` | Use `datetime.fromisoformat` (with Z→+00:00 normalization) as primary parser |
| `services/video/organizer.py:168` | Year regex `(20[12]\d)` only matched 2010–2029 | Widened to `(20\d{2})` covering 2000–2099 |

## Tests

69 video service + integration tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)