### PR TITLE
docs(#451): Close CLI docs gaps — document 23 missing params

### DIFF
--- a/.claude/epics/testing-qa/445.md
+++ b/.claude/epics/testing-qa/445.md
@@ -3,11 +3,11 @@ name: click-short-option-validation
 title: "Bug #445: Invalid Click Short Option Validation"
 github_issue: 445
 github_url: https://github.com/curdriceaurora/Local-File-Organizer/issues/445
-status: open
+status: closed
 priority: medium
 effort: 2-3 hours
 created: 2026-02-23T18:56:37Z
-updated: 2026-02-23T18:56:37Z
+updated: 2026-02-23T20:59:20Z
 epic: testing-qa
 category: CLI validation
 ---

--- a/.claude/epics/testing-qa/446.md
+++ b/.claude/epics/testing-qa/446.md
@@ -3,11 +3,11 @@ name: cli-docs-validation-gap
 title: "Bug #446: CLI Documentation Validation Gap"
 github_issue: 446
 github_url: https://github.com/curdriceaurora/Local-File-Organizer/issues/446
-status: open
+status: closed
 priority: high
 effort: 3-4 hours
 created: 2026-02-23T18:56:47Z
-updated: 2026-02-23T18:56:47Z
+updated: 2026-02-23T20:59:20Z
 epic: testing-qa
 category: CLI validation
 ---

--- a/.claude/epics/testing-qa/epic.md
+++ b/.claude/epics/testing-qa/epic.md
@@ -5,9 +5,9 @@ github_issue: 6
 github_url: https://github.com/curdriceaurora/Local-File-Organizer/issues/6
 status: open
 created: 2026-01-20T23:30:00Z
-updated: 2026-02-16T16:51:41Z
+updated: 2026-02-23T20:59:20Z
 labels: [enhancement, epic, testing]
-progress: 65%
+progress: 68%
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/6
 last_sync: 2026-02-19T00:43:37Z
 ---
@@ -170,10 +170,10 @@ Ensure docs are accurate
 ## Recent Bugs & Fixes
 
 ### CLI Validation Bugs
-- [ ] **#445** - Invalid Click Short Option Validation (M, 2-3h)
+- [x] **#445** - Invalid Click Short Option Validation (M, 2-3h)
   - Single dash "-" not valid as short option in Click
-  - Need proper short flag or remove short form
-  - **Status**: Standalone code bug (not part of #442 or #444)
+  - Fixed in PR #448: proper short flag or removed short form
+  - **Status**: Closed (fixed in PR #448)
 
 - [x] **#446** - CLI Documentation Validation Gap (CLOSED)
   - Inconsistent documentation requirements between command presence and parameter extraction

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -162,7 +162,7 @@ file-organizer analyze FILE [OPTIONS]
 ```
 
 **Arguments:**
-- `FILE` — Path to the file to analyze
+- `FILE_PATH` — Path to the file to analyze
 
 **Options:**
 - `--verbose, -v` — Show additional details (model name, processing time, content length)
@@ -362,6 +362,9 @@ Download a model via Ollama.
 file-organizer model pull MODEL_NAME
 ```
 
+**Arguments:**
+- `NAME` — Model name to download (e.g. `qwen2.5:3b-instruct-q4_K_M`)
+
 #### `model cache`
 
 Show model cache statistics.
@@ -528,16 +531,22 @@ file-organizer dedupe scan DIRECTORY [OPTIONS]
 Generate a duplication report.
 
 ```bash
-file-organizer dedupe report [OPTIONS]
+file-organizer dedupe report DIRECTORY [OPTIONS]
 ```
+
+**Arguments:**
+- `DIRECTORY` — Directory to scan
 
 #### `dedupe resolve`
 
 Interactively or automatically resolve duplicates.
 
 ```bash
-file-organizer dedupe resolve [OPTIONS]
+file-organizer dedupe resolve DIRECTORY [OPTIONS]
 ```
+
+**Arguments:**
+- `DIRECTORY` — Directory to scan for duplicates
 
 **Examples:**
 ```bash
@@ -576,7 +585,10 @@ Add a new rule to a rule set.
 file-organizer rules add RULE_NAME [OPTIONS]
 ```
 
-Options:
+**Arguments:**
+- `NAME` — Rule name
+
+**Options:**
 - `--ext TEXT` — File extension filter (e.g. `.pdf,.docx`)
 - `--pattern TEXT` — Filename glob pattern
 - `--action, -a TEXT` — Action type: `move`, `rename`, `tag`, `categorize`, `archive`, `copy`, `delete` (default: `move`)
@@ -592,6 +604,9 @@ Remove a rule from a rule set.
 file-organizer rules remove RULE_NAME [--set RULE_SET]
 ```
 
+**Arguments:**
+- `NAME` — Rule name to remove
+
 #### `rules toggle`
 
 Enable or disable a rule.
@@ -599,6 +614,9 @@ Enable or disable a rule.
 ```bash
 file-organizer rules toggle RULE_NAME [--set RULE_SET]
 ```
+
+**Arguments:**
+- `NAME` — Rule name to toggle
 
 #### `rules preview`
 
@@ -628,6 +646,9 @@ Import a rule set from a YAML file.
 ```bash
 file-organizer rules import FILE [--set RULE_SET]
 ```
+
+**Arguments:**
+- `FILE` — YAML file to import
 
 **Examples:**
 ```bash
@@ -673,8 +694,11 @@ Options:
 Apply accepted suggestions.
 
 ```bash
-file-organizer suggest apply [OPTIONS]
+file-organizer suggest apply DIRECTORY [OPTIONS]
 ```
+
+**Arguments:**
+- `DIRECTORY` — Directory to organize
 
 #### `suggest patterns`
 
@@ -727,6 +751,9 @@ Show details for a specific plugin.
 file-organizer marketplace info PLUGIN_NAME
 ```
 
+**Arguments:**
+- `NAME` — Plugin name
+
 #### `marketplace install`
 
 Install a plugin.
@@ -735,6 +762,9 @@ Install a plugin.
 file-organizer marketplace install PLUGIN_NAME [--version VERSION]
 ```
 
+**Arguments:**
+- `NAME` — Plugin to install
+
 #### `marketplace uninstall`
 
 Remove an installed plugin.
@@ -742,6 +772,9 @@ Remove an installed plugin.
 ```bash
 file-organizer marketplace uninstall PLUGIN_NAME
 ```
+
+**Arguments:**
+- `NAME` — Plugin to uninstall
 
 #### `marketplace review`
 
@@ -793,6 +826,9 @@ Update a specific plugin.
 file-organizer marketplace update PLUGIN_NAME
 ```
 
+**Arguments:**
+- `NAME` — Plugin to update
+
 ---
 
 ### `api` — Remote API Client
@@ -815,6 +851,10 @@ Authenticate and store access tokens.
 file-organizer api login [--base-url URL] [--save-token PATH]
 ```
 
+**Options:**
+- `--username` — Login username (prompted if not provided)
+- `--password` — Login password (prompted securely if not provided)
+
 #### `api me`
 
 Show current authenticated user.
@@ -831,13 +871,23 @@ Invalidate the current session token.
 file-organizer api logout [--base-url URL] [--token TOKEN]
 ```
 
+**Options:**
+- `--token` — Bearer token
+- `--refresh-token` — Refresh token to revoke
+
 #### `api files`
 
 List files via the API.
 
 ```bash
-file-organizer api files [OPTIONS]
+file-organizer api files PATH [OPTIONS]
 ```
+
+**Arguments:**
+- `PATH` — Directory to list
+
+**Options:**
+- `--token` — Bearer token
 
 #### `api system-status`
 
@@ -847,6 +897,9 @@ Show system status from the API server.
 file-organizer api system-status [--base-url URL]
 ```
 
+**Options:**
+- `--token` — Bearer token
+
 #### `api system-stats`
 
 Show system statistics from the API server.
@@ -854,6 +907,9 @@ Show system statistics from the API server.
 ```bash
 file-organizer api system-stats [--base-url URL]
 ```
+
+**Options:**
+- `--token` — Bearer token
 
 **Default base URL:** `http://localhost:8000`
 
@@ -948,6 +1004,9 @@ Import a profile from a file.
 ```bash
 file-organizer profile import FILE [OPTIONS]
 ```
+
+**Arguments:**
+- `FILE` — Profile file to import
 
 #### `profile current`
 
@@ -1122,8 +1181,12 @@ Options:
 Apply tags to a file and record for learning.
 
 ```bash
-file-organizer autotag apply FILE TAG...
+file-organizer autotag apply FILE_PATH TAG...
 ```
+
+**Arguments:**
+- `FILE_PATH` — File to tag
+- `TAGS` — One or more tags to apply
 
 #### `autotag popular`
 

--- a/tests/docs/test_cli_docs_accuracy.py
+++ b/tests/docs/test_cli_docs_accuracy.py
@@ -31,39 +31,6 @@ EXCLUDED_COMMANDS: set[str] = {
     # Hidden / internal aliases that duplicate other commands
 }
 
-# Pre-existing documentation gaps exposed by the f-string regex fix in #444.
-# Before the fix, _get_command_section() silently returned "" for header-documented
-# commands (the {2,4} quantifier was consumed by the f-string), so param validation
-# was skipped entirely. The regex fix now correctly extracts sections, revealing
-# these 23 parameters that are undocumented in cli-reference.md.
-#
-# Each entry is "command_path::param_kind::param_name".
-# TODO: Fix docs for these params, then remove entries from this set.
-KNOWN_PARAM_DOC_GAPS: set[str] = {
-    "analyze::argument::file_path",
-    "api files::argument::path",
-    "api files::option::token",
-    "api login::option::password",
-    "api login::option::username",
-    "api logout::option::refresh_token",
-    "api system-stats::option::token",
-    "api system-status::option::token",
-    "autotag apply::argument::file_path",
-    "autotag apply::argument::tags",
-    "dedupe report::argument::directory",
-    "dedupe resolve::argument::directory",
-    "marketplace info::argument::name",
-    "marketplace install::argument::name",
-    "marketplace uninstall::argument::name",
-    "marketplace update::argument::name",
-    "model pull::argument::name",
-    "profile import::argument::file",
-    "rules add::argument::name",
-    "rules import::argument::file",
-    "rules remove::argument::name",
-    "rules toggle::argument::name",
-    "suggest apply::argument::directory",
-}
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +321,6 @@ class TestRequiredArgsDocumented:
         commands = _get_commands()
 
         missing: list[str] = []
-        known_gaps_found: list[str] = []
         for cmd in commands:
             if cmd.path in EXCLUDED_COMMANDS:
                 continue
@@ -369,10 +335,6 @@ class TestRequiredArgsDocumented:
 
             for param in cmd.required_params:
                 if not _param_is_documented(section, param):
-                    gap_key = f"{cmd.path}::{param.kind}::{param.name}"
-                    if gap_key in KNOWN_PARAM_DOC_GAPS:
-                        known_gaps_found.append(gap_key)
-                        continue
                     label = (
                         f"--{param.name.replace('_', '-')}"
                         if param.kind == "option"
@@ -380,14 +342,8 @@ class TestRequiredArgsDocumented:
                     )
                     missing.append(f"`{cmd.path}` {param.kind} {label}")
 
-        if known_gaps_found:
-            print(
-                f"\n  [{len(known_gaps_found)} known param doc gap(s) skipped "
-                f"— see KNOWN_PARAM_DOC_GAPS in this file]"
-            )
-
         assert not missing, (
-            f"{len(missing)} NEW required parameter(s) missing from docs/cli-reference.md:\n"
+            f"{len(missing)} required parameter(s) missing from docs/cli-reference.md:\n"
             + "\n".join(f"  - {m}" for m in sorted(missing))
             + "\n\nFix: Document each required argument/option in the command's section."
         )
@@ -504,9 +460,6 @@ class TestMetavarAlignment:
 
             for param in cmd.required_params:
                 if param.kind != "argument" or not param.metavar:
-                    continue
-                gap_key = f"{cmd.path}::argument::{param.name}"
-                if gap_key in KNOWN_PARAM_DOC_GAPS:
                     continue
                 if param.metavar not in section:
                     mismatches.append(


### PR DESCRIPTION
## Summary

Close issue #451 by adding missing CLI parameter documentation and removing the `KNOWN_PARAM_DOC_GAPS` workaround from tests. Also close bugs #445 and #446.

- ✅ Added `**Arguments:**` and `**Options:**` subsections to 15 command sections in `docs/cli-reference.md` covering 23 missing required parameters
- ✅ Removed `KNOWN_PARAM_DOC_GAPS` set from `test_cli_docs_accuracy.py` — no more silent skips of undocumented params
- ✅ Updated CCPM: closed #445 (fixed in PR #448) and #446 (addressed in #444)
- ✅ Updated testing-qa epic progress: 68% (17/25 tasks complete)

## Test Plan

- [x] All 43 docs tests pass (5 accuracy + 38 helpers)
- [x] Pre-commit validation passes
- [x] Code-reviewer approved

## Commits

This PR includes 2 commits:
1. `55b42d1` — fix(#444): Add semantic validation for test logic and docstring accuracy
2. `3bdfb76` — docs(#451): Document 23 missing CLI params, remove KNOWN_PARAM_DOC_GAPS

🤖 Generated with Claude Code