### PR TITLE
fix(tests): accept scan_root kwarg in process_file mocks (unblock main CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Test mocks for the `scan_root` read-path contract (WP-2.1 follow-up)** — integration/parallel test doubles that replace `TextProcessor.process_file` (`test_organize_text_workflow`, `test_dedupe_flow`, `test_parallel_execution`, `test_undo_workflow`) now accept the keyword-only `scan_root` argument the dispatcher forwards since the SafeDir text-processor hardening (#1259). Previously these mocks raised `TypeError: got an unexpected keyword argument 'scan_root'`, so every file was marked failed — failing the full sharded `main` suite (and silently degrading `test_undo_workflow`, whose restore-state assertions passed trivially when nothing organized). No production-code change.
+
 ### Security
 
 - **Organize-pipeline traversal symlink hardening (WP-2.2, pull-back from fo-core)** — `core.file_ops.collect_files` now enumerates the scan tree via `core.path_guard.safe_walk` (skips symlinked files/dirs and hidden entries) instead of a raw `os.walk`: a symlink planted in the input tree (e.g. `escape -> /etc/passwd`) is no longer collected, organized, or read downstream, closing the symlink-exfiltration surface at the entry point of the organize pipeline (fo-core#270, WP-2.2 #1227). A directly provided symlinked input file is also rejected (`is_file()` follows symlinks, so it would otherwise be copied by `shutil.copy2`, exfiltrating its target). `core.file_ops.cleanup_empty_dirs` likewise switches its `rglob("*")` walk to `safe_walk(only_files=False, include_hidden=True)` so empty-directory cleanup never descends through a directory symlink while still removing empty hidden dirs. Behaviour for ordinary files is unchanged. `safe_walk` filters symlinks and hidden entries on every platform.

--- a/tests/core/test_parallel_execution.py
+++ b/tests/core/test_parallel_execution.py
@@ -34,7 +34,7 @@ class TestParallelExecution:
         with patch("file_organizer.core.organizer.TextProcessor") as MockProcessorCls:
             mock_processor = MockProcessorCls.return_value
 
-            def side_effect(path: Path) -> ProcessedFile:
+            def side_effect(path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
                 threading.Event().wait(timeout=0.1)  # Simulate delay
                 return ProcessedFile(
                     file_path=path,
@@ -80,7 +80,7 @@ class TestParallelExecution:
         with patch("file_organizer.core.organizer.TextProcessor") as MockProcessorCls:
             mock_processor = MockProcessorCls.return_value
 
-            def side_effect(path: Path) -> ProcessedFile:
+            def side_effect(path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
                 if "doc_2" in path.name:
                     raise ValueError("Simulated failure")
                 return ProcessedFile(

--- a/tests/integration/test_dedupe_flow.py
+++ b/tests/integration/test_dedupe_flow.py
@@ -50,7 +50,7 @@ def test_dedupe_flow_copy(mock_vision_cls, mock_text_cls, source_dir, output_dir
     mock_processor = MagicMock()
     mock_text_cls.return_value = mock_processor
 
-    def mock_process_file(file_path: Path) -> ProcessedFile:
+    def mock_process_file(file_path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
         # All files go to "deduped" folder; filename unchanged
         return ProcessedFile(
             file_path=file_path,
@@ -95,7 +95,7 @@ def test_dedupe_flow_hardlink(mock_vision_cls, mock_text_cls, source_dir, output
     mock_processor = MagicMock()
     mock_text_cls.return_value = mock_processor
 
-    def mock_process_file(file_path: Path) -> ProcessedFile:
+    def mock_process_file(file_path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
         return ProcessedFile(
             file_path=file_path,
             description="mock desc",

--- a/tests/integration/test_organize_text_workflow.py
+++ b/tests/integration/test_organize_text_workflow.py
@@ -58,7 +58,7 @@ class TestTextWorkflowsIntegration:
         mock_text_cls.return_value = mock_processor
 
         # When process_file is called, return a mapped ProcessedFile
-        def mock_process_file(file_path: Path) -> ProcessedFile:
+        def mock_process_file(file_path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
             name = file_path.stem
             return ProcessedFile(
                 file_path=file_path,
@@ -108,7 +108,7 @@ class TestTextWorkflowsIntegration:
         mock_processor = MagicMock()
         mock_text_cls.return_value = mock_processor
 
-        def mock_process_file(file_path: Path) -> ProcessedFile:
+        def mock_process_file(file_path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
             return ProcessedFile(
                 file_path=file_path,
                 description="desc",
@@ -142,7 +142,9 @@ class TestTextWorkflowsIntegration:
 
         # Force a collision by mapping everything to the exact same folder and filename
         # but with their original extension preserved by the organizer
-        def mock_process_file_collision(file_path: Path) -> ProcessedFile:
+        def mock_process_file_collision(
+            file_path: Path, *, scan_root: Path | None = None
+        ) -> ProcessedFile:
             return ProcessedFile(
                 file_path=file_path,
                 description="desc",

--- a/tests/integration/test_undo_workflow.py
+++ b/tests/integration/test_undo_workflow.py
@@ -39,7 +39,7 @@ class TestUndoTextWorkflow:
         mock_processor = MagicMock()
         mock_text_cls.return_value = mock_processor
 
-        def mock_process_file(file_path: Path) -> ProcessedFile:
+        def mock_process_file(file_path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
             return ProcessedFile(
                 file_path=file_path,
                 description="desc",
@@ -81,7 +81,7 @@ class TestUndoTextWorkflow:
         mock_processor = MagicMock()
         mock_text_cls.return_value = mock_processor
 
-        def mock_process_file(file_path: Path) -> ProcessedFile:
+        def mock_process_file(file_path: Path, *, scan_root: Path | None = None) -> ProcessedFile:
             return ProcessedFile(
                 file_path=file_path,
                 description="desc",


### PR DESCRIPTION
## Problem

The full sharded `Test` suite on `main` is red (7 failures across shards 1/5) with:

```
TypeError: ...mock_process_file() got an unexpected keyword argument 'scan_root'
```

Since the SafeDir text-processor hardening (**#1259**), `core.dispatcher.process_text_files` calls `text_processor.process_file(path, scan_root=scan_root)`. Several test doubles that replace `process_file` still declared `(file_path: Path)` only, so every file raised `TypeError` at call time → marked failed → `processed_files == 0`.

This slipped past the PR-level **Test PR suite** (changed-line diff-cover) but the full sharded `main` suite runs these integration/parallel tests.

## Affected tests (all now pass)

- `tests/integration/test_organize_text_workflow.py` (3 mocks)
- `tests/integration/test_dedupe_flow.py` (2 mocks)
- `tests/core/test_parallel_execution.py` (2 side-effects)
- `tests/integration/test_undo_workflow.py` (2 mocks) — was *silently* passing: its restore-state assertions held trivially because nothing organized. Fixing the mock restores real coverage.

## Fix

Widen the mock signatures to `(file_path, *, scan_root: Path | None = None)`, matching the real `process_file(self, file_path, *, scan_root=None)` contract. **Test-only change** — no production code touched.

## Not in scope (already deferred)

- `tests/web/test_router.py::TestSubRouterInclusion` (`'_IncludedRouter' object has no attribute 'path'`) → tracked debt **#1256**.

Verification: `pytest <the 4 files>` → 9 passed locally; ruff format + check clean; pymarkdown clean.

Part of epic #1221.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_