### PR TITLE
feat(security): route content-dedup hashing through SafeDir (WP-2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Content-dedup hash read-path symlink hardening (WP-2.1, pull-back from fo-core)** — `core.organizer`'s content-based deduplication now computes the SHA-256 digest via a new `_sha256_via_safedir` helper that reads through `SafeDir` on POSIX: a symlink swapped in between organize-time enumeration and the hash read is refused (`SymlinkRejected` → `None` hash, file kept) rather than dereferenced, closing the LLM-exfiltration vector in the dedup hash path (#264). Falls back to the legacy reader on Windows.
 - **Search corpus read-path symlink hardening (WP-2.1, pull-back from fo-core)** —
   `services.search.hybrid_retriever.read_text_safe` now reads corpus files via `SafeDir` on POSIX:
   a symlink swapped in between corpus enumeration and the content read is refused (`SymlinkRejected`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Content-dedup hash read-path symlink hardening (WP-2.1, pull-back from fo-core)** — `core.organizer`'s content-based deduplication now computes the SHA-256 digest via a new `_sha256_via_safedir` helper that reads through `SafeDir` on POSIX: a symlink swapped in between organize-time enumeration and the hash read is refused (`SymlinkRejected` → `None` hash, file kept) rather than dereferenced, closing the LLM-exfiltration vector in the dedup hash path (#264). Falls back to the legacy reader on Windows.
+- **Content-dedup hash read-path symlink hardening (WP-2.1, pull-back from fo-core)** — `core.organizer`'s content-based deduplication now computes the SHA-256 digest via a new `_sha256_via_safedir` helper that reads through `SafeDir` on POSIX: a symlink swapped in between organize-time enumeration and the hash read is refused (`SymlinkRejected` → `None` hash, file kept) rather than dereferenced, closing the symlink-exfiltration vector in the dedup hash path (WP-2.1, #1226). An optional `scan_root` enables anchored traversal (`SafeDir.open_anchored_reader`) closing the nested-ancestor TOCTOU. Falls back to the legacy reader on Windows.
 - **Search corpus read-path symlink hardening (WP-2.1, pull-back from fo-core)** —
   `services.search.hybrid_retriever.read_text_safe` now reads corpus files via `SafeDir` on POSIX:
   a symlink swapped in between corpus enumeration and the content read is refused (`SymlinkRejected`

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -311,7 +311,10 @@ class FileOrganizer:
             seen_hashes: dict[str, ProcessedFile | ProcessedImage] = {}
             deduped_processed: list[ProcessedFile | ProcessedImage] = []
             for pf in all_processed:
-                file_hash = self._sha256_via_safedir(pf.file_path)
+                # input_path is the trusted walked root: anchor the hash read so
+                # a symlink swapped into any intermediate directory under it is
+                # refused, not just the leaf's parent (#286, codex P1).
+                file_hash = self._sha256_via_safedir(pf.file_path, scan_root=input_path)
                 if file_hash is None:
                     # Unreadable or refused symlink — keep the file (handled later).
                     deduped_processed.append(pf)
@@ -382,7 +385,7 @@ class FileOrganizer:
         return result
 
     @staticmethod
-    def _sha256_via_safedir(file_path: Path) -> str | None:
+    def _sha256_via_safedir(file_path: Path, scan_root: Path | None = None) -> str | None:
         """Compute the SHA-256 hex digest of *file_path*, via SafeDir.
 
         Opens through :class:`file_organizer.utils.safedir.SafeDir` on POSIX so
@@ -391,15 +394,39 @@ class FileOrganizer:
         non-POSIX falls back to the legacy path-based open until the SafeDir
         Windows port lands.
 
+        When *scan_root* (the trusted directory that was walked to discover the
+        file) is supplied, the read uses ``SafeDir.open_anchored_reader`` to walk
+        every intermediate component between *scan_root* and *file_path* with
+        ``O_NOFOLLOW``, so a symlink swapped into ANY ancestor directory — not
+        just the leaf's parent — is detected (closes the nested-ancestor TOCTOU,
+        #286). Without *scan_root* the parent-rooted ``SafeDir.open_root`` path
+        is used (leaf protection only).
+
         Returns ``None`` when the file is unreadable or the read is refused —
         the caller treats that as "unknown hash" and keeps the file in the
         deduplicated output rather than dropping it.
         """
         hasher = hashlib.sha256()
+        relative: Path | None = None
+        if scan_root is not None:
+            try:
+                relative = file_path.relative_to(scan_root)
+            except ValueError:
+                # File is outside the trusted root — refuse rather than read.
+                return None
+            # ``relative_to`` is lexical: reject any ``..`` escape so the
+            # legacy fallback below can't read outside scan_root either.
+            if ".." in relative.parts:
+                return None
         if sys.platform != "win32":
             try:
-                with SafeDir.open_root(file_path.parent) as safe_dir:
-                    fd = safe_dir.open_for_reader(file_path.name)
+                root = scan_root if scan_root is not None else file_path.parent
+                with SafeDir.open_root(root) as safe_dir:
+                    if scan_root is not None:
+                        assert relative is not None  # set whenever scan_root given
+                        fd = safe_dir.open_anchored_reader(relative)
+                    else:
+                        fd = safe_dir.open_for_reader(file_path.name)
                     try:
                         fileobj = os.fdopen(fd, "rb", closefd=True)
                     except OSError:

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -313,7 +313,7 @@ class FileOrganizer:
             for pf in all_processed:
                 # input_path is the trusted walked root: anchor the hash read so
                 # a symlink swapped into any intermediate directory under it is
-                # refused, not just the leaf's parent (#286, codex P1).
+                # refused, not just the leaf's parent (nested-ancestor TOCTOU; codex P1).
                 file_hash = self._sha256_via_safedir(pf.file_path, scan_root=input_path)
                 if file_hash is None:
                     # Unreadable or refused symlink — keep the file (handled later).
@@ -390,7 +390,7 @@ class FileOrganizer:
 
         Opens through :class:`file_organizer.utils.safedir.SafeDir` on POSIX so
         a symlink swapped in between organize-time enumeration and the hash read
-        is refused (closes the LLM-exfiltration vector in #264). Windows /
+        is refused (closes the symlink-exfiltration vector; WP-2.1, #1226). Windows /
         non-POSIX falls back to the legacy path-based open until the SafeDir
         Windows port lands.
 
@@ -399,7 +399,7 @@ class FileOrganizer:
         every intermediate component between *scan_root* and *file_path* with
         ``O_NOFOLLOW``, so a symlink swapped into ANY ancestor directory — not
         just the leaf's parent — is detected (closes the nested-ancestor TOCTOU,
-        #286). Without *scan_root* the parent-rooted ``SafeDir.open_root`` path
+        nested-ancestor TOCTOU). Without *scan_root* the parent-rooted ``SafeDir.open_root`` path
         is used (leaf protection only).
 
         Returns ``None`` when the file is unreadable or the read is refused —

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -12,6 +12,9 @@ delegates to extracted modules for specific concerns:
 
 from __future__ import annotations
 
+import hashlib
+import os
+import sys
 import time
 from pathlib import Path
 from typing import ClassVar
@@ -36,6 +39,7 @@ from file_organizer.services import ProcessedFile, ProcessedImage, TextProcessor
 from file_organizer.services.audio.metadata_extractor import AudioMetadataExtractor
 from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
 from file_organizer.undo import UndoManager
+from file_organizer.utils.safedir import SafeDir, SymlinkRejected
 
 
 class FileOrganizer:
@@ -304,19 +308,12 @@ class FileOrganizer:
         # Organize
         # Content‑based deduplication: remove duplicate files based on file content hash
         if all_processed:
-            import hashlib
-
             seen_hashes: dict[str, ProcessedFile | ProcessedImage] = {}
             deduped_processed: list[ProcessedFile | ProcessedImage] = []
             for pf in all_processed:
-                try:
-                    hasher = hashlib.sha256()
-                    with pf.file_path.open("rb") as f:
-                        for chunk in iter(lambda: f.read(65536), b""):
-                            hasher.update(chunk)
-                    file_hash = hasher.hexdigest()
-                except OSError:
-                    # If we cannot read the file, keep it (it will be handled later)
+                file_hash = self._sha256_via_safedir(pf.file_path)
+                if file_hash is None:
+                    # Unreadable or refused symlink — keep the file (handled later).
                     deduped_processed.append(pf)
                     continue
                 if file_hash not in seen_hashes:
@@ -383,6 +380,54 @@ class FileOrganizer:
         display.show_summary(self.console, result, output_path, dry_run=self.dry_run)
 
         return result
+
+    @staticmethod
+    def _sha256_via_safedir(file_path: Path) -> str | None:
+        """Compute the SHA-256 hex digest of *file_path*, via SafeDir.
+
+        Opens through :class:`file_organizer.utils.safedir.SafeDir` on POSIX so
+        a symlink swapped in between organize-time enumeration and the hash read
+        is refused (closes the LLM-exfiltration vector in #264). Windows /
+        non-POSIX falls back to the legacy path-based open until the SafeDir
+        Windows port lands.
+
+        Returns ``None`` when the file is unreadable or the read is refused —
+        the caller treats that as "unknown hash" and keeps the file in the
+        deduplicated output rather than dropping it.
+        """
+        hasher = hashlib.sha256()
+        if sys.platform != "win32":
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    fd = safe_dir.open_for_reader(file_path.name)
+                    try:
+                        fileobj = os.fdopen(fd, "rb", closefd=True)
+                    except OSError:
+                        os.close(fd)
+                        raise
+                    with fileobj:
+                        for chunk in iter(lambda: fileobj.read(65536), b""):
+                            hasher.update(chunk)
+                return hasher.hexdigest()
+            except SymlinkRejected as exc:
+                logger.warning("Refused to hash symlinked file {}: {}", file_path, exc)
+                return None
+            except NotImplementedError:
+                logger.debug("SafeDir unavailable; hashing {} via legacy reader", file_path.name)
+            except (OSError, ValueError):
+                # ValueError covers SafeDir's name-validation rejection
+                # (filenames with backslash / NUL / path separators); OSError
+                # covers normal I/O failures. Both are "file unreadable"
+                # outcomes — return None so the caller keeps the file.
+                return None
+        # Legacy path-based fallback (Windows / NotImplementedError).
+        try:
+            with file_path.open("rb") as f:  # safedir: ok — Windows / NotImplementedError fallback
+                for chunk in iter(lambda: f.read(65536), b""):
+                    hasher.update(chunk)
+            return hasher.hexdigest()
+        except OSError:
+            return None
 
     # ------------------------------------------------------------------
     # Undo / Redo

--- a/tests/core/test_organizer_sha256_safedir.py
+++ b/tests/core/test_organizer_sha256_safedir.py
@@ -60,8 +60,11 @@ class TestSha256ViaSafedirBranches:
         with patch(
             "file_organizer.core.organizer.SafeDir.open_root",
             side_effect=SymlinkRejected("real.bin"),
-        ):
+        ) as mock_open_root:
             assert FileOrganizer._sha256_via_safedir(target) is None
+        # Lock in SafeDir-first behavior: a regression to always-legacy
+        # Path.open would never call open_root and this would catch it.
+        mock_open_root.assert_called_once()
 
     def test_not_implemented_falls_back_to_legacy_open(self, tmp_path: Path) -> None:
         target = tmp_path / "fallback.bin"
@@ -70,8 +73,10 @@ class TestSha256ViaSafedirBranches:
         with patch(
             "file_organizer.core.organizer.SafeDir.open_root",
             side_effect=NotImplementedError("no dir_fd"),
-        ):
+        ) as mock_open_root:
             assert FileOrganizer._sha256_via_safedir(target) == hashlib.sha256(payload).hexdigest()
+        # SafeDir was attempted first, then fell back to the legacy reader.
+        mock_open_root.assert_called_once()
 
     def test_fdopen_failure_closes_bare_fd(self, tmp_path: Path) -> None:
         target = tmp_path / "real.bin"
@@ -94,11 +99,13 @@ class TestSha256ViaSafedirBranches:
 
     def test_safedir_oserror_returns_none(self, tmp_path: Path) -> None:
         target = tmp_path / "x.bin"
+        target.write_bytes(b"data")  # exists, so the SafeDir branch is reached
         with patch(
             "file_organizer.core.organizer.SafeDir.open_root",
             side_effect=OSError("no such file"),
-        ):
+        ) as mock_open_root:
             assert FileOrganizer._sha256_via_safedir(target) is None
+        mock_open_root.assert_called_once()
 
     def test_safedir_valueerror_returns_none(self, tmp_path: Path) -> None:
         """SafeDir's name validation rejects filenames containing
@@ -113,8 +120,9 @@ class TestSha256ViaSafedirBranches:
         with patch(
             "file_organizer.core.organizer.SafeDir.open_root",
             side_effect=ValueError("name 'a\\b' contains path separator"),
-        ):
+        ) as mock_open_root:
             assert FileOrganizer._sha256_via_safedir(target) is None
+        mock_open_root.assert_called_once()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
@@ -127,13 +135,14 @@ class TestSha256ViaSafedirLegacyFallback:
         with patch(
             "file_organizer.core.organizer.SafeDir.open_root",
             side_effect=NotImplementedError(),
-        ):
+        ) as mock_open_root:
             assert FileOrganizer._sha256_via_safedir(target) is None
+        mock_open_root.assert_called_once()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestSha256ViaSafedirAnchored:
-    """``scan_root`` enables anchored traversal (#286): every intermediate
+    """``scan_root`` enables anchored traversal (nested-ancestor TOCTOU): every intermediate
     component between scan_root and the file is O_NOFOLLOW-checked."""
 
     def test_nested_file_under_real_dirs_hashes(self, tmp_path: Path) -> None:

--- a/tests/core/test_organizer_sha256_safedir.py
+++ b/tests/core/test_organizer_sha256_safedir.py
@@ -129,3 +129,52 @@ class TestSha256ViaSafedirLegacyFallback:
             side_effect=NotImplementedError(),
         ):
             assert FileOrganizer._sha256_via_safedir(target) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestSha256ViaSafedirAnchored:
+    """``scan_root`` enables anchored traversal (#286): every intermediate
+    component between scan_root and the file is O_NOFOLLOW-checked."""
+
+    def test_nested_file_under_real_dirs_hashes(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        nested = root / "a" / "b"
+        nested.mkdir(parents=True)
+        target = nested / "doc.bin"
+        payload = b"nested payload"
+        target.write_bytes(payload)
+        assert (
+            FileOrganizer._sha256_via_safedir(target, scan_root=root)
+            == hashlib.sha256(payload).hexdigest()
+        )
+
+    def test_symlinked_ancestor_is_refused(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        (root / "a").mkdir(parents=True)
+        outside = tmp_path / "outside"
+        (outside / "a").mkdir(parents=True)
+        secret = outside / "a" / "doc.bin"
+        secret.write_bytes(b"TOP SECRET")
+        # Swap root/a -> outside/a after "enumeration".
+        (root / "a").rmdir()
+        try:
+            (root / "a").symlink_to(outside / "a")
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+        # The path the walk would have yielded under the trusted root.
+        target = root / "a" / "doc.bin"
+        assert FileOrganizer._sha256_via_safedir(target, scan_root=root) is None
+
+    def test_path_outside_scan_root_returns_none(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"data")
+        assert FileOrganizer._sha256_via_safedir(outside, scan_root=root) is None
+
+    def test_dotdot_escape_returns_none(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        (tmp_path / "secret.bin").write_bytes(b"data")
+        escape = root / ".." / "secret.bin"
+        assert FileOrganizer._sha256_via_safedir(escape, scan_root=root) is None

--- a/tests/core/test_organizer_sha256_safedir.py
+++ b/tests/core/test_organizer_sha256_safedir.py
@@ -1,0 +1,131 @@
+"""Regression tests for ``FileOrganizer._sha256_via_safedir`` (PR3h).
+
+The dedup hasher routes file reads through ``SafeDir.open_root`` +
+``open_for_reader`` so a symlink swapped between organize-time
+enumeration and the hash read is refused. This file covers every
+branch the SafeDir migration introduced:
+
+- happy path on a real on-disk file (no mocks) — verifies the SHA-256
+  matches a stdlib reference
+- ``SymlinkRejected`` returns ``None`` (caller treats as "unknown
+  hash" and keeps the file rather than dropping it)
+- ``NotImplementedError`` falls back to the legacy ``path.open(...)``
+- ``os.fdopen`` failure after ``open_for_reader`` returned a raw fd:
+  the fd MUST be explicitly closed
+- generic ``OSError`` from SafeDir returns ``None``
+- legacy fallback ``OSError`` returns ``None``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from file_organizer.core.organizer import FileOrganizer
+from file_organizer.utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+]
+
+
+class TestSha256ViaSafedirHappyPath:
+    def test_real_file_hash_matches_stdlib(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.bin"
+        payload = b"the quick brown fox jumps over the lazy dog"
+        target.write_bytes(payload)
+        expected = hashlib.sha256(payload).hexdigest()
+        assert FileOrganizer._sha256_via_safedir(target) == expected
+
+    def test_large_file_chunked_hash(self, tmp_path: Path) -> None:
+        """Hash boundary: input larger than the 64 KiB chunk size must
+        still match the stdlib digest."""
+        target = tmp_path / "big.bin"
+        payload = b"a" * (128 * 1024 + 17)  # spans two chunks + tail
+        target.write_bytes(payload)
+        assert FileOrganizer._sha256_via_safedir(target) == hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestSha256ViaSafedirBranches:
+    def test_symlink_rejected_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.bin"
+        target.write_bytes(b"never read")
+        with patch(
+            "file_organizer.core.organizer.SafeDir.open_root",
+            side_effect=SymlinkRejected("real.bin"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+
+    def test_not_implemented_falls_back_to_legacy_open(self, tmp_path: Path) -> None:
+        target = tmp_path / "fallback.bin"
+        payload = b"fallback bytes"
+        target.write_bytes(payload)
+        with patch(
+            "file_organizer.core.organizer.SafeDir.open_root",
+            side_effect=NotImplementedError("no dir_fd"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) == hashlib.sha256(payload).hexdigest()
+
+    def test_fdopen_failure_closes_bare_fd(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.bin"
+        target.write_bytes(b"never read")
+        sentinel_fd = 4242
+
+        fake_safe_dir = MagicMock()
+        fake_safe_dir.open_for_reader.return_value = sentinel_fd
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = fake_safe_dir
+        fake_cm.__exit__.return_value = False
+
+        with (
+            patch("file_organizer.core.organizer.SafeDir.open_root", return_value=fake_cm),
+            patch("file_organizer.core.organizer.os.fdopen", side_effect=OSError("fdopen failed")),
+            patch("file_organizer.core.organizer.os.close") as mock_close,
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+            mock_close.assert_called_once_with(sentinel_fd)
+
+    def test_safedir_oserror_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.bin"
+        with patch(
+            "file_organizer.core.organizer.SafeDir.open_root",
+            side_effect=OSError("no such file"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+
+    def test_safedir_valueerror_returns_none(self, tmp_path: Path) -> None:
+        """SafeDir's name validation rejects filenames containing
+        backslash / NUL / path separators with ``ValueError``. On
+        POSIX such filenames are legal in the filesystem, so a
+        ``safe_walk`` enumerator can yield them. The helper must treat
+        them like any other unreadable file and return ``None`` rather
+        than letting the ``ValueError`` abort the entire organize run.
+        """
+        target = tmp_path / "ok.bin"
+        target.write_bytes(b"data")
+        with patch(
+            "file_organizer.core.organizer.SafeDir.open_root",
+            side_effect=ValueError("name 'a\\b' contains path separator"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestSha256ViaSafedirLegacyFallback:
+    def test_legacy_open_oserror_returns_none(self, tmp_path: Path) -> None:
+        """When SafeDir is unavailable AND the legacy path-open also
+        fails (e.g. file doesn't exist), the function returns None."""
+        target = tmp_path / "ghost.bin"
+        # File never created.
+        with patch(
+            "file_organizer.core.organizer.SafeDir.open_root",
+            side_effect=NotImplementedError(),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None


### PR DESCRIPTION
WP-2.1 read-path slice (#1226, epic #1221) — hardening the content-dedup hash path in `core/organizer.py`.

## Change
`FileOrganizer`'s content-based dedup loop previously hashed each file with an inline `hashlib.sha256()` + `file_path.open("rb")`. It now calls a new `_sha256_via_safedir(file_path)` static method that, on POSIX, reads through `SafeDir.open_root(parent).open_for_reader(name)` so a symlink swapped in between organize-time enumeration and the hash read is **refused** (`SymlinkRejected`) rather than dereferenced — closing the LLM-exfiltration vector in the dedup hash path (#264). `None` now signals "unreadable/refused", and the caller keeps the file in the deduplicated output (same behavior as the prior `OSError` branch). Windows / `NotImplementedError` → legacy path read.

Depends only on the merged `utils.safedir`.

## Verification
- ✅ `test_organizer_sha256_safedir` — 8 new cases pass
- ✅ existing organizer suite — 48 pass (no regression)
- ✅ ruff + format + mypy clean

Refs #1226

https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_