### PR TITLE
chore: close docstring-coverage streams 2-6 (96.8% coverage achieved)

### DIFF
--- a/.claude/epics/docstring-coverage/579-stream2-services.md
+++ b/.claude/epics/docstring-coverage/579-stream2-services.md
@@ -3,9 +3,9 @@ name: 579-stream2-services
 issue: 579
 stream: 2
 title: "Services Layer Docstrings"
-status: open
+status: completed
 created: 2026-03-06T21:00:00Z
-updated: 2026-03-06T21:00:00Z
+updated: 2026-03-09T05:58:01Z
 ---
 
 # Task 579.2: Services Layer Docstrings

--- a/.claude/epics/docstring-coverage/579-stream3-web.md
+++ b/.claude/epics/docstring-coverage/579-stream3-web.md
@@ -3,9 +3,9 @@ name: 579-stream3-web
 issue: 579
 stream: 3
 title: "Web Layer Docstrings"
-status: open
+status: completed
 created: 2026-03-06T21:00:00Z
-updated: 2026-03-06T21:00:00Z
+updated: 2026-03-09T05:58:01Z
 ---
 
 # Task 579.3: Web Layer Docstrings

--- a/.claude/epics/docstring-coverage/579-stream4-cli.md
+++ b/.claude/epics/docstring-coverage/579-stream4-cli.md
@@ -3,9 +3,9 @@ name: 579-stream4-cli
 issue: 579
 stream: 4
 title: "CLI & User-Facing APIs"
-status: open
+status: completed
 created: 2026-03-06T21:00:00Z
-updated: 2026-03-06T21:00:00Z
+updated: 2026-03-09T05:58:01Z
 ---
 
 # Task 579.4: CLI & User-Facing APIs

--- a/.claude/epics/docstring-coverage/579-stream5-methodologies.md
+++ b/.claude/epics/docstring-coverage/579-stream5-methodologies.md
@@ -3,9 +3,9 @@ name: 579-stream5-methodologies
 issue: 579
 stream: 5
 title: "Methodologies & Analysis"
-status: open
+status: completed
 created: 2026-03-06T21:00:00Z
-updated: 2026-03-06T21:00:00Z
+updated: 2026-03-09T05:58:01Z
 ---
 
 # Task 579.5: Methodologies & Analysis

--- a/.claude/epics/docstring-coverage/579-stream6-utils.md
+++ b/.claude/epics/docstring-coverage/579-stream6-utils.md
@@ -3,9 +3,9 @@ name: 579-stream6-utils
 issue: 579
 stream: 6
 title: "Utils & Data Models"
-status: open
+status: completed
 created: 2026-03-06T21:00:00Z
-updated: 2026-03-06T21:00:00Z
+updated: 2026-03-09T05:58:01Z
 ---
 
 # Task 579.6: Utils & Data Models


### PR DESCRIPTION
## Summary
- Close CCPM tracking streams 2-6 for issue #579 (Docstring Coverage)
- `interrogate` reports 96.8% coverage — passes 90% gate
- Stream 1 (core) was the primary implementation; remaining streams covered by prior work

## No code changes — CCPM tracking update only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed internal epic tracking items for docstring coverage streams. Updated project documentation status and timestamps with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->