### PR TITLE
refactor(tests): parametrize TestDisplaySummary (#959)

### DIFF
--- a/tests/integration/test_cli_dedupe_utils.py
+++ b/tests/integration/test_cli_dedupe_utils.py
@@ -291,10 +291,20 @@ class TestDisplaySummary:
 
         mock_console = MagicMock()
         with patch("file_organizer.cli.dedupe.console", mock_console):
-            display_summary(
-                total_groups, total_duplicates, total_removed, space_saved, dry_run=dry_run
-            )
+            display_summary(total_groups, total_duplicates, total_removed, space_saved, dry_run)
         assert mock_console.print.call_count == 4
+        # Verify the Panel content (4th print call, 1st positional arg)
+        panel = mock_console.print.call_args_list[3][0][0]
+        content = str(panel.renderable)
+        assert "Duplicate groups found:" in content
+        assert f"{total_groups}" in content
+        assert f"{total_duplicates}" in content
+        if dry_run:
+            assert "DRY RUN SUMMARY" in content
+            assert "would be removed" in content
+        else:
+            assert "DEDUPLICATION COMPLETE" in content
+            assert "Files removed:" in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Collapse 3 repetitive test methods in `TestDisplaySummary` into a single `@pytest.mark.parametrize` test with descriptive IDs (`dry_run_mode`, `live_run_mode`, `zero_files`)
- ~68% reduction in test code duplication (46 lines → 15 lines)
- No change in test coverage — all 3 scenarios preserved

## Note

Pre-existing T3 finding (mock `call_count == 4` without verifying call args) was carried forward unchanged — strengthening mock assertions is out of scope for this mechanical refactor.

## Test plan

- [x] All 3 parametrized cases pass: `pytest tests/integration/test_cli_dedupe_utils.py::TestDisplaySummary -v`
- [x] Full test file passes: `pytest tests/integration/test_cli_dedupe_utils.py -v` (28/28)
- [x] Pre-commit hooks pass
- [x] Audit against test-generation-patterns.md

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal testing improvements only. No new features or bug fixes are included in this update.

* **Tests**
  * Improved test organization and structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->