### PR TITLE
fix: address CodeRabbit review comments from PRs #510 and #511

### DIFF
--- a/.claude/epics/issue-remediation-462-480/execution-status.md
+++ b/.claude/epics/issue-remediation-462-480/execution-status.md
@@ -86,17 +86,20 @@ Parallel track:
 #479 (Metadata) [4-8h]    ⏳ Standalone
 ```
 
-### Issue #474: Remove CI workflow duplication 🚀 START NOW
+### Issue #474: Remove CI workflow duplication ✅ COMPLETE
 
-- **Status**: Open — no dependencies, start immediately
+- **Status**: ✅ Complete — merged via PR #511 (2026-02-28)
 - **Effort**: 4-6 hours (quickest Phase 4 task)
 - **Priority**: P2
-- **Scope**: Consolidate 3+ duplicate workflow definitions into single parameterized workflow
+- **Scope**: Deduplicate CI ownership while maintaining separate fast-path (`ci.yml`) and
+  breadth (`ci-full.yml`) workflows — removed `test-matrix` job from `ci-full.yml` (duplicate
+  of Linux 3.11/3.12 already covered by `ci.yml`), removed duplicate docstring step and
+  schedule trigger from `ci.yml`, added explicit ownership table to CONTRIBUTING.md
 - **GitHub Issue**: <https://github.com/curdriceaurora/Local-File-Organizer/issues/474>
 
-### Issue #475: Decouple optional feature dependencies 🚀 START NOW
+### Issue #475: Decouple optional feature dependencies ✅ COMPLETE
 
-- **Status**: Open — no dependencies, can run parallel to #474
+- **Status**: ✅ Complete — merged via PR #511 (2026-02-28)
 - **Effort**: 8-12 hours
 - **Priority**: P2
 - **Scope**: Guard optional imports (audio, video, dedup extras) to prevent import errors when optional packages are absent

--- a/src/file_organizer/methodologies/para/migration_manager.py
+++ b/src/file_organizer/methodologies/para/migration_manager.py
@@ -206,7 +206,7 @@ class PARAMigrationManager:
             total_count=len(files_to_migrate),
             by_category=by_category,
             estimated_size=total_size,
-            created_at=datetime.now(),
+            created_at=datetime.now(UTC),
         )
 
         logger.info(f"Migration plan created: {plan.total_count} files")
@@ -230,7 +230,7 @@ class PARAMigrationManager:
         Returns:
             MigrationReport with results
         """
-        start_time = datetime.now()
+        start_time = datetime.now(UTC)
         logger.info(f"Executing migration (dry_run={dry_run})")
 
         migrated: list[Path] = []
@@ -286,7 +286,7 @@ class PARAMigrationManager:
                 failed.append((migration_file.source_path, str(e)))
 
         # Calculate duration
-        duration = (datetime.now() - start_time).total_seconds()
+        duration = (datetime.now(UTC) - start_time).total_seconds()
 
         # Create report
         success = len(failed) == 0

--- a/src/file_organizer/models/audio_transcriber.py
+++ b/src/file_organizer/models/audio_transcriber.py
@@ -139,6 +139,8 @@ class AudioTranscriber:
             num_workers: Number of workers for CPU inference
 
         Raises:
+            ImportError: If faster-whisper is not installed.
+                Install with: ``pip install 'file-organizer[audio]'``
             ValueError: If model size or device is invalid
             RuntimeError: If model loading fails
         """

--- a/src/file_organizer/services/deduplication/image_dedup.py
+++ b/src/file_organizer/services/deduplication/image_dedup.py
@@ -61,6 +61,8 @@ class ImageDeduplicator:
                       - 21+: Potentially different images
 
         Raises:
+            ImportError: If imagededup is not installed.
+                Install with: ``pip install 'file-organizer[dedup]'``
             ValueError: If hash_method is not supported or threshold is invalid
         """
         if not _IMAGEDEDUP_AVAILABLE:

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -246,7 +246,11 @@ class TestCIFullWorkflow:
         """
         jobs = workflow.get("jobs", {})
         for job_name in ("test-macos", "test-windows"):
-            job = jobs.get(job_name, {})
+            assert job_name in jobs, (
+                f"Expected '{job_name}' job in CI Full workflow — "
+                "platform jobs must be present for cross-OS coverage"
+            )
+            job = jobs[job_name]
             steps = job.get("steps", [])
             for step in steps:
                 if not isinstance(step, dict):

--- a/tests/models/test_audio_transcriber.py
+++ b/tests/models/test_audio_transcriber.py
@@ -747,6 +747,7 @@ class TestStaticMethods:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 class TestMissingFasterWhisper:
     """AudioTranscriber raises ImportError with an actionable message when
     faster-whisper is not installed."""

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -784,6 +784,7 @@ class TestValidateImage:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 class TestMissingImagededupDep:
     """ImageDeduplicator raises ImportError with an actionable message when
     imagededup is not installed."""


### PR DESCRIPTION
## Summary

Follow-up fixes for CodeRabbit review comments that were raised on PRs #510 and #511 after merging.

### Changes

- **`tests/services/deduplication/test_image_dedup.py`** — Add missing `@pytest.mark.unit` to `TestMissingImagededupDep` class
- **`tests/models/test_audio_transcriber.py`** — Add missing `@pytest.mark.unit` to `TestMissingFasterWhisper` class
- **`tests/ci/test_workflows.py`** — Assert job existence before iterating steps in `test_ci_full_platform_jobs_do_not_collect_coverage` (fail loudly if job is missing)
- **`src/file_organizer/models/audio_transcriber.py`** — Add `ImportError` to `AudioTranscriber.__init__` Raises docstring
- **`src/file_organizer/services/deduplication/image_dedup.py`** — Add `ImportError` to `ImageDeduplicator.__init__` Raises docstring
- **`src/file_organizer/methodologies/para/migration_manager.py`** — Fix timezone-naive `datetime.now()` → `datetime.now(UTC)` (3 call sites)
- **`.claude/epics/.../execution-status.md`** — Update #474/#475 status to ✅ Complete

### Test plan

- [ ] All existing tests pass
- [ ] `migration_manager.py` datetime calls are now UTC-aware
- [ ] `@pytest.mark.unit` markers present on all relevant test classes
- [ ] Workflow CI test asserts job existence before checking steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced docstrings to document ImportError conditions when optional dependencies (faster-whisper, imagededup) are unavailable, including installation guidance.
  * Updated project documentation to reflect completed tasks and refined scope descriptions.

* **Tests**
  * Added unit test markers for improved test categorization.
  * Strengthened CI workflow validation with stricter job existence checks.

* **Chores**
  * Updated migration tracking to use UTC-aware timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->