### PR TITLE
feat(ci): add macOS + Windows runners to daily CI

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -30,6 +30,38 @@ jobs:
       - name: Run tests
         run: pytest tests/ --timeout=30 -n=auto --override-ini="addopts="
 
+  test-macos:
+    name: Test macOS (Python 3.12)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Download NLTK data
+        run: python -c "import nltk; nltk.download('stopwords', quiet=True); nltk.download('punkt', quiet=True); nltk.download('punkt_tab', quiet=True); nltk.download('wordnet', quiet=True)"
+      - name: Run tests
+        run: pytest tests/ --timeout=30 -n=auto --override-ini="addopts="
+
+  test-windows:
+    name: Test Windows (Python 3.12)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Download NLTK data
+        run: python -c "import nltk; nltk.download('stopwords', quiet=True); nltk.download('punkt', quiet=True); nltk.download('punkt_tab', quiet=True); nltk.download('wordnet', quiet=True)"
+      - name: Run tests
+        run: pytest tests/ --timeout=30 -n=auto --override-ini="addopts="
+
   frontend-compat:
     name: Frontend Compatibility (placeholder)
     runs-on: ubuntu-latest

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -328,6 +328,41 @@ class TestCIFullWorkflow:
             "that E2E tests are disabled"
         )
 
+    def test_ci_full_has_macos_job(self, workflow: dict) -> None:
+        """Verify CI Full includes a macOS runner (issue #370)."""
+        jobs = workflow.get("jobs", {})
+        assert "test-macos" in jobs, "CI Full should have a 'test-macos' job (issue #370)"
+        macos_job = jobs["test-macos"]
+        assert macos_job.get("runs-on") == "macos-latest", (
+            "macOS job must use macos-latest runner"
+        )
+
+    def test_ci_full_has_windows_job(self, workflow: dict) -> None:
+        """Verify CI Full includes a Windows runner (issue #371)."""
+        jobs = workflow.get("jobs", {})
+        assert "test-windows" in jobs, "CI Full should have a 'test-windows' job (issue #371)"
+        windows_job = jobs["test-windows"]
+        assert windows_job.get("runs-on") == "windows-latest", (
+            "Windows job must use windows-latest runner"
+        )
+
+    def test_ci_full_platform_jobs_use_python_312(self, workflow: dict) -> None:
+        """Verify macOS and Windows jobs use Python 3.12 only (issue #387 cost constraint)."""
+        jobs = workflow.get("jobs", {})
+        for job_name in ("test-macos", "test-windows"):
+            assert job_name in jobs, f"Expected {job_name} job in CI Full workflow"
+            job = jobs[job_name]
+            steps = job.get("steps", [])
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses", "")
+                if isinstance(uses, str) and "actions/setup-python" in uses:
+                    python_version = step.get("with", {}).get("python-version")
+                    assert python_version == "3.12", (
+                        f"{job_name} must use Python 3.12 only per issue #387 cost constraint"
+                    )
+
     def test_ci_full_has_concurrency(self, workflow: dict) -> None:
         """Verify CI Full workflow has concurrency settings to cancel stale runs."""
         assert "concurrency" in workflow, (


### PR DESCRIPTION
## Summary

- Adds `test-macos` job (`macos-latest`, Python 3.12) to `ci-full.yml`
- Adds `test-windows` job (`windows-latest`, Python 3.12) to `ci-full.yml`
- New platform jobs run independently from the existing `test-matrix` (ubuntu, 3.11+3.12)
- Adds 3 CI workflow tests to assert the new jobs exist and use Python 3.12 only

Per issue #387, macOS and Windows runners use Python 3.12 only (not a version matrix) to keep runner costs bounded. The daily `ci-full.yml` schedule is the only trigger — these do not run on every PR.

Closes #370
Closes #371
Closes #387

## Test plan

- [x] 46 CI workflow tests pass locally (`pytest tests/ci/ -v`)
- [x] Full test suite passes (3991 tests)
- [x] Pre-commit validation clean (ruff, mypy non-blocking only)
- [ ] Trigger `CI Full Matrix` workflow manually after merge to verify macOS + Windows columns go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)