### PR TITLE
test(#394): image file reader tests with magic-byte stubs and edge cases

### DIFF
--- a/tests/services/deduplication/test_image_file_readers.py
+++ b/tests/services/deduplication/test_image_file_readers.py
@@ -34,6 +34,7 @@ sys.modules.setdefault("PIL", _pil_mod)
 sys.modules.setdefault("PIL.Image", _pil_image_mod)
 
 from file_organizer.services.deduplication.image_utils import (  # noqa: E402
+    FORMAT_QUALITY_RANK,
     SUPPORTED_FORMATS,
     ImageMetadata,
     compare_image_quality,
@@ -182,6 +183,16 @@ class TestQualityScoreRanking:
         gif_score = get_format_quality_score(Path("a.gif"))
         for ext in [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"]:
             assert get_format_quality_score(Path(f"x{ext}")) >= gif_score
+
+    def test_full_ranking_is_total_order(self) -> None:
+        """Pin every rank so mid-table regressions (e.g. bmp < webp) are caught."""
+        scores = {ext: get_format_quality_score(Path(f"x{ext}")) for ext in FORMAT_QUALITY_RANK}
+        # Verify the documented ranking: PNG/TIFF (5) > BMP (4) > WEBP (3) > JPEG (2) > GIF (1)
+        assert scores[".png"] == scores[".tiff"] == scores[".tif"]
+        assert scores[".png"] > scores[".bmp"]
+        assert scores[".bmp"] > scores[".webp"]
+        assert scores[".webp"] > scores[".jpg"] == scores[".jpeg"]
+        assert scores[".jpg"] > scores[".gif"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses issue #394 from umbrella issue #611 (deferred multimedia testing).

Creates `tests/utils/test_image_file_readers.py` (20 tests) which complements the existing comprehensive `test_dedup_image_utils.py` by:

- **TestSupportedFormatsCompleteness**: all 8 formats registered (.jpg, .jpeg, .png, .gif, .bmp, .tiff, .tif, .webp); non-image extensions rejected; case-insensitive matching
- **TestMagicByteStubFiles**: validates PNG/JPEG/GIF/WEBP stubs pass the extension+PIL gate; verifies `.pdf` with PNG bytes is rejected before PIL is ever called (extension gate fires first)
- **TestQualityScoreRanking**: lossless > lossy (PNG > JPEG), TIFF == PNG, GIF is lowest; quality ordering is a total ranking
- **TestGetBestQualityImageEdgeCases**: single valid image returns itself; PNG beats JPEG at equal resolution
- **TestCompareImageQualityAdditional**: zero-resolution images fall back to format score for comparison
- **TestFindImagesAdditional**: empty directory, mixed-case extensions, hidden dot-prefix files

Uses the same PIL module-level mock pattern as the existing dedup test suite so no Pillow installation is required.

## Test plan

- [x] All 20 new tests pass
- [x] `ruff check` clean, `ruff format` applied
- [x] Smoke markers on two fast-path tests

## Related

- Closes #394
- Part of umbrella #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for image deduplication: format recognition (including case-insensitive extensions), magic-byte validation, quality scoring and total-order comparisons, and best-image selection behavior.
  * Covers edge cases (empty dirs, hidden files, mixed-case filenames, recursive control).
  * Tests are CI-friendly using targeted mocks and include unit, smoke, and CI markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->