### PR TITLE
Add dedupe preview regression tests for mtime and path ordering

### DIFF
--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -18,7 +18,15 @@ from file_organizer.api.routers.dedupe import _preview, router
 
 
 def _build_app(tmp_path: Path) -> tuple[FastAPI, TestClient, ApiSettings]:
-    """Create a minimal FastAPI app with the dedupe router."""
+    """
+    Create a FastAPI test application configured with the dedupe router and test settings.
+    
+    Parameters:
+        tmp_path (Path): Filesystem path that will be allowed for scans and set in test settings.
+    
+    Returns:
+        tuple[FastAPI, TestClient, ApiSettings]: A tuple containing the FastAPI app, a TestClient for that app, and the ApiSettings used for the test app.
+    """
     settings = ApiSettings(
         environment="test",
         auth_enabled=False,

--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -20,10 +20,10 @@ from file_organizer.api.routers.dedupe import _preview, router
 def _build_app(tmp_path: Path) -> tuple[FastAPI, TestClient, ApiSettings]:
     """
     Create a FastAPI test application configured with the dedupe router and test settings.
-    
+
     Parameters:
         tmp_path (Path): Filesystem path that will be allowed for scans and set in test settings.
-    
+
     Returns:
         tuple[FastAPI, TestClient, ApiSettings]: A tuple containing the FastAPI app, a TestClient for that app, and the ApiSettings used for the test app.
     """
@@ -210,8 +210,12 @@ class TestPreviewDuplicates:
         group = DedupeGroup(
             hash_value="abc123",
             files=[
-                DedupeFileInfo(path="/tmp/z-last.txt", size=100, modified=same_time, accessed=same_time),
-                DedupeFileInfo(path="/tmp/a-first.txt", size=100, modified=same_time, accessed=same_time),
+                DedupeFileInfo(
+                    path="/tmp/z-last.txt", size=100, modified=same_time, accessed=same_time
+                ),
+                DedupeFileInfo(
+                    path="/tmp/a-first.txt", size=100, modified=same_time, accessed=same_time
+                ),
             ],
             total_size=200,
             wasted_space=100,

--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -13,7 +13,8 @@ from fastapi.testclient import TestClient
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_current_active_user, get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
-from file_organizer.api.routers.dedupe import router
+from file_organizer.api.models import DedupeFileInfo, DedupeGroup
+from file_organizer.api.routers.dedupe import _preview, router
 
 
 def _build_app(tmp_path: Path) -> tuple[FastAPI, TestClient, ApiSettings]:
@@ -177,6 +178,41 @@ class TestScanDuplicates:
 @pytest.mark.unit
 class TestPreviewDuplicates:
     """Tests for POST /api/v1/dedupe/preview."""
+
+    def test_preview_keeps_oldest_file_by_modified_time(self) -> None:
+        older = datetime(2024, 1, 1, tzinfo=UTC)
+        newer = datetime(2024, 1, 2, tzinfo=UTC)
+        group = DedupeGroup(
+            hash_value="abc123",
+            files=[
+                DedupeFileInfo(path="/tmp/newer.txt", size=100, modified=newer, accessed=newer),
+                DedupeFileInfo(path="/tmp/older.txt", size=100, modified=older, accessed=older),
+            ],
+            total_size=200,
+            wasted_space=100,
+        )
+
+        preview = _preview([group])
+
+        assert preview[0].keep == "/tmp/older.txt"
+        assert preview[0].remove == ["/tmp/newer.txt"]
+
+    def test_preview_breaks_equal_mtime_ties_by_path(self) -> None:
+        same_time = datetime(2024, 1, 1, tzinfo=UTC)
+        group = DedupeGroup(
+            hash_value="abc123",
+            files=[
+                DedupeFileInfo(path="/tmp/z-last.txt", size=100, modified=same_time, accessed=same_time),
+                DedupeFileInfo(path="/tmp/a-first.txt", size=100, modified=same_time, accessed=same_time),
+            ],
+            total_size=200,
+            wasted_space=100,
+        )
+
+        preview = _preview([group])
+
+        assert preview[0].keep == "/tmp/a-first.txt"
+        assert preview[0].remove == ["/tmp/z-last.txt"]
 
     @patch("file_organizer.api.routers.dedupe.DuplicateDetector")
     def test_preview_success(self, mock_detector_cls, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add focused router tests for dedupe preview keep/remove selection
- verify the oldest file is kept when duplicate files have different modification times
- verify path ordering is used as a deterministic tie-breaker when modification times match

## Testing
- `pytest -q -o addopts='' tests/api/test_dedupe_router.py -k 'preview'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for deduplication preview logic.
  * Verifies deterministic selection: older-modified file kept when timestamps differ.
  * Verifies tie-breaking by lexicographic path when timestamps match.
  * No changes to API endpoints or request/response behavior.

* **Chores**
  * Clarified test helper documentation describing the test application setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->