### PR TITLE
feat(pre-commit): add diff-cover gate to pre-commit-validation.sh

### DIFF
--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -74,6 +74,25 @@ echo "✓ Docstring coverage"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Diff coverage gate (≥80% of changed lines must be covered)
+# Mirrors CI step in .github/workflows/ci.yml lines 184-185.
+# Skips gracefully when: not on a branch, no coverage.xml, or diff-cover
+# is not installed.
+# ---------------------------------------------------------------------------
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+if [[ -n "$CURRENT_BRANCH" ]] && command -v diff-cover &>/dev/null && [[ -f coverage.xml ]]; then
+  echo "▶ Diff coverage gate (>=80% of changed lines)"
+  git fetch origin main --quiet 2>/dev/null || true
+  diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+  echo "✓ Diff coverage gate"
+  echo ""
+else
+  echo "ℹ Diff coverage gate skipped (not on a branch, no coverage.xml, or diff-cover not installed)."
+  echo ""
+fi
+
+# ---------------------------------------------------------------------------
 # Coverage floor gates (unit ≥93% branch, integration ≥30% branch) are
 # enforced by CI on main-branch pushes — NOT here.
 #


### PR DESCRIPTION
## Summary

- Adds a diff-cover gate to `.claude/scripts/pre-commit-validation.sh` that mirrors the existing CI gate (`.github/workflows/ci.yml` lines 184-185)
- Same 80% threshold, same `--compare-branch=origin/main` setting
- Implemented as a conditional block (same pattern as the `interrogate` docstring gate) — skips gracefully when not on a named branch, `coverage.xml` doesn't exist, or `diff-cover` isn't installed
- Fetches `origin/main` before running so the compare ref is always current
- `diff-cover` is already in `pyproject.toml` `[dev]` extras — no new deps

## Test plan

- [ ] `tests/ci/test_guardrail_governance.py` — 5/5 pass (script's canonical `run_step` list unchanged)
- [ ] `bash .claude/scripts/pre-commit-validation.sh` — passes locally; diff gate shows "No lines with coverage information in this diff" for commits to `.claude/` scripts

Closes #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)