### PR TITLE
fix(daemon): make PID liveness check portable on Windows (fix CI Full Matrix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ dev = [
     "pytest-timeout>=2.2.0,<2.5.0",  # 2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture)
     "pytest-xdist~=3.5",
     "pytest-randomly~=3.15",
-    "mypy~=1.8",
+    "mypy>=1.8,<1.20",  # 1.20.x regression: INTERNAL ERROR crash in the mypy-changed CI hook (python/mypy); pin below until fixed upstream
     "types-PyYAML~=6.0",
     "ruff>=0.1.0",  # 0.x — unstable API, keep >=
     "black>=23.12,<27.0",

--- a/src/file_organizer/daemon/pid.py
+++ b/src/file_organizer/daemon/pid.py
@@ -153,6 +153,11 @@ class PidFileManager:
             # Signal 0 checks process existence without sending a signal.
             os.kill(pid, 0)
             return True
+        except OverflowError:
+            # A corrupted PID file can hold an integer too large for the
+            # platform's pid_t; such a process cannot exist.
+            logger.debug("PID %d is outside the supported range", pid)
+            return False
         except ProcessLookupError:
             # Process does not exist
             logger.debug("PID %d is not running (stale PID file)", pid)

--- a/src/file_organizer/daemon/pid.py
+++ b/src/file_organizer/daemon/pid.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -114,8 +115,42 @@ class PidFileManager:
         if pid is None:
             return False
 
+        # A non-positive PID is never a real process. On POSIX, os.kill(0, 0)
+        # and os.kill(-1, 0) broadcast to entire process groups rather than
+        # probing a single process, so reject them up front.
+        if pid <= 0:
+            logger.debug("PID %d is not a valid process id", pid)
+            return False
+
+        return self._pid_is_alive(pid)
+
+    @staticmethod
+    def _pid_is_alive(pid: int) -> bool:
+        """Return True if a process with the given PID currently exists.
+
+        This is a liveness probe, not a signal: it must never affect the
+        target process.
+
+        On POSIX, sending signal 0 with os.kill is the portable existence
+        check. On Windows, os.kill does **not** support signal 0 as a probe —
+        for any signal other than CTRL_C/CTRL_BREAK it calls TerminateProcess,
+        which would *kill* the target (including this very process when the
+        recorded PID is our own). psutil.pid_exists is used there instead.
+
+        Args:
+            pid: A positive process id to check.
+
+        Returns:
+            True if the process exists, False otherwise.
+        """
+        if sys.platform == "win32":
+            # Avoid os.kill on Windows: it maps signal 0 to TerminateProcess.
+            import psutil
+
+            return psutil.pid_exists(pid)
+
         try:
-            # Signal 0 checks process existence without sending a signal
+            # Signal 0 checks process existence without sending a signal.
             os.kill(pid, 0)
             return True
         except ProcessLookupError:

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -204,6 +204,20 @@ class TestIsRunning:
         ):
             assert pid_manager.is_running(pid_file) is False
 
+    def test_huge_pid_not_running(self, pid_manager: PidFileManager, pid_file: Path) -> None:
+        """A corrupted PID file with an out-of-range PID is not running.
+
+        On POSIX, os.kill raises OverflowError (not OSError) for an integer
+        larger than the platform's pid_t. is_running must absorb it and return
+        False rather than letting it crash callers like `daemon status`.
+        """
+        pid_file.write_text(str(10**100))
+        with (
+            mock.patch("file_organizer.daemon.pid.sys.platform", "linux"),
+            mock.patch("file_organizer.daemon.pid.os.kill", side_effect=OverflowError),
+        ):
+            assert pid_manager.is_running(pid_file) is False
+
     def test_is_running_on_windows_reports_dead_pid(
         self, pid_manager: PidFileManager, pid_file: Path
     ) -> None:

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -142,3 +143,55 @@ class TestIsRunning:
         """is_running returns False for an empty PID file."""
         pid_file.write_text("")
         assert pid_manager.is_running(pid_file) is False
+
+    @pytest.mark.parametrize("bad_pid", ["0", "-1"])
+    def test_non_positive_pid_not_running(
+        self, pid_manager: PidFileManager, pid_file: Path, bad_pid: str
+    ) -> None:
+        """is_running rejects non-positive PIDs without probing.
+
+        os.kill(0, 0) / os.kill(-1, 0) broadcast to whole process groups on
+        POSIX, so a 0 or negative PID must short-circuit to False and must
+        never reach os.kill.
+        """
+        pid_file.write_text(bad_pid)
+        with mock.patch("file_organizer.daemon.pid.os.kill") as mock_kill:
+            assert pid_manager.is_running(pid_file) is False
+        mock_kill.assert_not_called()
+
+    def test_is_running_on_windows_uses_psutil_not_os_kill(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """On Windows, is_running must use psutil.pid_exists, never os.kill.
+
+        os.kill on Windows maps signal 0 to TerminateProcess, so probing the
+        current PID with os.kill would terminate this process. This regression
+        guards the Windows CI hang/abort caused by that behavior.
+        """
+        pid_file.write_text(str(os.getpid()))
+        fake_psutil = mock.MagicMock()
+        fake_psutil.pid_exists.return_value = True
+        with (
+            mock.patch("file_organizer.daemon.pid.sys.platform", "win32"),
+            mock.patch("file_organizer.daemon.pid.os.kill") as mock_kill,
+            mock.patch.dict("sys.modules", {"psutil": fake_psutil}),
+        ):
+            assert pid_manager.is_running(pid_file) is True
+        mock_kill.assert_not_called()
+        fake_psutil.pid_exists.assert_called_once_with(os.getpid())
+
+    def test_is_running_on_windows_reports_dead_pid(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """On Windows, a PID psutil reports as absent is not running."""
+        pid_file.write_text("4000000")
+        fake_psutil = mock.MagicMock()
+        fake_psutil.pid_exists.return_value = False
+        with (
+            mock.patch("file_organizer.daemon.pid.sys.platform", "win32"),
+            mock.patch("file_organizer.daemon.pid.os.kill") as mock_kill,
+            mock.patch.dict("sys.modules", {"psutil": fake_psutil}),
+        ):
+            assert pid_manager.is_running(pid_file) is False
+        mock_kill.assert_not_called()
+        fake_psutil.pid_exists.assert_called_once_with(4000000)

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -195,9 +195,7 @@ class TestIsRunning:
         ):
             assert pid_manager.is_running(pid_file) is True
 
-    def test_generic_oserror_not_running(
-        self, pid_manager: PidFileManager, pid_file: Path
-    ) -> None:
+    def test_generic_oserror_not_running(self, pid_manager: PidFileManager, pid_file: Path) -> None:
         """On POSIX, any other OSError from os.kill is treated as not running."""
         pid_file.write_text("12345")
         with (

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -15,7 +15,7 @@ import pytest
 
 from file_organizer.daemon.pid import PidFileManager
 
-pytestmark = [pytest.mark.unit, pytest.mark.smoke]
+pytestmark = [pytest.mark.unit, pytest.mark.smoke, pytest.mark.ci]
 
 
 @pytest.fixture
@@ -179,6 +179,32 @@ class TestIsRunning:
             assert pid_manager.is_running(pid_file) is True
         mock_kill.assert_not_called()
         fake_psutil.pid_exists.assert_called_once_with(os.getpid())
+
+    def test_permission_error_means_running(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """On POSIX, an EPERM from os.kill means the process exists.
+
+        A process owned by another user raises PermissionError for signal 0,
+        which still proves the process is alive.
+        """
+        pid_file.write_text("12345")
+        with (
+            mock.patch("file_organizer.daemon.pid.sys.platform", "linux"),
+            mock.patch("file_organizer.daemon.pid.os.kill", side_effect=PermissionError),
+        ):
+            assert pid_manager.is_running(pid_file) is True
+
+    def test_generic_oserror_not_running(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """On POSIX, any other OSError from os.kill is treated as not running."""
+        pid_file.write_text("12345")
+        with (
+            mock.patch("file_organizer.daemon.pid.sys.platform", "linux"),
+            mock.patch("file_organizer.daemon.pid.os.kill", side_effect=OSError),
+        ):
+            assert pid_manager.is_running(pid_file) is False
 
     def test_is_running_on_windows_reports_dead_pid(
         self, pid_manager: PidFileManager, pid_file: Path


### PR DESCRIPTION
## Why the Windows full-matrix job was failing

The nightly **CI Full Matrix** `Test Windows (Python 3.12)` job has failed every run while Linux/macOS pass. I pulled the actual failed-job logs rather than trusting the path-separator hypothesis in the supplied playbook — and the signature is a different class:

```
collected 19041 items / 14763 deselected / 4278 selected
...
tests\daemon\test_pid.py ...............
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======== 3749 passed, 2 skipped, 14763 deselected in 524.76s ========
Traceback (most recent call last):
  File ".../pytest_timeout.py", line 518, in timeout_timer
    stdout, stderr = capman.read_global_capture()
  File ".../_pytest/capture.py", line 779, in read_global_capture
    assert self._global_capturing is not None
AssertionError
##[error]Process completed with exit code 1.
```

Key observations across two nightly runs (different random seeds):
- The abort is **always anchored to `tests/daemon/test_pid.py`** — at 87% in one run, 23% in another. Not order-dependent → not flaky; a specific test there is fatal.
- ~527 of the 4278 selected tests never ran because the session was torn down mid-flight.

### Root cause

`PidFileManager.is_running()` probed process existence with `os.kill(pid, 0)`. On POSIX, signal 0 is the portable existence check. **On Windows, `os.kill` does not support signal 0 as a probe** — for any signal other than `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` it calls `TerminateProcess(handle, sig)`. So `test_current_process_is_running` → `is_running` → `os.kill(os.getpid(), 0)` **attempted to terminate the pytest process itself**, producing the `KeyboardInterrupt` + pytest-timeout `capman` `AssertionError` + exit code 1.

This is also a genuine **production correctness bug**: the daemon's liveness check never worked on Windows.

I verified the mechanism by simulating Windows `os.kill` semantics: the old path raises "would TerminateProcess self"; the new path returns the right answer via `psutil.pid_exists` and never touches `os.kill`.

## Fix

- Probe liveness through a `_pid_is_alive()` helper. On `win32`, use `psutil.pid_exists` (psutil is already a **core** dependency). Elsewhere, keep the existing `os.kill(pid, 0)` semantics unchanged — the green POSIX path is untouched.
- Reject non-positive PIDs up front (`os.kill(0, 0)` / `os.kill(-1, 0)` broadcast to whole process groups on POSIX — a latent bug).
- Regression tests: assert the win32 path uses `psutil.pid_exists` and **never** calls `os.kill`; cover the non-positive-PID guard and the win32 dead-PID case.

All other `os.kill` references in the test suite are mocked, so they were never the cause; `test_dead_pid_not_running` (pid 4000000) calls real `os.kill` on Windows but `OpenProcess` on a non-existent PID fails harmlessly.

## Validation

- `tests/daemon/` — 118 passed (19 in `test_pid.py`, incl. 4 new).
- `ruff` + `mypy` clean on changed files.
- Cross-platform behavior verified by simulating both the old (self-terminating) and new (psutil) `os.kill` regimes.
- Next: dispatching `ci-full.yml` (`workflow_dispatch`) against this branch to confirm the real `windows-latest` job goes green end-to-end.

https://claude.ai/code/session_01YGpwVnaLBREGnpoYZkz6iD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGpwVnaLBREGnpoYZkz6iD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon process liveness detection with safer edge-case handling and better cross-platform behavior (Windows and POSIX).

* **Tests**
  * Added comprehensive tests covering non-positive, permission, overflow/corrupted, and platform-specific PID scenarios.

* **Chores**
  * Relaxed mypy dev dependency constraint from `~=1.8` to `>=1.8,<1.20`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->