### PR TITLE
fix(tests): exclude superpowers/ docs and dedent code blocks in shard-5 CI

### DIFF
--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -44,8 +44,14 @@ def mkdocs_config() -> dict:
 
 @pytest.fixture(scope="session")
 def all_doc_files(docs_dir: Path) -> list[Path]:
-    """Return all markdown files under the docs directory."""
-    return list(docs_dir.rglob("*.md"))
+    """Return all markdown files under the docs directory.
+
+    Excludes docs/superpowers/ — internal AI-authored planning and specification
+    documents that contain partial code snippets and example content intended for
+    insertion into other files, not syntactically complete standalone Python or
+    navigable internal links.
+    """
+    return [f for f in docs_dir.rglob("*.md") if "superpowers" not in f.parts]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/docs/test_code_examples.py
+++ b/tests/docs/test_code_examples.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 import re
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -65,8 +66,9 @@ class TestPythonCodeExamples:
             python_blocks = extract_code_blocks(content, "python")
 
             for i, block in enumerate(python_blocks):
-                # Skip blocks that are clearly fragments/comments only
-                stripped = block.strip()
+                # Dedent before stripping to handle code blocks inside list items,
+                # where all lines carry the list indentation as leading whitespace.
+                stripped = textwrap.dedent(block).strip()
                 if not stripped:
                     continue
                 # Skip blocks that start with #! (shebang) or are just comments


### PR DESCRIPTION
## Failure summary

**Workflow**: CI (main, shard 5) — runs on every push to `main`
**Jobs**: Test (shard 5, py3.11) and Test (shard 5, py3.12)
**Date**: 2026-04-08
**Run IDs**: 24118668680, 24121724426

## RCA per failure

### Failure 1 — `test_internal_links_resolve` (2 broken links)

**File**: `docs/superpowers/plans/2026-04-07-a3-playwright-e2e-docs.md`

The plan doc contains fenced code blocks showing *example markdown content* that the implementer should paste into `docs/developer/index.md` and `docs/developer/testing.md`. Inside those code blocks, relative links like `[Browser E2E Tests (Playwright)](playwright-e2e.md)` are correct when resolved from the target files' `docs/developer/` directory — but the test resolved them relative to the plan doc (`docs/superpowers/plans/`) where no such file exists.

**Fix**: exclude `docs/superpowers/` from `all_doc_files` — the link-integrity check is designed for published developer docs, not internal planning documents.

### Failure 2 — `test_python_examples_parse` (7 syntax errors)

Six errors in `docs/superpowers/` plan/spec docs:
- Partial code snippets (function signatures without bodies — e.g., `def _process_file(...):` with no body)
- Function bodies split across consecutive code blocks

One error in `docs/developer/playwright-e2e.md`:
- Code block inside a numbered list item; all lines carry 3-space list indentation. After `block.strip()` the first line's indent was removed but subsequent lines kept it, making `ast.parse()` see `import pytest` at col 0 then `from playwright.sync_api import Page` at col 3 — unexpected indent.

**Fix**: (a) exclude `docs/superpowers/` from `all_doc_files` (handles 6 errors); (b) use `textwrap.dedent(block)` before `strip()`/`ast.parse()` so uniform list-item indentation is stripped first (handles the `playwright-e2e.md` case).

### Non-actionable — Windows `KeyboardInterrupt`

All 983 Windows tests **passed** (159 s). A `KeyboardInterrupt` fired during teardown of the final test file (`tests\daemon\test_pid.py`), causing exit code 1 despite the suite succeeding. This is a transient GitHub Actions runner signal issue, not a code regression. No fix applied.

## Fix per failure

| # | Failure | Fix |
|---|---------|-----|
| 1 | Broken links in plan doc code blocks | `conftest.py`: exclude `docs/superpowers/` from `all_doc_files` |
| 2a | Partial code snippets in plan/spec docs | Same exclusion |
| 2b | Indented code in list item (`playwright-e2e.md`) | `test_code_examples.py`: `textwrap.dedent(block)` before parse |
| 3 | Windows `KeyboardInterrupt` | Not actionable — transient infra flake |

## Validation results

```
tests/docs/test_link_integrity.py::TestInternalLinkIntegrity::test_internal_links_resolve PASSED
tests/docs/test_code_examples.py::TestPythonCodeExamples::test_python_examples_parse PASSED
tests/docs/ — 176 passed, 1 xfailed (full suite, no regressions)
```

## Residual risk / follow-up notes

- The `docs/superpowers/` exclusion is intentional and permanent: these are AI-authored planning docs that will always contain partial code and cross-file example content. If a future PR adds real developer docs under `superpowers/`, they should be moved to an appropriate published directory.
- The `textwrap.dedent` change is safe: it only removes a common leading-whitespace prefix; blocks without leading indentation are unaffected.
- The Windows `KeyboardInterrupt` flake should be monitored. If it recurs consistently, increasing `timeout-minutes` for the Windows job in `ci-full.yml` or switching to a faster runner may help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved code example validation in documentation to properly handle indented code blocks in lists
  * Enhanced documentation test filtering for better test organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->