### PR TITLE
fix(tests): set mock model_type for TextProcessor validation

### DIFF
--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -23,6 +23,7 @@ pytestmark = [pytest.mark.unit]
 def mock_text_model() -> MagicMock:
     """Mocked TextModel instance."""
     model = MagicMock()
+    model.config.model_type = ModelType.TEXT
     model.is_initialized = True
     # Default generate response to something predictable
     model.generate.return_value = "Mocked AI Response"

--- a/tests/services/test_text_processor_logging.py
+++ b/tests/services/test_text_processor_logging.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from file_organizer.models.base import ModelType
 from file_organizer.services.text_processor import TextProcessor
 
 # ---------------------------------------------------------------------------
@@ -21,6 +22,7 @@ from file_organizer.services.text_processor import TextProcessor
 def mock_text_model():
     """Return a MagicMock that stands in for TextModel."""
     model = MagicMock()
+    model.config.model_type = ModelType.TEXT
     model.is_initialized = True
     # First call: description, second: folder name, third: filename
     model.generate.side_effect = [


### PR DESCRIPTION
## Summary
- PR #689 added `model_type` validation to `TextProcessor.__init__` but the mock fixtures in two test files didn't set `config.model_type = ModelType.TEXT`
- This caused 90 test errors on main CI (run #22936823182)
- Adds `model.config.model_type = ModelType.TEXT` to mock fixtures in both `test_text_processor.py` and `test_text_processor_logging.py`

## Test plan
- [x] All 82 tests in both files pass locally
- [x] No other test files affected (verified via CI error log — only these two files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixtures to properly configure model type settings, improving test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->