### PR TITLE
fix: change python fence to text for marker-list block in testing.md

### DIFF
--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -39,7 +39,7 @@ tests/
 
 Use pytest markers to categorize tests:
 
-```python
+```text
 @pytest.mark.unit          # Unit tests (isolated, fast)
 @pytest.mark.smoke         # Critical path tests (< 30s total, pre-commit validation)
 @pytest.mark.integration   # Integration tests (cross-module workflows)


### PR DESCRIPTION
## Root Cause

`docs/developer/testing.md` block 1 contained a ` ```python ` fenced block listing bare `@pytest.mark.*` decorators with no function body — invalid Python syntax. The CI test `test_python_examples_parse` parses all `python`-fenced blocks and failed with:

```
AssertionError: Found 1 Python syntax error(s) in docs:
  developer/testing.md (block 1): invalid syntax at line 9
```

## Fix

Changed the fence language from `python` to `text`. The block is a documentation reference list, not runnable code.

## Test plan

- [x] `pytest tests/docs/test_code_examples.py::TestPythonCodeExamples::test_python_examples_parse` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)