### PR TITLE
feat(cli): add parallel flags to preview command (#727)

### DIFF
--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -16,6 +16,7 @@ def _resolve_parallel_settings(
     sequential: bool,
     max_workers: int | None,
     prefetch_depth: int,
+    no_prefetch: bool = False,
 ) -> tuple[int | None, int]:
     """Validate and resolve parallel worker/prefetch settings.
 
@@ -23,6 +24,7 @@ def _resolve_parallel_settings(
         sequential: Whether to force single-worker sequential processing.
         max_workers: Requested worker count, or None for auto.
         prefetch_depth: Requested prefetch queue depth.
+        no_prefetch: Backward-compatible alias for prefetch_depth=0.
 
     Returns:
         Tuple of (resolved_workers, resolved_prefetch_depth).
@@ -33,7 +35,7 @@ def _resolve_parallel_settings(
     if sequential and max_workers not in (None, 1):
         console.print("[red]Error: --sequential cannot be combined with --max-workers > 1[/red]")
         raise typer.Exit(code=2)
-    return (1 if sequential else max_workers, 0 if sequential else prefetch_depth)
+    return (1 if sequential else max_workers, 0 if (sequential or no_prefetch) else prefetch_depth)
 
 
 def organize(
@@ -78,7 +80,7 @@ def organize(
     if dry_run or _g.dry_run:
         console.print("[yellow]Dry run mode — no files will be moved.[/yellow]")
     resolved_workers, resolved_prefetch_depth = _resolve_parallel_settings(
-        sequential, max_workers, prefetch_depth
+        sequential, max_workers, prefetch_depth, no_prefetch
     )
 
     try:
@@ -138,7 +140,7 @@ def preview(
     """Preview how files would be organized (dry-run)."""
     console.print(f"[bold]Previewing[/bold] {input_dir}")
     resolved_workers, resolved_prefetch_depth = _resolve_parallel_settings(
-        sequential, max_workers, prefetch_depth
+        sequential, max_workers, prefetch_depth, no_prefetch
     )
 
     try:

--- a/tests/cli/test_cli_organize.py
+++ b/tests/cli/test_cli_organize.py
@@ -222,7 +222,7 @@ class TestOrganize:
         mock_cls.assert_called_once_with(
             dry_run=False,
             parallel_workers=None,
-            prefetch_depth=2,
+            prefetch_depth=0,
             enable_vision=True,
             no_prefetch=True,
         )
@@ -403,7 +403,7 @@ class TestPreview:
         mock_cls.assert_called_once_with(
             dry_run=True,
             parallel_workers=None,
-            prefetch_depth=2,
+            prefetch_depth=0,
             enable_vision=True,
             no_prefetch=True,
         )


### PR DESCRIPTION
## Summary

- Adds `--max-workers`, `--sequential`, `--no-vision`/`--text-only`, `--prefetch-depth`, and `--no-prefetch` to the `preview` CLI command, mirroring the full flag surface already present on `organize`
- `--sequential` and `--max-workers > 1` conflict guard (exit 2) is consistent with `organize`
- `enable_vision=not no_vision` is passed explicitly so the **two-layer vision fallback** applies in dry-run previews: (1) `enable_vision=False` skips init entirely; (2) if `enable_vision=True` but `VisionProcessor` fails to initialize, `init_vision_processor` returns `None` and `organize()` routes to `_fallback_by_extension` — this holds for any future `VisionProcessor` implementation
- 7 new `TestPreview` tests cover each flag individually, the `--text-only` alias, and the conflict guard

## Test plan

- [x] All 18 `tests/cli/test_cli_organize.py` tests pass (`--no-cov`)
- [x] Pre-commit validation passes (ruff, hooks, smoke, ci, websocket, web-ui, codespell, deptry)
- [x] `test_preview_no_vision` and `test_preview_text_only_alias` both assert `enable_vision=False` is forwarded to `FileOrganizer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new CLI options to the preview command: `--max-workers`, `--sequential`, `--no-vision`, `--prefetch-depth`, and `--no-prefetch` for enhanced control over file organization behavior.
  * Added validation preventing simultaneous use of `--sequential` with `--max-workers > 1` to ensure consistent execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->