### PR TITLE
feat(security): path-safety primitives (WP-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Path-safety primitives (WP-1.1, pull-back from fo-core)** — added `file_organizer.utils.safedir`
+  (`SafeDir`, a POSIX `dir_fd`+`O_NOFOLLOW` primitive that rejects symlink traversal and path-component
+  injection, raising `SymlinkRejected`), `file_organizer.core.path_guard` (`validate_within_roots`,
+  `safe_walk`, `PathTraversalError`), and `file_organizer.cli.path_validation` (`resolve_cli_path`,
+  `validate_pair`). Foundation for the symlink/TOCTOU hardening series; not yet wired into call sites.
+
 ### Changed
 
 - **Desktop app consolidated on pywebview** — removed the Tauri v2 / Rust / sidecar architecture

--- a/src/file_organizer/cli/path_validation.py
+++ b/src/file_organizer/cli/path_validation.py
@@ -1,0 +1,147 @@
+"""CLI-layer path validation — the user-input boundary for fo commands.
+
+Epic A.cli (hardening roadmap #154, §2.5) wires every path-taking CLI
+command through this helper before any filesystem operation. Two public
+surfaces:
+
+- ``resolve_cli_path(path, *, must_exist, must_be_dir)`` — resolve a single
+  argument, surface existence / type errors as ``typer.BadParameter``
+  (so typer prints a usage-level error rather than a traceback).
+- ``validate_pair(input_dir, output_dir)`` — cross-argument coherence
+  for commands that take both an input and an output directory. Rejects
+  the classic ``organize IN IN/sub`` footgun where output sits inside
+  input, plus the mirror case and the identity case.
+
+Neither helper uses ``core.path_guard.validate_within_roots`` directly:
+that helper is for validating *derived* paths against a pre-declared
+root set (used inside service-layer walkers). The CLI boundary doesn't
+have a pre-declared root — the user's arguments **are** the roots.
+This helper exists to resolve + sanity-check those arguments before
+they become the allowed roots for downstream code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+
+def _resolve_user_path(path: Path) -> Path:
+    """Resolve ``path`` with all resolution failures surfaced as ``BadParameter``.
+
+    ``Path.resolve()`` raises ``RuntimeError`` (Python < 3.13) or ``OSError``
+    (Python >= 3.13) on symlink loops and other OS-level resolution failures;
+    ``Path.expanduser()`` raises ``RuntimeError`` for unknown ``~user``. The
+    CLI contract is to surface these as ``BadParameter`` (typer usage error,
+    exit 2) rather than letting a raw traceback escape.
+    """
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        raise typer.BadParameter(f"Unable to resolve path {path!s}: {exc}") from exc
+
+
+def resolve_cli_path(
+    path: Path,
+    *,
+    must_exist: bool = True,
+    must_be_dir: bool = True,
+) -> Path:
+    """Resolve a CLI path argument and validate it at the argparse boundary.
+
+    Normalises ``..``, resolves symlinks, anchors relatives against the
+    current working directory, and — by default — asserts the path exists
+    and is a directory. Callers that accept a file (``fo analyze FILE``)
+    or a not-yet-created output directory (``fo organize IN OUT`` where
+    OUT doesn't exist yet) opt out via the two keyword flags.
+
+    Args:
+        path: The typer-delivered ``Path`` argument. May be relative,
+            contain ``..``, or be a symlink — all normalised.
+        must_exist: If True (default), raise ``typer.BadParameter`` when
+            the resolved path is not on disk. Pass False for commands
+            that intentionally create the path.
+        must_be_dir: If True (default), raise ``typer.BadParameter`` when
+            the resolved path exists but is not a directory. Pass False
+            for commands that take a file argument.
+
+    Returns:
+        The resolved absolute ``Path`` — downstream code can rely on
+        ``.is_absolute()`` and a fully-normalised form.
+
+    Raises:
+        typer.BadParameter: Missing path (when ``must_exist=True``),
+            path-exists-but-not-a-directory (when ``must_be_dir=True``), or
+            any OS-level resolution failure (symlink loop, unknown ``~user``).
+            Typer renders these as ``Usage: ... Invalid value ...`` rather
+            than a Python traceback.
+    """
+    resolved = _resolve_user_path(path)
+
+    if must_exist and not resolved.exists():
+        raise typer.BadParameter(f"Path does not exist: {path!s} (resolved to {resolved!s})")
+    if must_be_dir and resolved.exists() and not resolved.is_dir():
+        raise typer.BadParameter(
+            f"Path exists but is not a directory: {path!s} (resolved to {resolved!s})"
+        )
+    return resolved
+
+
+def validate_pair(input_dir: Path, output_dir: Path) -> None:
+    """Reject incoherent input/output directory pairs at the CLI boundary.
+
+    Three cases are flagged:
+
+    - **output inside input**: ``fo organize ~/docs ~/docs/sorted`` would
+      have the organizer write destination files into the same tree it's
+      reading. User almost certainly meant a sibling directory.
+    - **input inside output**: mirror image — the organizer could walk
+      into the output tree while scanning the input.
+    - **identical paths**: ``fo organize X X`` is never legitimate —
+      read-and-write on the same tree.
+
+    All three resolve both paths before comparing, so a symlink pointing
+    back into the sibling tree is caught just like a literal nested path.
+
+    Args:
+        input_dir: Input directory — resolved defensively even though callers
+            typically pass an already-resolved path from ``resolve_cli_path``.
+            The re-resolve is load-bearing for symlink-based evasion: a caller
+            that passed ``Path("out_link")`` pointing at ``in_dir/subdir``
+            would slip past the ``relative_to`` comparison without it.
+        output_dir: Output directory — resolved defensively (same reasoning).
+
+    Raises:
+        typer.BadParameter: When the pair is incoherent by any of the
+            three rules above, OR when resolution itself fails (symlink
+            loop, unknown ``~user``). The message names the specific
+            violation so the user can spot the argument ordering mistake.
+    """
+    in_resolved = _resolve_user_path(input_dir)
+    out_resolved = _resolve_user_path(output_dir)
+
+    if in_resolved == out_resolved:
+        raise typer.BadParameter(
+            f"Input and output refer to the same path: {in_resolved!s}. Pass different directories."
+        )
+    try:
+        out_resolved.relative_to(in_resolved)
+    except ValueError:
+        pass
+    else:
+        raise typer.BadParameter(
+            f"Output directory {output_dir!s} (resolved to {out_resolved!s}) "
+            f"is inside the input directory {input_dir!s}. The organizer "
+            "would write to the same tree it's reading."
+        )
+    try:
+        in_resolved.relative_to(out_resolved)
+    except ValueError:
+        pass
+    else:
+        raise typer.BadParameter(
+            f"Input directory {input_dir!s} (resolved to {in_resolved!s}) "
+            f"is inside the output directory {output_dir!s}. The organizer "
+            "would walk the output tree while scanning the input."
+        )

--- a/src/file_organizer/core/path_guard.py
+++ b/src/file_organizer/core/path_guard.py
@@ -1,0 +1,202 @@
+"""Path-validation and safe-walk helpers for CLI commands.
+
+Epic A.foundation (hardening roadmap #154). Provides two primitives:
+
+- `validate_within_roots(path, allowed_roots)` — assert `path` resolves inside
+  one of the supplied roots and return its canonical absolute form. Raises
+  `PathTraversalError` otherwise. A.cli wires this into every CLI command
+  that accepts a path argument (see Appendix A.4 of the roadmap spec for
+  the full command surface).
+- `safe_walk(root, *, follow_symlinks=False, include_hidden=False)` — yield
+  files under `root`, filtering symlinks and hidden entries by default.
+  Replaces raw `rglob("*")` / `glob("*")` in the **user-input walker
+  surfaces** migrated by A.foundation: analytics, pattern analysis,
+  misplacement detection, dedup detection, copilot, JD/PARA scans, and
+  the `cli/{benchmark,doctor,suggest,utilities}` search/scan commands.
+  System-managed walkers that operate on app-owned state are deliberately
+  out of scope (see *Scope note* below) and continue to use `glob`/`rglob`
+  until they cross a user-input boundary.
+
+Scope note — system-managed paths that *don't* need `safe_walk`:
+
+- `undo/validator.py` (trash directory, system-managed)
+- `services/copilot/rules/rule_manager.py` (app-shipped rule yamls)
+- `services/intelligence/profile_{manager,migrator}.py` (profile/backup dir)
+- `config/path_migration.py` (legacy XDG migration, run once)
+- `parallel/persistence.py` (job-queue state, internal only)
+- `methodologies/para/migration_manager.py` (internal migration helper)
+- `core/file_ops.py::collect_files` (called on a pre-validated organize
+  root; safe_walk adoption here tracked as a follow-up)
+
+Design invariants:
+
+- `validate_within_roots()` returns/compares **resolved** paths: input and
+  roots are normalized via `Path.resolve()` before any comparison or
+  traversal-check, so callers get the canonical form back and don't need
+  to re-resolve. `safe_walk()` yields the *lexical* paths produced by
+  `Path.glob()` / `Path.rglob()` after applying its filters — callers
+  that need canonical paths should resolve them explicitly.
+- `PathTraversalError` is a `ValueError` subclass so existing
+  `except ValueError` handlers keep working.
+- `safe_walk`'s hidden-file filter applies to the path **relative to `root`**
+  — if the caller explicitly walks a hidden directory (e.g. scanning
+  `.git/` intentionally), the root component doesn't veto every descendant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+
+class PathTraversalError(ValueError):
+    """Raised when a path escapes the declared set of allowed roots.
+
+    Subclasses `ValueError` so callers that want to catch this specifically
+    can do so, while generic `except ValueError` paths continue to work.
+    """
+
+
+def validate_within_roots(path: Path, allowed_roots: Iterable[Path]) -> Path:
+    """Resolve `path` and assert it lives inside one of `allowed_roots`.
+
+    Returns the resolved absolute path. Raises `PathTraversalError` if:
+
+    - `allowed_roots` is empty (no roots = nothing is allowed).
+    - The resolved path is outside every resolved root.
+
+    Each root is resolved before comparison, so symlinked roots are handled
+    correctly. A resolved path exactly equal to a root is allowed (e.g.
+    `fo analyze DIR` where the directory itself is the target).
+
+    Args:
+        path: The path to validate. May be relative, contain `..`, or be a
+            symlink — all normalized by `Path.resolve()`.
+        allowed_roots: The set of directories the path must be inside.
+            Typically the CLI command's input and output directories plus
+            any configured system locations (trash, cache) that the command
+            legitimately touches.
+
+    Returns:
+        The resolved absolute form of `path`.
+
+    Raises:
+        PathTraversalError: If `allowed_roots` is empty, if `path`
+            resolves outside every root, or if `path.resolve()` itself
+            fails (cyclic symlink, stale handle). Callers expecting
+            `PathTraversalError` / `ValueError` shouldn't have to also
+            handle `RuntimeError` from the resolver.
+    """
+    try:
+        roots = [r.resolve() for r in allowed_roots]
+    except (RuntimeError, OSError) as exc:
+        raise PathTraversalError(f"Failed to resolve allowed roots: {exc}") from exc
+    if not roots:
+        raise PathTraversalError(f"No allowed roots declared; cannot validate {path!r}")
+    try:
+        resolved = path.resolve()
+    except (RuntimeError, OSError) as exc:
+        raise PathTraversalError(
+            f"Failed to resolve {path!r} (likely a symlink cycle or stale handle): {exc}"
+        ) from exc
+    for root in roots:
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            continue
+        return resolved
+    raise PathTraversalError(
+        f"Path {path!r} (resolved to {resolved!r}) is outside allowed roots: "
+        f"{[str(r) for r in roots]}"
+    )
+
+
+def safe_walk(
+    root: Path,
+    *,
+    pattern: str = "*",
+    recursive: bool = True,
+    only_files: bool = True,
+    follow_symlinks: bool = False,
+    include_hidden: bool = False,
+) -> Iterator[Path]:
+    """Walk `root` with security filters.
+
+    Drop-in replacement for raw `rglob("*")` / `glob("*")` in every
+    user-supplied-root walker.
+
+    Default filters (security-safe):
+
+    - Symlinks (both file and directory symlinks) are skipped — their
+      targets may live outside `root` (e.g. a malicious symlink from
+      `indexed_dir/escape -> /etc/passwd`).
+    - Hidden entries — any path with a component that starts with `.`,
+      relative to `root` — are skipped. Catches `.git/`, `.env`,
+      `.ssh/authorized_keys`, and similar credential-bearing paths.
+
+    The hidden-file check is relative to `root`: if `root` itself is a
+    hidden directory (`.config/fo/…`), descendants with non-hidden parts
+    are still yielded. Only components inside the walked subtree are
+    filtered.
+
+    Args:
+        root: Directory to walk. If it doesn't exist, yields nothing.
+        pattern: Glob pattern to match. Default `"*"` (every entry).
+        recursive: If True, walk recursively (`rglob`); if False, walk
+            only the top level (`glob`). Default True.
+        only_files: If True (default), yield files only — directories are
+            filtered out. Pass False to yield directories and other
+            non-file entries too (used by e.g. empty-directory cleanup).
+        follow_symlinks: If True, include symlinked *files* in the output.
+            **Does not descend into symlinked directories** on Python
+            3.11–3.12 because `Path.rglob()` / `Path.glob()` never
+            recurse through directory symlinks on those versions (the
+            `recurse_symlinks` parameter only exists in 3.13+). Default
+            False (secure — skip symlink entries entirely).
+        include_hidden: If True, include dot-prefixed files and descendants
+            of dot-prefixed directories. Default False (secure).
+
+    Yields:
+        `Path` objects for each entry under `root` that matches `pattern`
+        and passes the filters.
+    """
+    try:
+        if not root.exists():
+            return
+        # Reject a symlinked root when follow_symlinks=False. Without this,
+        # `rglob()` on a directory symlink enumerates the target tree —
+        # including paths outside the caller's allowed root — before the
+        # per-entry symlink filter ever runs (the first yielded entries
+        # are descendants, not the symlink itself).
+        if not follow_symlinks and root.is_symlink():
+            return
+    except OSError:
+        return
+    glob_iter = root.rglob(pattern) if recursive else root.glob(pattern)
+    for entry in glob_iter:
+        # Per-entry OSError (PermissionError, stale NFS handle, etc.) skips
+        # that entry instead of aborting the whole walk — walkers like the
+        # doctor scan need to continue past inaccessible siblings.
+        try:
+            if not follow_symlinks and entry.is_symlink():
+                continue
+            # Hidden filter is relative to root so an explicit scan of a
+            # hidden directory doesn't get vetoed by the root component.
+            # Lexical `relative_to` (no `resolve()`) avoids a per-entry
+            # `realpath` syscall — safe because rglob/glob on Python
+            # 3.11–3.13 doesn't descend into directory symlinks, so every
+            # yielded entry lives lexically under root.
+            if not include_hidden:
+                try:
+                    rel_parts = entry.relative_to(root).parts
+                except ValueError:
+                    # Defensive: rglob yielded something outside root
+                    # (race with a concurrent rename/delete). Skip.
+                    continue
+                if any(part.startswith(".") for part in rel_parts):
+                    continue
+            if only_files and not entry.is_file():
+                continue
+        except OSError:
+            continue
+        yield entry

--- a/src/file_organizer/utils/safedir.py
+++ b/src/file_organizer/utils/safedir.py
@@ -1,0 +1,579 @@
+r"""POSIX-safe directory-fd filesystem operations.
+
+Implementation of #266 in the security hardening series (#264). The
+``SafeDir`` primitive holds an open directory file descriptor and routes
+every operation through ``dir_fd=`` + ``O_NOFOLLOW``. PRs 3–6 thread it
+through the read-side ingestion, dedupe, undo, and watcher paths.
+
+Design invariants:
+
+- **Every method takes a path *component*, never a path.** Names
+  containing ``/``, ``\\``, ``..``, ``.``, NUL, or empty strings are
+  rejected with ``ValueError`` before any syscall. This makes
+  attacker-controlled segments — file content, AI output, watcher event
+  payloads — unable to escape the held directory.
+- **``O_NOFOLLOW`` is always set on opens.** On Linux this raises
+  ``ELOOP`` when the named entry is a symlink; we translate that to a
+  typed ``SymlinkRejected`` (subclass of ``OSError``) so callers can
+  catch the security-relevant case specifically while generic
+  ``except OSError`` paths continue to work.
+- **No path-string reconstruction.** Every syscall uses
+  ``dir_fd=self.fd`` with the bare component. There is no code path
+  that builds ``str(self.path) + "/" + name`` and hands it to a syscall.
+- **fd lifetime is via context manager only.** The ``__exit__`` releases
+  the held fd; double-exit is harmless. The class deliberately does not
+  expose a public ``close()`` to discourage leak-prone usage patterns.
+
+Platform: POSIX only. Windows has no equivalent for ``dir_fd=`` /
+``O_NOFOLLOW``; ``open_root`` raises ``NotImplementedError`` there. PR
+CI is Linux; nightly Windows runs skip the dependent test modules. See
+#264 for the deferral rationale.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path, PurePath
+from types import TracebackType
+from typing import Self
+
+__all__ = ["SafeDir", "SymlinkRejected"]
+
+
+_INVALID_NAME_CHARS = frozenset({"/", "\\", "\x00"})
+_RESERVED_NAMES = frozenset({"", ".", ".."})
+
+# ``O_PATH`` (Linux 2.6.39+) has a surprising interaction with ``O_NOFOLLOW``:
+# instead of refusing to dereference a symlink, the pair returns an fd
+# referring to the symlink itself. That breaks the documented contract of
+# ``open_child`` ("if the entry is a symlink, raises SymlinkRejected") — any
+# caller that later uses the resulting fd for an inode-pinning or existence
+# check would silently operate on the symlink. Reject the flag at the API
+# boundary; if a future caller genuinely needs ``O_PATH`` semantics, ship
+# a dedicated method that handles the post-open ``fstat(S_ISLNK)`` check.
+# On platforms that don't define ``O_PATH`` (macOS, BSD), the bug doesn't
+# exist; the guard falls through harmlessly via the ``getattr`` default.
+_O_PATH = getattr(os, "O_PATH", 0)
+
+
+class SymlinkRejected(OSError):
+    """Raised when a SafeDir operation refuses to dereference a symlink.
+
+    Subclasses ``OSError`` so existing ``except OSError`` paths continue
+    to work while security-relevant callers can catch this specifically.
+    The original ``OSError`` (``errno=ELOOP``) is wrapped, not replaced —
+    ``__cause__`` / ``__context__`` carry the underlying error.
+    """
+
+
+def _validate_name(name: str) -> None:
+    r"""Reject anything that isn't a single safe path component.
+
+    Raises ``ValueError`` for any of:
+
+    - Reserved (``""``, ``"."``, ``".."``).
+    - Contains path-separator characters (``/`` on POSIX, plus ``\\``
+      defensively — even on POSIX, ``\\`` in a filename is unusual and
+      catching it here matches the Windows-portable invariant if/when
+      ``SafeDir`` ships on Windows).
+    - Contains NUL.
+
+    This runs *before* any syscall so traversal payloads never reach the
+    kernel.
+    """
+    if not isinstance(name, str):
+        raise ValueError(f"name must be str, got {type(name).__name__}")
+    if name in _RESERVED_NAMES:
+        raise ValueError(f"reserved component name: {name!r}")
+    for ch in name:
+        if ch in _INVALID_NAME_CHARS:
+            raise ValueError(f"name contains forbidden character {ch!r}: {name!r}")
+
+
+def _wrap_open_errno(err: OSError, name: str) -> OSError:
+    """Translate symlink-related open failures into ``SymlinkRejected``.
+
+    On Linux, ``os.open(path, O_DIRECTORY | O_NOFOLLOW)`` against a
+    symlink-to-directory returns ``ENOTDIR`` (because the symlink inode
+    itself isn't a directory) rather than ``ELOOP``. On a regular-file
+    target with ``O_NOFOLLOW`` you get ``ELOOP``. Callers can't tell
+    these apart from the errno alone, so we map both through this
+    helper. Non-symlink causes (``ENOTDIR`` against a regular file when
+    ``O_DIRECTORY`` was set) are passed through unchanged.
+
+    Disambiguation requires an extra ``lstat`` — see
+    ``_check_symlink_under`` below.
+    """
+    if err.errno == errno.ELOOP:
+        wrapped = SymlinkRejected(
+            err.errno,
+            f"refused to open symlinked entry: {name!r}",
+            err.filename,
+        )
+        wrapped.__cause__ = err
+        return wrapped
+    return err
+
+
+def _raise_symlink_rejected(name: str, cause: OSError) -> None:
+    """Raise ``SymlinkRejected`` chained to *cause*."""
+    wrapped = SymlinkRejected(
+        cause.errno,
+        f"refused to open symlinked entry: {name!r}",
+        cause.filename,
+    )
+    wrapped.__cause__ = cause
+    raise wrapped
+
+
+def _is_symlink_at(name: str, dir_fd: int) -> bool:
+    """True if *name* under *dir_fd* is a symlink, False otherwise.
+
+    Used after an open fails to disambiguate ``ENOTDIR``-on-symlink from
+    ``ENOTDIR``-on-regular-file. Returns False on any stat failure (the
+    entry vanished, permissions changed, etc.) — the caller will then
+    re-raise the original open error, which is the correct behavior:
+    the open didn't follow a symlink, so we don't owe a
+    ``SymlinkRejected``.
+    """
+    try:
+        st = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    import stat as _stat
+
+    return _stat.S_ISLNK(st.st_mode)
+
+
+class SafeDir:
+    """Holds an open directory fd; every operation uses ``dir_fd=`` + ``O_NOFOLLOW``.
+
+    Construct via ``SafeDir.open_root(path)`` — direct construction is
+    not part of the public API. Always use as a context manager so the
+    fd is released:
+
+        with SafeDir.open_root(organize_root) as sd:
+            with sd.open_subdir("documents") as sub:
+                for entry in sub.scandir():
+                    ...
+    """
+
+    __slots__ = ("_fd", "_closed")
+
+    def __init__(self, fd: int) -> None:
+        """Wrap an already-open directory fd.
+
+        Internal — public construction goes through ``open_root``;
+        ``open_subdir`` uses this directly to wrap the fd it has just
+        opened. The constructor does not validate that *fd* is a
+        directory fd; callers must.
+        """
+        self._fd = fd
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Construction & lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def open_root(cls, path: str | os.PathLike[str]) -> Self:
+        """Open *path* as the root of a SafeDir.
+
+        *path* is the only place a multi-component path enters this API —
+        every subsequent operation must use single component names.
+        Accepts ``str`` and ``os.PathLike`` (including ``pathlib.Path``);
+        the value is normalized to ``Path`` at the entry boundary.
+
+        Raises:
+            NotImplementedError: On Windows. ``dir_fd=`` and
+                ``O_NOFOLLOW`` are POSIX-only; the Windows port is
+                deferred (see #264).
+            SymlinkRejected: If *path* itself is a symlink. The caller
+                must hand a real directory; we don't follow whatever it
+                might point at.
+            OSError: If *path* doesn't exist, isn't a directory, or
+                can't be opened.
+        """
+        if sys.platform == "win32":  # pragma: no cover - platform skip
+            raise NotImplementedError(
+                "SafeDir requires POSIX dir_fd / O_NOFOLLOW support; Windows port deferred (#264)"
+            )
+        # Normalize at the boundary so str/PathLike callers (CLI args,
+        # un-typed config values) don't trip on ``path.is_symlink()`` below
+        # with AttributeError instead of the documented SymlinkRejected /
+        # OSError. The conversion is idempotent for an existing Path.
+        path = Path(path)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            fd = os.open(str(path), flags)
+        except OSError as exc:
+            # ``O_DIRECTORY | O_NOFOLLOW`` against a symlink-to-dir returns
+            # ENOTDIR on Linux (the symlink inode isn't a directory).
+            # Disambiguate via lstat — symlink → SymlinkRejected, anything
+            # else → propagate.
+            if exc.errno == errno.ELOOP or (exc.errno == errno.ENOTDIR and path.is_symlink()):
+                _raise_symlink_rejected(str(path), exc)
+            raise _wrap_open_errno(exc, str(path)) from exc
+        return cls(fd)
+
+    @property
+    def fd(self) -> int:
+        """Underlying directory fd (read-only, intended for diagnostics).
+
+        Callers should *not* perform syscalls on this fd directly — use
+        the methods on this class instead, which keep the
+        ``dir_fd=`` + ``O_NOFOLLOW`` invariant.
+
+        Raises ``ValueError`` if the SafeDir has been closed: the
+        stored fd would be -1, and reading it would invite the caller
+        into operating on whatever (unrelated) directory POSIX
+        eventually recycles the original fd number for.
+        """
+        self._check_open()
+        return self._fd
+
+    def _check_open(self) -> None:
+        """Raise ``ValueError`` if this SafeDir has already been closed.
+
+        POSIX fd numbers are recycled — if a caller retains a
+        ``SafeDir`` past its ``__exit__`` and then invokes a method on
+        it, the underlying ``dir_fd=`` would address whatever
+        directory the kernel reassigned the fd to (any subsequent
+        ``os.open``, including unrelated ones inside the same process).
+        That's a silent correctness bug: ``scandir`` / ``unlink`` /
+        ``rename_into`` would operate on the wrong directory rather
+        than failing with ``EBADF``. Every public method calls this
+        first so the failure is loud and immediate.
+        """
+        if self._closed:
+            raise ValueError("SafeDir has been closed; cannot use after context-manager exit")
+
+    def __enter__(self) -> Self:
+        """Enter the context manager; return *self* unchanged."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Release the held directory fd. Idempotent on double-exit.
+
+        Closing an already-closed fd would raise ``EBADF``, which is
+        noise in failure-path teardown; suppress it.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        fd_to_close = self._fd
+        # Invalidate the stored fd so accidental late access via
+        # ``self._fd`` can't reach a recycled directory. Even if
+        # ``_check_open`` is bypassed (e.g. via direct attribute access),
+        # a syscall using -1 fails immediately with ``EBADF``.
+        self._fd = -1
+        try:
+            os.close(fd_to_close)
+        except OSError:  # pragma: no cover - defensive
+            pass
+
+    # ------------------------------------------------------------------
+    # Open: file / subdirectory / reader-fd
+    # ------------------------------------------------------------------
+
+    def open_child(self, name: str, *, flags: int = os.O_RDONLY, mode: int = 0o666) -> int:
+        """Open the entry *name* under this directory.
+
+        Always sets ``O_NOFOLLOW``; if the entry is a symlink, raises
+        ``SymlinkRejected``. *flags* is OR-ed in on top so callers can
+        request e.g. ``os.O_WRONLY | os.O_CREAT`` for non-create
+        operations (the SafeDir invariant still holds: the open is
+        anchored to ``self.fd`` and never follows a symlink).
+
+        *mode* is the file permission mode for newly created files (only
+        consulted when ``O_CREAT`` is in *flags*). Defaults to
+        ``0o666`` — matching the high-level ``open()`` builtin so files
+        end up at ``0o644`` under the typical ``022`` umask, NOT
+        ``0o755`` (which the lower-level ``os.open`` would produce with
+        its surprising ``0o777`` default). Callers needing private
+        files can pass ``mode=0o600`` explicitly.
+
+        ``os.O_PATH`` is rejected — on Linux it changes ``O_NOFOLLOW``
+        semantics so the symlink itself is opened rather than refused
+        (see the ``_O_PATH`` module-level note). Callers that need
+        ``O_PATH`` should add a dedicated method that handles the
+        post-open ``S_ISLNK`` check.
+
+        Three errno cases shadow the documented "symlink →
+        SymlinkRejected" contract because their flag combinations fire
+        before the ``O_NOFOLLOW`` path:
+
+        - ``EEXIST`` from ``O_CREAT | O_EXCL`` against an existing
+          symlink — the kernel reports "name taken" before honouring
+          O_NOFOLLOW.
+        - ``ENOTDIR`` from ``O_DIRECTORY`` against a symlink — the
+          symlink inode itself isn't a directory.
+        - ``ELOOP`` — the direct rejection path for the simple
+          ``O_RDONLY | O_NOFOLLOW`` case.
+
+        All three are disambiguated via ``lstat``: if the entry is a
+        symlink, raise ``SymlinkRejected``; otherwise propagate the
+        original error (legitimate "already exists" / "wrong type" cases
+        on non-symlinks). Same pattern as ``open_subdir`` and
+        ``open_root``.
+
+        Returns the opened fd. Caller is responsible for closing it
+        (use ``os.fdopen`` / ``os.close`` / ``contextlib.closing``).
+        """
+        self._check_open()
+        _validate_name(name)
+        if _O_PATH and (flags & _O_PATH):
+            raise ValueError(
+                "open_child does not support O_PATH: O_PATH|O_NOFOLLOW "
+                "would return an fd for the symlink instead of refusing it"
+            )
+        try:
+            return os.open(name, flags | os.O_NOFOLLOW, mode=mode, dir_fd=self._fd)
+        except OSError as exc:
+            # ELOOP is the direct symlink-rejection path. EEXIST shadows
+            # it under O_CREAT|O_EXCL; ENOTDIR shadows it under
+            # O_DIRECTORY. Disambiguate via lstat. Tolerating the
+            # one-syscall TOCTOU between failed open and lstat is fine:
+            # the open already didn't follow a symlink, and a same-name
+            # swap-in just means the entry IS now a symlink, which is
+            # still the security-relevant case.
+            shadowed_by_symlink = exc.errno in (
+                errno.EEXIST,
+                errno.ENOTDIR,
+            ) and _is_symlink_at(name, self._fd)
+            if exc.errno == errno.ELOOP or shadowed_by_symlink:
+                _raise_symlink_rejected(name, exc)
+            raise _wrap_open_errno(exc, name) from exc
+
+    def open_for_reader(self, name: str) -> int:
+        """Open *name* read-only with ``O_NOFOLLOW`` and return its fd.
+
+        The canonical 'pass to a content reader' helper. Wrap with
+        ``os.fdopen(fd, "rb")`` and hand to ``fitz.open(stream=...)`` /
+        ``Image.open(...)`` / ``pypdf.PdfReader(...)`` / etc.
+
+        Raises:
+            ValueError: If *name* isn't a safe component.
+            SymlinkRejected: If *name* is a symlink.
+            FileNotFoundError: If *name* doesn't exist.
+            OSError: For other open failures (permission, etc.).
+        """
+        return self.open_child(name, flags=os.O_RDONLY)
+
+    def open_subdir(self, name: str) -> SafeDir:
+        """Open subdirectory *name* and return a new SafeDir wrapping its fd.
+
+        Use as a context manager so the new fd is released:
+
+            with sd.open_subdir("category") as sub:
+                ...
+        """
+        self._check_open()
+        _validate_name(name)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            fd = os.open(name, flags, dir_fd=self._fd)
+        except OSError as exc:
+            # ENOTDIR can mean "the entry is a symlink (whose own inode
+            # isn't a directory)" or "the entry is a regular file".
+            # ``_is_symlink_at`` resolves the ambiguity.
+            if exc.errno == errno.ELOOP or (
+                exc.errno == errno.ENOTDIR and _is_symlink_at(name, self._fd)
+            ):
+                _raise_symlink_rejected(name, exc)
+            raise _wrap_open_errno(exc, name) from exc
+        return SafeDir(fd)
+
+    def open_anchored_reader(self, relative_path: str | os.PathLike[str]) -> int:
+        """Walk *relative_path* from this SafeDir and open the leaf as a reader fd.
+
+        Each intermediate component is opened via :meth:`open_subdir` (which
+        uses ``O_NOFOLLOW``), and the leaf is opened via
+        :meth:`open_for_reader`. An attacker-controlled ancestor swapped to
+        a symlink between directory enumeration and this read is refused with
+        :class:`SymlinkRejected`, not dereferenced — closes the nested-
+        ancestor TOCTOU window (#286) that the parent-rooted pattern leaves
+        open.
+
+        Args:
+            relative_path: A relative path under this SafeDir. Must not be
+                absolute and must not contain ``..`` components. May be a
+                ``str`` or any ``os.PathLike`` (typically ``PurePath`` /
+                ``Path``).
+
+        Returns:
+            The reader file descriptor for the leaf. Caller owns lifetime —
+            wrap with ``os.fdopen(fd, "rb", closefd=True)`` and close on
+            ``fdopen`` failure (``os.close(fd)``). The intermediate subdir
+            fds opened during traversal are released before this returns.
+
+        Raises:
+            ValueError: If *relative_path* is absolute, contains ``..``, is
+                empty, or any component fails :func:`_validate_name`.
+            SymlinkRejected: If any component (intermediate or leaf) is a
+                symlink at open time.
+            OSError: For other open failures (permission denied, missing
+                component, etc.).
+        """
+        self._check_open()
+        rel = PurePath(relative_path) if not isinstance(relative_path, PurePath) else relative_path
+        if rel.is_absolute():
+            raise ValueError(f"open_anchored_reader requires a relative path, got absolute {rel!r}")
+        parts = rel.parts
+        if not parts:
+            raise ValueError("open_anchored_reader requires a non-empty relative path")
+        if any(part == ".." for part in parts):
+            raise ValueError(f"open_anchored_reader refuses '..' components in {rel!r}")
+        # Walk intermediates inside an ExitStack so any subdir fd is closed
+        # exactly once even if a later component raises. The leaf fd is
+        # handed back open — caller owns its lifetime (see Returns above).
+        with contextlib.ExitStack() as stack:
+            current = self
+            for component in parts[:-1]:
+                current = stack.enter_context(current.open_subdir(component))
+            return current.open_for_reader(parts[-1])
+
+    # ------------------------------------------------------------------
+    # Inspect / list / stat
+    # ------------------------------------------------------------------
+
+    def scandir(self) -> Iterator[str]:
+        """Yield names (``str``) of non-symlink entries in this directory.
+
+        **Returns plain names, not ``os.DirEntry`` objects.** Exposing
+        ``DirEntry`` would let callers reach ``entry.is_file()``,
+        ``entry.is_dir()``, and ``entry.stat()`` — all of which default
+        to ``follow_symlinks=True``. Even after filtering symlinks at
+        scan time, a TOCTOU swap (regular file → symlink) between
+        ``is_symlink()`` and a downstream ``entry.stat()`` would let
+        the caller classify or stat the attacker's target. Returning
+        only the name keeps that footgun out of reach: any subsequent
+        operation must route through SafeDir's own methods, which all
+        enforce ``follow_symlinks=False`` / ``O_NOFOLLOW``.
+
+        Callers needing type/metadata for a yielded name should call
+        ``self.lstat(name)`` and inspect ``S_ISREG`` / ``S_ISDIR`` etc.
+        explicitly. Reads use ``self.open_for_reader(name)``;
+        subdirectories use ``self.open_subdir(name)``. Both are
+        symlink-safe under SafeDir's invariants.
+
+        Symlinks present at scan time are filtered out via the cached
+        ``DirEntry.is_symlink()``. The check uses ``readdir``-cached
+        ``d_type`` rather than a fresh ``lstat``, so a *post*-scan
+        swap-in could still yield a name that has since become a
+        symlink — but that's the caller's atomic check via
+        ``lstat`` / ``open_for_reader`` to handle correctly, and
+        SafeDir's other operations already refuse symlinks.
+
+        The underlying ``os.scandir(self.fd)`` reads the directory by
+        file descriptor (no path-string lookup that could be
+        intercepted). **Names are materialized eagerly** rather than
+        yielded lazily: ``os.scandir(fd)`` internally ``dup``-s the fd,
+        so the ``ScandirIterator`` has its own handle that would
+        survive ``SafeDir.__exit__``. A lazy generator could keep
+        yielding names after the context closed — violating the
+        lifecycle guarantee that operations are bounded by the
+        ``with`` block. Eager materialization also ensures the
+        ``ScandirIterator`` is closed before this method returns, so
+        the dup'd fd doesn't leak.
+
+        For typical SafeDir trees (a user's organize root) directory
+        sizes are bounded by ``safe_walk``-style enumeration limits;
+        materializing N names of average length ~50 bytes costs N×50
+        bytes which is negligible up to ~100K entries.
+        """
+        self._check_open()
+        names: list[str] = []
+        with os.scandir(self._fd) as it:
+            for entry in it:
+                try:
+                    if entry.is_symlink():
+                        continue
+                except OSError:
+                    # Per-entry stat failure (race with deletion,
+                    # permission flip, etc.) — skip defensively. Matches
+                    # safe_walk's stance.
+                    continue
+                names.append(entry.name)
+        return iter(names)
+
+    def lstat(self, name: str) -> os.stat_result:
+        """Stat *name* without following symlinks (``lstat`` semantics).
+
+        Useful for inode-pinning workflows (PR4 / PR5): capture
+        ``(st_dev, st_ino, st_size)`` here, then re-call before any
+        destructive operation and refuse on mismatch.
+        """
+        self._check_open()
+        _validate_name(name)
+        return os.stat(name, dir_fd=self._fd, follow_symlinks=False)
+
+    # ------------------------------------------------------------------
+    # Mutate: create / remove / rename
+    # ------------------------------------------------------------------
+
+    def mkdir(self, name: str, mode: int = 0o755) -> None:
+        """Create a subdirectory *name* relative to this dir's fd.
+
+        The created directory is *not* opened or returned; call
+        ``open_subdir(name)`` afterwards if you need to operate on it.
+        Separating create from open lets the caller decide whether to
+        re-stat or use ``O_DIRECTORY | O_NOFOLLOW`` semantics on the
+        follow-up open.
+        """
+        self._check_open()
+        _validate_name(name)
+        os.mkdir(name, mode=mode, dir_fd=self._fd)
+
+    def unlink(self, name: str) -> None:
+        """Remove a file (not a directory) *name* relative to this dir's fd.
+
+        Uses ``os.unlink`` with ``dir_fd=`` so the unlink target is
+        resolved through the held directory — not via a path string
+        that could be intercepted.
+        """
+        self._check_open()
+        _validate_name(name)
+        os.unlink(name, dir_fd=self._fd)
+
+    def rename_into(self, name: str, other: SafeDir, other_name: str) -> None:
+        """Rename ``self/name`` to ``other/other_name`` atomically.
+
+        Uses ``os.rename(name, other_name, src_dir_fd=self.fd,
+        dst_dir_fd=other.fd)`` — atomic on POSIX within the same
+        filesystem. Both component names are validated.
+
+        **Source is lstat'd before rename and a symlink raises
+        ``SymlinkRejected``.** ``os.rename`` has no ``O_NOFOLLOW``
+        equivalent — if a caller enumerates via ``scandir`` (which
+        filters symlinks) and then a TOCTOU attacker swaps ``name``
+        for a symlink before the rename, the symlink would be moved
+        into the managed destination, contaminating the trusted output
+        tree with a pointer outside the SafeDir root. The lstat check
+        narrows that window from "scan-to-rename" (caller-dependent
+        duration) down to "lstat-to-rename" (~one syscall) — the
+        residual race is acknowledged and acceptable given the kernel
+        offers no atomic alternative.
+
+        Caller is responsible for ensuring ``other`` is on the same
+        filesystem; cross-filesystem renames will raise ``OSError``
+        (``EXDEV``) and the caller must fall back to copy + unlink (see
+        ``undo/durable_move.py`` for the existing pattern).
+        """
+        self._check_open()
+        other._check_open()
+        _validate_name(name)
+        _validate_name(other_name)
+        if _is_symlink_at(name, self._fd):
+            cause = OSError(errno.ELOOP, "refused to rename a symlinked source")
+            _raise_symlink_rejected(name, cause)
+        os.rename(name, other_name, src_dir_fd=self._fd, dst_dir_fd=other._fd)

--- a/tests/cli/test_path_validation.py
+++ b/tests/cli/test_path_validation.py
@@ -1,0 +1,232 @@
+"""Unit tests for src/cli/path_validation.py (Epic A.cli, hardening roadmap #154).
+
+The helper wraps ``core.path_guard.validate_within_roots`` with CLI-specific
+ergonomics: human-readable errors via ``typer.BadParameter`` (so argparse/typer
+surfaces them at the usage boundary rather than bubbling a raw
+``PathTraversalError`` up to an end user), plus default-on existence and
+directory-type checks for commands that take a directory argument.
+
+Covered contracts:
+
+- ``resolve_cli_path(path, *, must_exist, must_be_dir)`` normalises ``..``,
+  resolves symlinks in the root, and returns a canonical absolute ``Path``.
+- Raises ``typer.BadParameter`` when the path doesn't exist (``must_exist``)
+  or isn't a directory (``must_be_dir``) — **not** ``FileNotFoundError``
+  so typer prints the usage-level error rather than a Python traceback.
+- ``validate_pair(input_dir, output_dir)`` catches the classic footgun
+  where ``output_dir`` sits inside ``input_dir`` (the organizer would then
+  write into the tree it's reading). Raises ``typer.BadParameter``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+from file_organizer.cli.path_validation import resolve_cli_path, validate_pair
+
+# --------------------------------------------------------------------------
+# resolve_cli_path — happy paths
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestResolveCliPath:
+    def test_existing_directory_is_returned_resolved(self, tmp_path: Path) -> None:
+        """A plain existing directory passes through and comes back resolved."""
+        result = resolve_cli_path(tmp_path)
+        assert result == tmp_path.resolve()
+        assert result.is_absolute()
+
+    def test_dotdot_traversal_is_normalized(self, tmp_path: Path) -> None:
+        """``/a/b/../c`` must resolve to ``/a/c``. Same security property the
+        A.foundation walker sweep relied on, but re-checked at the CLI layer
+        so downstream code sees a canonical path.
+        """
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        weird = tmp_path / "sub" / ".." / "sub"
+        result = resolve_cli_path(weird)
+        assert result == nested.resolve()
+
+    def test_relative_path_resolved_against_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Typer delivers plain ``Path(arg)`` which is relative. The helper
+        anchors it to the current working directory so all downstream
+        validation works on an absolute form.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "sub").mkdir()
+        result = resolve_cli_path(Path("sub"))
+        assert result == (tmp_path / "sub").resolve()
+
+    def test_must_exist_false_allows_missing_path(self, tmp_path: Path) -> None:
+        """Commands that *create* their output dir (e.g. ``organize OUTPUT``
+        when OUTPUT doesn't exist yet) pass ``must_exist=False`` — the
+        helper still resolves ``..`` but doesn't require the path on disk.
+        """
+        missing = tmp_path / "will_be_created"
+        result = resolve_cli_path(missing, must_exist=False)
+        assert result == missing.resolve()
+
+    def test_must_be_dir_false_allows_file_argument(self, tmp_path: Path) -> None:
+        """Commands that take a file (``fo analyze FILE``) pass
+        ``must_be_dir=False`` — directory check doesn't apply.
+        """
+        file_path = tmp_path / "target.txt"
+        file_path.write_text("x")
+        result = resolve_cli_path(file_path, must_be_dir=False)
+        assert result == file_path.resolve()
+
+
+# --------------------------------------------------------------------------
+# resolve_cli_path — error paths (F1 — every external call handled)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestResolveCliPathErrors:
+    def test_missing_path_raises_bad_parameter(self, tmp_path: Path) -> None:
+        """Non-existent path with ``must_exist=True`` surfaces as
+        ``typer.BadParameter`` — typer renders this as
+        ``Usage: ... Error: Invalid value for '...': Path does not exist: ...``
+        instead of a Python traceback.
+        """
+        missing = tmp_path / "nope"
+        with pytest.raises(typer.BadParameter, match="does not exist"):
+            resolve_cli_path(missing)
+
+    def test_file_when_dir_expected_raises_bad_parameter(self, tmp_path: Path) -> None:
+        """``fo organize INPUT`` pointed at a file gets a helpful error
+        rather than a later ``NotADirectoryError`` from the service layer.
+        """
+        file_path = tmp_path / "single.txt"
+        file_path.write_text("x")
+        with pytest.raises(typer.BadParameter, match="not a directory"):
+            resolve_cli_path(file_path, must_be_dir=True)
+
+    def test_error_message_includes_original_input(self, tmp_path: Path) -> None:
+        """The user wrote ``../nope``; the error message shows that literal
+        (so they can spot the typo) and the resolved form (so they can see
+        where `..` led).
+        """
+        missing = tmp_path / ".." / "nope"
+        with pytest.raises(typer.BadParameter) as excinfo:
+            resolve_cli_path(missing)
+        # T4: both halves must appear — disjunction would pass even if the
+        # original literal is ever dropped from the message.
+        message = str(excinfo.value)
+        assert str(missing) in message
+        assert str(missing.resolve()) in message
+
+    def test_resolution_failure_becomes_bad_parameter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``Path.resolve`` can raise ``RuntimeError`` (py<3.13) or ``OSError``
+        (py>=3.13) on symlink loops and unresolvable ``~user``. The helper's
+        contract is to surface these as ``typer.BadParameter`` so typer emits
+        a usage error (exit 2) instead of an internal traceback.
+        """
+
+        def _boom(_self: Path, *_: object, **__: object) -> Path:
+            raise OSError("ELOOP: synthetic symlink loop")
+
+        # Narrow patch: only Path.resolve calls via file_organizer.cli.path_validation
+        # raise — leaves the rest of the test machinery (pytest internals, tmp_path,
+        # other imported modules) free to resolve paths normally.
+        monkeypatch.setattr("file_organizer.cli.path_validation.Path.resolve", _boom)
+        with pytest.raises(typer.BadParameter) as excinfo:
+            resolve_cli_path(tmp_path / "anywhere")
+        assert "Unable to resolve path" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# validate_pair — input/output dir coherence
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestValidatePair:
+    def test_disjoint_input_output_accepted(self, tmp_path: Path) -> None:
+        """The common case — ``fo organize IN OUT`` where the two
+        directories are unrelated — must not raise.
+        """
+        in_dir = tmp_path / "in"
+        out_dir = tmp_path / "out"
+        in_dir.mkdir()
+        out_dir.mkdir()
+        # No exception means pass.
+        validate_pair(in_dir, out_dir)
+
+    def test_output_inside_input_rejected(self, tmp_path: Path) -> None:
+        """``fo organize IN IN/subdir`` would have the organizer write
+        destination files into the same tree it's reading from — a
+        classic footgun. Reject it at the CLI boundary so the user sees
+        a typer usage error, not a partially-corrupted output tree.
+        """
+        in_dir = tmp_path / "src"
+        in_dir.mkdir()
+        out_dir = in_dir / "nested_out"
+        with pytest.raises(typer.BadParameter, match="inside the input"):
+            validate_pair(in_dir, out_dir)
+
+    def test_input_inside_output_rejected(self, tmp_path: Path) -> None:
+        """Mirror of the above: if the user declares ``fo organize SRC/a OUT``
+        where ``OUT`` is actually the parent of ``SRC/a``, the organizer
+        could walk the output tree while scanning the input tree."""
+        out_dir = tmp_path / "out"
+        in_dir = out_dir / "nested_in"
+        out_dir.mkdir()
+        in_dir.mkdir()
+        with pytest.raises(typer.BadParameter, match="inside the output"):
+            validate_pair(in_dir, out_dir)
+
+    def test_identical_input_and_output_rejected(self, tmp_path: Path) -> None:
+        """``fo organize X X`` is never a legitimate request — the organizer
+        would read + write the same tree. Reject with a clear message.
+        """
+        same = tmp_path / "same"
+        same.mkdir()
+        with pytest.raises(typer.BadParameter, match="same path"):
+            validate_pair(same, same)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only symlink semantics")
+    def test_symlink_resolution_defeats_attempted_escape(self, tmp_path: Path) -> None:
+        """A user passing ``OUT`` that's a symlink to somewhere inside ``IN``
+        must still be rejected — the check runs against the resolved path,
+        not the surface string.
+        """
+        in_dir = tmp_path / "in"
+        real_out_inside_in = in_dir / "real_out"
+        in_dir.mkdir()
+        real_out_inside_in.mkdir()
+        out_link = tmp_path / "out_link"
+        out_link.symlink_to(real_out_inside_in)
+        with pytest.raises(typer.BadParameter, match="inside the input"):
+            validate_pair(in_dir, out_link)
+
+
+# --------------------------------------------------------------------------
+# Sanity: the helper is cwd-independent so CI and local runs agree
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+def test_resolve_cli_path_works_regardless_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The helper resolves absolute paths internally, so changing cwd
+    shouldn't change the outcome for an absolute input.
+    """
+    monkeypatch.chdir(os.sep)  # root of filesystem
+    result = resolve_cli_path(tmp_path)
+    assert result == tmp_path.resolve()

--- a/tests/core/test_path_guard.py
+++ b/tests/core/test_path_guard.py
@@ -1,0 +1,388 @@
+"""Unit tests for src/core/path_guard.py (Epic A.foundation, hardening roadmap #154).
+
+The `path_guard` module provides two primitives:
+
+- `validate_within_roots(path, allowed_roots)` — assert `path` is inside one
+  of `allowed_roots` and return its resolved absolute form. Raises
+  `PathTraversalError` otherwise. Used by A.cli to harden every CLI command
+  that takes a path argument.
+- `safe_walk(root, *, follow_symlinks, include_hidden)` — yield files under
+  `root`, filtering symlinks and hidden entries by default. Used by A.walkers
+  to replace raw `rglob("*")` calls that risk indexing `/etc/passwd` or
+  `.env` / `.ssh/authorized_keys`.
+
+These tests pin both the happy path and the security-boundary behavior
+(symlinks resolve outside, `..` traversal, hidden-dir semantics when root
+itself is hidden).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from file_organizer.core.path_guard import PathTraversalError, safe_walk, validate_within_roots
+
+# --------------------------------------------------------------------------
+# validate_within_roots
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestValidateWithinRoots:
+    def test_path_equal_to_root_is_allowed(self, tmp_path: Path) -> None:
+        """A command invoked with its root as the path arg is legitimate."""
+        assert validate_within_roots(tmp_path, [tmp_path]) == tmp_path.resolve()
+
+    def test_path_strictly_inside_root_is_allowed(self, tmp_path: Path) -> None:
+        nested = tmp_path / "sub" / "file.txt"
+        nested.parent.mkdir()
+        nested.write_text("hi")
+        result = validate_within_roots(nested, [tmp_path])
+        assert result == nested.resolve()
+
+    def test_path_outside_root_raises(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / "elsewhere"
+        with pytest.raises(PathTraversalError, match="outside allowed roots"):
+            validate_within_roots(outside, [tmp_path])
+
+    def test_dotdot_traversal_is_normalized_and_rejected(self, tmp_path: Path) -> None:
+        """`<tmp>/allowed/../outside` resolves to `<tmp>/outside`; must fail
+        even though the literal string starts with an allowed-root prefix.
+        """
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        traversal = inside / ".." / ".." / "etc"
+        with pytest.raises(PathTraversalError):
+            validate_within_roots(traversal, [inside])
+
+    def test_multiple_roots_any_match_allows(self, tmp_path: Path) -> None:
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        root_a.mkdir()
+        root_b.mkdir()
+        target = root_b / "file.txt"
+        target.write_text("x")
+        # Matches the second root — must not raise.
+        result = validate_within_roots(target, [root_a, root_b])
+        assert result == target.resolve()
+
+    def test_empty_allowed_roots_raises(self, tmp_path: Path) -> None:
+        """A command with no declared roots cannot validate any path —
+        refuse rather than silently accept everything.
+        """
+        with pytest.raises(PathTraversalError, match="No allowed roots"):
+            validate_within_roots(tmp_path, [])
+
+    def test_returns_resolved_absolute_path(self, tmp_path: Path) -> None:
+        """Caller gets the canonical resolved form back, not the original
+        (which may be relative or contain symlinks) — enables safe downstream
+        use without re-resolving.
+        """
+        rel_cwd = tmp_path / "sub"
+        rel_cwd.mkdir()
+        result = validate_within_roots(rel_cwd, [tmp_path])
+        assert result.is_absolute()
+        assert result == rel_cwd.resolve()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only symlink semantics")
+    def test_symlink_inside_root_resolving_outside_raises(self, tmp_path: Path) -> None:
+        """A symlink inside `allowed` that points at `/outside` must fail:
+        resolve() follows the link, the comparison catches it.
+        """
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = inside / "escape"
+        link.symlink_to(outside)
+        with pytest.raises(PathTraversalError):
+            validate_within_roots(link, [inside])
+
+    def test_resolve_runtime_error_is_wrapped_as_path_traversal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cyclic symlinks make `Path.resolve()` raise `RuntimeError`, not
+        `ValueError`. Callers expect `PathTraversalError` / `ValueError`
+        uniformly, so the helper must wrap resolver failures.
+        """
+        path = tmp_path / "cyclic"
+        original_resolve = Path.resolve
+
+        def raise_cycle(self: Path, strict: bool = False) -> Path:
+            if self == path:
+                raise RuntimeError("symlink loop")
+            return original_resolve(self, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", raise_cycle)
+        with pytest.raises(PathTraversalError, match="symlink cycle or stale handle"):
+            validate_within_roots(path, [tmp_path])
+
+    def test_allowed_root_resolve_failure_raises_path_traversal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A broken allowed root (cyclic symlink, OS error) must also be
+        surfaced as `PathTraversalError` — not a raw `RuntimeError`.
+        """
+        bad_root = tmp_path / "bad_root"
+        original_resolve = Path.resolve
+
+        def raise_for_bad(self: Path, strict: bool = False) -> Path:
+            if self == bad_root:
+                raise OSError("device offline")
+            return original_resolve(self, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", raise_for_bad)
+        with pytest.raises(PathTraversalError, match="resolve allowed roots"):
+            validate_within_roots(tmp_path / "x.txt", [bad_root])
+
+
+# --------------------------------------------------------------------------
+# safe_walk
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestSafeWalk:
+    def test_yields_plain_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        result = sorted(p.name for p in safe_walk(tmp_path))
+        assert result == ["a.txt", "b.txt"]
+
+    def test_skips_hidden_files_by_default(self, tmp_path: Path) -> None:
+        (tmp_path / "visible.txt").write_text("v")
+        (tmp_path / ".hidden").write_text("h")
+        names = {p.name for p in safe_walk(tmp_path)}
+        assert names == {"visible.txt"}
+
+    def test_skips_files_under_hidden_dirs_by_default(self, tmp_path: Path) -> None:
+        (tmp_path / "visible.txt").write_text("v")
+        hidden = tmp_path / ".git"
+        hidden.mkdir()
+        (hidden / "config").write_text("x")
+        names = {p.name for p in safe_walk(tmp_path)}
+        assert names == {"visible.txt"}
+
+    def test_include_hidden_returns_them(self, tmp_path: Path) -> None:
+        (tmp_path / "visible.txt").write_text("v")
+        (tmp_path / ".hidden").write_text("h")
+        hidden_dir = tmp_path / ".git"
+        hidden_dir.mkdir()
+        (hidden_dir / "config").write_text("x")
+        names = {p.name for p in safe_walk(tmp_path, include_hidden=True)}
+        assert names == {"visible.txt", ".hidden", "config"}
+
+    def test_hidden_filter_is_relative_to_root(self, tmp_path: Path) -> None:
+        """If the user explicitly walks a hidden directory (e.g. they cd
+        into `.git/` and run `fo analyze`), the files inside shouldn't all
+        be filtered just because the root itself starts with a dot.
+        """
+        hidden_root = tmp_path / ".hidden_root"
+        hidden_root.mkdir()
+        (hidden_root / "normal.txt").write_text("x")
+        (hidden_root / ".nested").write_text("skip-me")
+        names = {p.name for p in safe_walk(hidden_root)}
+        assert names == {"normal.txt"}
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only symlink semantics")
+    def test_skips_symlinks_by_default(self, tmp_path: Path) -> None:
+        (tmp_path / "real.txt").write_text("r")
+        target = tmp_path / "target.txt"
+        target.write_text("t")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+        names = {p.name for p in safe_walk(tmp_path)}
+        # target.txt is a real file; link.txt is a symlink and must be skipped.
+        assert names == {"real.txt", "target.txt"}
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only symlink semantics")
+    def test_skips_symlinked_directories(self, tmp_path: Path) -> None:
+        """A symlinked directory's contents must not be yielded by default —
+        the whole subtree could live outside the allowed root.
+        """
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        (real_dir / "inside.txt").write_text("x")
+        link_dir = tmp_path / "link"
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+        # The link itself is a symlink — rglob may or may not descend
+        # depending on follow_symlinks default. Our helper skips any path
+        # that has a symlink component.
+        walked = list(safe_walk(tmp_path))
+        names = {p.name for p in walked}
+        assert "inside.txt" in names  # real subtree reachable directly
+        # link/inside.txt would be a dup via the symlink — must be absent.
+        rel_paths = {str(p.relative_to(tmp_path)) for p in walked}
+        assert "link/inside.txt" not in rel_paths
+
+    def test_follow_symlinks_flag_includes_linked_files(self, tmp_path: Path) -> None:
+        if sys.platform == "win32":
+            pytest.skip("POSIX-only symlink semantics")
+        target = tmp_path / "target.txt"
+        target.write_text("t")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+        names = {p.name for p in safe_walk(tmp_path, follow_symlinks=True)}
+        assert names == {"target.txt", "link.txt"}
+
+    def test_nonexistent_root_yields_empty(self, tmp_path: Path) -> None:
+        result = list(safe_walk(tmp_path / "does-not-exist"))
+        assert result == []
+
+    def test_empty_root_yields_empty(self, tmp_path: Path) -> None:
+        result = list(safe_walk(tmp_path))
+        assert result == []
+
+    def test_directory_is_not_yielded_by_default(self, tmp_path: Path) -> None:
+        """Default `only_files=True`: directories are never yielded."""
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        (subdir / "file.txt").write_text("x")
+        yielded = list(safe_walk(tmp_path))
+        assert len(yielded) == 1
+        assert yielded[0].name == "file.txt"
+        assert yielded[0].is_file()
+
+    def test_only_files_false_yields_directories_too(self, tmp_path: Path) -> None:
+        """`only_files=False` is used by empty-directory cleanup and similar
+        callers that operate on directory entries.
+        """
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "file.txt").write_text("x")
+        yielded = {p.name for p in safe_walk(tmp_path, only_files=False)}
+        assert yielded == {"sub", "file.txt"}
+
+    def test_non_recursive_yields_top_level_only(self, tmp_path: Path) -> None:
+        (tmp_path / "top.txt").write_text("t")
+        deep = tmp_path / "sub" / "deep.txt"
+        deep.parent.mkdir()
+        deep.write_text("d")
+        yielded = {p.name for p in safe_walk(tmp_path, recursive=False)}
+        assert yielded == {"top.txt"}
+
+    def test_custom_pattern_filters(self, tmp_path: Path) -> None:
+        """Callers that previously did `rglob("*.py")` or `rglob(query)`
+        pass their pattern through `pattern=...` and keep the security
+        filters.
+        """
+        (tmp_path / "keep.py").write_text("x")
+        (tmp_path / "skip.txt").write_text("x")
+        yielded = {p.name for p in safe_walk(tmp_path, pattern="*.py")}
+        assert yielded == {"keep.py"}
+
+    def test_custom_pattern_still_filters_symlinks(self, tmp_path: Path) -> None:
+        """Security defaults hold even when a custom pattern is used."""
+        if sys.platform == "win32":
+            pytest.skip("POSIX-only symlink semantics")
+        target = tmp_path / "real.py"
+        target.write_text("x")
+        link = tmp_path / "link.py"
+        link.symlink_to(target)
+        yielded = {p.name for p in safe_walk(tmp_path, pattern="*.py")}
+        assert yielded == {"real.py"}
+
+    def test_symlinked_root_rejected_when_follow_symlinks_false(self, tmp_path: Path) -> None:
+        """Security: a directory symlink passed as `root` must not enumerate
+        its target. The per-entry symlink filter only catches descendants —
+        `rglob()` on a symlink root yields paths from the target first, and
+        the root itself is never checked unless we guard it upfront.
+        """
+        if sys.platform == "win32":
+            pytest.skip("POSIX-only symlink semantics")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("secret")
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        linked_root = inside / "link_root"
+        linked_root.symlink_to(outside, target_is_directory=True)
+
+        # Default follow_symlinks=False → walking a symlinked root yields
+        # nothing (rather than leaking `outside/secret.txt`).
+        assert list(safe_walk(linked_root)) == []
+
+        # With follow_symlinks=True the caller opts into traversal.
+        walked = list(safe_walk(linked_root, follow_symlinks=True))
+        assert any(p.name == "secret.txt" for p in walked)
+
+    def test_nonexistent_root_after_stat_error_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`root.exists()` / `root.is_symlink()` can themselves raise OSError
+        (e.g. stale NFS handle). The helper must yield nothing instead of
+        propagating.
+        """
+        ghost = tmp_path / "ghost"
+
+        def raise_exists(self: Path) -> bool:
+            if self == ghost:
+                raise OSError("stale handle")
+            return True
+
+        monkeypatch.setattr(Path, "exists", raise_exists)
+        assert list(safe_walk(ghost)) == []
+
+    def test_per_entry_permission_error_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One inaccessible entry must not abort the whole walk.
+
+        Callers like `doctor.scan_directory` scan directories that may
+        contain entries whose `is_symlink()` / `is_file()` raise
+        `PermissionError`. The walker skips those entries and keeps going.
+        """
+        good = tmp_path / "good.txt"
+        good.write_text("x")
+        bad = tmp_path / "bad.txt"
+        bad.write_text("x")
+
+        original_is_symlink = Path.is_symlink
+
+        def _raise_for_bad(self: Path) -> bool:
+            if self.name == "bad.txt":
+                raise PermissionError(f"denied: {self}")
+            return original_is_symlink(self)
+
+        monkeypatch.setattr(Path, "is_symlink", _raise_for_bad)
+        yielded = {p.name for p in safe_walk(tmp_path)}
+        assert yielded == {"good.txt"}
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestPathTraversalError:
+    def test_is_value_error_subclass(self) -> None:
+        """Downstream code that catches ValueError continues to work —
+        PathTraversalError just adds a dedicated class for precise except
+        clauses.
+        """
+        assert issubclass(PathTraversalError, ValueError)
+
+
+# --------------------------------------------------------------------------
+# Sanity: the helper must not rely on cwd-relative paths
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+def test_helpers_work_regardless_of_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The helpers resolve absolute paths internally, so changing cwd
+    shouldn't change the outcome.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    inside = root / "file.txt"
+    inside.write_text("x")
+    monkeypatch.chdir(os.sep)  # root of filesystem
+    result = validate_within_roots(inside, [root])
+    assert result == inside.resolve()
+    walked = list(safe_walk(root))
+    assert walked == [inside.resolve()]

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -1,0 +1,699 @@
+"""Tests for ``utils.safedir`` — POSIX-safe directory-fd filesystem operations.
+
+Implementation of #266 in the security hardening series (#264).
+
+`SafeDir` holds an open directory file descriptor and exposes operations
+that route through `dir_fd=` + `O_NOFOLLOW`. The invariant: every operation
+takes a single path *component*, never a path string, so attacker-controlled
+segments can't escape the held directory.
+
+Threat model coverage anchored by these tests:
+
+- Symlink swap between enumeration and read — `open_for_reader` /
+  `open_child` raise `SymlinkRejected` rather than dereferencing.
+- Component-name injection — names containing `/`, `\\`, `..`, or NUL are
+  rejected with `ValueError` before any syscall.
+- File-descriptor leaks — context-manager exit releases the held fd.
+- Cross-directory atomicity — `rename_into` between two `SafeDir`s uses
+  `os.rename` with both source and destination `dir_fd`.
+
+Platform: POSIX only. Windows has no equivalent for `O_NOFOLLOW` /
+`dir_fd=`; the `SafeDir.open_root` factory raises `NotImplementedError`
+there (see #264 for the deferral).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from file_organizer.utils.safedir import SafeDir, SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only primitive"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Component-name validation
+# ---------------------------------------------------------------------------
+
+
+class TestNameValidation:
+    """Every method that takes a *name* must reject path-component injection."""
+
+    @pytest.fixture
+    def sd(self, tmp_path: Path):
+        with SafeDir.open_root(tmp_path) as sd:
+            yield sd
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "a/b",
+            "../escape",
+            "..",
+            ".",
+            "",
+            "a\x00b",
+            "foo\\bar",
+            "/abs",
+        ],
+    )
+    def test_open_child_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.open_child(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", "", "x\x00y"])
+    def test_open_for_reader_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.open_for_reader(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", "."])
+    def test_open_subdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.open_subdir(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", ".."])
+    def test_lstat_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.lstat(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
+    def test_unlink_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.unlink(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
+    def test_mkdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.mkdir(bad_name)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_open_root_and_close_on_context_exit(self, tmp_path: Path) -> None:
+        """Context exit closes the held fd."""
+        sd = SafeDir.open_root(tmp_path)
+        fd = sd.fd
+        sd.__exit__(None, None, None)
+        with pytest.raises(OSError):
+            # Closed fd — fstat raises EBADF.
+            os.fstat(fd)
+
+    def test_open_for_reader_returns_readable_fd(self, tmp_path: Path) -> None:
+        (tmp_path / "data.txt").write_bytes(b"hello")
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_for_reader("data.txt")
+            try:
+                assert os.read(fd, 5) == b"hello"
+            finally:
+                os.close(fd)
+
+    def test_open_for_reader_via_fdopen(self, tmp_path: Path) -> None:
+        """Confirms the canonical 'pass to library reader' pattern works."""
+        (tmp_path / "data.txt").write_bytes(b"payload")
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_for_reader("data.txt")
+            with os.fdopen(fd, "rb") as f:
+                assert f.read() == b"payload"
+
+    def test_scandir_yields_names(self, tmp_path: Path) -> None:
+        (tmp_path / "a").write_text("x")
+        (tmp_path / "b").write_text("y")
+        with SafeDir.open_root(tmp_path) as sd:
+            names = sorted(sd.scandir())
+        assert names == ["a", "b"]
+        # Yielded values are plain strings, not DirEntry objects —
+        # callers can't reach symlink-following helpers.
+        for name in names:
+            assert isinstance(name, str)
+
+    def test_scandir_materializes_eagerly_so_iteration_cannot_outlive_safedir(
+        self, tmp_path: Path
+    ) -> None:
+        """``os.scandir(fd)`` dup's the fd, so a lazy generator could
+        keep yielding entries after ``SafeDir.__exit__`` closed the
+        SafeDir. Materializing names eagerly is the lifecycle
+        guarantee: the iterator returned by ``scandir()`` doesn't hold
+        an OS handle and can be safely consumed after the SafeDir is
+        closed (the data is already in memory; only future *operations*
+        on the SafeDir fail).
+        """
+        (tmp_path / "a").write_text("x")
+        (tmp_path / "b").write_text("y")
+        sd = SafeDir.open_root(tmp_path)
+        try:
+            it = sd.scandir()
+        finally:
+            sd.__exit__(None, None, None)
+        # Iterator survives SafeDir exit (names are already materialized);
+        # this is the contract — data is safe to consume, but no further
+        # syscalls happen.
+        assert sorted(it) == ["a", "b"]
+
+    def test_scandir_filters_symlinks(self, tmp_path: Path) -> None:
+        """``DirEntry.is_file()`` / ``.stat()`` default to following
+        symlinks; filtering them out of scandir prevents naive callers
+        from classifying a symlink-to-file as a regular file (which
+        would bypass the SafeDir invariant before reaching
+        ``open_for_reader``).
+        """
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        (organize / "regular.txt").write_text("real")
+        try:
+            (organize / "link").symlink_to(tmp_path / "honey")
+            (organize / "link_to_dir").symlink_to(tmp_path, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            names = list(sd.scandir())
+        assert names == ["regular.txt"]
+
+    def test_lstat_does_not_follow_symlink(self, tmp_path: Path) -> None:
+        (tmp_path / "target").write_text("target content")
+        try:
+            (tmp_path / "link").symlink_to(tmp_path / "target")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(tmp_path) as sd:
+            st = sd.lstat("link")
+        import stat as _stat
+
+        assert _stat.S_ISLNK(st.st_mode), "lstat should report the symlink, not the target"
+
+    def test_unlink_removes_via_dir_fd(self, tmp_path: Path) -> None:
+        target = tmp_path / "doomed"
+        target.write_text("x")
+        with SafeDir.open_root(tmp_path) as sd:
+            sd.unlink("doomed")
+        assert not target.exists()
+
+    def test_mkdir_creates_subdir(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            sd.mkdir("new_category")
+        assert (tmp_path / "new_category").is_dir()
+
+    def test_open_subdir_returns_new_safedir(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "leaf.txt").write_bytes(b"leaf content")
+        with SafeDir.open_root(tmp_path) as root, root.open_subdir("sub") as sub:
+            fd = sub.open_for_reader("leaf.txt")
+            try:
+                assert os.read(fd, 12) == b"leaf content"
+            finally:
+                os.close(fd)
+
+    def test_rename_into_same_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "old").write_text("data")
+        with SafeDir.open_root(tmp_path) as sd:
+            sd.rename_into("old", sd, "new")
+        assert not (tmp_path / "old").exists()
+        assert (tmp_path / "new").read_text() == "data"
+
+    def test_rename_into_cross_dir(self, tmp_path: Path) -> None:
+        src_dir = tmp_path / "src"
+        dst_dir = tmp_path / "dst"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "doc.txt").write_text("moved")
+        with (
+            SafeDir.open_root(src_dir) as src,
+            SafeDir.open_root(dst_dir) as dst,
+        ):
+            src.rename_into("doc.txt", dst, "doc.txt")
+        assert not (src_dir / "doc.txt").exists()
+        assert (dst_dir / "doc.txt").read_text() == "moved"
+
+    def test_rename_into_rejects_symlinked_source(self, tmp_path: Path) -> None:
+        """``os.rename`` has no O_NOFOLLOW. A TOCTOU swap (scandir
+        yields a regular file, then attacker replaces it with a symlink
+        before rename) would otherwise move the symlink into the
+        managed destination — contaminating the trusted output tree
+        with a pointer outside the SafeDir root.
+        """
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        src_dir = tmp_path / "src"
+        dst_dir = tmp_path / "dst"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        try:
+            (src_dir / "report.pdf").symlink_to(tmp_path / "honey")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with (
+            SafeDir.open_root(src_dir) as src,
+            SafeDir.open_root(dst_dir) as dst,
+            pytest.raises(SymlinkRejected),
+        ):
+            src.rename_into("report.pdf", dst, "report.pdf")
+
+        # Destination must remain empty — no symlink leaked through.
+        assert list(dst_dir.iterdir()) == []
+        # Source symlink remains in place (rename refused).
+        assert (src_dir / "report.pdf").is_symlink()
+
+
+# ---------------------------------------------------------------------------
+# Symlink rejection — the headline security guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkRejection:
+    """`O_NOFOLLOW` on every open. A swapped symlink raises `SymlinkRejected`."""
+
+    def test_open_for_reader_rejects_symlinked_file(self, tmp_path: Path) -> None:
+        honey = tmp_path / "honey"
+        honey.write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "report.pdf").symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                sd.open_for_reader("report.pdf")
+
+    def test_open_child_rejects_symlinked_file(self, tmp_path: Path) -> None:
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link").symlink_to(tmp_path / "honey")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                sd.open_child("link")
+
+    def test_open_subdir_rejects_symlinked_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "honey_dir"
+        target.mkdir()
+        (target / "secret.txt").write_text("oops")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "documents").symlink_to(target, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                sd.open_subdir("documents")
+
+    def test_open_root_rejects_symlinked_root(self, tmp_path: Path) -> None:
+        """If the root passed to ``open_root`` is itself a symlink, refuse."""
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        try:
+            link = tmp_path / "link"
+            link.symlink_to(real_root, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with pytest.raises(SymlinkRejected):
+            SafeDir.open_root(link)
+
+    def test_open_root_rejects_symlinked_root_when_passed_as_string(self, tmp_path: Path) -> None:
+        """``open_root`` accepts str / PathLike callers too.
+
+        Before the boundary-normalization fix, the ``ENOTDIR`` error path
+        called ``path.is_symlink()`` directly — which would raise
+        ``AttributeError`` instead of the documented ``SymlinkRejected``
+        when a CLI/config caller passed an un-typed string.
+        """
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        try:
+            link = tmp_path / "link"
+            link.symlink_to(real_root, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        # Pass the path as a string, not a Path object.
+        with pytest.raises(SymlinkRejected):
+            SafeDir.open_root(str(link))
+
+    def test_symlink_rejected_is_oserror(self) -> None:
+        """``SymlinkRejected`` subclasses ``OSError`` so existing handlers work."""
+        assert issubclass(SymlinkRejected, OSError)
+
+    def test_open_child_rejects_o_path(self, tmp_path: Path) -> None:
+        """``O_PATH | O_NOFOLLOW`` on Linux returns an fd for the symlink
+        itself instead of raising ELOOP — that would silently violate the
+        documented "no symlinks" contract. The public API must refuse it.
+
+        On platforms without ``O_PATH`` (macOS, BSD) the bug doesn't exist;
+        ``_O_PATH == 0`` makes this skip cleanly.
+        """
+        if not hasattr(os, "O_PATH"):
+            pytest.skip("O_PATH is Linux-only; bug doesn't exist on this platform")
+
+        (tmp_path / "regular").write_text("x")
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(ValueError, match="O_PATH"):
+                sd.open_child("regular", flags=os.O_PATH)
+
+    def test_open_child_rejects_o_path_even_for_real_files(self, tmp_path: Path) -> None:
+        """Predicate-negative: the rejection fires on the flag, not on whether
+        the entry is a symlink. A regular file with ``O_PATH`` must still be
+        refused so callers can't 'just happen to' use the flag safely and
+        later trip on it with an attacker-controlled symlink (T10).
+        """
+        if not hasattr(os, "O_PATH"):
+            pytest.skip("O_PATH is Linux-only")
+
+        (tmp_path / "regular").write_text("x")
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(ValueError, match="O_PATH"):
+                sd.open_child("regular", flags=os.O_PATH | os.O_RDONLY)
+
+    def test_open_child_excl_create_rejects_symlinked_target(self, tmp_path: Path) -> None:
+        """``O_CREAT|O_EXCL`` returns EEXIST (not ELOOP) on an existing
+        symlink. The documented contract is "symlink → SymlinkRejected",
+        so this case must disambiguate via lstat rather than leak through
+        as ``FileExistsError``. Otherwise an exclusive-create caller might
+        treat ``EEXIST`` as benign "file already exists" and miss the
+        symlink-swap attack.
+        """
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "out.txt").symlink_to(tmp_path / "honey")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        excl_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        with SafeDir.open_root(organize) as sd, pytest.raises(SymlinkRejected):
+            sd.open_child("out.txt", flags=excl_flags)
+
+    def test_open_child_excl_create_passes_through_real_file_eexist(self, tmp_path: Path) -> None:
+        """T10 predicate-negative: when the existing entry is a regular
+        file (not a symlink), ``O_CREAT|O_EXCL`` must still surface
+        ``FileExistsError``, not ``SymlinkRejected``. The disambiguation
+        check fires only on actual symlinks.
+        """
+        (tmp_path / "out.txt").write_text("already here")
+        excl_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        with SafeDir.open_root(tmp_path) as sd, pytest.raises(FileExistsError):
+            sd.open_child("out.txt", flags=excl_flags)
+
+    def test_open_child_excl_create_succeeds_for_new_name(self, tmp_path: Path) -> None:
+        """T10 positive control: ``O_CREAT|O_EXCL`` on a non-existent name
+        succeeds (no symlink, no existing file). Confirms the new error
+        path doesn't break the happy case.
+        """
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_child("fresh.txt", flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+            try:
+                os.write(fd, b"hello")
+            finally:
+                os.close(fd)
+        assert (tmp_path / "fresh.txt").read_bytes() == b"hello"
+
+    def test_open_child_creates_files_with_non_executable_mode(self, tmp_path: Path) -> None:
+        """`os.open` defaults `mode=0o777`; with the typical 022 umask
+        that gives 0o755 — files created via SafeDir would be
+        unexpectedly executable. The default must match the high-level
+        `open()` builtin (0o666 pre-umask → 0o644 post-umask).
+        """
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_child("output.txt", flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+            os.close(fd)
+        st = (tmp_path / "output.txt").stat()
+        import stat as _stat
+
+        # The exact mode depends on the test environment's umask, but
+        # under no reasonable umask (000 through 077) does 0o666 produce
+        # an executable file. Assert no execute bits anywhere.
+        exec_bits = _stat.S_IXUSR | _stat.S_IXGRP | _stat.S_IXOTH
+        assert (st.st_mode & exec_bits) == 0, (
+            f"file created with executable bits: {oct(st.st_mode)}"
+        )
+
+    def test_open_child_honors_explicit_mode(self, tmp_path: Path) -> None:
+        """Callers can request stricter permissions (e.g. 0o600 for
+        secret-bearing files). The explicit mode is passed through to
+        `os.open` so the umask is still applied.
+        """
+        # Set a permissive umask so the explicit mode is what we observe.
+        # umask is restored by the conftest fixture isolation; for this
+        # test we just need to know the umask doesn't strip our bits.
+        prev_umask = os.umask(0)
+        try:
+            with SafeDir.open_root(tmp_path) as sd:
+                fd = sd.open_child(
+                    "secret.txt",
+                    flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    mode=0o600,
+                )
+                os.close(fd)
+        finally:
+            os.umask(prev_umask)
+        st = (tmp_path / "secret.txt").stat()
+        assert (st.st_mode & 0o777) == 0o600, (
+            f"explicit mode 0o600 not honored: {oct(st.st_mode & 0o777)}"
+        )
+
+    def test_open_child_directory_flag_rejects_symlinked_target(self, tmp_path: Path) -> None:
+        """``O_DIRECTORY`` against a symlink returns ENOTDIR (not ELOOP) —
+        the symlink inode itself isn't a directory. Disambiguate via lstat
+        so the contract holds: callers using the generic ``open_child``
+        helper with ``O_DIRECTORY`` get the documented ``SymlinkRejected``
+        rather than ``NotADirectoryError`` for symlinked targets.
+        """
+        honey_dir = tmp_path / "honey"
+        honey_dir.mkdir()
+        (honey_dir / "secret.txt").write_text("do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "documents").symlink_to(honey_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd, pytest.raises(SymlinkRejected):
+            sd.open_child("documents", flags=os.O_DIRECTORY)
+
+    def test_open_child_directory_flag_propagates_enotdir_for_regular_file(
+        self, tmp_path: Path
+    ) -> None:
+        """T10 predicate-negative: ``O_DIRECTORY`` against a regular file
+        must still surface ``NotADirectoryError``, not ``SymlinkRejected``.
+        Disambiguation fires only on actual symlinks.
+        """
+        (tmp_path / "regular.txt").write_text("not a directory")
+        with SafeDir.open_root(tmp_path) as sd, pytest.raises(NotADirectoryError):
+            sd.open_child("regular.txt", flags=os.O_DIRECTORY)
+
+
+# ---------------------------------------------------------------------------
+# Resource lifetime
+# ---------------------------------------------------------------------------
+
+
+class TestResourceLifetime:
+    """Verify the held fd is released on context-manager exit and on subdir
+    chains.
+
+    `T13` from `test-generation-patterns.md` — using `tmp_path` everywhere
+    rather than hardcoded paths.
+    """
+
+    def _count_fds(self) -> int | None:
+        """Return the number of open fds for this process, or None on platforms
+        where ``/proc/self/fd`` is unavailable (e.g. macOS).
+        """
+        proc = Path("/proc/self/fd")
+        if not proc.is_dir():
+            return None
+        return len(list(proc.iterdir()))
+
+    def test_context_manager_releases_root_fd(self, tmp_path: Path) -> None:
+        before = self._count_fds()
+        if before is None:
+            pytest.skip("/proc/self/fd not available on this platform")
+        for _ in range(20):
+            with SafeDir.open_root(tmp_path):
+                pass
+        after = self._count_fds()
+        assert after is not None
+        # Allow a small slack for any incidental fd churn (logging, gc).
+        assert after - before <= 2, f"fd leak: before={before} after={after}"
+
+    def test_context_manager_releases_subdir_fd(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        before = self._count_fds()
+        if before is None:
+            pytest.skip("/proc/self/fd not available on this platform")
+        with SafeDir.open_root(tmp_path) as root:
+            for _ in range(20):
+                with root.open_subdir("sub"):
+                    pass
+        after = self._count_fds()
+        assert after is not None
+        assert after - before <= 2, f"fd leak: before={before} after={after}"
+
+    def test_close_does_not_doublefree(self, tmp_path: Path) -> None:
+        """Exiting the context manager twice is harmless."""
+        sd = SafeDir.open_root(tmp_path)
+        sd.__exit__(None, None, None)
+        # Calling exit again must NOT raise (it could happen if the user
+        # writes their own try/finally + with-statement).
+        sd.__exit__(None, None, None)
+
+
+class TestUseAfterClose:
+    """Methods must refuse to operate on a closed SafeDir.
+
+    POSIX recycles fd numbers eagerly — if a caller retains a closed
+    ``SafeDir`` and then invokes a method on it, the stale ``self._fd``
+    could address an unrelated directory that the kernel reassigned
+    that number to (after any subsequent ``os.open`` in the same
+    process). Each method calls ``self._check_open()`` first so the
+    failure is loud rather than silently operating on the wrong dir.
+    """
+
+    @pytest.fixture
+    def closed_sd(self, tmp_path: Path) -> SafeDir:
+        sd = SafeDir.open_root(tmp_path)
+        sd.__exit__(None, None, None)
+        return sd
+
+    def test_fd_property_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            _ = closed_sd.fd
+
+    def test_open_child_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.open_child("anything")
+
+    def test_open_for_reader_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.open_for_reader("anything")
+
+    def test_open_subdir_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.open_subdir("anything")
+
+    def test_scandir_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            list(closed_sd.scandir())
+
+    def test_lstat_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.lstat("anything")
+
+    def test_mkdir_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.mkdir("anything")
+
+    def test_unlink_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.unlink("anything")
+
+    def test_rename_into_raises_on_closed_self(self, tmp_path: Path) -> None:
+        closed = SafeDir.open_root(tmp_path)
+        closed.__exit__(None, None, None)
+        with SafeDir.open_root(tmp_path) as live:
+            with pytest.raises(ValueError, match="closed"):
+                closed.rename_into("a", live, "b")
+
+    def test_rename_into_raises_on_closed_other(self, tmp_path: Path) -> None:
+        other = SafeDir.open_root(tmp_path)
+        other.__exit__(None, None, None)
+        with SafeDir.open_root(tmp_path) as live:
+            with pytest.raises(ValueError, match="closed"):
+                live.rename_into("a", other, "b")
+
+    def test_underlying_fd_invalidated_to_neg_one(self, tmp_path: Path) -> None:
+        """Defense in depth: even if ``_check_open`` is bypassed via
+        direct attribute access, the stored fd is -1 so any syscall
+        fails with EBADF rather than operating on a recycled fd."""
+        sd = SafeDir.open_root(tmp_path)
+        sd.__exit__(None, None, None)
+        assert sd._fd == -1
+
+
+# ---------------------------------------------------------------------------
+# Error semantics: missing entries
+# ---------------------------------------------------------------------------
+
+
+class TestMissingEntries:
+    def test_open_for_reader_missing_file_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.open_for_reader("nope.txt")
+
+    def test_open_subdir_missing_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.open_subdir("nope")
+
+    def test_unlink_missing_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.unlink("nope")
+
+    def test_lstat_missing_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.lstat("nope")
+
+
+# ---------------------------------------------------------------------------
+# T10 predicate-negative cases for the symlink rejection
+# ---------------------------------------------------------------------------
+
+
+class TestPredicateNegatives:
+    """`test-generation-patterns.md` T10: every predicate needs a negative
+    case with the same surface shape but wrong context.
+
+    The predicate here is "is this entry a symlink that we should refuse?"
+    The wrong-context cases below all look like potentially-dangerous
+    operations but are in fact safe and must succeed.
+    """
+
+    def test_regular_file_named_like_symlink_not_rejected(self, tmp_path: Path) -> None:
+        """A regular file whose name is "link" or "shortcut" is fine."""
+        (tmp_path / "link").write_bytes(b"actually a regular file")
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_for_reader("link")
+            try:
+                assert os.read(fd, 64) == b"actually a regular file"
+            finally:
+                os.close(fd)
+
+    def test_regular_directory_named_like_symlink_not_rejected(self, tmp_path: Path) -> None:
+        """A regular directory at a name that *looks* like a link is fine."""
+        (tmp_path / "documents_link").mkdir()
+        (tmp_path / "documents_link" / "x").write_text("x")
+        with SafeDir.open_root(tmp_path) as sd, sd.open_subdir("documents_link") as sub:
+            assert set(sub.scandir()) == {"x"}
+
+    def test_root_at_real_path_not_rejected(self, tmp_path: Path) -> None:
+        """`open_root` on a real directory (whatever the parent has done) is fine.
+
+        Same surface shape as `test_open_root_rejects_symlinked_root` — a
+        directory at the supplied path. Wrong context: the directory is real.
+        """
+        real = tmp_path / "organize"
+        real.mkdir()
+        with SafeDir.open_root(real) as sd:
+            # Verify the fd actually points at the right inode.
+            assert os.fstat(sd.fd).st_ino == real.stat().st_ino


### PR DESCRIPTION
Implements **WP-1.1** (#1223) of the fo-core pull-back plan (epic #1221) — the path-safety foundation.

## What's added (ported from `curdriceaurora/fo-core`, re-targeted to `file_organizer.*`)

| Module | Public API |
|--------|-----------|
| `utils/safedir.py` | `SafeDir` — POSIX `dir_fd`+`O_NOFOLLOW` primitive (TOCTOU-safe; rejects symlink traversal & path-component injection), `SymlinkRejected(OSError)` |
| `core/path_guard.py` | `validate_within_roots`, `safe_walk`, `PathTraversalError` |
| `cli/path_validation.py` | `resolve_cli_path`, `validate_pair` |

All three are self-contained (stdlib + `typer`), with **no internal cross-imports** — ported verbatim. This is the base layer the symlink/TOCTOU hardening series builds on; **not yet wired into any call sites** (that's WP-2.x).

## Tests
Ported `test_safedir.py`, `test_path_guard.py`, `test_path_validation.py` (imports + one string-literal monkeypatch target re-targeted to `file_organizer.*`). **117 cases pass locally**; POSIX-only skips preserved for the Windows/macOS matrix.

## Verification
- ✅ `ruff check` + `ruff format --check` clean
- ✅ `mypy` (strict) — 0 errors in the three new modules
- ✅ 117 tests pass

## Deferred (tracked, not dropped)
- `test_safedir_anchored.py` → **WP-2.1** (depends on the `utils/readers` anchored helper)
- Wiring `resolve_cli_path` into CLI commands + the wiring rail → **WP-6.1**

Closes #1223

https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced path-safety validation for command-line input handling to prevent symlink traversal and path-injection attacks.
  * Added secure filesystem operations that reject unsafe paths and enforce proper directory boundaries.

* **Tests**
  * Added comprehensive test coverage for new path-safety validation and secure filesystem operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->