### PR TITLE
chore(deps): remove stale [dependency-groups] and document uv add --optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,20 @@ pip install -e ".[dev]"
 file-organizer --version
 ```
 
+### Adding Dev Dependencies
+
+This project uses `uv` for local dependency management but CI installs via
+`pip install -e ".[dev,search]"`, which reads from `[project.optional-dependencies]`
+in `pyproject.toml`. Always use `--optional dev` (not `--dev`) when adding
+test/dev packages so they land in the right section:
+
+```bash
+uv add --optional dev <package>
+```
+
+Using `uv add --dev <package>` writes to `[dependency-groups]` instead, which pip
+does not read — the package installs locally but CI fails with `ModuleNotFoundError`.
+
 ### Pre-Commit Hooks (Automatic Validation)
 
 This project uses automated pre-commit validation to catch common issues before commits:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -442,8 +442,3 @@ DEP002 = [
     # netCDF4: mixed-case name causes deptry matching issues; used in scientific.py
     "netCDF4",
 ]
-
-[dependency-groups]
-dev = [
-    "asgi-lifespan>=2.1.0",
-]


### PR DESCRIPTION
## Summary

- Removes the stale `[dependency-groups]` section left in `pyproject.toml` after PR #954. The `asgi-lifespan` entry there was a duplicate — the package is already in `[project.optional-dependencies] dev` (the section CI reads via `pip install -e ".[dev,search]"`).
- Adds a note to `CONTRIBUTING.md` explaining why `uv add --optional dev <pkg>` must be used instead of `uv add --dev <pkg>`.

## Root cause (from #955)

`uv add --dev` writes to `[dependency-groups]` (PEP 735, uv-specific). CI uses `pip install -e ".[dev,search]"` which only reads `[project.optional-dependencies]`. The two sections are invisible to each other, so packages added with `--dev` work locally but cause `ModuleNotFoundError` in CI.

Note: a `[tool.uv] dev-dependencies-section` config key was investigated — it does not exist in uv. The fix is a workflow convention documented in CONTRIBUTING.md.

## Test plan

- [ ] `[dependency-groups]` section absent from `pyproject.toml`
- [ ] `CONTRIBUTING.md` contains `uv add --optional dev` guidance
- [ ] CI passes (no `ModuleNotFoundError` on collection)

Closes #955