### PR TITLE
fix(tests): patch platform.system in TestRollback to fix Windows CI failure

### DIFF
--- a/tests/updater/test_installer.py
+++ b/tests/updater/test_installer.py
@@ -213,19 +213,22 @@ class TestRollback:
         backup = tmp_path / "test-app.bak"
         backup.write_bytes(b"old binary")
 
-        assert inst.rollback("test-app") is True
+        with patch("platform.system", return_value="Linux"):
+            assert inst.rollback("test-app") is True
 
     def test_rollback_no_backup(self, tmp_path):
         inst = UpdateInstaller(install_dir=tmp_path)
-        assert inst.rollback("test-app") is False
+        with patch("platform.system", return_value="Linux"):
+            assert inst.rollback("test-app") is False
 
     def test_rollback_failure(self, tmp_path):
         inst = UpdateInstaller(install_dir=tmp_path)
         backup = tmp_path / "test-app.bak"
         backup.write_bytes(b"old binary")
 
-        with patch("shutil.move", side_effect=OSError("fail")):
-            assert inst.rollback("test-app") is False
+        with patch("platform.system", return_value="Linux"):
+            with patch("shutil.move", side_effect=OSError("fail")):
+                assert inst.rollback("test-app") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Failure Summary

- **Workflow**: CI Full Matrix
- **Job**: Test Windows (Python 3.12)
- **Step**: Run tests
- **Date**: 2026-04-06
- **Run**: #24022019865

## RCA

`TestRollback.test_rollback_success` fails on Windows because:

1. `rollback("test-app")` calls `_resolve_target("test-app")`
2. On Windows, `_resolve_target` appends `.exe` → target is `test-app.exe`
3. Backup path computed as `test-app.exe.bak`
4. Test created `test-app.bak` (no `.exe` suffix)
5. `backup.exists()` → `False` → `rollback` returns `False`
6. `assert inst.rollback("test-app") is True` → **AssertionError**

Bug introduced in PR #1104 (commit 2f28a35b). Other test classes in the same file (`TestInstall`) mock `platform.system` to avoid this — `TestRollback` did not.

## Fix

Add `with patch("platform.system", return_value="Linux"):` to all three `TestRollback` methods, matching the existing pattern used by `TestInstall.test_install_success` and `test_install_with_backup`.

`test_rollback_no_backup` and `test_rollback_failure` also updated for consistency — `test_rollback_failure` was passing on Windows for the wrong reason (backup not found → early `False` before `shutil.move` mock was exercised).

## Validation

- All 45 tests in `tests/updater/test_installer.py` pass locally
- Ruff lint and format: clean
- All pre-commit hooks: pass
- Only `tests/updater/test_installer.py` changed

## Residual Risk / Follow-up

None. Pure test fix, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced rollback test coverage by improving platform-specific test scenarios for Linux environments.

---

**Note:** This release contains internal testing improvements with no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->