### PR TITLE
fix(services): replace bare except-Exception with specific types

### DIFF
--- a/src/file_organizer/services/analytics/storage_analyzer.py
+++ b/src/file_organizer/services/analytics/storage_analyzer.py
@@ -236,7 +236,7 @@ class StorageAnalyzer:
                     yield from self._walk_directory(item, max_depth, current_depth + 1)
         except PermissionError:
             logger.warning(f"Permission denied: {path}")
-        except Exception as e:
+        except OSError as e:
             logger.error(f"Error walking {path}: {e}")
 
     def walk_directory(self, path: Path, max_depth: int | None = None) -> Any:

--- a/src/file_organizer/services/analyzer.py
+++ b/src/file_organizer/services/analyzer.py
@@ -75,7 +75,7 @@ Output ONLY the category name, nothing else."""
 
         return category
 
-    except Exception as e:
+    except (RuntimeError, ValueError, OSError, AttributeError) as e:
         logger.error(f"Failed to generate category: {e}")
         return "general"
 
@@ -109,7 +109,7 @@ DESCRIPTION:"""
 
         return description if description else "Document content analysis"
 
-    except Exception as e:
+    except (RuntimeError, ValueError, OSError, AttributeError) as e:
         logger.error(f"Failed to generate description: {e}")
         return "Document content analysis"
 

--- a/src/file_organizer/services/audio/metadata_extractor.py
+++ b/src/file_organizer/services/audio/metadata_extractor.py
@@ -101,7 +101,7 @@ class AudioMetadataExtractor:
         # Try mutagen first (more comprehensive)
         try:
             return self._extract_with_mutagen(audio_path)
-        except Exception as e:
+        except (OSError, ValueError, KeyError, AttributeError) as e:
             logger.warning(f"Mutagen extraction failed: {e}")
             if self.use_fallback:
                 logger.info("Falling back to tinytag")
@@ -358,7 +358,7 @@ class AudioMetadataExtractor:
             try:
                 metadata = self.extract(audio_path)
                 results.append(metadata)
-            except Exception as e:
+            except (OSError, ValueError, ImportError, KeyError) as e:
                 logger.error(f"Failed to extract metadata from {audio_path}: {e}")
                 # Continue with other files
 

--- a/src/file_organizer/services/audio/organizer.py
+++ b/src/file_organizer/services/audio/organizer.py
@@ -256,7 +256,7 @@ class AudioOrganizer:
                 plan.planned_moves.append(
                     FileMove(source=source, destination=dest, audio_type=audio_type)
                 )
-            except Exception as exc:
+            except (KeyError, ValueError, TypeError) as exc:
                 plan.skipped_files.append((source, str(exc)))
 
         return plan
@@ -287,7 +287,7 @@ class AudioOrganizer:
             try:
                 rel_path = self.generate_path(audio_type, metadata)
                 dest = base_path / rel_path
-            except Exception as exc:
+            except (KeyError, ValueError, TypeError) as exc:
                 result.skipped_files.append((source, str(exc)))
                 continue
 
@@ -375,7 +375,7 @@ class AudioOrganizer:
                 audio_type=audio_type,
                 success=True,
             )
-        except Exception as exc:
+        except OSError as exc:
             logger.error(f"Failed to move {source}: {exc}")
             return FileMove(
                 source=source,

--- a/src/file_organizer/services/audio/preprocessor.py
+++ b/src/file_organizer/services/audio/preprocessor.py
@@ -152,7 +152,7 @@ class AudioPreprocessor:
             # (input file existence already validated above)
             logger.debug(f"ffmpeg not found ({e}), falling back to pydub")
             return self._convert_with_pydub(audio_path, output_path, sample_rate, channels)
-        except Exception as e:
+        except (subprocess.SubprocessError, RuntimeError, OSError) as e:
             logger.error(f"Conversion failed: {e}")
             raise
 

--- a/src/file_organizer/services/audio/transcriber.py
+++ b/src/file_organizer/services/audio/transcriber.py
@@ -178,7 +178,7 @@ class AudioTranscriber:
                 "faster-whisper is required for audio transcription. "
                 "Install it with: pip install faster-whisper"
             ) from e
-        except Exception as e:
+        except (OSError, RuntimeError, ValueError) as e:
             logger.error(f"Failed to load model: {e}")
             raise
 
@@ -282,7 +282,7 @@ class AudioTranscriber:
 
             return result
 
-        except Exception as e:
+        except (OSError, RuntimeError, ValueError) as e:
             logger.error(f"Transcription failed: {e}")
             raise
 
@@ -305,7 +305,7 @@ class AudioTranscriber:
             try:
                 result = self.transcribe(audio_path, options)
                 results.append(result)
-            except Exception as e:
+            except (OSError, RuntimeError, ValueError, ImportError) as e:
                 logger.error(f"Failed to transcribe {audio_path}: {e}")
                 # Continue with other files
 

--- a/src/file_organizer/services/audio/utils.py
+++ b/src/file_organizer/services/audio/utils.py
@@ -188,7 +188,7 @@ def validate_audio_file(audio_path: str | Path) -> tuple[bool, str | None]:
         if duration <= 0:
             return False, "Audio file has zero duration"
         return True, None
-    except Exception as e:
+    except (OSError, ValueError, RuntimeError) as e:
         return False, f"Failed to read audio file: {str(e)}"
 
 

--- a/src/file_organizer/services/auto_tagging/content_analyzer.py
+++ b/src/file_organizer/services/auto_tagging/content_analyzer.py
@@ -187,7 +187,7 @@ class ContentTagAnalyzer:
             scored_keywords.sort(key=lambda x: x[1], reverse=True)
             return scored_keywords[:top_n]
 
-        except Exception as e:
+        except (OSError, UnicodeDecodeError, ValueError) as e:
             logger.error(f"Error extracting keywords from {file_path}: {e}")
             return []
 
@@ -230,7 +230,7 @@ class ContentTagAnalyzer:
 
             return sorted(entities)[:20]  # Limit to top 20
 
-        except Exception as e:
+        except (OSError, UnicodeDecodeError, ValueError) as e:
             logger.error(f"Error extracting entities from {file_path}: {e}")
             return []
 
@@ -250,7 +250,7 @@ class ContentTagAnalyzer:
             try:
                 tags = self.analyze_file(file_path)
                 results[file_path] = tags
-            except Exception as e:
+            except (OSError, UnicodeDecodeError, ValueError) as e:
                 logger.error(f"Error analyzing {file_path}: {e}")
                 results[file_path] = []
 
@@ -340,7 +340,7 @@ class ContentTagAnalyzer:
             # Return top words
             return [word for word, _ in word_freq.most_common(20)]
 
-        except Exception as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug(f"Could not extract content tags from {file_path}: {e}")
             return []
 
@@ -369,7 +369,7 @@ class ContentTagAnalyzer:
             # - python-docx for Word documents
             # - pypdf for PDFs
 
-        except Exception as e:
+        except OSError as e:
             logger.debug(f"Could not extract metadata from {file_path}: {e}")
 
         return tags
@@ -421,7 +421,7 @@ class ContentTagAnalyzer:
             except UnicodeDecodeError:
                 return file_path.read_text(encoding="latin-1")
 
-        except Exception as e:
+        except OSError as e:
             logger.debug(f"Could not read {file_path}: {e}")
             return ""
 

--- a/src/file_organizer/services/auto_tagging/tag_learning.py
+++ b/src/file_organizer/services/auto_tagging/tag_learning.py
@@ -454,7 +454,7 @@ class TagLearningEngine:
 
             logger.debug(f"Saved learning data to {storage_path}")
 
-        except Exception as e:
+        except (OSError, TypeError, ValueError) as e:
             logger.error(f"Error saving learning data: {e}")
 
     def _load_data(self) -> None:
@@ -491,5 +491,5 @@ class TagLearningEngine:
 
             logger.info(f"Loaded learning data: {len(self.tag_usage)} tags tracked")
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as e:
             logger.error(f"Error loading learning data: {e}")

--- a/src/file_organizer/services/auto_tagging/tag_recommender.py
+++ b/src/file_organizer/services/auto_tagging/tag_recommender.py
@@ -221,7 +221,7 @@ class TagRecommender:
             try:
                 recommendation = self.recommend_tags(file_path, top_n=top_n)
                 results[file_path] = recommendation
-            except Exception as e:
+            except (OSError, ValueError, KeyError) as e:
                 logger.error(f"Error recommending tags for {file_path}: {e}")
                 results[file_path] = TagRecommendation(file_path=file_path, suggestions=[])
 
@@ -324,7 +324,7 @@ class TagRecommender:
 
             return normalized
 
-        except Exception as e:
+        except (OSError, ValueError, ZeroDivisionError) as e:
             logger.debug(f"Error getting content suggestions: {e}")
             return []
 
@@ -343,7 +343,7 @@ class TagRecommender:
 
             return suggestions
 
-        except Exception as e:
+        except (KeyError, ValueError) as e:
             logger.debug(f"Error getting behavior suggestions: {e}")
             return []
 

--- a/src/file_organizer/services/copilot/engine.py
+++ b/src/file_organizer/services/copilot/engine.py
@@ -187,7 +187,7 @@ class CopilotEngine:
         if self._text_model is not None:
             try:
                 return self._generate_with_llm(intent, exec_result)
-            except Exception as exc:
+            except (RuntimeError, ValueError, OSError, AttributeError) as exc:
                 logger.warning("LLM generation failed, falling back to template: {}", exc)
 
         # Template fallback

--- a/src/file_organizer/services/copilot/executor.py
+++ b/src/file_organizer/services/copilot/executor.py
@@ -74,7 +74,7 @@ class CommandExecutor:
 
         try:
             return handler(intent)
-        except Exception as exc:
+        except Exception as exc:  # Intentional catch-all: plugin-style dispatch to arbitrary handlers
             logger.error("Executor error for {}: {}", intent.intent_type.value, exc)
             return ExecutionResult(
                 success=False,
@@ -288,7 +288,7 @@ class CommandExecutor:
                 results = retriever.retrieve(query, top_k=20)
                 # Scope results to search_root only
                 matches = [str(p) for p, _ in results if Path(p).is_relative_to(search_root)]
-            except Exception as exc:
+            except (RuntimeError, ValueError, OSError) as exc:
                 logger.warning("Retriever failed in _handle_find, falling back: {}", exc)
                 matches = []
             if matches:

--- a/src/file_organizer/services/copilot/rules/rule_manager.py
+++ b/src/file_organizer/services/copilot/rules/rule_manager.py
@@ -69,7 +69,7 @@ class RuleManager:
 
         try:
             raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except Exception:
+        except (OSError, yaml.YAMLError, ValueError, KeyError):
             logger.warning("Failed to parse rule set '{}'", name, exc_info=True)
             return RuleSet(name=name)
 

--- a/src/file_organizer/services/deduplication/backup.py
+++ b/src/file_organizer/services/deduplication/backup.py
@@ -94,7 +94,7 @@ class BackupManager:
         # Copy file to backup directory
         try:
             shutil.copy2(file_path, backup_path)
-        except Exception as e:
+        except (OSError, shutil.Error) as e:
             raise OSError(f"Failed to create backup: {e}") from e
 
         # Update manifest
@@ -151,7 +151,7 @@ class BackupManager:
         # Copy backup to target location
         try:
             shutil.copy2(backup_path, target_path)
-        except Exception as e:
+        except (OSError, shutil.Error) as e:
             raise OSError(f"Failed to restore backup: {e}") from e
 
         return target_path
@@ -186,7 +186,7 @@ class BackupManager:
                     try:
                         backup_path.unlink()
                         removed_backups.append(backup_path)
-                    except Exception:
+                    except OSError:
                         # Keep retention cleanup non-fatal but observable.
                         logger.debug(
                             "Failed to remove old backup file %s during cleanup",

--- a/src/file_organizer/services/deduplication/detector.py
+++ b/src/file_organizer/services/deduplication/detector.py
@@ -218,7 +218,7 @@ class DuplicateDetector:
                     if options.progress_callback:
                         try:
                             options.progress_callback(processed, total)
-                        except Exception:
+                        except (TypeError, ValueError, RuntimeError):
                             logger.debug("Progress callback failed", exc_info=True)
 
     def find_duplicates_of_file(

--- a/src/file_organizer/services/deduplication/document_dedup.py
+++ b/src/file_organizer/services/deduplication/document_dedup.py
@@ -141,7 +141,7 @@ class DocumentDeduplicator:
 
             return similarity
 
-        except Exception as e:
+        except (OSError, ValueError, ImportError) as e:
             logger.error(f"Error comparing documents: {e}")
             return None
 

--- a/src/file_organizer/services/deduplication/embedder.py
+++ b/src/file_organizer/services/deduplication/embedder.py
@@ -121,7 +121,7 @@ class DocumentEmbedder:
 
             return np.asarray(dense_embeddings)
 
-        except Exception as e:
+        except ValueError as e:
             logger.error(f"Error during fit_transform: {e}")
             raise
 
@@ -246,7 +246,7 @@ class DocumentEmbedder:
 
             logger.info(f"Saved vectorizer to {path}")
 
-        except Exception as e:
+        except (OSError, pickle.PicklingError) as e:
             logger.error(f"Error saving vectorizer: {e}")
 
     def load_model(self, path: Path) -> None:
@@ -262,7 +262,7 @@ class DocumentEmbedder:
             self.is_fitted = True
             logger.info(f"Loaded vectorizer from {path}")
 
-        except Exception as e:
+        except (OSError, pickle.UnpicklingError, ValueError) as e:
             logger.error(f"Error loading vectorizer: {e}")
             raise
 
@@ -289,7 +289,7 @@ class DocumentEmbedder:
 
             logger.debug(f"Saved {len(self.embedding_cache)} embeddings to cache")
 
-        except Exception as e:
+        except (OSError, pickle.PicklingError) as e:
             logger.error(f"Error saving cache: {e}")
 
     def _load_cache(self) -> None:
@@ -303,7 +303,7 @@ class DocumentEmbedder:
 
             logger.info(f"Loaded {len(self.embedding_cache)} embeddings from cache")
 
-        except Exception as e:
+        except (OSError, pickle.UnpicklingError, ValueError) as e:
             logger.error(f"Error loading cache: {e}")
 
     def __del__(self) -> None:

--- a/src/file_organizer/services/deduplication/extractor.py
+++ b/src/file_organizer/services/deduplication/extractor.py
@@ -65,7 +65,7 @@ class DocumentExtractor:
                 logger.warning(f"No extractor for {extension}, treating as text")
                 return self._extract_text(file_path)
 
-        except Exception as e:
+        except (OSError, ValueError, ImportError) as e:
             logger.error(f"Error extracting text from {file_path}: {e}")
             return ""
 
@@ -85,7 +85,7 @@ class DocumentExtractor:
                 text = self.extract_text(file_path)
                 results[file_path] = text
                 logger.debug(f"Extracted {len(text)} chars from {file_path.name}")
-            except Exception as e:
+            except (OSError, ValueError, ImportError) as e:
                 logger.warning(f"Failed to extract {file_path}: {e}")
                 results[file_path] = ""
 
@@ -144,7 +144,7 @@ class DocumentExtractor:
         except ImportError:
             logger.error("pypdf not installed. Install with: pip install pypdf")
             return ""
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error(f"Error extracting PDF {file_path}: {e}")
             return ""
 
@@ -179,7 +179,7 @@ class DocumentExtractor:
         except ImportError:
             logger.error("python-docx not installed. Install with: pip install python-docx")
             return ""
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             logger.error(f"Error extracting DOCX {file_path}: {e}")
             return ""
 
@@ -211,7 +211,7 @@ class DocumentExtractor:
 
             return text
 
-        except Exception as e:
+        except OSError as e:
             logger.error(f"Error reading text file {file_path}: {e}")
             return ""
 
@@ -253,7 +253,7 @@ class DocumentExtractor:
 
                 return text
 
-        except Exception as e:
+        except (OSError, ValueError, ImportError) as e:
             logger.error(f"Error extracting RTF {file_path}: {e}")
             return ""
 
@@ -304,7 +304,7 @@ class DocumentExtractor:
 
             return full_text
 
-        except Exception as e:
+        except (OSError, KeyError, ValueError) as e:
             logger.error(f"Error extracting ODT {file_path}: {e}")
             return ""
 

--- a/src/file_organizer/services/deduplication/image_dedup.py
+++ b/src/file_organizer/services/deduplication/image_dedup.py
@@ -122,7 +122,7 @@ class ImageDeduplicator:
         except OSError as e:
             logger.warning(f"Could not read image {image_path}: {e}")
             return None
-        except Exception as e:
+        except (ValueError, RuntimeError) as e:
             logger.error(f"Error processing image {image_path}: {e}")
             return None
 
@@ -419,5 +419,5 @@ class ImageDeduplicator:
             return True, None
         except OSError as e:
             return False, f"Cannot read image: {e}"
-        except Exception as e:
+        except (ValueError, RuntimeError) as e:
             return False, f"Corrupt or invalid image: {e}"

--- a/src/file_organizer/services/deduplication/image_utils.py
+++ b/src/file_organizer/services/deduplication/image_utils.py
@@ -110,7 +110,7 @@ def get_image_metadata(image_path: Path) -> ImageMetadata | None:
     except OSError as e:
         logger.warning(f"Could not read image {image_path}: {e}")
         return None
-    except Exception as e:
+    except (ValueError, RuntimeError) as e:
         logger.error(f"Error getting metadata for {image_path}: {e}")
         return None
 
@@ -127,7 +127,7 @@ def get_image_dimensions(image_path: Path) -> tuple[int, int] | None:
     try:
         with Image.open(image_path) as img:
             return img.size
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.warning(f"Could not get dimensions for {image_path}: {e}")
         return None
 
@@ -144,7 +144,7 @@ def get_image_format(image_path: Path) -> str | None:
     try:
         with Image.open(image_path) as img:
             return img.format
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.warning(f"Could not determine format for {image_path}: {e}")
         return None
 
@@ -202,7 +202,7 @@ def validate_image_file(image_path: Path) -> tuple[bool, str | None]:
 
     except OSError as e:
         return False, f"Cannot read image: {e}"
-    except Exception as e:
+    except (ValueError, RuntimeError) as e:
         return False, f"Corrupt or invalid image: {e}"
 
 

--- a/src/file_organizer/services/deduplication/quality.py
+++ b/src/file_organizer/services/deduplication/quality.py
@@ -179,7 +179,7 @@ class ImageQualityAnalyzer:
                     color_depth=color_depth,
                     modification_time=modification_time,
                 )
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.warning(f"Failed to extract metrics from {path}: {e}")
             return None
 

--- a/src/file_organizer/services/deduplication/reporter.py
+++ b/src/file_organizer/services/deduplication/reporter.py
@@ -129,7 +129,7 @@ class StorageReporter:
 
             logger.info(f"Exported duplicate report to {output_path}")
 
-        except Exception as e:
+        except OSError as e:
             logger.error(f"Error exporting to CSV: {e}")
             raise
 
@@ -146,6 +146,6 @@ class StorageReporter:
 
             logger.info(f"Exported duplicate report to {output_path}")
 
-        except Exception as e:
+        except OSError as e:
             logger.error(f"Error exporting to JSON: {e}")
             raise

--- a/src/file_organizer/services/deduplication/viewer.py
+++ b/src/file_organizer/services/deduplication/viewer.py
@@ -126,7 +126,7 @@ class ComparisonViewer:
             try:
                 metadata = self._get_image_metadata(img_path)
                 metadata_list.append(metadata)
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 self.console.print(f"[yellow]Warning: Could not load {img_path}: {e}[/yellow]")
 
         if not metadata_list:
@@ -337,7 +337,7 @@ class ComparisonViewer:
 
                 return "\n".join(ascii_lines)
 
-        except Exception:
+        except (OSError, ValueError):
             return None
 
     def _prompt_user_action(self, image_count: int) -> UserAction:
@@ -449,7 +449,7 @@ class ComparisonViewer:
         """
         try:
             metadata_list = [self._get_image_metadata(img) for img in images]
-        except Exception as e:
+        except (OSError, ValueError) as e:
             self.console.print(f"[yellow]Warning: Could not auto-select: {e}[/yellow]")
             return DuplicateReview([], [], skipped=True)
 
@@ -552,7 +552,7 @@ class ComparisonViewer:
             metadata = self._get_image_metadata(image_path)
             table = self._create_image_info_table(1, metadata)
             self.console.print(table)
-        except Exception as e:
+        except (OSError, ValueError) as e:
             self.console.print(f"[red]Error loading image metadata: {e}[/red]")
 
     def interactive_select(
@@ -580,7 +580,7 @@ class ComparisonViewer:
                     f"  [{idx}] {metadata.path.name} "
                     f"({metadata.dimensions}, {metadata.size_mb:.2f} MB)"
                 )
-            except Exception:
+            except (OSError, ValueError):
                 self.console.print(f"  [{idx}] {img_path.name} (could not load)")
 
         # Get selection

--- a/src/file_organizer/services/intelligence/folder_learner.py
+++ b/src/file_organizer/services/intelligence/folder_learner.py
@@ -328,5 +328,5 @@ class FolderPreferenceLearner:
             self.total_choices = data.get("total_choices", 0)
 
             logger.info(f"Loaded {len(self.type_folder_map)} folder preferences")
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             logger.error(f"Error loading preferences: {e}")

--- a/src/file_organizer/services/intelligence/preference_database.py
+++ b/src/file_organizer/services/intelligence/preference_database.py
@@ -184,7 +184,7 @@ class PreferenceDatabaseManager:
                 self._initialized = True
                 logger.info("Preference database initialization complete")
 
-            except Exception as e:
+            except (sqlite3.Error, OSError) as e:
                 conn.rollback()
                 logger.error(f"Database initialization failed: {e}")
                 raise
@@ -239,7 +239,7 @@ class PreferenceDatabaseManager:
                 conn.execute("BEGIN")
                 yield conn
                 conn.commit()
-            except Exception as e:
+            except (sqlite3.Error, OSError) as e:
                 conn.rollback()
                 logger.error(f"Transaction failed: {e}")
                 raise
@@ -326,7 +326,7 @@ class PreferenceDatabaseManager:
                 if pref_id is None:
                     raise RuntimeError("Failed to retrieve preference ID after insert/update")
                 return pref_id
-            except Exception as e:
+            except (sqlite3.Error, OSError, RuntimeError) as e:
                 logger.error(f"Failed to add preference: {e}")
                 raise
 

--- a/src/file_organizer/services/intelligence/preference_store.py
+++ b/src/file_organizer/services/intelligence/preference_store.py
@@ -230,7 +230,7 @@ class PreferenceStore:
                 print(f"Error: Corrupted JSON in {self.preference_file}: {e}")
                 return self._try_load_backup()
 
-            except Exception as e:
+            except (OSError, KeyError, TypeError, ValueError) as e:
                 print(f"Error loading preferences: {e}")
                 self._preferences = self._create_empty_preferences()
                 self._loaded = True
@@ -262,7 +262,7 @@ class PreferenceStore:
             self.save_preferences()
             return True
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error loading backup: {e}, using defaults...")
             self._preferences = self._create_empty_preferences()
             self._loaded = True
@@ -297,7 +297,7 @@ class PreferenceStore:
 
                 return True
 
-            except Exception as e:
+            except (OSError, TypeError, ValueError) as e:
                 print(f"Error saving preferences: {e}")
                 return False
 
@@ -487,7 +487,7 @@ class PreferenceStore:
 
                 return True
 
-            except Exception as e:
+            except (OSError, TypeError, ValueError) as e:
                 print(f"Error exporting preferences: {e}")
                 return False
 
@@ -539,7 +539,7 @@ class PreferenceStore:
                 print(f"Error: Invalid JSON in import file: {e}")
                 return False
 
-            except Exception as e:
+            except (OSError, KeyError, TypeError, ValueError) as e:
                 print(f"Error importing preferences: {e}")
                 return False
 

--- a/src/file_organizer/services/intelligence/profile_exporter.py
+++ b/src/file_organizer/services/intelligence/profile_exporter.py
@@ -91,7 +91,7 @@ class ProfileExporter:
 
             return True
 
-        except Exception as e:
+        except (OSError, TypeError, ValueError) as e:
             print(f"Error exporting profile: {e}")
             return False
 
@@ -175,7 +175,7 @@ class ProfileExporter:
 
             return True
 
-        except Exception as e:
+        except (OSError, TypeError, ValueError) as e:
             print(f"Error exporting selective preferences: {e}")
             return False
 
@@ -243,7 +243,7 @@ class ProfileExporter:
             print(f"Error: Invalid JSON in export file: {e}")
             return False
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             print(f"Error validating export: {e}")
             return False
 
@@ -283,7 +283,7 @@ class ProfileExporter:
 
             return preview
 
-        except Exception as e:
+        except (OSError, ValueError, KeyError) as e:
             print(f"Error creating export preview: {e}")
             return None
 
@@ -309,7 +309,7 @@ class ProfileExporter:
             else:
                 return f"{size_bytes / (1024 * 1024):.1f} MB"
 
-        except Exception:
+        except (TypeError, ValueError, OSError):
             return "Unknown"
 
     def export_multiple(self, profile_names: list[str], output_dir: Path) -> dict[str, bool]:

--- a/src/file_organizer/services/intelligence/profile_importer.py
+++ b/src/file_organizer/services/intelligence/profile_importer.py
@@ -104,7 +104,7 @@ class ProfileImporter:
             valid = len(errors) == 0
             return ValidationResult(valid, errors, warnings, profile_data)
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             errors.append(f"Validation error: {e}")
             return ValidationResult(False, errors, warnings)
 
@@ -265,7 +265,7 @@ class ProfileImporter:
 
             return preview
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error creating import preview: {e}")
             return None
 
@@ -299,7 +299,7 @@ class ProfileImporter:
             # Full import
             return self._import_full_profile(data, profile_name)
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error importing profile: {e}")
             return None
 
@@ -461,7 +461,7 @@ class ProfileImporter:
 
             print(f"Created backup: {backup_path}")
 
-        except Exception as e:
+        except (OSError, TypeError, ValueError) as e:
             print(f"Warning: Failed to create backup: {e}")
 
     def import_selective(
@@ -515,6 +515,6 @@ class ProfileImporter:
             # Import filtered data
             return self._import_selective_profile(filtered_data, filtered_data["profile_name"])
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error importing selective preferences: {e}")
             return None

--- a/src/file_organizer/services/intelligence/profile_manager.py
+++ b/src/file_organizer/services/intelligence/profile_manager.py
@@ -204,7 +204,7 @@ class ProfileManager:
 
             return True
 
-        except Exception as e:
+        except (OSError, TypeError, ValueError) as e:
             print(f"Error saving profile to disk: {e}")
             return False
 
@@ -238,7 +238,7 @@ class ProfileManager:
             print(f"Error: Corrupted profile file: {profile_name} - {e}")
             return None
 
-        except Exception as e:
+        except (OSError, KeyError, TypeError, ValueError) as e:
             print(f"Error loading profile: {profile_name} - {e}")
             return None
 
@@ -248,7 +248,7 @@ class ProfileManager:
             if self.active_profile_file.exists():
                 with open(self.active_profile_file, encoding="utf-8") as f:
                     return f.read().strip()
-        except Exception as e:
+        except OSError as e:
             print(f"Error reading active profile: {e}")
 
         return "default"
@@ -273,7 +273,7 @@ class ProfileManager:
 
             return True
 
-        except Exception as e:
+        except OSError as e:
             print(f"Error setting active profile: {e}")
             return False
 
@@ -399,14 +399,14 @@ class ProfileManager:
             backup_path = profile_path.parent / f"{profile_path.name}.deleted.backup"
             try:
                 shutil.copy2(profile_path, backup_path)
-            except Exception as e:
+            except OSError as e:
                 print(f"Warning: Failed to create backup: {e}")
 
             # Delete profile file
             try:
                 profile_path.unlink()
                 return True
-            except Exception as e:
+            except OSError as e:
                 print(f"Error deleting profile: {e}")
                 return False
 

--- a/src/file_organizer/services/intelligence/profile_merger.py
+++ b/src/file_organizer/services/intelligence/profile_merger.py
@@ -135,7 +135,7 @@ class ProfileMerger:
 
             return merged_profile
 
-        except Exception as e:
+        except (OSError, KeyError, TypeError, ValueError) as e:
             print(f"Error merging profiles: {e}")
             return None
 
@@ -430,7 +430,7 @@ class ProfileMerger:
 
             return self.profile_manager.get_profile(name)
 
-        except Exception as e:
+        except (OSError, KeyError, TypeError, ValueError) as e:
             print(f"Error creating merged profile: {e}")
             return None
 
@@ -492,6 +492,6 @@ class ProfileMerger:
             )
             return conflicts
 
-        except Exception as e:
+        except (KeyError, TypeError, ValueError) as e:
             print(f"Error detecting conflicts: {e}")
             return conflicts

--- a/src/file_organizer/services/intelligence/profile_migrator.py
+++ b/src/file_organizer/services/intelligence/profile_migrator.py
@@ -84,7 +84,7 @@ class ProfileMigrator:
             # Execute migration
             return self._execute_migration(profile_name, profile, target_version, backup_path)
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error migrating profile: {e}")
             return False
 
@@ -170,7 +170,7 @@ class ProfileMigrator:
 
             try:
                 migrated_data = migration_func(migrated_data)
-            except Exception as e:
+            except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
                 print(f"Error during migration step {step}: {e}")
                 if backup_path:
                     self.rollback_migration(profile_name, backup_path)
@@ -279,7 +279,7 @@ class ProfileMigrator:
             print(f"Created migration backup: {backup_path}")
             return backup_path
 
-        except Exception as e:
+        except OSError as e:
             print(f"Error creating migration backup: {e}")
             return None
 
@@ -329,7 +329,7 @@ class ProfileMigrator:
 
             return success
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error rolling back migration: {e}")
             return False
 
@@ -363,7 +363,7 @@ class ProfileMigrator:
             print("Profile validation successful")
             return True
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error validating migration: {e}")
             return False
 
@@ -412,7 +412,7 @@ class ProfileMigrator:
             profile_dict = profile.to_dict()
             return list(profile_dict.get("migration_history", []))
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             print(f"Error getting migration history: {e}")
             return None
 
@@ -442,7 +442,7 @@ class ProfileMigrator:
 
             return backups
 
-        except Exception as e:
+        except OSError as e:
             print(f"Error listing backups: {e}")
             return []
 

--- a/src/file_organizer/services/intelligence/template_manager.py
+++ b/src/file_organizer/services/intelligence/template_manager.py
@@ -356,7 +356,7 @@ class TemplateManager:
 
             return self.profile_manager.get_profile(profile_name)
 
-        except Exception as e:
+        except (OSError, KeyError, TypeError, ValueError) as e:
             print(f"Error creating profile from template: {e}")
             return None
 
@@ -439,7 +439,7 @@ class TemplateManager:
 
             return True
 
-        except Exception as e:
+        except (OSError, KeyError, TypeError, ValueError) as e:
             print(f"Error creating custom template: {e}")
             return False
 
@@ -551,6 +551,6 @@ class TemplateManager:
 
             return comparison
 
-        except Exception as e:
+        except (KeyError, TypeError, ValueError) as e:
             print(f"Error comparing templates: {e}")
             return None

--- a/src/file_organizer/services/suggestion_feedback.py
+++ b/src/file_organizer/services/suggestion_feedback.py
@@ -351,7 +351,7 @@ class SuggestionFeedback:
 
             logger.info(f"Loaded {len(self.feedback_entries)} feedback entries")
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             logger.error(f"Failed to load feedback: {e}")
             self.feedback_entries = []
             self.pattern_adjustments = {}
@@ -370,7 +370,7 @@ class SuggestionFeedback:
 
             logger.debug(f"Saved {len(self.feedback_entries)} feedback entries")
 
-        except Exception as e:
+        except (OSError, TypeError, ValueError) as e:
             logger.error(f"Failed to save feedback: {e}")
 
     def export_feedback(self, output_file: Path) -> None:

--- a/src/file_organizer/services/text_processor.py
+++ b/src/file_organizer/services/text_processor.py
@@ -199,7 +199,7 @@ class TextProcessor:
                 filename=file_path.stem,
                 error=str(e),
             )
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.exception(f"Failed to process {file_path.name}: {e}")
             return ProcessedFile(
                 file_path=file_path,
@@ -271,7 +271,7 @@ SUMMARY:"""
                     summary = summary[len(prefix) :].strip()
 
             return summary
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to generate description: {e}")
             return f"Content about {content[:100]}..."
 
@@ -350,7 +350,7 @@ CATEGORY:"""
             logger.info(f"Folder name generated ({len(result)} chars)")
             return result
 
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to generate folder name: {e}")
             return "documents"
 
@@ -434,7 +434,7 @@ FILENAME:"""
             logger.info(f"Filename generated ({len(result)} chars)")
             return result
 
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to generate filename: {e}")
             return "document"
 

--- a/src/file_organizer/services/video/metadata_extractor.py
+++ b/src/file_organizer/services/video/metadata_extractor.py
@@ -222,7 +222,7 @@ class VideoMetadataExtractor:
                 metadata.duration = frame_count / metadata.fps
 
             return True
-        except Exception:
+        except (OSError, ValueError, RuntimeError):
             logger.debug(f"OpenCV extraction failed for {video_path.name}", exc_info=True)
             return False
         finally:

--- a/src/file_organizer/services/video/scene_detector.py
+++ b/src/file_organizer/services/video/scene_detector.py
@@ -335,7 +335,7 @@ class SceneDetector:
             try:
                 result = self.detect_scenes(video_path, method)
                 results.append(result)
-            except Exception as e:
+            except (OSError, ValueError, ImportError, RuntimeError) as e:
                 logger.error(f"Failed to detect scenes in {video_path}: {e}")
                 # Continue with other files
 

--- a/src/file_organizer/services/vision_processor.py
+++ b/src/file_organizer/services/vision_processor.py
@@ -205,7 +205,7 @@ class VisionProcessor:
                 processing_time=processing_time,
             )
 
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.exception(f"Failed to process {file_path.name}: {e}")
             return ProcessedImage(
                 file_path=file_path,
@@ -300,7 +300,7 @@ Provide a clear, descriptive paragraph (100-150 words)."""
                 max_tokens=250,
             )
             return response.strip()
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to generate description: {e}")
             return f"Image from {image_path.name}"
 
@@ -343,7 +343,7 @@ If there's no readable text, respond with "NO_TEXT"."""
 
             return response
 
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to extract text: {e}")
             return None
 
@@ -417,7 +417,7 @@ CATEGORY:"""
             logger.info(f"Final folder name: '{result}'")
             return result
 
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to generate folder name: {e}")
             return "images"
 
@@ -494,7 +494,7 @@ FILENAME:"""
             logger.info(f"Final filename: '{result}'")
             return result
 
-        except Exception as e:
+        except (RuntimeError, ValueError, OSError, AttributeError) as e:
             logger.error(f"Failed to generate filename: {e}")
             return image_path.stem
 
@@ -511,7 +511,7 @@ FILENAME:"""
 
         try:
             return self.vision_model.generate(**kwargs)
-        except Exception as exc:
+        except Exception as exc:  # Intentional catch-all: circuit-breaker for any backend error
             if self._is_fatal_backend_error(exc):
                 self._trip_backend_circuit(exc)
             raise


### PR DESCRIPTION
## Summary
- Phase 1 of #1024: Replace bare `except Exception` in `services/` directory
- Replaced 107 instances with specific exception types based on what each try block actually does
- Added `# Intentional catch-all` comments to 2 legitimate catch-alls (circuit-breaker, plugin dispatch)
- All files pass ruff lint and AST parse checks

Partial fix for #1024

## Test plan
- [x] All 37 modified files pass syntax/AST validation
- [x] All ruff lint checks pass
- [x] Only 2 intentional `except Exception` remain (documented with comments)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)