### PR TITLE
chore: add status:closed to stale analysis files in pm:next

### DIFF
--- a/.claude/epics/desktopui-test-coverage/572-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/572-analysis.md
@@ -5,6 +5,8 @@ title: API Router & Middleware Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 50
 parallelization_factor: 3.0
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #572

--- a/.claude/epics/desktopui-test-coverage/573-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/573-analysis.md
@@ -5,6 +5,8 @@ title: TUI View Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 18
 parallelization_factor: 2.0
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #573

--- a/.claude/epics/desktopui-test-coverage/574-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/574-analysis.md
@@ -5,6 +5,8 @@ title: Models, Client & Config Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 25
 parallelization_factor: 2.5
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #574

--- a/.claude/epics/desktopui-test-coverage/575-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/575-analysis.md
@@ -5,6 +5,8 @@ title: Plugin System & Marketplace Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 32
 parallelization_factor: 2.5
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #575

--- a/.claude/epics/desktopui-test-coverage/576-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/576-analysis.md
@@ -5,6 +5,8 @@ title: Updater & Watcher Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 28
 parallelization_factor: 2.0
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #576

--- a/.claude/epics/desktopui-test-coverage/577-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/577-analysis.md
@@ -5,6 +5,8 @@ title: CLI Command Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 22
 parallelization_factor: 2.5
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #577

--- a/.claude/epics/desktopui-test-coverage/578-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/578-analysis.md
@@ -5,6 +5,8 @@ title: Integration & End-to-End Workflow Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 45
 parallelization_factor: 1.5
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #578

--- a/.claude/epics/desktopui-test-coverage/579-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/579-analysis.md
@@ -5,6 +5,8 @@ title: Docstring Coverage via Interrogate
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 30
 parallelization_factor: 3.0
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #579

--- a/.claude/epics/desktopui-test-coverage/581-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/581-analysis.md
@@ -5,6 +5,8 @@ title: Services Layer Tests
 analyzed: 2026-03-06T17:45:30Z
 estimated_hours: 60
 parallelization_factor: 3.0
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #581

--- a/.claude/epics/desktopui-test-coverage/656-analysis.md
+++ b/.claude/epics/desktopui-test-coverage/656-analysis.md
@@ -4,6 +4,8 @@ title: Audit Test-Generation PR Review Comments — Anti-Pattern Ruleset
 analyzed: 2026-03-08T02:53:46Z
 estimated_hours: 6
 parallelization_factor: 2.0
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #656

--- a/.claude/epics/issue-580-web-route-tests/636-analysis.md
+++ b/.claude/epics/issue-580-web-route-tests/636-analysis.md
@@ -5,6 +5,8 @@ title: Web Route Tests - Error Paths & Edge Cases for 100% Coverage
 analyzed: 2026-03-06T22:19:42Z
 estimated_hours: 12.0
 parallelization_factor: 3.5
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #636

--- a/.claude/epics/testing-qa/536.md
+++ b/.claude/epics/testing-qa/536.md
@@ -4,9 +4,9 @@ title: Implement Smoke Test Suite for PR CI Optimization
 epic: testing-qa
 priority: Medium
 effort: 2-3 hours
-status: open
+status: closed
 created: 2026-03-06T02:39:16Z
-updated: 2026-03-06T02:39:16Z
+updated: 2026-03-09T06:06:50Z
 github: https://github.com/curdriceaurora/Local-File-Organizer/issues/616
 ---
 

--- a/.claude/epics/testing-qa/639-analysis.md
+++ b/.claude/epics/testing-qa/639-analysis.md
@@ -4,6 +4,8 @@ title: refactor: consolidate web route test helpers and fixtures
 analyzed: 2026-03-07T14:02:53Z
 estimated_hours: 3
 parallelization_factor: 1.5
+status: closed
+updated: 2026-03-09T06:06:50Z
 ---
 
 # Parallel Work Analysis: Issue #639


### PR DESCRIPTION
CCPM housekeeping — 12 analysis files missing status frontmatter were surfacing as available work in pm:next. All parent GitHub issues are closed.