### PR TITLE
docs(testing): add os.utime/deadline-loop patterns; add --cov-branch (#900 stream 6)

### DIFF
--- a/.claude/scripts/measure-integration-coverage.sh
+++ b/.claude/scripts/measure-integration-coverage.sh
@@ -5,6 +5,7 @@ coverage erase
 pytest tests/ -m "integration" \
     --strict-markers \
     --cov=file_organizer \
+    --cov-branch \
     --cov-report=term-missing \
     --override-ini="addopts=" \
     "$@"

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -375,6 +375,36 @@ event.wait(timeout=5)
 assert event.is_set()
 ```
 
+#### Pattern: Staleness check (file-watcher tests)
+
+Use `os.utime()` to advance a file's modification time without sleeping:
+
+```python
+# Instead of: time.sleep(1)
+import os
+
+old_mtime = path.stat().st_mtime
+os.utime(path, (old_mtime + 60, old_mtime + 60))
+```
+
+#### Pattern: Background job polling
+
+Use a deadline loop with a short inner sleep for background threads:
+
+```python
+# Instead of: time.sleep(2)
+import time
+import pytest
+
+deadline = time.monotonic() + 5.0
+while time.monotonic() < deadline:
+    if condition_met():
+        break
+    time.sleep(0.05)
+else:
+    pytest.fail("Timed out waiting for condition")
+```
+
 ## Test Coverage by Epic
 
 ### Epic #571: Desktop UI Test Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,10 @@ addopts = [
     "--cov-report=xml",
     "--cov-fail-under=95",
     "--timeout=30",
+    # Branch coverage baseline (integration tests only, not a CI gate):
+    # Measured 2026-03-19 via measure-integration-coverage.sh: TOTAL ~30%
+    # Floor (rounded down to nearest 5%): 30%
+    # To enforce: add --cov-branch --cov-fail-under=30 to measure-integration-coverage.sh
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",


### PR DESCRIPTION
## Summary

- **docs/developer/testing.md**: Add `os.utime` (staleness-check) and deadline-loop patterns to the flaky-test guidance section, alongside the existing `event.wait()` pattern
- **.claude/scripts/measure-integration-coverage.sh**: Add `--cov-branch` so the measurement script reports branch coverage
- **pyproject.toml**: Document measured baseline branch coverage (comment only — not a hard gate yet)

Part of #900.