### PR TITLE
feat(ci): broaden isinstance guardrail to full test suite (Phase 2C)

### DIFF
--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -489,10 +489,11 @@ def test_changed_tests_have_no_sole_isinstance_assertions() -> None:
     - ``str`` return  → ``assert result == "expected_string"``
     - ``dict`` return → ``assert result == {...}`` or assert specific keys/values
 
-    Applies to changed files only (TODO: broaden to full suite after clean-up).
+    Applies to the full test suite (all pre-existing violations were cleaned in
+    phases 3A and 3B before this guardrail was broadened).
     """
     violations: list[str] = []
-    for path in _git_changed_test_files():
+    for path in _changed_test_files():
         source = path.read_text(encoding="utf-8")
         violations.extend(_find_sole_isinstance_assertions(source, str(path)))
 


### PR DESCRIPTION
## Summary

- Switches `test_changed_tests_have_no_sole_isinstance_assertions` from diff-scoped (`_git_changed_test_files`) to full-suite (`_changed_test_files`)
- All pre-existing `assert isinstance(x, T)` sole-assertion violations were cleaned in phases 3A (#924) and 3B (#925) before broadening
- Zero violations on full suite confirmed locally

## Part of rules augmentation plan

Phase 2C (final phase) of `.claude/prds/rules-augmentation-plan.md`. Completes the G1 (WEAK_ISINSTANCE_ASSERTION) gap closure:
- Phase 1: Rule T1 strengthened ✅ (PR #922)
- Phase 2B: isinstance guardrail created (diff-scoped) ✅ (PR #922)
- Phase 3A: 45 integration test files cleaned ✅ (PR #924)
- Phase 3B: Tracked files outside integration/ cleaned ✅ (PR #925)
- Phase 2C: Guardrail broadened to full suite ← this PR

## Test plan
- [x] `pytest tests/ci/test_test_quality_guardrails.py::test_changed_tests_have_no_sole_isinstance_assertions` — passes (0 violations)
- [x] `pytest tests/ci/` — all ci guardrails pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test quality guardrails to scan the entire test suite, ensuring more comprehensive validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->