### PR TITLE
docs(ci): reconcile provider/CI closeout and codify 7-stream MECE plan

### DIFF
--- a/docs/plans/2026-03-16-mece-multi-pr-delivery-register.md
+++ b/docs/plans/2026-03-16-mece-multi-pr-delivery-register.md
@@ -21,9 +21,9 @@ Scope covered in this register:
 | PR Stream | Issues | Type | Priority | Quick Win | Wave | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | PR-A: Provider/CI/Epic closeout reconciliation | #723, #816, #706 | Governance closeout | P0 | Yes | 1 | No new provider runtime behavior; reconciles completion claims and dependencies |
-| PR-B: MLX provider | #819 | Feature | P1 | Medium | 2 | Provider integration for Apple-local inference path |
-| PR-C: Claude provider | #820 | Feature | P1 | Medium | 2 | Anthropic cloud provider path |
-| PR-D: User-facing parallelism/resource controls | #727 | Feature | P1 | Medium | 1 | CLI/TUI runtime controls |
+| PR-B: MLX provider | #819 | Feature | P1 | No | 2 | Provider integration for Apple-local inference path |
+| PR-C: Claude provider | #820 | Feature | P1 | No | 2 | Anthropic cloud provider path |
+| PR-D: User-facing parallelism/resource controls | #727 | Feature | P1 | No | 1 | CLI/TUI runtime controls |
 | PR-E: Semantic naming quality investigation | #719 | Feature/Experiment | P2 | Yes | 1 | Corpus + benchmark + fallback experiments |
 | PR-F: TUI analytics completion | #720 | Feature | P3 | No | 1 | Low-priority UX completion |
 | PR-G: Hybrid retrieval + embedding cache | #715 | Feature | P1 | No | 3 | Largest scope; architecture bottleneck for epic closeout |

--- a/tests/ci/test_mece_multi_pr_delivery_register.py
+++ b/tests/ci/test_mece_multi_pr_delivery_register.py
@@ -14,6 +14,15 @@ REGISTER_REL = "docs/plans/2026-03-16-mece-multi-pr-delivery-register.md"
 REGISTER_PATH = FO_ROOT / REGISTER_REL
 EXPECTED_ISSUES = {706, 715, 719, 720, 723, 727, 816, 819, 820}
 EXPECTED_PRIORITIES = {"P0", "P1", "P2", "P3"}
+EXPECTED_STREAM_VALUES: dict[str, dict[str, object]] = {
+    "PR-A": {"priority": "P0", "wave": 1, "quick_win": True},
+    "PR-B": {"priority": "P1", "wave": 2, "quick_win": False},
+    "PR-C": {"priority": "P1", "wave": 2, "quick_win": False},
+    "PR-D": {"priority": "P1", "wave": 1, "quick_win": False},
+    "PR-E": {"priority": "P2", "wave": 1, "quick_win": True},
+    "PR-F": {"priority": "P3", "wave": 1, "quick_win": False},
+    "PR-G": {"priority": "P1", "wave": 3, "quick_win": False},
+}
 
 
 def _extract_metadata(text: str) -> dict[str, object]:
@@ -54,9 +63,15 @@ def test_delivery_register_has_mece_partition_and_valid_wave_plan() -> None:
         assert isinstance(stream, dict)
         stream_id = str(stream["id"])
         stream_ids.add(stream_id)
+        expected = EXPECTED_STREAM_VALUES.get(stream_id)
+        assert expected is not None, f"Unexpected stream id in metadata: {stream_id}"
+
         assert stream["priority"] in EXPECTED_PRIORITIES
+        assert stream["priority"] == expected["priority"]
         assert isinstance(stream["quick_win"], bool)
+        assert stream["quick_win"] is expected["quick_win"]
         assert int(stream["wave"]) in {1, 2, 3}
+        assert int(stream["wave"]) == expected["wave"]
 
         issues = stream["issues"]
         assert isinstance(issues, list)


### PR DESCRIPTION
## Summary
- add a canonical MECE multi-PR delivery register for the open issue set (#820 #819 #816 #727 #723 #720 #719 #715 #706)
- add a CI reconciliation guard test that enforces:
  - exactly 7 non-overlapping PR streams
  - one-to-one issue-to-stream mapping for the 9 issues
  - priority/wave integrity
  - repository evidence for #723 (llama.cpp foundation) and #816 (benchmark split CI)
- codify epic bookkeeping stance: #706 stays open, with #715 as the main long-running bottleneck

## Why
Issue definitions were drifting from repository reality and from each other. This change adds a machine-checked register so closeout claims and sequencing assumptions stay synchronized with the codebase.

## Validation
- `pytest tests/ci/test_mece_multi_pr_delivery_register.py -q --no-cov`
- pre-commit hooks run as part of commit and pass on this branch

## Governance outcomes in this PR
- #723 reconciled as implementation-complete foundation (tracking closeout)
- #816 reconciled as implementation-complete CI split (tracking closeout)
- #706 reconciled as epic tracker (not directly closed by this PR)

Closes #723
Closes #816
Refs #706
Refs #715
Refs #819
Refs #820
Refs #727
Refs #719
Refs #720


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a MECE multi-PR delivery register describing scope, PR streams (A–G), waves, dependency graph, reconciliation evidence, and closeout assertions; includes embedded machine-readable metadata.

* **Tests**
  * Added automated validations that extract and verify the embedded metadata (format_version, pr_stream_count, issues_in_scope, wave_order, stream properties), confirm evidence content references, and assert reconciliation/closeout assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->