### PR TITLE
fix(dedupe): sort group files by mtime before selecting keep/remove

### DIFF
--- a/src/file_organizer/api/routers/dedupe.py
+++ b/src/file_organizer/api/routers/dedupe.py
@@ -81,16 +81,17 @@ def _scan_duplicates(
 def _preview(groups: list[DedupeGroup]) -> list[DedupePreviewGroup]:
     """Build a preview response summarizing what a dedupe run would remove.
 
-    Files are sorted by modified time (oldest first) so the oldest copy is
-    always kept and newer duplicates are removed.  This matches the CLI
-    behaviour in dedupe_v2.py and makes selection deterministic across
-    platforms regardless of filesystem iteration order.
+    Files are sorted by (modified time, path) so the oldest copy is always
+    kept and newer duplicates are removed.  The path tie-breaker ensures
+    stable selection when two files share an identical mtime.  This matches
+    the CLI behaviour in dedupe_v2.py and is deterministic regardless of
+    filesystem iteration order.
     """
     previews: list[DedupePreviewGroup] = []
     for group in groups:
         if not group.files:
             continue
-        sorted_files = sorted(group.files, key=lambda f: f.modified)
+        sorted_files = sorted(group.files, key=lambda f: (f.modified, f.path))
         keep = sorted_files[0].path
         remove = [file.path for file in sorted_files[1:]]
         previews.append(DedupePreviewGroup(hash_value=group.hash_value, keep=keep, remove=remove))

--- a/src/file_organizer/api/routers/dedupe.py
+++ b/src/file_organizer/api/routers/dedupe.py
@@ -79,13 +79,20 @@ def _scan_duplicates(
 
 
 def _preview(groups: list[DedupeGroup]) -> list[DedupePreviewGroup]:
-    """Build a preview response summarizing what a dedupe run would remove."""
+    """Build a preview response summarizing what a dedupe run would remove.
+
+    Files are sorted by modified time (oldest first) so the oldest copy is
+    always kept and newer duplicates are removed.  This matches the CLI
+    behaviour in dedupe_v2.py and makes selection deterministic across
+    platforms regardless of filesystem iteration order.
+    """
     previews: list[DedupePreviewGroup] = []
     for group in groups:
         if not group.files:
             continue
-        keep = group.files[0].path
-        remove = [file.path for file in group.files[1:]]
+        sorted_files = sorted(group.files, key=lambda f: f.modified)
+        keep = sorted_files[0].path
+        remove = [file.path for file in sorted_files[1:]]
         previews.append(DedupePreviewGroup(hash_value=group.hash_value, keep=keep, remove=remove))
     return previews
 


### PR DESCRIPTION
## Summary

- `_preview()` in `api/routers/dedupe.py` was taking `group.files[0]` as the file to keep, relying on filesystem dict iteration order from `get_duplicates()` — non-deterministic across platforms
- On the CI runner, `test_execute_removes_duplicates` saw `keep.txt` removed instead of `remove_me.txt`, causing the integration coverage gate to fail on main

## Fix

Sort files by `modified` timestamp (oldest first) before selecting keep/remove, matching the existing CLI behaviour in `dedupe_v2.py:178`. The oldest copy is always kept; newer duplicates are removed.

## Test plan

- [ ] `test_execute_removes_duplicates` passes (creates `keep.txt` before `remove_me.txt`; oldest = keep.txt is now always kept)
- [ ] Integration coverage gate passes on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate file handling is now deterministic: selection of which file to keep uses modification timestamps with a consistent tie-breaker by path, producing stable, repeatable deduplication results regardless of file ordering. Preview behavior is clarified so retained/removed files are no longer ambiguous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->