### PR TITLE
[codex] Add focused regression tests for recent CI fixes

### DIFF
--- a/tests/integration/test_api_dedupe_routes.py
+++ b/tests/integration/test_api_dedupe_routes.py
@@ -17,9 +17,11 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
+import file_organizer.api.routers.dedupe as dedupe_module
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_current_active_user, get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
+from file_organizer.api.models import DedupeFileInfo, DedupeGroup
 from file_organizer.api.routers.dedupe import router as dedupe_router
 
 pytestmark = pytest.mark.integration
@@ -223,6 +225,46 @@ class TestDedupeExecute:
         assert not duplicate.exists()
         assert original.exists()
         assert len(list(exec_dir.iterdir())) == 1
+
+    def test_execute_skips_group_when_preview_keep_target_is_missing(
+        self,
+        dedupe_client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        exec_dir = tmp_path / "missing_keep_dir"
+        exec_dir.mkdir()
+        real_file = exec_dir / "keep.txt"
+        real_file.write_text("same content")
+        missing_keep = exec_dir / "ghost.txt"
+
+        def fake_scan_duplicates(_path: Path, _request: object) -> tuple[list[DedupeGroup], dict[str, int]]:
+            return (
+                [
+                    DedupeGroup(
+                        hash_value="hash-1",
+                        files=[
+                            DedupeFileInfo(path=str(missing_keep), size=12, modified=100.0, accessed=100.0),
+                            DedupeFileInfo(path=str(real_file), size=12, modified=100.0, accessed=100.0),
+                        ],
+                        total_size=24,
+                        wasted_space=12,
+                    )
+                ],
+                {"scanned_files": 2},
+            )
+
+        monkeypatch.setattr(dedupe_module, "_scan_duplicates", fake_scan_duplicates)
+
+        r = dedupe_client.post(
+            "/dedupe/execute",
+            json={"path": str(exec_dir), "dry_run": False, "trash": False},
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["removed"] == []
+        assert real_file.exists()
 
     def test_execute_response_shape(self, dedupe_client: TestClient, tmp_path: Path) -> None:
         shape_dir = tmp_path / "shape_dir"

--- a/tests/integration/test_api_dedupe_routes.py
+++ b/tests/integration/test_api_dedupe_routes.py
@@ -238,14 +238,20 @@ class TestDedupeExecute:
         real_file.write_text("same content")
         missing_keep = exec_dir / "ghost.txt"
 
-        def fake_scan_duplicates(_path: Path, _request: object) -> tuple[list[DedupeGroup], dict[str, int]]:
+        def fake_scan_duplicates(
+            _path: Path, _request: object
+        ) -> tuple[list[DedupeGroup], dict[str, int]]:
             return (
                 [
                     DedupeGroup(
                         hash_value="hash-1",
                         files=[
-                            DedupeFileInfo(path=str(missing_keep), size=12, modified=100.0, accessed=100.0),
-                            DedupeFileInfo(path=str(real_file), size=12, modified=100.0, accessed=100.0),
+                            DedupeFileInfo(
+                                path=str(missing_keep), size=12, modified=100.0, accessed=100.0
+                            ),
+                            DedupeFileInfo(
+                                path=str(real_file), size=12, modified=100.0, accessed=100.0
+                            ),
                         ],
                         total_size=24,
                         wasted_space=12,

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -432,6 +432,34 @@ class TestEdgeCasesAndErrorHandling:
         # access_frequency should be 1.0 when days_since_modified == 0
         assert features.access_frequency == 1.0
 
+    def test_metadata_extraction_clamps_tiny_negative_day_offsets(
+        self,
+        extractor: FeatureExtractor,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Tiny future-skewed timestamps should clamp to zero days instead of going negative."""
+        import file_organizer.methodologies.para.ai.feature_extractor as fe_module
+
+        class MockStat:
+            def __init__(self, *, now: float) -> None:
+                self.st_size = 7
+                self.st_atime = now + 0.1
+                self.st_mtime = now + 0.2
+                self.st_birthtime = now + 0.3
+
+        test_file = tmp_path / "fresh-skewed.txt"
+        test_file.write_text("content")
+        now = 2_000_000_000.0
+
+        monkeypatch.setattr(fe_module.time, "time", lambda: now)
+        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+
+        features = extractor.extract_metadata_features(test_file)
+        assert features.days_since_modified == 0.0
+        assert features.days_since_created == 0.0
+        assert features.access_frequency == 1.0
+
     def test_structural_features_with_inaccessible_parent_dir(
         self,
         extractor: FeatureExtractor,


### PR DESCRIPTION
## What changed
- add an API dedupe regression test that exercises `execute_deduplication()` when preview selects a missing keep target and verifies the real duplicate is not deleted
- add a PARA feature extractor regression test that simulates tiny future-skewed timestamps and verifies `days_since_modified` / `days_since_created` clamp to `0.0`

## Why
The most recent CI-fix commit introduced behavior that was only protected by implementation changes. These tests lock in the intended edge-case behavior around missing keep targets and timestamp precision drift.

## Impact
This keeps the scope tight to the recently changed paths while reducing the chance of those fixes regressing in future refactors.

## Validation
- `pytest tests/integration/test_api_dedupe_routes.py tests/methodologies/para/test_feature_extractor.py -q --override-ini=addopts=`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test verifying the deduplication endpoint responds successfully when a configured keep file is missing, returns no removed files, and preserves the existing file.
  * Added a unit test confirming metadata extraction clamps tiny negative time offsets so days-since and access-frequency values are non-negative/normalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->