### PR TITLE
fix(tests): repair three nightly CI failures

### DIFF
--- a/tests/cli/test_cli_dedupe.py
+++ b/tests/cli/test_cli_dedupe.py
@@ -533,8 +533,8 @@ class TestDisplayDuplicateGroup:
         output = console.export_text()
         assert "Duplicate Group 1/3" in output
         assert "abc123def4567890..." in output
-        assert "/a/file1.txt" in output
-        assert "/a/file2.txt" in output
+        assert str(Path("/a/file1.txt")) in output
+        assert str(Path("/a/file2.txt")) in output
         assert "Potential space savings: 1.0 KB" in output
 
     def test_displays_group_no_keep(self, capsys):
@@ -552,8 +552,8 @@ class TestDisplayDuplicateGroup:
         )
         output = console.export_text()
         assert "Duplicate Group 2/5" in output
-        assert "/x/y.txt" in output
-        assert "/x/z.txt" in output
+        assert str(Path("/x/y.txt")) in output
+        assert str(Path("/x/z.txt")) in output
         assert "Potential space savings: 500.0 B" in output
 
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1350,8 +1350,8 @@ class TestJSONOutputFormat:
 
         output = json.loads(mock_echo.call_args[0][0])
         assert output["directory"] == str(tmp_path)
-        # Must be absolute
-        assert output["directory"].startswith("/")
+        # Must be absolute (cross-platform: Unix starts with /, Windows with drive letter)
+        assert Path(output["directory"]).is_absolute()
 
     def test_json_missing_groups_sorted(self, tmp_path):
         """JSON missing_groups list is sorted alphabetically."""

--- a/tests/docs/test_doc_file_paths.py
+++ b/tests/docs/test_doc_file_paths.py
@@ -92,8 +92,8 @@ ALLOWLIST: frozenset[str] = frozenset()
 
 
 def _is_glob_pattern(path: str) -> bool:
-    """Return True if path contains shell glob characters."""
-    return "*" in path or "?" in path or "[" in path
+    """Return True if path contains shell glob characters or template placeholders."""
+    return "*" in path or "?" in path or "[" in path or "<" in path
 
 
 def _excluded_doc_dir(md_file: Path) -> bool:
@@ -111,7 +111,7 @@ def _get_doc_path_params() -> list[tuple[str, str]]:
 
     Returns only pairs that:
     - Are not from excluded doc directories (e.g. docs/plans/)
-    - Do not contain glob wildcards
+    - Do not contain glob wildcards or template placeholders (e.g. ``<module>``)
     - Are not in the ALLOWLIST
     """
     params: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary

Fixes all failing jobs from the 2026-04-07 nightly CI runs (CI Full Matrix run #24068052353 and CI run #24060456503).

## Failure Summary

| Workflow | Job | Failure Count | Date |
|----------|-----|--------------|------|
| CI Full Matrix | Test Linux shard 5 (py3.11) | 2 tests | 2026-04-07 |
| CI Full Matrix | Test Linux shard 5 (py3.12) | 2 tests | 2026-04-07 |
| CI Full Matrix | Test Windows (py3.12) | 3 tests | 2026-04-07 |
| CI | Test shard 5 (py3.11) | 2 tests | 2026-04-07 |
| CI | Test shard 5 (py3.12) | 2 tests | 2026-04-07 |

## RCA & Fix Per Failure

### Failure 1: `tests/docs/test_doc_file_paths.py` (Linux shard 5)

**RCA**: `docs/superpowers/plans/2026-04-06-integration-coverage-ratchet.md` uses template placeholder syntax (`<module>`, `<domain>`) inside backtick-wrapped paths. The `PATH_PATTERN` regex matches these as file references and `test_referenced_path_exists` asserts they exist — but `src/file_organizer/api/<module>.py` and `tests/<domain>/test_<module>_integration.py` are templates, not real paths. The `_excluded_doc_dir` filter only excludes `docs/plans/` (top-level), not `docs/superpowers/plans/`.

**Fix**: Extend `_is_glob_pattern()` to also return `True` for paths containing `<`, treating angle-bracket placeholders as non-assertable alongside shell glob characters. This is the most general fix — any future planning doc with `<placeholder>` paths will also be skipped.

### Failure 2: `tests/cli/test_cli_dedupe.py::TestDisplayDuplicateGroup` (Windows py3.12)

**RCA**: Two assertions compared Unix-style string literals (`"/a/file1.txt"`) against Rich table output that uses `str(Path(...))`. On Windows, `str(Path("/a/file1.txt"))` returns `\a\file1.txt`, so the `in output` check fails.

**Fix**: Replace string literals with `str(Path(...))` in both assertions so the comparison uses the OS-native path separator.

### Failure 3: `tests/cli/test_doctor.py::TestJSONOutputFormat::test_json_directory_is_absolute_path` (Windows py3.12)

**RCA**: `assert output["directory"].startswith("/")` hardcodes Unix path prefix. On Windows, `tmp_path` resolves to a `C:\...` path.

**Fix**: Replace with `Path(output["directory"]).is_absolute()` which is cross-platform.

## Validation

- All 3 fixed test cases pass locally via `.venv/bin/pytest`
- `ruff check` and `ruff format --check` pass on all changed files
- All pre-commit hooks pass (run with venv on PATH)
- Diff contains only the 3 test files directly related to the CI failures

## Residual Risk

None. All fixes are test-only changes with no production code impact. The Windows failures were pre-existing (path separator assumptions); the Linux failure was introduced by the planning doc added in the most recent main push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated CLI duplicate display assertions to use cross-platform path handling
* Enhanced absolute path validation for cross-platform compatibility in doctor command tests
* Improved path pattern detection to account for template placeholders in documentation validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->