### PR TITLE
chore: add versioning-strategy to prevent Dependabot widening ~= pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- Add `versioning-strategy: increase-if-necessary` to pip ecosystem in dependabot.yml
- Prevents Dependabot from opening PRs that widen `~=X.Y` to `>=X,<Z` ranges
- Closed 10 such PRs (#1044-#1053) that were defeating the intentional pinning from #1037

## Test plan
- [x] YAML valid (pre-commit check-yaml passes)
- [ ] Next Dependabot run respects the strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration for Python package dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->