### PR TITLE
fix(ci): promote warnings import, add fallback failure guard, and add sync comment

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -27,6 +27,8 @@ jobs:
           # Legacy MD031 violation files are excluded during the burn-down phase;
           # the CI ratchet test (tests/ci/test_md031_ratchet.py) tracks the global
           # count and blocks any net increase. Remove entries as violations are fixed.
+          # LEGACY_EXCLUDE must stay in sync with the 'exclude' regex in the
+          # pymarkdown hook in .pre-commit-config.yaml.  Update both together.
           LEGACY_EXCLUDE='^(\.claude/|memory/test-generation-patterns\.md|docs/internal/|docs/testing/|docs/developer/testing\.md|\.github/copilot-instructions\.md|src/file_organizer/services/deduplication/README_IMAGE_DEDUP\.md|tests/fixtures/)'
           mapfile -t FILES < <(git ls-files '*.md' | grep -vE "$LEGACY_EXCLUDE" || true)
           if (( ${#FILES[@]} )); then

--- a/tests/ci/test_md031_ratchet.py
+++ b/tests/ci/test_md031_ratchet.py
@@ -12,6 +12,7 @@ Reduce the baseline as violations are fixed in follow-up batches.
 from __future__ import annotations
 
 import subprocess
+import warnings
 from pathlib import Path
 
 import pytest
@@ -45,13 +46,36 @@ def _run_pymarkdown_md031(files: list[Path]) -> list[str]:
 
 
 def _get_changed_md_files() -> list[Path]:
-    """Return .md files changed vs origin/main that exist on disk."""
+    """Return .md files changed vs origin/main that exist on disk.
+
+    Falls back to HEAD^..HEAD if origin/main is unavailable (e.g. shallow
+    clones or local branches without a remote fetch).
+    """
     result = subprocess.run(
         ["git", "diff", "--name-only", "--diff-filter=ACMR", "origin/main...HEAD"],
         capture_output=True,
         text=True,
         cwd=FO_ROOT,
     )
+    if result.returncode != 0 or "unknown revision" in result.stderr or "fatal" in result.stderr:
+        warnings.warn(
+            f"MD031 ratchet: origin/main unavailable, falling back to HEAD^..HEAD "
+            f"({result.stderr.strip()!r})",
+            stacklevel=2,
+        )
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", "HEAD^..HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=FO_ROOT,
+        )
+        if result.returncode != 0 or "fatal" in result.stderr:
+            warnings.warn(
+                f"MD031 ratchet: HEAD^..HEAD fallback also failed (rc={result.returncode}) "
+                f"({result.stderr.strip()!r}); returning no changed files",
+                stacklevel=2,
+            )
+            return []
     paths = []
     for line in result.stdout.splitlines():
         if line.endswith(".md"):


### PR DESCRIPTION
## Summary

Addresses CodeRabbit nitpick findings on #943:

- **`test_md031_ratchet.py`**: moved inline `import warnings` to module-level top-of-file import.
- **`_get_changed_md_files`**: when the `HEAD^..HEAD` fallback subprocess also fails (non-zero returncode or `fatal` in stderr), emit `warnings.warn` with the returncode and stderr, then return `[]` — so the test skips clearly rather than proceeding with an empty list for an undiagnosed reason.
- **`docs-lint.yml`**: add comment above `LEGACY_EXCLUDE` directing maintainers to keep it in sync with the `exclude` regex in `.pre-commit-config.yaml`.

## Test plan

- [ ] CI passes
- [ ] Fallback warning fires when `origin/main` unavailable, and second warning fires when `HEAD^..HEAD` also fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of CI processes with enhanced error handling for git operations, including fallback behavior when standard git commands fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->