### PR TITLE
fix(ci): diff-cover for PR gate; fix integration coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
         python-version: ${{ github.event_name == 'pull_request' && fromJson('["3.11"]') || fromJson('["3.11", "3.12"]') }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          # fetch-depth: 0 is required for the diff-cover step on PRs —
+          # shallow clones lack the merge-base needed to compute the changed-line diff.
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -178,8 +182,6 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.python-version == '3.11'
         run: |
           pip install diff-cover --quiet
-          rm -f .git/shallow.lock
-          git fetch origin main
           diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
       - name: Check docstring coverage
         if: matrix.python-version == '3.11' && github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- **PR coverage gate (#855)**: Replace broken global  (incompatible with speed-curated ci-marker subset) with  — checks that lines changed in the PR are ≥80% covered. Preserves fast ci test speed, enforces coverage on new/changed code specifically.
- **Integration coverage gate (#856)**: Correct floor from 70% → 34% (measured baseline: 33.8% on 2026-03-17). 70% would have failed immediately on the first main push. 34% is the ratchet starting point toward 90% target.

## Test plan

- [ ] PR CI:  step runs and gates on changed-line coverage
- [ ] Integration gate: passes on next main push (34% ≥ 33.8% baseline)
- [ ] ci-marked test speed unchanged (no new tests added to ci suite)

Closes #855 (partial — diff-cover gate live)
Ratchet floor for #856 — 34% → 90% incrementally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI PR runs now report coverage but no longer enforce an 80% fail threshold.
  * Added a PR-only diff coverage gate that compares changes against main and enforces an 80% diff coverage threshold.
  * Lowered the integration-test coverage floor to 33% and updated CI checks and messaging to reflect the new baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->