### PR TITLE
test(#390): add missing _extract_text response variants — N/A and NO TEXT

### DIFF
--- a/tests/services/test_vision_processor.py
+++ b/tests/services/test_vision_processor.py
@@ -386,6 +386,30 @@ class TestVisionProcessorDescriptionAndOCR:
 
         assert result is None
 
+    def test_extract_text_na_response(
+        self, vision_processor: VisionProcessor, mock_vision_model: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test 'N/A' response returns None."""
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8")
+        mock_vision_model.generate.return_value = "N/A"
+
+        result = vision_processor._extract_text(img)
+
+        assert result is None
+
+    def test_extract_text_no_text_with_space(
+        self, vision_processor: VisionProcessor, mock_vision_model: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test 'NO TEXT' (with space) response returns None."""
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8")
+        mock_vision_model.generate.return_value = "NO TEXT"
+
+        result = vision_processor._extract_text(img)
+
+        assert result is None
+
 
 @pytest.mark.unit
 class TestVisionProcessorFolderAndFilename:


### PR DESCRIPTION
## Summary

Addresses issue #390 from umbrella issue #611 (deferred multimedia testing).

The `_extract_text()` method checks `response.upper() in ["NO_TEXT", "NO TEXT", "NONE", "N/A"]`. The existing test suite covered `NO_TEXT` and `NONE` but missed:

- `"N/A"` → should return `None`
- `"NO TEXT"` (space instead of underscore) → should return `None`

Added two tests to `TestVisionProcessorDescriptionAndOCR`:
- `test_extract_text_na_response`
- `test_extract_text_no_text_with_space`

## Test plan

- [x] All 42 vision processor tests pass
- [x] `ruff check` clean, `ruff format` no changes needed

## Related

- Closes #390
- Part of umbrella #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)