### PR TITLE
feat(ci): add PR coverage gate (80%) + integration coverage gate (70%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
   test-integration:
     name: Integration coverage gate
     needs: changes
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Closes #855. Partial progress on #856.

## Changes

### #855 — PR coverage gate at 80%

Previously, \`--override-ini="addopts="\` on PRs stripped the \`--cov-fail-under=95\` from \`addopts\`, so **no coverage threshold fired on any PR**. A new module could be added at 0% coverage and the PR would pass.

**Fix**: Added \`--cov-fail-under=80\` explicitly to the PR branch of the test step.

| Branch | Threshold | Suite |
|--------|-----------|-------|
| PR | **80%** (new) | \`-m "ci and not benchmark"\` |
| main | 95% (unchanged) | \`-m "not benchmark"\` |

### #856 — Integration coverage gate at 70% (ratchet floor)

Added a new \`test-integration\` job (main-push only):

\`\`\`
pytest tests/ -m "integration" --cov-fail-under=70
\`\`\`

14 integration test files, ~72 tests, mocked AI, real filesystem. **70% is the initial ratchet floor** — bump threshold in each PR that closes a gap, toward the 90% target in #856.

## Validation

Pre-commit hooks (check-yaml, ruff, ci guardrails): all passed ✅

## Residual Risk

- If the \`ci\`-subset is currently <80%, CI on this PR will catch it immediately.
- Integration gate validated on first main-push after merge. If 70% is not met, a follow-up lowers the floor to baseline and opens gap issues.
- #856 remains open until the gate reaches 90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened code quality standards by requiring 80% test coverage for pull requests.
  * Introduced comprehensive integration testing with 70% coverage threshold to enhance validation and ensure reliability before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->