### PR TITLE
fix(ci): update stale PYPI_TOKEN test to expect OIDC publishing

### DIFF
--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -393,7 +393,11 @@ class TestReleaseWorkflow:
             "publish-pypi job must have id-token: write for OIDC trusted publishing"
         )
         environment = publish_job.get("environment")
-        assert environment == "pypi", (
+        if isinstance(environment, dict):
+            environment_name = environment.get("name")
+        else:
+            environment_name = environment
+        assert environment_name == "pypi", (
             "publish-pypi job must use the 'pypi' GitHub environment for OIDC"
         )
 


### PR DESCRIPTION
## Summary

- `test_release_uses_secrets_for_pypi` was asserting that `release.yml` references `PYPI_TOKEN`, but PR #699 switched to OIDC trusted publishing which requires no API token.
- Renamed to `test_release_uses_oidc_for_pypi` and updated assertions to verify OIDC configuration: `id-token: write` permission and `environment: pypi`.

## Test plan

- [x] `pytest tests/ci/test_workflows.py::TestReleaseWorkflow::test_release_uses_oidc_for_pypi` passes locally
- [x] No other tests changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI/CD release workflow validation to verify OIDC-based PyPI authentication instead of secret-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->