### PR TITLE
fix(ci): use OIDC trusted publishing for PyPI in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
   publish-pypi:
     needs: build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -35,7 +38,6 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: dist/
 
   github-release:


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission to `publish-pypi` job (required for OIDC token exchange)
- Add `environment: pypi` to match the trusted publisher configured on pypi.org
- Remove `password: ${{ secrets.PYPI_TOKEN }}` — not needed with trusted publishing

## Why

The `v2.0.0-alpha.2` release workflow failed at the PyPI publish step because the job lacked the `id-token: write` permission needed for OIDC. This PR fixes the workflow so future tags (starting with re-tagging `v2.0.0-alpha.2` after merge) publish `local-file-organizer` to PyPI automatically.

## Test plan

- [ ] Merge this PR
- [ ] Delete and re-push `v2.0.0-alpha.2` tag to re-trigger `release.yml`
- [ ] Verify `publish-pypi` job succeeds and `local-file-organizer 2.0.0a2` appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)