### PR TITLE
fix(ci): replace string matching with AST call nodes in S1/S2 guardrail

### DIFF
--- a/tests/ci/test_search_code_quality.py
+++ b/tests/ci/test_search_code_quality.py
@@ -104,7 +104,9 @@ def _find_unguarded_traversals(path: Path) -> list[str]:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
 
-        calls = [n for n in ast.walk(node) if isinstance(n, ast.Call)]
+        # Collect calls from this function's own body only — do not descend into
+        # nested functions/classes so inner-scope guards cannot satisfy outer checks.
+        calls = [n for child in node.body for n in ast.walk(child) if isinstance(n, ast.Call)]
 
         # Does the function traverse files? (rglob or os.walk only — not bare walk())
         has_rglob = any(isinstance(c.func, ast.Attribute) and c.func.attr == "rglob" for c in calls)


### PR DESCRIPTION
## Summary

Hotfix for two CodeRabbit findings from PR #927 that merged before fixes were applied.

- **Remove unused `_func_source_lines` helper** — never called anywhere; violated BLE001 (bare `except Exception`) in the same file that enforces BLE001 for the search service
- **Replace `ast.unparse()` string matching with AST call-node matching** in `_find_unguarded_traversals`:
  - `rglob`: `Attribute.attr == "rglob"` 
  - `os.walk`: `Attribute.attr == "walk"` AND `value.id == "os"` (was matching any bare `walk()` call)
  - `is_symlink`: `Attribute.attr == "is_symlink"`
  - `startswith(".")`: `Attribute.attr == "startswith"` + `Constant(".")` arg check

String matching on `ast.unparse()` was exploitable by docstrings and comments, and matched unqualified `walk()` calls as false positives.

## Test plan
- [x] `pytest tests/ci/test_search_code_quality.py -v` — 2 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved code-quality checks to use AST-based call-node matching for more reliable detection of traversal, symlink guards, and hidden-file patterns; limited analysis to a function's top-level body to avoid false positives from nested scopes.

* **Refactor**
  * Removed an unused test helper and updated related documentation, simplifying the test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->