### PR TITLE
chore: sync desktopui-test-coverage CCPM task states to closed

### DIFF
--- a/.claude/epics/desktopui-test-coverage/573.md
+++ b/.claude/epics/desktopui-test-coverage/573.md
@@ -1,8 +1,8 @@
 ---
 name: TUI View Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/573
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/574.md
+++ b/.claude/epics/desktopui-test-coverage/574.md
@@ -1,8 +1,8 @@
 ---
 name: Models, Client & Config Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/574
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/575.md
+++ b/.claude/epics/desktopui-test-coverage/575.md
@@ -1,8 +1,8 @@
 ---
 name: Plugin System & Marketplace Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/575
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/576.md
+++ b/.claude/epics/desktopui-test-coverage/576.md
@@ -1,8 +1,8 @@
 ---
 name: Updater & Watcher Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/576
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/577.md
+++ b/.claude/epics/desktopui-test-coverage/577.md
@@ -1,8 +1,8 @@
 ---
 name: CLI Command Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/577
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/578.md
+++ b/.claude/epics/desktopui-test-coverage/578.md
@@ -1,8 +1,8 @@
 ---
 name: Integration & End-to-End Workflow Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/578
 depends_on: [572, 575, 577, 580, 581]
 parallel: false

--- a/.claude/epics/desktopui-test-coverage/579.md
+++ b/.claude/epics/desktopui-test-coverage/579.md
@@ -1,8 +1,8 @@
 ---
 name: Docstring Coverage via Interrogate
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/579
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/580.md
+++ b/.claude/epics/desktopui-test-coverage/580.md
@@ -1,8 +1,8 @@
 ---
 name: Web Route & HTMX Endpoint Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/580
 depends_on: []
 parallel: true

--- a/.claude/epics/desktopui-test-coverage/581.md
+++ b/.claude/epics/desktopui-test-coverage/581.md
@@ -1,8 +1,8 @@
 ---
 name: Services Layer Tests
-status: open
+status: closed
 created: 2026-03-02T21:00:22Z
-updated: 2026-03-02T21:08:31Z
+updated: 2026-03-09T06:05:32Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/581
 depends_on: []
 parallel: true


### PR DESCRIPTION
CCPM housekeeping — issues #573–#581 all closed on GitHub but local task files still showed `open`. Syncing states to match reality so pm:next stops surfacing them as available work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Archived and finalized internal task tracking records for development items, updating their completion status and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->