### PR TITLE
fix(tests): accept **kwargs in Path.stat lambdas for Python 3.12 compat

### DIFF
--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1387,7 +1387,7 @@ class TestPlatformSpecificBranches:
 
         # Monkeypatch both os.name and Path.stat
         monkeypatch.setattr(os, "name", "nt")
-        monkeypatch.setattr(Path, "stat", lambda self: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda self, *args, **kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)
@@ -1418,7 +1418,7 @@ class TestPlatformSpecificBranches:
 
         # Monkeypatch both os.name and Path.stat
         monkeypatch.setattr(os, "name", "posix")
-        monkeypatch.setattr(Path, "stat", lambda self: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda self, *args, **kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)
@@ -1455,7 +1455,7 @@ class TestPlatformSpecificBranches:
             st_birthtime = birthtime_120_days_ago
             st_mode = real_mode  # required by Path.is_dir() via pathlib internals
 
-        monkeypatch.setattr(Path, "stat", lambda self: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda self, *args, **kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -588,7 +588,7 @@ class TestEdgeCasesAndErrorHandling:
         # Mock os module in the feature_extractor namespace
         monkeypatch.setattr(fe_module.os, "name", "nt")
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
 
         # Mock hasattr to return False for st_birthtime
         original_hasattr = builtins.hasattr
@@ -630,7 +630,7 @@ class TestEdgeCasesAndErrorHandling:
         # Mock os module in the feature_extractor namespace
         monkeypatch.setattr(fe_module.os, "name", "posix")
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
 
         # Mock hasattr to return False for st_birthtime
         original_hasattr = builtins.hasattr


### PR DESCRIPTION
## Summary

- Python 3.12's `Path.exists()` calls `self.stat(follow_symlinks=True)` internally
- 5 test lambdas used `lambda self: MockStat()` / `lambda _self: MockStat(now=now)` — no `**kwargs`
- This caused `TypeError: <lambda>() got an unexpected keyword argument 'follow_symlinks'` when pytest's `tmpdir` plugin called `p.exists()` during `pytest_runtest_makereport` teardown
- The crash manifests as an xdist `INTERNALERROR` (same class of bug as #1086)
- `TestPlatformSpecificPaths` already used `*args, **kwargs` correctly; apply the same to the 3 remaining lambdas in `TestPlatformSpecificBranches` and 2 in `TestEdgeCasesAndErrorHandling`

## Test plan

- [x] All 7 affected tests pass locally
- [x] CI on main (no more xdist INTERNALERROR on `test_metadata_windows_platform_creation_time`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure mocks to support flexible argument passing patterns, improving test robustness and compatibility across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->