### PR TITLE
feat(security): route EPUB reads through SafeDir (WP-2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **EPUB read-path symlink hardening (WP-2.1, pull-back from fo-core)** — `utils.epub_enhanced` now
+  reads EPUBs via `SafeDir` (`_read_epub_safedir`): on POSIX the file is opened with
+  `O_NOFOLLOW`/`dir_fd` and a symlink swapped in after the directory walk is refused with
+  `SymlinkRejected` instead of being dereferenced, closing the symlink-following surface in the
+  enhanced-EPUB ingestion path (#264). Falls back to the legacy reader on Windows. Requires
+  `ebooklib>=0.20` for the fileobj branch.
+
 ### Added
 
 - **Atomic write primitive (WP-1.2, pull-back from fo-core)** — added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ parsers = [
     "python-docx~=1.0",
     "openpyxl~=3.1",
     "python-pptx>=0.6.0",  # 0.x — unstable API, keep >=
-    "ebooklib>=0.18",  # 0.x — unstable API, keep >=
+    "ebooklib>=0.20,<1",  # 0.x — unstable API; 0.20 added the isinstance guard around os.path.isdir required for SafeDir's fileobj read path (WP-2.1 / #264)
     "beautifulsoup4~=4.12",
     "lxml~=4.9",
 ]

--- a/src/file_organizer/utils/epub_enhanced.py
+++ b/src/file_organizer/utils/epub_enhanced.py
@@ -104,6 +104,16 @@ def _read_epub_safedir(file_path: Path) -> epub.EpubBook:
         return _read_epub_legacy_checked(file_path)
 
     with safe_dir_cm as safe_dir:
+        # Parent-rooted open: ``O_NOFOLLOW`` protects the LEAF, closing the
+        # primary walk-to-read symlink-swap on the EPUB file itself (#264).
+        # A residual nested-ancestor window remains (#286): ``open_root`` still
+        # resolves the multi-component ``file_path.parent`` by path, so an
+        # *ancestor* directory swapped to a symlink after enumeration is
+        # followed. The full close needs ``open_anchored_reader`` anchored at
+        # the walked organize root (``scan_root``); that context is threaded by
+        # the readers-dispatch / text_processor slice of WP-2.1 (#1226), where
+        # this call site is upgraded to anchored. (Anchoring at the filesystem
+        # root here instead would over-refuse legitimate symlinked ancestors.)
         fd = safe_dir.open_for_reader(file_path.name)
         # fdopen takes ownership only once it returns; explicitly close
         # the raw fd if fdopen itself raises.

--- a/src/file_organizer/utils/epub_enhanced.py
+++ b/src/file_organizer/utils/epub_enhanced.py
@@ -52,7 +52,21 @@ from loguru import logger
 from file_organizer.utils.safedir import SafeDir, SymlinkRejected
 
 
-def _read_epub_safedir(file_path: Path) -> Any:
+def _read_epub_legacy_checked(file_path: Path) -> epub.EpubBook:
+    """Legacy path-based ``epub.read_epub`` with a best-effort symlink refusal.
+
+    Used only when SafeDir's POSIX ``O_NOFOLLOW``/``dir_fd`` primitives are
+    unavailable (Windows / ``NotImplementedError``). SafeDir can't provide a
+    TOCTOU-safe open there, but we still **fail closed** on an obvious symlink
+    rather than blindly dereferencing it (qodo). The ``lstat``-then-read check
+    has an inherent TOCTOU window that only the SafeDir fd path closes fully.
+    """
+    if file_path.is_symlink():
+        raise SymlinkRejected(f"refused to read symlinked EPUB without SafeDir: {file_path}")
+    return epub.read_epub(file_path)
+
+
+def _read_epub_safedir(file_path: Path) -> epub.EpubBook:
     """Open *file_path* via SafeDir and pass the fileobj to ``epub.read_epub``.
 
     On POSIX, opens the file with ``SafeDir.open_for_reader`` so a
@@ -62,16 +76,21 @@ def _read_epub_safedir(file_path: Path) -> Any:
     in the enhanced-EPUB ingestion path (#264).
 
     On Windows (where SafeDir's POSIX primitives raise
-    ``NotImplementedError``) falls back to direct
-    ``epub.read_epub(file_path)`` — preserves the legacy API.
+    ``NotImplementedError``) falls back to ``_read_epub_legacy_checked``,
+    which still refuses an obvious symlink (best-effort) before the
+    legacy path-based read.
 
     Requires ``ebooklib>=0.20`` so the fileobj branch of
     ``epub.read_epub`` works correctly; older versions called
     ``os.path.isdir`` unconditionally on the input and raised
     ``TypeError`` for file-likes.
+
+    Raises:
+        SymlinkRejected: The EPUB (or, on the fallback path, the file
+            itself) is a symlink and is refused rather than dereferenced.
     """
     if sys.platform == "win32":
-        return epub.read_epub(file_path)
+        return _read_epub_legacy_checked(file_path)
 
     # Narrowly catch NotImplementedError only around the SafeDir
     # construction step. If ``epub.read_epub(fileobj)`` (or any
@@ -82,7 +101,7 @@ def _read_epub_safedir(file_path: Path) -> Any:
         safe_dir_cm = SafeDir.open_root(file_path.parent)
     except NotImplementedError:
         logger.debug("SafeDir unavailable; using legacy epub.read_epub for {}", file_path.name)
-        return epub.read_epub(file_path)
+        return _read_epub_legacy_checked(file_path)
 
     with safe_dir_cm as safe_dir:
         fd = safe_dir.open_for_reader(file_path.name)
@@ -244,6 +263,10 @@ class EnhancedEPUBReader:
         Raises:
             EPUBProcessingError: If file cannot be read or parsed
             FileNotFoundError: If file does not exist
+            SymlinkRejected: If the EPUB is a symlink — refused (and
+                surfaced unwrapped, as an ``OSError`` subclass) rather
+                than dereferenced, so callers can distinguish a refused
+                symlink from a malformed EPUB.
         """
         file_path = Path(file_path)
 
@@ -744,6 +767,8 @@ def get_epub_metadata(file_path: str | Path) -> EPUBMetadata:
 
     Raises:
         EPUBProcessingError: If file cannot be read
+        SymlinkRejected: If the EPUB is a symlink — refused (an ``OSError``
+            subclass, surfaced unwrapped) rather than dereferenced.
     """
     if not EBOOKLIB_AVAILABLE:
         raise ImportError("ebooklib is not installed. Install with: pip install ebooklib")

--- a/src/file_organizer/utils/epub_enhanced.py
+++ b/src/file_organizer/utils/epub_enhanced.py
@@ -12,7 +12,9 @@ This module provides advanced EPUB processing capabilities including:
 from __future__ import annotations
 
 import io
+import os
 import re
+import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,6 +48,56 @@ except ImportError:
     XMLParsedAsHTMLWarning = None  # type: ignore[assignment,misc]
 
 from loguru import logger
+
+from file_organizer.utils.safedir import SafeDir, SymlinkRejected
+
+
+def _read_epub_safedir(file_path: Path) -> Any:
+    """Open *file_path* via SafeDir and pass the fileobj to ``epub.read_epub``.
+
+    On POSIX, opens the file with ``SafeDir.open_for_reader`` so a
+    symlink swapped into the directory between the walk and this read
+    is refused with ``SymlinkRejected`` (an ``OSError`` subclass)
+    rather than dereferenced — closes the symlink-following surface
+    in the enhanced-EPUB ingestion path (#264).
+
+    On Windows (where SafeDir's POSIX primitives raise
+    ``NotImplementedError``) falls back to direct
+    ``epub.read_epub(file_path)`` — preserves the legacy API.
+
+    Requires ``ebooklib>=0.20`` so the fileobj branch of
+    ``epub.read_epub`` works correctly; older versions called
+    ``os.path.isdir`` unconditionally on the input and raised
+    ``TypeError`` for file-likes.
+    """
+    if sys.platform == "win32":
+        return epub.read_epub(file_path)
+
+    # Narrowly catch NotImplementedError only around the SafeDir
+    # construction step. If ``epub.read_epub(fileobj)`` (or any
+    # downstream library code) raised NotImplementedError, an outer
+    # except would silently retry the same file through the path-based
+    # reader — reopening the symlink-following surface this helper closes.
+    try:
+        safe_dir_cm = SafeDir.open_root(file_path.parent)
+    except NotImplementedError:
+        logger.debug("SafeDir unavailable; using legacy epub.read_epub for {}", file_path.name)
+        return epub.read_epub(file_path)
+
+    with safe_dir_cm as safe_dir:
+        fd = safe_dir.open_for_reader(file_path.name)
+        # fdopen takes ownership only once it returns; explicitly close
+        # the raw fd if fdopen itself raises.
+        try:
+            fileobj = os.fdopen(fd, "rb", closefd=True)
+        except OSError:
+            os.close(fd)
+            raise
+        with fileobj:
+            # ebooklib reads the ZIP synchronously; the returned EpubBook
+            # holds all content in memory before this returns, so closing
+            # fileobj on context exit is safe.
+            return epub.read_epub(fileobj)
 
 
 class EPUBProcessingError(Exception):
@@ -199,8 +251,13 @@ class EnhancedEPUBReader:
             raise FileNotFoundError(f"EPUB file not found: {file_path}")
 
         try:
-            book = epub.read_epub(file_path)
+            book = _read_epub_safedir(file_path)
             logger.debug(f"Successfully opened EPUB: {file_path.name}")
+        except SymlinkRejected:
+            # SafeDir refused a symlinked EPUB. Surface the security-specific
+            # OSError unchanged so callers can distinguish a refused symlink
+            # from an ordinary malformed EPUB.
+            raise
         except Exception as e:  # Intentional catch-all: ebooklib raises library-specific errors
             raise EPUBProcessingError(f"Failed to read EPUB file {file_path}: {e}") from e
 
@@ -694,8 +751,13 @@ def get_epub_metadata(file_path: str | Path) -> EPUBMetadata:
     file_path = Path(file_path)
 
     try:
-        book = epub.read_epub(file_path)
+        book = _read_epub_safedir(file_path)
         reader = EnhancedEPUBReader()
         return reader._extract_metadata(book)
+    except SymlinkRejected:
+        # As in EnhancedEPUBReader.read_epub — let the SafeDir refusal
+        # propagate untouched so callers can distinguish symlink rejection
+        # from ordinary parsing failures.
+        raise
     except Exception as e:  # Intentional catch-all: ebooklib raises library-specific errors
         raise EPUBProcessingError(f"Failed to read EPUB metadata: {e}") from e

--- a/tests/utils/test_epub_enhanced_safedir.py
+++ b/tests/utils/test_epub_enhanced_safedir.py
@@ -147,3 +147,47 @@ class TestEnhancedReaderRefusesSymlink:
         reader = EnhancedEPUBReader()
         content = reader.read_epub(target)
         assert content.metadata.title == "Reg Test Book"
+
+
+class TestSafeDirUnavailableFallback:
+    """When SafeDir is unavailable (Windows / NotImplementedError), the
+    fallback still fails closed on symlinks but parses real files (Copilot)."""
+
+    def test_fallback_refuses_symlink(self, tmp_path: Path) -> None:
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from file_organizer.utils.epub_enhanced import EnhancedEPUBReader
+
+        real = tmp_path / "real.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        reader = EnhancedEPUBReader()
+        # Simulate a platform without SafeDir's POSIX primitives.
+        with patch(
+            "file_organizer.utils.epub_enhanced.SafeDir.open_root",
+            side_effect=NotImplementedError,
+        ):
+            with pytest.raises(SymlinkRejected):
+                reader.read_epub(organize / "decoy.epub")
+
+    def test_fallback_parses_real_file(self, tmp_path: Path) -> None:
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from file_organizer.utils.epub_enhanced import EnhancedEPUBReader
+
+        target = tmp_path / "book.epub"
+        _make_minimal_epub(target)
+
+        reader = EnhancedEPUBReader()
+        with patch(
+            "file_organizer.utils.epub_enhanced.SafeDir.open_root",
+            side_effect=NotImplementedError,
+        ):
+            content = reader.read_epub(target)
+        assert content.metadata.title == "Reg Test Book"

--- a/tests/utils/test_epub_enhanced_safedir.py
+++ b/tests/utils/test_epub_enhanced_safedir.py
@@ -1,0 +1,149 @@
+"""Regression tests for SafeDir-routed reads in
+``utils/epub_enhanced.py`` (PR3g #282).
+
+Verifies that ``EnhancedEPUBReader.read_epub`` and ``get_epub_metadata``
+refuse a symlinked EPUB rather than dereferencing it. The hardening
+landed alongside the rail bare-open detection in PR3g; without this
+regression, a future refactor that silently reverts to
+``epub.read_epub(file_path)`` would only show up in a security audit.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from file_organizer.utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+def _make_minimal_epub(path: Path) -> None:
+    """Build a smallest-possible EPUB so ebooklib can parse it.
+
+    Matches the structure used in PR3a's reader tests — just enough to
+    pass ebooklib's container/manifest checks.
+    """
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr(
+            "META-INF/container.xml",
+            (
+                '<?xml version="1.0"?>'
+                '<container version="1.0" '
+                'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+                "<rootfiles>"
+                '<rootfile full-path="content.opf" '
+                'media-type="application/oebps-package+xml"/>'
+                "</rootfiles></container>"
+            ),
+        )
+        zf.writestr(
+            "content.opf",
+            (
+                '<?xml version="1.0"?>'
+                '<package version="2.0" xmlns="http://www.idpf.org/2007/opf" '
+                'unique-identifier="bookid">'
+                '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+                "<dc:title>Reg Test Book</dc:title>"
+                '<dc:identifier id="bookid">test</dc:identifier>'
+                "<dc:language>en</dc:language></metadata>"
+                '<manifest><item id="ch1" href="ch1.xhtml" '
+                'media-type="application/xhtml+xml"/></manifest>'
+                '<spine><itemref idref="ch1"/></spine></package>'
+            ),
+        )
+        zf.writestr(
+            "ch1.xhtml",
+            "<html><body><p>regression test chapter</p></body></html>",
+        )
+
+
+class TestEnhancedReaderRefusesSymlink:
+    """``EnhancedEPUBReader.read_epub`` must refuse a symlinked EPUB."""
+
+    def test_read_epub_refuses_symlinked_file(self, tmp_path: Path) -> None:
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from file_organizer.utils.epub_enhanced import EnhancedEPUBReader
+
+        real = tmp_path / "secret.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        reader = EnhancedEPUBReader()
+        # The security-specific OSError subclass propagates — callers
+        # can distinguish symlink rejection from a malformed EPUB.
+        with pytest.raises(SymlinkRejected):
+            reader.read_epub(organize / "decoy.epub")
+
+    def test_get_epub_metadata_refuses_symlinked_file(self, tmp_path: Path) -> None:
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from file_organizer.utils.epub_enhanced import get_epub_metadata
+
+        real = tmp_path / "real.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        with pytest.raises(SymlinkRejected):
+            get_epub_metadata(organize / "link.epub")
+
+    def test_read_epub_does_not_invoke_path_based_read_on_symlink(self, tmp_path: Path) -> None:
+        """Belt-and-suspenders: even if the read fails some other way,
+        verify ``epub.read_epub`` is never called with the symlink
+        path. Patches the underlying library binding to detect the
+        unsafe call.
+        """
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from file_organizer.utils.epub_enhanced import EnhancedEPUBReader
+
+        real = tmp_path / "real.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        reader = EnhancedEPUBReader()
+        with patch("file_organizer.utils.epub_enhanced.epub.read_epub") as spy:
+            # SymlinkRejected fires before epub.read_epub gets called.
+            with pytest.raises(SymlinkRejected):
+                reader.read_epub(organize / "decoy.epub")
+            # Lock in: epub.read_epub was never invoked with the
+            # symlinked path (or anything else).
+            assert spy.call_count == 0
+
+    def test_read_epub_still_works_for_real_file(self, tmp_path: Path) -> None:
+        """Sanity check: the hardening doesn't break the happy path."""
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from file_organizer.utils.epub_enhanced import EnhancedEPUBReader
+
+        target = tmp_path / "book.epub"
+        _make_minimal_epub(target)
+
+        reader = EnhancedEPUBReader()
+        content = reader.read_epub(target)
+        assert content.metadata.title == "Reg Test Book"


### PR DESCRIPTION
First atomic slice of **WP-2.1 read-path hardening** (#1226, epic #1221) — wiring the merged `SafeDir` primitive into the EPUB ingestion path.

## Change
`utils/epub_enhanced.py` — `EnhancedEPUBReader.read_epub` and `read_epub_metadata` now read via a new `_read_epub_safedir(file_path)`:
- POSIX: opens the EPUB with `SafeDir.open_for_reader` (`O_NOFOLLOW` + `dir_fd`) and passes the fileobj to `epub.read_epub`, so a symlink swapped into the directory after the walk is **refused with `SymlinkRejected`** instead of dereferenced — closes the symlink-following exfiltration surface (#264).
- Windows / `NotImplementedError`: falls back to the legacy `epub.read_epub(file_path)`.
- `SymlinkRejected` propagates unwrapped so callers can distinguish a refused symlink from a malformed EPUB.

Depends only on the already-merged `utils.safedir`. Requires `ebooklib>=0.20` (fileobj branch).

## Verification
- ✅ `test_epub_enhanced_safedir` — 4 new cases pass (with ebooklib installed)
- ✅ existing `test_epub_enhanced` + `_coverage` — 43 pass (no regression)
- ✅ ruff + format clean; no new mypy findings (the 2 pre-existing findings in this file are on `main` and outside CI's `models/`-scoped type-check)

Scope: standalone safedir read only. The readers-dispatch + `text_processor` core path, dedup, search, para, and organizer read-paths are the remaining WP-2.1 slices (separate atomic PRs).

Refs #1226

https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_