### PR TITLE
ci: cache Playwright virtualenv and fix venv activation gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,9 @@ jobs:
           restore-keys: playwright-${{ runner.os }}-${{ matrix.browser }}-
       - name: Install Playwright browser
         # --with-deps pulls the system libs the browser needs on a fresh runner.
-        run: python -m playwright install --with-deps ${{ matrix.browser }}
+        run: |
+          . .venv-playwright/bin/activate
+          python -m playwright install --with-deps ${{ matrix.browser }}
       - name: Cache NLTK data
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,8 +262,20 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+      - name: Cache Playwright virtualenv
+        id: playwright-venv-cache
+        uses: actions/cache@v5
+        with:
+          path: .venv-playwright
+          # Shared across all three browser legs: they run the same Python env.
+          key: playwright-venv-${{ runner.os }}-py3.12-${{ hashFiles('pyproject.toml') }}
+          restore-keys: playwright-venv-${{ runner.os }}-py3.12-
       - name: Install dependencies
+        if: steps.playwright-venv-cache.outputs.cache-hit != 'true'
         run: |
+          python -m venv .venv-playwright
+          . .venv-playwright/bin/activate
+          python -m pip install --upgrade pip
           # [dev] provides pytest-playwright; [search] keeps parity with other
           # test jobs so imports don't break at collection time.
           pip install -e ".[dev,search]"
@@ -289,7 +301,9 @@ jobs:
           key: nltk-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: nltk-${{ runner.os }}-
       - name: Download NLTK data
-        run: python -c "import nltk; nltk.download('stopwords', quiet=True); nltk.download('punkt', quiet=True); nltk.download('punkt_tab', quiet=True); nltk.download('wordnet', quiet=True)"
+        run: |
+          . .venv-playwright/bin/activate
+          python -c "import nltk; nltk.download('stopwords', quiet=True); nltk.download('punkt', quiet=True); nltk.download('punkt_tab', quiet=True); nltk.download('wordnet', quiet=True)"
       - name: Run Playwright suite
         # Overriding addopts is required because pyproject.toml's default
         # addopts filter out e2e/playwright-marked tests in normal runs.
@@ -297,6 +311,7 @@ jobs:
         # surface on the third attempt. Traces/screenshots/videos are
         # retained only on failure to keep artifact size manageable.
         run: |
+          . .venv-playwright/bin/activate
           pytest tests/playwright/ \
             --browser ${{ matrix.browser }} \
             --tracing retain-on-failure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
         with:
           path: .venv-playwright
           # Shared across all three browser legs: they run the same Python env.
-          key: playwright-venv-${{ runner.os }}-py3.12-${{ hashFiles('pyproject.toml') }}
+          key: playwright-venv-${{ runner.os }}-py3.12-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: playwright-venv-${{ runner.os }}-py3.12-
       - name: Install dependencies
         if: steps.playwright-venv-cache.outputs.cache-hit != 'true'

--- a/src/file_organizer/web/templates/files/_results.html
+++ b/src/file_organizer/web/templates/files/_results.html
@@ -154,7 +154,12 @@
                 data-file-kind="{{ entry.kind }}"
             >
                 <label class="file-select">
-                    <input type="checkbox" data-file-select value="{{ entry.path }}">
+                    <input
+                        type="checkbox"
+                        data-file-select
+                        value="{{ entry.path }}"
+                        aria-label="Select {{ 'folder' if entry.is_dir else 'file' }} {{ entry.name }}"
+                    >
                 </label>
                 <div class="file-thumb">
                     {% if entry.thumbnail_url %}


### PR DESCRIPTION
Each Playwright matrix leg was rebuilding the Python virtualenv from scratch on every run. Additionally, after moving package installation into a dedicated `.venv-playwright`, several steps still invoked Python without activating the venv — causing `ModuleNotFoundError` at runtime.

## Changes

**Virtualenv caching**
- Add `actions/cache@v5` step caching `.venv-playwright`, keyed on `runner.os + py3.12 + hashFiles('pyproject.toml')`; key is browser-agnostic so all three matrix legs share the same cache entry
- Gate `Install dependencies` on `cache-hit != 'true'`; the step now creates the venv, upgrades pip, and installs `.[dev,search]` + `pytest-rerunfailures` inside it

**Venv activation gaps (bug fixes)**
- `Install Playwright browser` — was calling `python -m playwright install` against system Python after playwright was moved into the venv; now activates first
- `Download NLTK data` and `Run Playwright suite` — same fix; `. .venv-playwright/bin/activate` prepended to each `run` block

**Template a11y fix (unblocked by the above)**
- File-browser checkboxes (`input[type=checkbox][data-file-select]`) had no accessible label; axe-core flagged this as a critical violation causing `test_a11y_files_page` to fail
- Adds `aria-label="Select folder/file {{ entry.name }}"` to each checkbox in `_results.html`; the wrapping `<label class="file-select">` carries no text so was not satisfying the rule alone