### PR TITLE
feat(core): WP-4.1 anti-cascade — vision-timeout fallback + sequential retry + parallel timeout-cascade fix (#1231)

### DIFF
--- a/src/file_organizer/core/dispatcher.py
+++ b/src/file_organizer/core/dispatcher.py
@@ -358,7 +358,19 @@ def process_image_files(
             # Retry also failed (timeout, vision error, …). Record as a
             # genuine failure now — there's no second-level retry.
             retry_err = retry_result.error or "Unknown error"
-            if _is_timeout_error(retry_err):
+            # A timeout, OR a saturation abort on a still-never-started task
+            # (the previous retry's thread is still hung on the single worker,
+            # so this candidate never ran), both mean the vision model never
+            # classified this file. With no second-level retry, degrade to
+            # metadata fallback rather than the error folder — otherwise one
+            # hung retry would cascade the remaining never-run candidates into
+            # failures, reintroducing the very cascade this path prevents
+            # (#1287 review).
+            never_ran_saturation = (
+                retry_err.startswith("Aborted: worker pool saturated")
+                and not retry_result.non_retryable
+            )
+            if _is_timeout_error(retry_err) or never_ran_saturation:
                 fb = compute_fallback(retry_result.path)
                 _fallback_confidence = 0.5 if fb.source == "fallback_exif" else 0.3
                 processed.append(

--- a/src/file_organizer/core/dispatcher.py
+++ b/src/file_organizer/core/dispatcher.py
@@ -8,7 +8,7 @@ and handles progress display for each batch.  Extracted from
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from rich.console import Console
@@ -19,12 +19,118 @@ from file_organizer.core.types import (
     ERROR_FALLBACK_FOLDER,
     VIDEO_FALLBACK_FOLDER,
 )
+from file_organizer.parallel.config import ParallelConfig
 from file_organizer.parallel.processor import ParallelProcessor
 from file_organizer.services import ProcessedFile, ProcessedImage, TextProcessor, VisionProcessor
+from file_organizer.services.vision_fallback import compute_fallback
 
 if TYPE_CHECKING:
-    from file_organizer.services.audio.metadata_extractor import AudioMetadataExtractor
+    from file_organizer.services.audio.metadata_extractor import (
+        AudioMetadata,
+        AudioMetadataExtractor,
+    )
     from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
+
+
+def _maybe_transcribe(
+    audio_path: Path,
+    *,
+    metadata: AudioMetadata,
+    transcriber: Any | None,
+    max_transcribe_seconds: float | None,
+) -> str | None:
+    """Return a transcript when a transcriber is set and duration is within cap.
+
+    Returns ``None`` for any of:
+    - No transcriber configured (the default; metadata-only categorization).
+    - Duration exceeds ``max_transcribe_seconds`` (skip and warn — long files
+      would dominate the organize wall-clock time).
+    - The transcriber raises a recoverable exception (FileNotFound,
+      RuntimeError, ImportError); we degrade to metadata-only categorization
+      rather than aborting the entire organize batch on a single bad file.
+    """
+    if transcriber is None:
+        return None
+    # Defensive guard: a duck-typed transcriber that doesn't expose
+    # `generate(audio_path)` would otherwise raise AttributeError and abort
+    # the per-file dispatcher loop. Treat invalid transcribers the same as
+    # missing — degrade to metadata-only with a warning.
+    if not callable(getattr(transcriber, "generate", None)):
+        logger.warning(
+            "Invalid transcriber for {} (missing generate()); using metadata only.",
+            audio_path.name,
+        )
+        return None
+    duration = getattr(metadata, "duration", None)
+    if (
+        max_transcribe_seconds is not None
+        and isinstance(duration, (int, float))
+        and duration > max_transcribe_seconds
+    ):
+        logger.warning(
+            "Audio {} exceeds transcribe cap ({:.1f}s > {:.1f}s); using metadata only.",
+            audio_path.name,
+            float(duration),
+            float(max_transcribe_seconds),
+        )
+        return None
+    try:
+        result = transcriber.generate(str(audio_path))
+    except (FileNotFoundError, OSError, ValueError, RuntimeError, ImportError) as exc:
+        # OSError + ValueError cover malformed / unsupported audio
+        # (faster-whisper / ctranslate2 surface decode failures via these).
+        # Without them the exception escapes to the outer per-file handler
+        # and marks the file as failed in AUDIO_FALLBACK_FOLDER, regressing
+        # a file that's otherwise classifiable from metadata alone. Treat
+        # transcription as a best-effort enhancement: degrade to
+        # metadata-only categorization on any recoverable failure.
+        logger.warning("Audio transcription failed for {}: {}", audio_path.name, exc)
+        return None
+    # `transcriber` is typed as `Any` so mypy can't see `generate`'s return
+    # type; cast to str to satisfy the no-any-return gate. AudioModel.generate
+    # is contracted to return str (verified in `models/audio_model.py:generate`).
+    return str(result)
+
+
+def _to_transcription_result(transcript: str | None, metadata: AudioMetadata) -> Any:
+    """Wrap a plain transcript string for `AudioClassifier.classify(transcription=...)`.
+
+    The classifier's keyword/speaker scoring expects a ``TranscriptionResult``
+    dataclass with ``.text``, ``.duration``, and ``.segments``. The transcriber's
+    ``generate`` returns a plain ``str``, so we construct a minimal stand-in here.
+    ``segments=[]`` disables the segment-based speaker-count heuristic; that's
+    intentional — without real word-level timestamps we'd be inventing signal.
+
+    Returns ``None`` when ``transcript`` is missing/empty so the classifier's
+    existing ``if transcription is not None`` guard skips the transcription
+    phase cleanly.
+    """
+    if not transcript:
+        return None
+    from file_organizer.services.audio.transcriber import (
+        TranscriptionOptions,
+        TranscriptionResult,
+    )
+
+    return TranscriptionResult(
+        text=transcript,
+        segments=[],
+        language="",
+        language_confidence=0.0,
+        duration=getattr(metadata, "duration", 0.0),
+        options=TranscriptionOptions(),
+    )
+
+
+def _is_timeout_error(error_msg: str) -> bool:
+    """Match the dispatcher's timeout-error sentinel.
+
+    The parallel processor emits ``"Timed out after Xs"`` (see
+    ``parallel/processor.py``) when it abandons a long-running task.
+    Other errors (read failures, corrupt files) take the regular failure
+    path. Match by prefix so the timing-suffix doesn't have to be exact.
+    """
+    return error_msg.startswith("Timed out after")
 
 
 def process_text_files(
@@ -113,6 +219,10 @@ def process_image_files(
         List of processed image results.
     """
     processed: list[ProcessedImage] = []
+    # #432: track paths whose pool-saturation abort is retryable
+    # (never-started; collateral damage) so we can run them sequentially
+    # after the parallel pass finishes.
+    retry_paths: list[Path] = []
 
     with create_progress(console) as progress:
         task = progress.add_task("Processing images...", total=len(files))
@@ -139,21 +249,141 @@ def process_image_files(
                     )
             else:
                 error_msg = file_result.error or "Unknown error"
-                logger.error("Failed to process {}: {}", file_result.path, error_msg)
+                # #406: vision timeouts go through the metadata fallback path
+                # instead of being dropped into the error bucket. Other
+                # failures (read error, corrupt image, …) still error-out.
+                if _is_timeout_error(error_msg):
+                    fb = compute_fallback(file_result.path)
+                    logger.info(
+                        "Vision timed out for {}; categorized via {} → {}",
+                        file_result.path.name,
+                        fb.source,
+                        fb.folder,
+                    )
+                    # Per-source confidence (#409). The vision model never
+                    # actually classified this file; we're going off metadata.
+                    # EXIF dates are more trustworthy than pure filename
+                    # heuristics, so they earn a slightly higher score.
+                    _fallback_confidence = 0.5 if fb.source == "fallback_exif" else 0.3
+                    processed.append(
+                        ProcessedImage(
+                            file_path=file_result.path,
+                            description="",
+                            folder_name=fb.folder,
+                            filename=fb.filename,
+                            source=fb.source,
+                            # Carry the timeout's wall-clock through so the
+                            # #410 summary's p95/p99 reflect this image's real
+                            # worst-case latency.
+                            inference_ms=file_result.duration_ms,
+                            confidence=_fallback_confidence,
+                            # NB: no `error` field — the file is not a failure
+                        )
+                    )
+                    progress.update(
+                        task,
+                        advance=1,
+                        description=f"[yellow]⚠[/yellow] {file_result.path.name} (fallback)",
+                    )
+                else:
+                    # #432: pool-saturation aborts on never-started tasks
+                    # carry ``non_retryable=False``. Queue them for a
+                    # post-pass sequential retry instead of recording them as
+                    # failures — they never actually ran, so marking them
+                    # failed is collateral damage.
+                    if (
+                        error_msg.startswith("Aborted: worker pool saturated")
+                        and not file_result.non_retryable
+                    ):
+                        retry_paths.append(file_result.path)
+                        progress.update(
+                            task,
+                            advance=1,
+                            description=f"[yellow]⟳[/yellow] {file_result.path.name} (will retry)",
+                        )
+                        continue
+                    logger.error("Failed to process {}: {}", file_result.path, error_msg)
+                    processed.append(
+                        ProcessedImage(
+                            file_path=file_result.path,
+                            description="",
+                            folder_name=ERROR_FALLBACK_FOLDER,
+                            filename=file_result.path.stem,
+                            error=error_msg,
+                            # #409: dispatcher-built failures must surface in
+                            # the "Review recommended" section.
+                            confidence=0.0,
+                        )
+                    )
+                    progress.update(
+                        task,
+                        advance=1,
+                        description=f"[red]✗[/red] {file_result.path.name} (Failed)",
+                    )
+
+    # #432: Sequential retry for pool-saturation collateral. The parallel
+    # processor marked these as never-started (non_retryable=False), so rerun
+    # them one-at-a-time before reporting failure.
+    #
+    # The retry must run with ``max_workers=1`` and ``prefetch_depth=0`` —
+    # reusing the caller's parallel_processor with its original multi-worker
+    # config can re-saturate if a retried file hangs again. The single-worker
+    # config gives deterministic degraded-mode recovery: each retry runs
+    # alone, and a still-hung backend produces a clean per-file timeout
+    # instead of cascade-failing other retry candidates.
+    #
+    # We inherit the operator-tunable ``timeout_per_file`` from the caller's
+    # config so ``--timeout-per-file`` (#396) still applies.
+    if retry_paths:
+        logger.warning(
+            "Pool aborted on hung tasks; retrying {} untried image(s) sequentially.",
+            len(retry_paths),
+        )
+
+        retry_config = ParallelConfig(
+            max_workers=1,
+            prefetch_depth=0,
+            timeout_per_file=parallel_processor.config.timeout_per_file,
+            retry_count=0,  # no second-level retry
+        )
+        retry_processor = ParallelProcessor(config=retry_config)
+
+        def _retry_one_image(path: Path) -> ProcessedImage:
+            return vision_processor.process_file(path)
+
+        for retry_result in retry_processor.process_batch_iter(retry_paths, _retry_one_image):
+            if retry_result.success:
+                processed.append(retry_result.result)
+                continue
+            # Retry also failed (timeout, vision error, …). Record as a
+            # genuine failure now — there's no second-level retry.
+            retry_err = retry_result.error or "Unknown error"
+            if _is_timeout_error(retry_err):
+                fb = compute_fallback(retry_result.path)
+                _fallback_confidence = 0.5 if fb.source == "fallback_exif" else 0.3
                 processed.append(
                     ProcessedImage(
-                        file_path=file_result.path,
+                        file_path=retry_result.path,
                         description="",
-                        folder_name=ERROR_FALLBACK_FOLDER,
-                        filename=file_result.path.stem,
-                        error=error_msg,
+                        folder_name=fb.folder,
+                        filename=fb.filename,
+                        source=fb.source,
+                        inference_ms=retry_result.duration_ms,
+                        confidence=_fallback_confidence,
                     )
                 )
-                progress.update(
-                    task,
-                    advance=1,
-                    description=f"[red]✗[/red] {file_result.path.name} (Failed)",
+                continue
+            logger.error("Sequential retry failed for {}: {}", retry_result.path, retry_err)
+            processed.append(
+                ProcessedImage(
+                    file_path=retry_result.path,
+                    description="",
+                    folder_name=ERROR_FALLBACK_FOLDER,
+                    filename=retry_result.path.stem,
+                    error=retry_err,
+                    confidence=0.0,
                 )
+            )
 
     return processed
 
@@ -162,6 +392,8 @@ def process_audio_files(
     files: list[Path],
     *,
     extractor_cls: type[AudioMetadataExtractor] | None = None,
+    transcriber: Any | None = None,
+    max_transcribe_seconds: float | None = None,
 ) -> list[ProcessedFile]:
     """Process audio files using the metadata pipeline (no AI model required).
 
@@ -169,6 +401,18 @@ def process_audio_files(
         files: Audio file paths to process.
         extractor_cls: Optional extractor class override so organizer-level
             patch targets continue to intercept metadata extraction in tests.
+        transcriber: Optional transcriber object exposing
+            ``generate(audio_path: str) -> str`` (typically ``AudioModel``).
+            When provided, each file within the duration cap is transcribed
+            and the result attached to ``ProcessedFile.transcript`` for the
+            organizer's text-categorization path. ``None`` preserves the
+            metadata-only behavior. Transcription is best-effort: a recoverable
+            failure degrades to metadata-only categorization rather than
+            failing the file (anti-cascade audio path).
+        max_transcribe_seconds: Per-file duration cap; files longer than this
+            skip transcription and fall back to metadata-only categorization.
+            ``None`` (the default at this layer) means no cap — the
+            CLI/organizer layer applies its policy default and threads it down.
 
     Returns:
         List of processed file results.
@@ -186,7 +430,18 @@ def process_audio_files(
     for audio_path in files:
         try:
             metadata = extractor.extract(audio_path)
-            classification = classifier.classify(metadata)
+
+            # Transcribe FIRST so the result can influence classification.
+            # Otherwise the user pays transcription cost and gets the same
+            # metadata-only folder routing — defeating the transcribe path.
+            transcript = _maybe_transcribe(
+                audio_path,
+                metadata=metadata,
+                transcriber=transcriber,
+                max_transcribe_seconds=max_transcribe_seconds,
+            )
+            transcription = _to_transcription_result(transcript, metadata)
+            classification = classifier.classify(metadata, transcription=transcription)
             dest_path = organizer.generate_path(classification.audio_type, metadata)
 
             folder_name = dest_path.parent.as_posix()
@@ -208,6 +463,7 @@ def process_audio_files(
                     folder_name=folder_name,
                     filename=filename_stem,
                     error=None,
+                    transcript=transcript,
                 )
             )
             logger.debug("Audio processed: {} → {}/{}", audio_path.name, folder_name, filename_stem)

--- a/src/file_organizer/core/dispatcher.py
+++ b/src/file_organizer/core/dispatcher.py
@@ -51,13 +51,16 @@ def _maybe_transcribe(
     """
     if transcriber is None:
         return None
-    # Defensive guard: a duck-typed transcriber that doesn't expose
-    # `generate(audio_path)` would otherwise raise AttributeError and abort
-    # the per-file dispatcher loop. Treat invalid transcribers the same as
-    # missing — degrade to metadata-only with a warning.
-    if not callable(getattr(transcriber, "generate", None)):
+    # Accept the repo's ``AudioTranscriber`` (``transcribe(path) ->
+    # TranscriptionResult``) as well as a ``generate(path) -> str`` duck-type
+    # (#1287 review). A transcriber exposing neither is treated as invalid —
+    # degrade to metadata-only with a warning rather than raising
+    # AttributeError and aborting the per-file dispatcher loop.
+    transcribe_fn = getattr(transcriber, "transcribe", None)
+    generate_fn = getattr(transcriber, "generate", None)
+    if not callable(transcribe_fn) and not callable(generate_fn):
         logger.warning(
-            "Invalid transcriber for {} (missing generate()); using metadata only.",
+            "Invalid transcriber for {} (no transcribe()/generate()); using metadata only.",
             audio_path.name,
         )
         return None
@@ -75,7 +78,15 @@ def _maybe_transcribe(
         )
         return None
     try:
-        result = transcriber.generate(str(audio_path))
+        if callable(transcribe_fn):
+            # Repo's AudioTranscriber returns a TranscriptionResult (.text);
+            # a duck-typed transcribe() may already return a str.
+            result = transcribe_fn(str(audio_path))
+            text = getattr(result, "text", result)
+        elif callable(generate_fn):
+            text = generate_fn(str(audio_path))
+        else:  # pragma: no cover - guarded above
+            return None
     except (FileNotFoundError, OSError, ValueError, RuntimeError, ImportError) as exc:
         # OSError + ValueError cover malformed / unsupported audio
         # (faster-whisper / ctranslate2 surface decode failures via these).
@@ -86,10 +97,12 @@ def _maybe_transcribe(
         # metadata-only categorization on any recoverable failure.
         logger.warning("Audio transcription failed for {}: {}", audio_path.name, exc)
         return None
-    # `transcriber` is typed as `Any` so mypy can't see `generate`'s return
-    # type; cast to str to satisfy the no-any-return gate. AudioModel.generate
-    # is contracted to return str (verified in `models/audio_model.py:generate`).
-    return str(result)
+    if text is None:
+        return None
+    # ``transcriber`` is typed as ``Any`` so mypy can't see the return type;
+    # cast to str to satisfy the no-any-return gate. AudioTranscriber yields a
+    # TranscriptionResult.text (str) and AudioModel.generate returns str.
+    return str(text)
 
 
 def _to_transcription_result(transcript: str | None, metadata: AudioMetadata) -> Any:

--- a/src/file_organizer/parallel/processor.py
+++ b/src/file_organizer/parallel/processor.py
@@ -7,6 +7,7 @@ retry logic, progress reporting, and graceful shutdown.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -24,6 +25,8 @@ from typing import Any, cast
 from file_organizer.parallel.config import ExecutorType, ParallelConfig
 from file_organizer.parallel.executor import create_executor
 from file_organizer.parallel.result import BatchResult, FileResult
+
+logger = logging.getLogger(__name__)
 
 
 def _execute_with_timing(
@@ -237,7 +240,7 @@ class ParallelProcessor:
         except Exception as exc:
             return FileResult(path=path, success=False, error=str(exc))
 
-    def _process_with_executor(
+    def _process_with_executor(  # noqa: C901 — complexity from nested state-tracking closures
         self,
         exec_instance: ThreadPoolExecutor | ProcessPoolExecutor,
         files: list[Path],
@@ -274,6 +277,10 @@ class ParallelProcessor:
         pending: set[Future[FileResult]] = set()
         future_paths: dict[Future[FileResult], Path] = {}
         future_started: dict[Future[FileResult], float | None] = {}
+        # Queue time is tracked separately: if a task never gets a worker thread
+        # within `timeout` seconds of submission, all workers are saturated by
+        # abandoned tasks and we must abort to avoid an infinite hang.
+        future_queued_at: dict[Future[FileResult], float] = {}
         iterator = iter(files)
         iterator_exhausted = False
 
@@ -288,6 +295,7 @@ class ParallelProcessor:
                 pending.add(future)
                 future_paths[future] = path
                 future_started[future] = None
+                future_queued_at[future] = time.monotonic()
                 return True
             except StopIteration:
                 iterator_exhausted = True
@@ -320,26 +328,57 @@ class ParallelProcessor:
                 pending.remove(future)
                 path = future_paths.pop(future)
                 future_started.pop(future, None)
+                future_queued_at.pop(future, None)
                 yield finalize_result(self._collect_result(future, path))
                 submit_round_of_work()
 
-            # Check for and handle timeouts
+            saturation = self._check_pool_saturation(
+                pending,
+                future_paths,
+                future_started,
+                future_queued_at,
+                timeout,
+                finalize_result,
+            )
+            if saturation is not None:
+                cleanup_state["force_nonblocking_shutdown"] = owns_executor
+                yield from saturation
+                # #432 follow-up: unsubmitted files at the iterator tail are
+                # never-started by definition; flag them retryable so the
+                # dispatcher's sequential pass picks them up. Without this, a
+                # saturation with N in-flight + M unsubmitted still mass-fails
+                # the M tail for the same reason the in-flight retry was meant
+                # to fix.
+                for remaining_path in iterator:
+                    yield finalize_result(
+                        FileResult(
+                            path=remaining_path,
+                            success=False,
+                            error="Aborted: worker pool saturated by hung tasks",
+                            non_retryable=False,
+                        )
+                    )
+                return
+
+            # Check for running-task timeouts
             timeout_handling = self._handle_timeouts(
                 pending,
                 future_paths,
                 future_started,
+                future_queued_at,
                 timeout,
                 poll_interval,
                 finalize_result,
             )
             if timeout_handling is not None:
-                should_abort, timeout_results = timeout_handling
+                should_abort, needs_nonblocking, timeout_results = timeout_handling
+                if needs_nonblocking:
+                    cleanup_state["force_nonblocking_shutdown"] = owns_executor
                 if not should_abort:
                     yield from timeout_results
                     submit_round_of_work()
                     continue
 
-                cleanup_state["force_nonblocking_shutdown"] = owns_executor
                 yield from timeout_results
                 # Abort remaining files from iterator
                 for remaining_path in iterator:
@@ -356,29 +395,111 @@ class ParallelProcessor:
 
             submit_round_of_work()
 
+    def _check_pool_saturation(
+        self,
+        pending: set[Future[FileResult]],
+        future_paths: dict[Future[FileResult], Path],
+        future_started: dict[Future[FileResult], float | None],
+        future_queued_at: dict[Future[FileResult], float],
+        timeout: float,
+        finalize_result: Callable[[FileResult], FileResult],
+    ) -> list[FileResult] | None:
+        """Detect and handle worker-pool saturation caused by abandoned tasks.
+
+        Returns a list of finalized error results for all pending tasks if the
+        pool is saturated (all pending tasks queued for > 2 × timeout without
+        starting), or None if the pool is healthy.  The 2× multiplier gives
+        temporarily-busy pools (abandoned tasks that finish in O(timeout)) time
+        to free a slot before declaring permanent saturation.
+        """
+        if not pending:
+            return None
+        now = time.monotonic()
+        # Only futures that have never started (future_started[f] is None) AND
+        # have been queued for longer than 2×timeout count as stalled. Futures
+        # already picked up by a worker have a float start time and are excluded.
+        stalled = [
+            f
+            for f in pending
+            if future_started.get(f) is None
+            and not f.running()
+            and (now - future_queued_at.get(f, now)) > timeout * 2
+        ]
+        if not stalled:
+            return None
+        logger.warning(
+            "Worker pool saturated: %d queued tasks waited > %.0fs without "
+            "starting. Aborting remaining work. "
+            "Hint: raise `--timeout-per-file` (#396) or lower `--workers` "
+            "(#408) — on low-memory hardware running large vision models, "
+            "concurrent slots often exhaust unified memory and trigger this "
+            "saturation path.",
+            len(stalled),
+            timeout * 2,
+        )
+        results: list[FileResult] = []
+        for f in list(pending):
+            # #432: distinguish never-started tasks (collateral, should be
+            # retryable in a degraded mode) from in-flight tasks (truly hung —
+            # don't retry). The dispatcher's image path scans for
+            # ``non_retryable=False`` saturation aborts and reruns them
+            # sequentially so a 2-3 hung-image case doesn't collateral-fail
+            # every untried file in the batch.
+            never_started = future_started.get(f) is None and not f.running()
+            f.cancel()
+            abort_path = future_paths.pop(f)
+            future_started.pop(f, None)
+            future_queued_at.pop(f, None)
+            pending.discard(f)
+            results.append(
+                finalize_result(
+                    FileResult(
+                        path=abort_path,
+                        success=False,
+                        error="Aborted: worker pool saturated by hung tasks",
+                        non_retryable=not never_started,
+                    )
+                )
+            )
+        return results
+
     def _handle_timeouts(
         self,
         pending: set[Future[FileResult]],
         future_paths: dict[Future[FileResult], Path],
         future_started: dict[Future[FileResult], float | None],
+        future_queued_at: dict[Future[FileResult], float],
         timeout: float,
         poll_interval: float,
         finalize_result: Callable[[FileResult], FileResult],
-    ) -> tuple[bool, list[FileResult]] | None:
+    ) -> tuple[bool, bool, list[FileResult]] | None:
         """Check for and handle timed-out tasks.
+
+        ``non_retryable=True`` is set **only** on the uncancellable-running
+        branch — where ``future.cancel()`` returned ``False`` because a thread
+        is actively executing the task. Retrying such a task would submit a
+        new future while the original thread is still running, risking resource
+        exhaustion. Futures that were cancelled successfully (task never
+        started) do *not* receive ``non_retryable=True`` and may be retried
+        by the caller.
 
         Args:
             pending: Set of pending futures.
             future_paths: Mapping of futures to file paths.
             future_started: Mapping of futures to start times.
+            future_queued_at: Mapping of futures to submission times.
             timeout: Timeout threshold in seconds.
             poll_interval: Polling interval for drift compensation.
-            owns_executor: Whether we own the executor.
             finalize_result: Function to finalize results.
 
         Returns:
-            None if no timeout was handled, or tuple of
-            (should_abort_processing, finalized_results_to_yield).
+            None if no timeout was handled, or a 3-tuple of
+            (should_abort_processing, needs_nonblocking_shutdown,
+            finalized_results_to_yield).
+
+            should_abort_processing=True means drain the iterator and stop.
+            needs_nonblocking_shutdown=True means set force_nonblocking_shutdown
+            so the executor does not hang waiting for a stuck thread.
         """
         now = time.monotonic()
 
@@ -387,7 +508,7 @@ class ParallelProcessor:
             if future_started[future] is None and future.running():
                 future_started[future] = now - poll_interval
 
-        # Check for timeouts
+        # Check for running-task timeouts
         for future in list(pending):
             start_time = future_started[future]
             if start_time is None:
@@ -400,6 +521,7 @@ class ParallelProcessor:
                     pending.remove(future)
                     del future_paths[future]
                     del future_started[future]
+                    future_queued_at.pop(future, None)
                     timed_out_result = finalize_result(
                         FileResult(
                             path=path,
@@ -407,29 +529,66 @@ class ParallelProcessor:
                             error=f"Timed out after {timeout}s",
                         )
                     )
-                    return (False, [timed_out_result])
+                    return (False, False, [timed_out_result])
 
                 if future.done():
+                    # Task completed in the narrow window between cancel() and
+                    # done() — a race that only occurs on some OS schedulers
+                    # (commonly macOS).  Preserve the actual result rather than
+                    # reporting a phantom timeout: the backdated
+                    # ``future_started[future] = now - poll_interval`` (above)
+                    # can trip the elapsed-time check up to ``poll_interval``
+                    # seconds early, so a task that genuinely finished within
+                    # the configured timeout was otherwise being reported as
+                    # ``non_retryable=True`` and discarding its actual return
+                    # value.
                     pending.remove(future)
-                    completed_path = future_paths.pop(future)
-                    future_started.pop(future, None)
+                    del future_paths[future]
+                    del future_started[future]
+                    future_queued_at.pop(future, None)
                     try:
-                        completed_result = finalize_result(future.result())
+                        race_result = future.result()
                     except Exception as exc:
-                        completed_result = finalize_result(
-                            FileResult(path=completed_path, success=False, error=str(exc))
+                        # The task completed but raised — surface the real
+                        # exception text rather than a timeout.
+                        race_result = finalize_result(
+                            FileResult(path=path, success=False, error=str(exc))
                         )
-                    return (False, [completed_result])
+                    else:
+                        race_result = finalize_result(race_result)
+                    return (False, False, [race_result])
 
-                abort_results = self._abort_remaining_work(
-                    pending,
-                    future_paths,
-                    future_started,
-                    finalize_result,
-                    timed_out_future=future,
-                    timeout=timeout,
+                # Task is running and cannot be cancelled.  Abandon it —
+                # remove from tracking so other files continue normally.
+                # The thread will finish on its own (Ollama will eventually
+                # respond); we set needs_nonblocking_shutdown so the executor
+                # doesn't hang on cleanup waiting for it.
+                logger.warning(
+                    "Task for %s timed out after %.0fs and could not be cancelled "
+                    "(thread still running in background); continuing with remaining files",
+                    path,
+                    timeout,
                 )
-                return (True, abort_results)
+                pending.remove(future)
+                del future_paths[future]
+                del future_started[future]
+                future_queued_at.pop(future, None)
+                abandoned_result = finalize_result(
+                    FileResult(
+                        path=path,
+                        success=False,
+                        error=f"Timed out after {timeout}s",
+                        non_retryable=True,
+                    )
+                )
+                # The abandoned thread still occupies the worker slot until it
+                # exits naturally.  Reset the saturation-detection clock for all
+                # remaining queued futures so the 2×timeout guard doesn't fire
+                # while that thread is still winding down.
+                _reset_time = time.monotonic()
+                for _remaining in pending:
+                    future_queued_at[_remaining] = _reset_time
+                return (False, True, [abandoned_result])
 
         return None
 

--- a/src/file_organizer/parallel/processor.py
+++ b/src/file_organizer/parallel/processor.py
@@ -132,17 +132,25 @@ class ParallelProcessor:
 
             results.extend(succeeded)
 
-            if any(self._is_non_retryable_failure(result) for result in failed):
-                results.extend(failed)
-                remaining = []
-                break
+            # A single attempt can mix non-retryable failures (e.g. an
+            # uncancellable hung task) with retryable ones (e.g. a queued
+            # never-started saturation abort). Stopping on the non-retryable
+            # one before collecting the retryable ones would strand the queued
+            # file as a failure without ever running it (#1287 review).
+            non_retryable_failed = [r for r in failed if self._is_non_retryable_failure(r)]
+            retryable_failed = [r for r in failed if not self._is_non_retryable_failure(r)]
 
-            # On last attempt, include failures in results
+            # Non-retryable failures are final — retrying would submit a new
+            # future while the original thread is still running.
+            results.extend(non_retryable_failed)
+
             if attempt == self._config.retry_count:
-                results.extend(failed)
+                # No attempts left: retryable failures are final too.
+                results.extend(retryable_failed)
+                remaining = []
             else:
-                # Retry only the failures
-                remaining = [r.path for r in failed]
+                # Retry only the retryable failures.
+                remaining = [r.path for r in retryable_failed]
 
         batch_elapsed_ms = (time.perf_counter() - batch_start) * 1000
         succeeded_count = sum(1 for r in results if r.success)
@@ -527,6 +535,11 @@ class ParallelProcessor:
                             path=path,
                             success=False,
                             error=f"Timed out after {timeout}s",
+                            # The file consumed ~timeout seconds before being
+                            # cancelled; record it so the dispatcher's fallback
+                            # ``inference_ms`` reflects real worst-case latency
+                            # rather than 0ms (#1287 review).
+                            duration_ms=(now - start_time) * 1000,
                         )
                     )
                     return (False, False, [timed_out_result])
@@ -579,6 +592,10 @@ class ParallelProcessor:
                         success=False,
                         error=f"Timed out after {timeout}s",
                         non_retryable=True,
+                        # The thread ran ~timeout seconds before being abandoned;
+                        # record it so the dispatcher's fallback ``inference_ms``
+                        # reflects real worst-case latency, not 0ms (#1287 review).
+                        duration_ms=(now - start_time) * 1000,
                     )
                 )
                 # The abandoned thread still occupies the worker slot until it

--- a/src/file_organizer/services/text_processor.py
+++ b/src/file_organizer/services/text_processor.py
@@ -33,6 +33,13 @@ class ProcessedFile:
     original_content: str | None = None
     processing_time: float = 0.0
     error: str | None = None
+    # Best-effort audio transcript (#WP-4.1 anti-cascade audio path).
+    # Populated by the dispatcher's audio pipeline when a transcriber is
+    # configured and transcription succeeds within the duration cap; None
+    # for metadata-only categorization or when transcription degraded on a
+    # recoverable failure. Stored for the organizer's text-categorization
+    # path; rendering consumers are out of scope for this port.
+    transcript: str | None = None
 
 
 # Stop-words and noise words filtered from AI-generated names.

--- a/src/file_organizer/services/vision_fallback.py
+++ b/src/file_organizer/services/vision_fallback.py
@@ -1,0 +1,176 @@
+"""Degraded categorization path for images that timed out in the vision model (#406).
+
+When ``VisionProcessor`` exceeds the dispatcher's per-file timeout (#396),
+the abandoned thread leaves the file uncategorized. Rather than counting
+it as a hard failure, we run a metadata-only fallback that synthesizes a
+folder + filename from:
+
+1. **EXIF metadata** — ``DateTime`` and ``Model`` tags via Pillow's
+   ``Image.getexif()``. Yields ``Images/<Year>/<Month>/`` placements that
+   match a typical date-based photo layout.
+2. **Filename pattern recognition** — well-known patterns such as
+   ``Screenshot YYYY-MM-DD …`` or ``IMG_YYYYMMDD_HHMMSS.jpg`` lock the
+   file to ``Images/Screenshots/<Year>/`` and ``Images/Photos/<Year>/<Month>/``.
+3. **Generic bucket** — anything that matches neither lands in
+   ``Images/Untagged/``.
+
+The result carries a ``source`` marker that the summary uses to surface a
+"categorized via fallback" count, distinct from the success and failure
+totals. Fallback placements are intentionally low-confidence (the vision
+model never saw the image) and should be reviewed before any destructive
+rename / move.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from loguru import logger
+
+# Folder name returned when neither EXIF nor filename gave a usable hint.
+_UNTAGGED_FOLDER = "Images/Untagged"
+
+
+FallbackSource = Literal["fallback_exif", "fallback_filename"]
+
+
+@dataclass(frozen=True)
+class FallbackResult:
+    """Folder + filename + provenance from the degraded image path."""
+
+    folder: str
+    filename: str
+    source: FallbackSource
+
+
+# ----------------------------------------------------------------------
+# Filename heuristics — checked in order, first match wins.
+# Each entry: (compiled regex, builder taking the match → FallbackResult)
+# ----------------------------------------------------------------------
+
+# "Screenshot 2026-05-22 at 14.03.07.png"
+_SCREENSHOT_PATTERN = re.compile(
+    r"^Screenshot\s+(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})",
+    re.IGNORECASE,
+)
+
+# "IMG_20260522_140307.jpg" or "VID_20260522_140307.mp4"
+_IMG_DATESTAMP_PATTERN = re.compile(
+    r"^(?:IMG|VID|PXL|DSC)_(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})",
+    re.IGNORECASE,
+)
+
+
+def _from_filename(path: Path) -> FallbackResult | None:
+    """Try filename-based categorization. Returns None if no pattern matched."""
+    name = path.name
+    if (m := _SCREENSHOT_PATTERN.match(name)) is not None:
+        year = m.group("year")
+        return FallbackResult(
+            folder=f"Images/Screenshots/{year}",
+            filename=path.stem,
+            source="fallback_filename",
+        )
+    if (m := _IMG_DATESTAMP_PATTERN.match(name)) is not None:
+        year = m.group("year")
+        month = m.group("month")
+        return FallbackResult(
+            folder=f"Images/Photos/{year}/{month}",
+            filename=path.stem,
+            source="fallback_filename",
+        )
+    return None
+
+
+def _from_exif(path: Path) -> FallbackResult | None:
+    """Try EXIF-based categorization. Returns None if Pillow / EXIF unavailable."""
+    try:
+        from PIL import ExifTags, Image
+    except ImportError:
+        return None
+
+    try:
+        with Image.open(path) as img:
+            exif = img.getexif()
+    except Exception:
+        # Truncated image, format Pillow doesn't recognise, permission error, …
+        return None
+
+    if not exif:
+        return None
+
+    # Map numeric tag IDs to names so we can ask by name.
+    tag_by_name: dict[str, int] = {v: k for k, v in ExifTags.TAGS.items()}
+    date_tag_id = tag_by_name.get("DateTimeOriginal") or tag_by_name.get("DateTime")
+    if date_tag_id is None:  # pragma: no cover — Pillow's TAGS always has these
+        return None
+    raw = exif.get(date_tag_id)
+    if not raw:
+        return None
+
+    # EXIF date format: "YYYY:MM:DD HH:MM:SS". The standard doesn't carry
+    # a timezone, so a naive datetime is the honest representation; we
+    # only ever read .year / .month off it, never use it as an absolute
+    # instant. Suppress ruff DTZ007 — the warning's tzinfo recommendation
+    # would invent a timezone we don't actually have.
+    try:
+        dt = datetime.strptime(str(raw), "%Y:%m:%d %H:%M:%S")  # noqa: DTZ007
+    except ValueError:
+        return None
+
+    return FallbackResult(
+        folder=f"Images/Photos/{dt.year:04d}/{dt.month:02d}",
+        filename=path.stem,
+        source="fallback_exif",
+    )
+
+
+def compute_fallback(file_path: Path) -> FallbackResult:
+    """Synthesize a folder + filename for an image that timed out in vision (#406).
+
+    Resolution order:
+      1. EXIF DateTime / DateTimeOriginal → ``Images/Photos/<Year>/<Month>/``
+      2. Filename pattern (``Screenshot YYYY-MM-DD`` / ``IMG_YYYYMMDD_HHMMSS``)
+      3. ``Images/Untagged/`` with the file's stem as the filename
+
+    Always returns a result — the caller never has to handle ``None``.
+
+    Args:
+        file_path: Path to the image whose vision inference timed out.
+
+    Returns:
+        A ``FallbackResult`` carrying the folder, filename, and the
+        ``source`` marker (``"fallback_exif"`` or ``"fallback_filename"``).
+        Generic-bucket placements are reported as ``"fallback_filename"``
+        because the filename — not the (empty) EXIF — is what dictated them.
+    """
+    if (exif_result := _from_exif(file_path)) is not None:
+        logger.debug(
+            "Fallback categorization for {}: source=fallback_exif → {}",
+            file_path.name,
+            exif_result.folder,
+        )
+        return exif_result
+
+    if (filename_result := _from_filename(file_path)) is not None:
+        logger.debug(
+            "Fallback categorization for {}: source=fallback_filename → {}",
+            file_path.name,
+            filename_result.folder,
+        )
+        return filename_result
+
+    logger.debug(
+        "Fallback categorization for {}: source=fallback_filename → {} (untagged)",
+        file_path.name,
+        _UNTAGGED_FOLDER,
+    )
+    return FallbackResult(
+        folder=_UNTAGGED_FOLDER,
+        filename=file_path.stem,
+        source="fallback_filename",
+    )

--- a/src/file_organizer/services/vision_fallback.py
+++ b/src/file_organizer/services/vision_fallback.py
@@ -105,10 +105,20 @@ def _from_exif(path: Path) -> FallbackResult | None:
 
     # Map numeric tag IDs to names so we can ask by name.
     tag_by_name: dict[str, int] = {v: k for k, v in ExifTags.TAGS.items()}
-    date_tag_id = tag_by_name.get("DateTimeOriginal") or tag_by_name.get("DateTime")
-    if date_tag_id is None:  # pragma: no cover — Pillow's TAGS always has these
-        return None
-    raw = exif.get(date_tag_id)
+    # Prefer DateTimeOriginal (capture time) but fall back to the standard
+    # DateTime tag when that's all the image carries. Each candidate must be
+    # resolved against the IMAGE's exif, not just the global tag table:
+    # DateTimeOriginal's id always exists in ``ExifTags.TAGS``, so selecting it
+    # unconditionally would mask a DateTime-only image and silently degrade to
+    # the filename path (#1287 review).
+    raw = None
+    for tag_name in ("DateTimeOriginal", "DateTime"):
+        tag_id = tag_by_name.get(tag_name)
+        if tag_id is not None:
+            value = exif.get(tag_id)
+            if value:
+                raw = value
+                break
     if not raw:
         return None
 

--- a/src/file_organizer/services/vision_processor.py
+++ b/src/file_organizer/services/vision_processor.py
@@ -15,11 +15,18 @@ from loguru import logger
 from file_organizer.models import VisionModel
 from file_organizer.models.base import BaseModel, ModelConfig, ModelType
 from file_organizer.models.provider_factory import get_vision_model
+from file_organizer.services.inference_timer import time_inference
 
 
 @dataclass
 class ProcessedImage:
-    """Result of image processing."""
+    """Result of image processing.
+
+    The ``source`` field indicates how the categorization was produced:
+    ``"vision"`` is the normal AI-model path; ``"fallback_exif"`` and
+    ``"fallback_filename"`` mark low-confidence placements assigned by
+    the metadata-only fallback (#406) when the vision call timed out.
+    """
 
     file_path: Path
     description: str
@@ -29,6 +36,20 @@ class ProcessedImage:
     extracted_text: str | None = None
     processing_time: float = 0.0
     error: str | None = None
+    source: str = "vision"
+    # Wall-clock duration of the inference path measured in milliseconds
+    # (#410). Populated even on the error / fallback paths so summary
+    # aggregation (p50/p95/p99) reflects every per-file attempt, not just
+    # the happy path. None on results assembled without going through
+    # process_file (e.g. metadata-only fallback constructed by the
+    # dispatcher).
+    inference_ms: float | None = None
+    # Categorization confidence in [0.0, 1.0] (#409). 1.0 = happy-path
+    # vision inference, 0.5 = EXIF-based fallback, 0.3 = filename-only
+    # fallback (#406 metadata path), 0.0 = error / no usable result.
+    # Files below `AppConfig.processing.low_confidence_threshold` are
+    # surfaced in the summary's "Review recommended" section.
+    confidence: float = 1.0
 
 
 class VisionProcessor:
@@ -117,11 +138,50 @@ class VisionProcessor:
         Returns:
             ProcessedImage with metadata
         """
-        import time
-
         file_path = Path(file_path)
         start_time = time.time()
 
+        # Per-file inference timer (#410). The context manager exposes the
+        # measured duration on ``_timer.elapsed_ms`` and emits a structured
+        # ``vision_inference_ms=<N>`` log line for invoked calls. The inner
+        # method returns a (result, model_invoked) tuple so timing is
+        # attributed only when a model call was actually attempted —
+        # pre-inference early returns (circuit-open, file-not-found) do not
+        # contribute to the p95/p99 sample set.
+        with time_inference("vision", file_path) as _timer:
+            result, model_invoked = self._process_file_inner(
+                file_path,
+                start_time=start_time,
+                generate_description=generate_description,
+                generate_folder=generate_folder,
+                generate_filename=generate_filename,
+                perform_ocr=perform_ocr,
+            )
+            if model_invoked:
+                _timer.mark_invoked()
+        if model_invoked:
+            result.inference_ms = _timer.elapsed_ms
+        return result
+
+    def _process_file_inner(
+        self,
+        file_path: Path,
+        *,
+        start_time: float,
+        generate_description: bool,
+        generate_folder: bool,
+        generate_filename: bool,
+        perform_ocr: bool,
+    ) -> tuple[ProcessedImage, bool]:
+        """Inner body of :meth:`process_file`.
+
+        Returns ``(result, model_invoked)``. ``model_invoked`` is True iff at
+        least one model call (description / OCR / folder / filename) was
+        attempted — regardless of whether it succeeded or raised. Failed-but-
+        attempted inferences contribute to the #410 p95/p99 summary; pre-
+        inference early returns (circuit-open, file-not-found) do not.
+        """
+        model_invoked = False
         try:
             if self._is_circuit_open():
                 logger.warning(
@@ -134,44 +194,58 @@ class VisionProcessor:
                     file_path.name,
                     error_message,
                 )
-                return ProcessedImage(
-                    file_path=file_path,
-                    description=f"Image from {file_path.name}",
-                    folder_name="images",
-                    filename=file_path.stem,
-                    error=error_message,
+                return (
+                    ProcessedImage(
+                        file_path=file_path,
+                        description=f"Image from {file_path.name}",
+                        folder_name="images",
+                        filename=file_path.stem,
+                        error=error_message,
+                        confidence=0.0,
+                    ),
+                    False,  # no model call attempted
                 )
 
             # Validate file exists
             if not file_path.exists():
-                return ProcessedImage(
-                    file_path=file_path,
-                    description="",
-                    folder_name="errors",
-                    filename=file_path.stem,
-                    error="File not found",
+                return (
+                    ProcessedImage(
+                        file_path=file_path,
+                        description="",
+                        folder_name="errors",
+                        filename=file_path.stem,
+                        error="File not found",
+                        confidence=0.0,
+                    ),
+                    False,  # no model call attempted
                 )
 
             # Generate description
             description = ""
             if generate_description:
                 logger.debug(f"Analyzing image: {file_path.name}")
+                model_invoked = True
                 description = self._generate_description(file_path)
                 logger.debug(f"Generated description ({len(description)} chars)")
                 if self._is_circuit_open():
                     error_message = self._circuit_open_error()
-                    return ProcessedImage(
-                        file_path=file_path,
-                        description=description or f"Image from {file_path.name}",
-                        folder_name="images",
-                        filename=file_path.stem,
-                        error=error_message,
+                    return (
+                        ProcessedImage(
+                            file_path=file_path,
+                            description=description or f"Image from {file_path.name}",
+                            folder_name="images",
+                            filename=file_path.stem,
+                            error=error_message,
+                            confidence=0.0,
+                        ),
+                        True,  # the call that tripped the circuit DID happen
                     )
 
             # Extract text if needed
             extracted_text = None
             has_text = False
             if perform_ocr:
+                model_invoked = True
                 extracted_text = self._extract_text(file_path)
                 has_text = bool(extracted_text and len(extracted_text.strip()) > 10)
                 if has_text and extracted_text is not None:
@@ -180,6 +254,7 @@ class VisionProcessor:
             # Generate folder name
             folder_name = ""
             if generate_folder:
+                model_invoked = True
                 # Use extracted text if available, otherwise use description
                 context: str = (extracted_text or description) if has_text else description
                 folder_name = self._generate_folder_name(file_path, context)
@@ -188,6 +263,7 @@ class VisionProcessor:
             # Generate filename
             filename = ""
             if generate_filename:
+                model_invoked = True
                 # Use extracted text if available, otherwise use description
                 context = (extracted_text or description) if has_text else description
                 filename = self._generate_filename(file_path, context)
@@ -195,24 +271,31 @@ class VisionProcessor:
 
             processing_time = time.time() - start_time
 
-            return ProcessedImage(
-                file_path=file_path,
-                description=description,
-                folder_name=folder_name,
-                filename=filename,
-                has_text=has_text,
-                extracted_text=extracted_text[:500] if extracted_text else None,
-                processing_time=processing_time,
+            return (
+                ProcessedImage(
+                    file_path=file_path,
+                    description=description,
+                    folder_name=folder_name,
+                    filename=filename,
+                    has_text=has_text,
+                    extracted_text=extracted_text[:500] if extracted_text else None,
+                    processing_time=processing_time,
+                ),
+                model_invoked,
             )
 
         except Exception as e:
             logger.exception(f"Failed to process {file_path.name}: {e}")
-            return ProcessedImage(
-                file_path=file_path,
-                description="",
-                folder_name="errors",
-                filename=file_path.stem,
-                error=str(e),
+            return (
+                ProcessedImage(
+                    file_path=file_path,
+                    description="",
+                    folder_name="errors",
+                    filename=file_path.stem,
+                    error=str(e),
+                    confidence=0.0,
+                ),
+                model_invoked,
             )
 
     def _clean_ai_generated_name(self, name: str, max_words: int = 3) -> str:

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -522,6 +522,58 @@ class TestProcessImageFiles:
         assert results[0].error == "Corrupt JPEG data: 12 extraneous bytes"
         assert results[0].confidence == 0.0
 
+    def test_retry_saturation_abort_routes_through_vision_fallback(self) -> None:
+        # #1287 review: the sequential retry reuses one single-worker
+        # processor for all retry candidates. If an earlier retry hangs, its
+        # thread occupies the lone worker and the remaining candidates get
+        # never-started saturation aborts (``non_retryable=False``). Those must
+        # degrade to the #406 metadata fallback rather than the error folder —
+        # otherwise one hung retry cascades the untried candidates into
+        # failures, reintroducing the cascade this path exists to prevent.
+        from file_organizer.core.dispatcher import process_image_files
+
+        path = Path("/mock/photos/retry_never_ran.jpg")
+        initial_abort = _make_file_result(
+            success=False,
+            path=path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        # Retry pass: this candidate never started (collateral of a hung peer).
+        retry_saturated = _make_file_result(
+            success=False,
+            path=path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        mock_pp = MagicMock()
+        mock_pp.config.timeout_per_file = 60.0
+        mock_pp.process_batch_iter.return_value = iter([initial_abort])
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry_saturated])
+        with patch("file_organizer.core.dispatcher.compute_fallback") as mock_fb:
+            fb = MagicMock()
+            fb.source = "fallback_filename"
+            fb.folder = "Images/Photos/untagged"
+            fb.filename = "retry_never_ran"
+            mock_fb.return_value = fb
+            progress_ctx = _make_progress_ctx()
+            with (
+                patch(_PROGRESS_TARGET, return_value=progress_ctx),
+                patch("file_organizer.core.dispatcher.ParallelProcessor", return_value=retry_pp),
+            ):
+                results = process_image_files(
+                    [path],
+                    vision_processor=MagicMock(),
+                    parallel_processor=mock_pp,
+                    console=MagicMock(),
+                )
+        # Degraded to metadata fallback, not the error folder — no cascade.
+        assert len(results) == 1
+        assert results[0].error is None
+        assert results[0].source == "fallback_filename"
+        assert results[0].folder_name == "Images/Photos/untagged"
+
     def test_failure_result_unknown_error(self) -> None:
         from file_organizer.core.dispatcher import process_image_files
 

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -50,13 +50,22 @@ def _make_file_result(
     path: Path,
     result: object | None = None,
     error: str | None = None,
+    non_retryable: bool = True,
+    duration_ms: float = 0.0,
 ) -> MagicMock:
-    """Return a MagicMock parallel processor file result."""
+    """Return a MagicMock parallel processor file result.
+
+    ``non_retryable=True`` is the historical default (existing tests assume
+    aborted tasks aren't retried). The #432 retry path requires callers to pass
+    ``non_retryable=False`` to opt into the dispatcher's sequential retry pass.
+    """
     fr = MagicMock()
     fr.success = success
     fr.path = path
     fr.result = result
     fr.error = error
+    fr.non_retryable = non_retryable
+    fr.duration_ms = duration_ms
     return fr
 
 
@@ -320,6 +329,199 @@ class TestProcessImageFiles:
         assert results[0].file_path == file_path
         assert results[0].filename == "missing"
 
+    def test_pool_saturation_retryable_aborts_run_sequentially(self) -> None:
+        # #432: when the parallel processor returns saturation aborts
+        # tagged ``non_retryable=False`` (never-started tasks), the
+        # dispatcher reruns them sequentially via ``vision_processor``
+        # rather than mass-failing them as collateral damage.
+        from file_organizer.core.dispatcher import process_image_files
+        from file_organizer.services import ProcessedImage
+
+        hung_path = Path("/mock/photos/hung.jpg")
+        retry1 = Path("/mock/photos/never_started_1.jpg")
+        retry2 = Path("/mock/photos/never_started_2.jpg")
+
+        # Parallel processor yields one truly-hung abort (non_retryable)
+        # + two never-started aborts (retryable).
+        hung_fr = _make_file_result(
+            success=False,
+            path=hung_path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=True,
+        )
+        retry1_fr = _make_file_result(
+            success=False,
+            path=retry1,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        retry2_fr = _make_file_result(
+            success=False,
+            path=retry2,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        # Retry pass also runs through the parallel processor (preserves
+        # timeout / cancellation enforcement). Yield successful retries.
+        retry1_success = _make_file_result(
+            success=True,
+            path=retry1,
+            result=ProcessedImage(
+                file_path=retry1,
+                description="d1",
+                folder_name="ok",
+                filename="never_started_1",
+            ),
+        )
+        retry2_success = _make_file_result(
+            success=True,
+            path=retry2,
+            result=ProcessedImage(
+                file_path=retry2,
+                description="d2",
+                folder_name="ok",
+                filename="never_started_2",
+            ),
+        )
+        # Initial processor (multi-worker) yields the saturation batch.
+        mock_pp = MagicMock()
+        mock_pp.config.timeout_per_file = 60.0  # real float for ParallelConfig() validation
+        mock_pp.process_batch_iter.return_value = iter([hung_fr, retry1_fr, retry2_fr])
+
+        # Retry processor is a fresh single-worker ParallelProcessor —
+        # reusing the original multi-worker config can re-saturate. Patch
+        # the class at the dispatcher's import site so we can assert it was
+        # built with ``max_workers=1, prefetch_depth=0``.
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry1_success, retry2_success])
+
+        vp = MagicMock()
+        progress_ctx = _make_progress_ctx()
+        with (
+            patch(_PROGRESS_TARGET, return_value=progress_ctx),
+            patch(
+                "file_organizer.core.dispatcher.ParallelProcessor", return_value=retry_pp
+            ) as mock_pp_cls,
+        ):
+            results = process_image_files(
+                [hung_path, retry1, retry2],
+                vision_processor=vp,
+                parallel_processor=mock_pp,
+                console=MagicMock(),
+            )
+
+        # 1 genuinely-hung failure + 2 sequential successes.
+        by_path = {r.file_path: r for r in results}
+        assert by_path[hung_path].error == "Aborted: worker pool saturated by hung tasks"
+        assert by_path[retry1].error is None
+        assert by_path[retry1].folder_name == "ok"
+        assert by_path[retry2].error is None
+        assert by_path[retry2].folder_name == "ok"
+        # Initial multi-worker processor was used once; retry processor
+        # was constructed with single-worker + no-prefetch.
+        assert mock_pp.process_batch_iter.call_count == 1
+        assert mock_pp_cls.call_count == 1
+        retry_config = mock_pp_cls.call_args.kwargs["config"]
+        assert retry_config.max_workers == 1
+        assert retry_config.prefetch_depth == 0
+        # Operator-tunable timeout is inherited from the caller's config.
+        assert retry_config.timeout_per_file == 60.0
+        # Retry processor.process_batch_iter was called with just the
+        # never-started paths.
+        assert retry_pp.process_batch_iter.call_count == 1
+        retry_paths_arg = retry_pp.process_batch_iter.call_args.args[0]
+        assert set(retry_paths_arg) == {retry1, retry2}
+
+    def test_retry_timeout_routes_through_vision_fallback(self) -> None:
+        # #432 follow-up: the sequential retry pass runs through
+        # ``parallel_processor.process_batch_iter`` so the per-file timeout
+        # is enforced. When a retry hits that timeout, the dispatcher must
+        # route the file through the same #406 EXIF fallback path the initial
+        # pass uses — preserving the operator-facing classification rather
+        # than letting the timeout escape as a generic error.
+        from file_organizer.core.dispatcher import process_image_files
+
+        path = Path("/mock/photos/retry_timeout.jpg")
+        initial_abort = _make_file_result(
+            success=False,
+            path=path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        retry_timeout = _make_file_result(
+            success=False,
+            path=path,
+            error="Timed out after 60s",
+            duration_ms=60000.0,
+        )
+        mock_pp = MagicMock()
+        mock_pp.config.timeout_per_file = 60.0
+        mock_pp.process_batch_iter.return_value = iter([initial_abort])
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry_timeout])
+        with patch("file_organizer.core.dispatcher.compute_fallback") as mock_fb:
+            fb = MagicMock()
+            fb.source = "fallback_exif"
+            fb.folder = "Images/Photos/2024/01"
+            fb.filename = "retry_timeout"
+            mock_fb.return_value = fb
+            progress_ctx = _make_progress_ctx()
+            with (
+                patch(_PROGRESS_TARGET, return_value=progress_ctx),
+                patch("file_organizer.core.dispatcher.ParallelProcessor", return_value=retry_pp),
+            ):
+                results = process_image_files(
+                    [path],
+                    vision_processor=MagicMock(),
+                    parallel_processor=mock_pp,
+                    console=MagicMock(),
+                )
+        assert len(results) == 1
+        assert results[0].source == "fallback_exif"
+        assert results[0].folder_name == "Images/Photos/2024/01"
+        # Carries timer duration through for #410 p95/p99 accounting.
+        assert results[0].inference_ms == 60000.0
+
+    def test_retry_generic_error_falls_to_error_folder(self) -> None:
+        # #432 follow-up: non-timeout retry failures (e.g. corrupt image
+        # data, vision-model error) record as genuine failures in the
+        # ``errors`` folder — there's no second-level retry.
+        from file_organizer.core.dispatcher import process_image_files
+        from file_organizer.core.types import ERROR_FALLBACK_FOLDER
+
+        path = Path("/mock/photos/retry_bad.jpg")
+        initial_abort = _make_file_result(
+            success=False,
+            path=path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        retry_err = _make_file_result(
+            success=False,
+            path=path,
+            error="Corrupt JPEG data: 12 extraneous bytes",
+        )
+        mock_pp = MagicMock()
+        mock_pp.config.timeout_per_file = 60.0
+        mock_pp.process_batch_iter.return_value = iter([initial_abort])
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry_err])
+        progress_ctx = _make_progress_ctx()
+        with (
+            patch(_PROGRESS_TARGET, return_value=progress_ctx),
+            patch("file_organizer.core.dispatcher.ParallelProcessor", return_value=retry_pp),
+        ):
+            results = process_image_files(
+                [path],
+                vision_processor=MagicMock(),
+                parallel_processor=mock_pp,
+                console=MagicMock(),
+            )
+        assert len(results) == 1
+        assert results[0].folder_name == ERROR_FALLBACK_FOLDER
+        assert results[0].error == "Corrupt JPEG data: 12 extraneous bytes"
+        assert results[0].confidence == 0.0
+
     def test_failure_result_unknown_error(self) -> None:
         from file_organizer.core.dispatcher import process_image_files
 
@@ -536,6 +738,195 @@ class TestProcessAudioFiles:
             results = process_audio_files(paths, extractor_cls=mock_extractor_cls)
 
         assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# Audio best-effort transcription (WP-4.1 anti-cascade audio path)
+# ---------------------------------------------------------------------------
+
+
+class TestAudioTranscription:
+    """Tests for _maybe_transcribe / _to_transcription_result + wiring."""
+
+    def test_maybe_transcribe_none_transcriber_returns_none(self) -> None:
+        from file_organizer.core.dispatcher import _maybe_transcribe
+
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=10.0),
+            transcriber=None,
+            max_transcribe_seconds=None,
+        )
+        assert result is None
+
+    def test_maybe_transcribe_invalid_transcriber_degrades(self) -> None:
+        """A transcriber missing generate() degrades to metadata-only."""
+        from file_organizer.core.dispatcher import _maybe_transcribe
+
+        bad = object()  # no .generate
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=10.0),
+            transcriber=bad,
+            max_transcribe_seconds=None,
+        )
+        assert result is None
+
+    def test_maybe_transcribe_over_cap_skips(self) -> None:
+        from file_organizer.core.dispatcher import _maybe_transcribe
+
+        transcriber = MagicMock()
+        transcriber.generate.return_value = "should not be called"
+        result = _maybe_transcribe(
+            Path("/mock/long.mp3"),
+            metadata=MagicMock(duration=900.0),
+            transcriber=transcriber,
+            max_transcribe_seconds=600.0,
+        )
+        assert result is None
+        transcriber.generate.assert_not_called()
+
+    def test_maybe_transcribe_success_returns_text(self) -> None:
+        from file_organizer.core.dispatcher import _maybe_transcribe
+
+        transcriber = MagicMock()
+        transcriber.generate.return_value = "hello world"
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=10.0),
+            transcriber=transcriber,
+            max_transcribe_seconds=600.0,
+        )
+        assert result == "hello world"
+        transcriber.generate.assert_called_once_with("/mock/a.mp3")
+
+    def test_maybe_transcribe_recoverable_error_degrades(self) -> None:
+        """A RuntimeError during transcription degrades, not aborts."""
+        from file_organizer.core.dispatcher import _maybe_transcribe
+
+        transcriber = MagicMock()
+        transcriber.generate.side_effect = RuntimeError("decode failed")
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=10.0),
+            transcriber=transcriber,
+            max_transcribe_seconds=None,
+        )
+        assert result is None
+
+    def test_to_transcription_result_empty_returns_none(self) -> None:
+        from file_organizer.core.dispatcher import _to_transcription_result
+
+        assert _to_transcription_result(None, MagicMock(duration=5.0)) is None
+        assert _to_transcription_result("", MagicMock(duration=5.0)) is None
+
+    def test_to_transcription_result_wraps_text(self) -> None:
+        from file_organizer.core.dispatcher import _to_transcription_result
+        from file_organizer.services.audio.transcriber import TranscriptionResult
+
+        out = _to_transcription_result("some words", MagicMock(duration=12.5))
+        assert isinstance(out, TranscriptionResult)
+        assert out.text == "some words"
+        assert out.segments == []
+        assert out.duration == 12.5
+
+    def test_process_audio_attaches_transcript_and_passes_to_classifier(self) -> None:
+        """End-to-end: transcript attaches to ProcessedFile and reaches classify()."""
+        from file_organizer.core.dispatcher import process_audio_files
+
+        audio_path = Path("/mock/podcasts/ep1.mp3")
+        meta = MagicMock()
+        meta.artist = None
+        meta.title = None
+        meta.duration = 30.0
+
+        audio_type = MagicMock()
+        audio_type.value = "podcast"
+        classification = MagicMock()
+        classification.audio_type = audio_type
+
+        dest = MagicMock(spec=Path)
+        dest.parent = MagicMock()
+        dest.parent.as_posix.return_value = "Podcasts"
+        dest.stem = "ep1"
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract.return_value = meta
+        mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
+
+        mock_classifier_instance = MagicMock()
+        mock_classifier_instance.classify.return_value = classification
+        mock_organizer_instance = MagicMock()
+        mock_organizer_instance.generate_path.return_value = dest
+
+        transcriber = MagicMock()
+        transcriber.generate.return_value = "episode transcript text"
+
+        with (
+            patch(_AUDIO_CLASSIFIER_TARGET, return_value=mock_classifier_instance),
+            patch(_AUDIO_ORGANIZER_TARGET, return_value=mock_organizer_instance),
+        ):
+            results = process_audio_files(
+                [audio_path],
+                extractor_cls=mock_extractor_cls,
+                transcriber=transcriber,
+                max_transcribe_seconds=600.0,
+            )
+
+        assert len(results) == 1
+        assert results[0].transcript == "episode transcript text"
+        # The classifier received a TranscriptionResult (not None).
+        _, kwargs = mock_classifier_instance.classify.call_args
+        assert kwargs["transcription"] is not None
+        assert kwargs["transcription"].text == "episode transcript text"
+
+    def test_process_audio_transcription_failure_does_not_fail_file(self) -> None:
+        """A transcription failure degrades to metadata-only — file still classified."""
+        from file_organizer.core.dispatcher import process_audio_files
+
+        audio_path = Path("/mock/music/song.mp3")
+        meta = MagicMock()
+        meta.artist = "Band"
+        meta.title = "Song"
+        meta.duration = 20.0
+
+        audio_type = MagicMock()
+        audio_type.value = "music"
+        classification = MagicMock()
+        classification.audio_type = audio_type
+
+        dest = MagicMock(spec=Path)
+        dest.parent = MagicMock()
+        dest.parent.as_posix.return_value = "Music/Band"
+        dest.stem = "Song"
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract.return_value = meta
+        mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
+
+        mock_classifier_instance = MagicMock()
+        mock_classifier_instance.classify.return_value = classification
+        mock_organizer_instance = MagicMock()
+        mock_organizer_instance.generate_path.return_value = dest
+
+        transcriber = MagicMock()
+        transcriber.generate.side_effect = RuntimeError("whisper crashed")
+
+        with (
+            patch(_AUDIO_CLASSIFIER_TARGET, return_value=mock_classifier_instance),
+            patch(_AUDIO_ORGANIZER_TARGET, return_value=mock_organizer_instance),
+        ):
+            results = process_audio_files(
+                [audio_path],
+                extractor_cls=mock_extractor_cls,
+                transcriber=transcriber,
+            )
+
+        # File is NOT failed — it's classified from metadata, transcript is None.
+        assert len(results) == 1
+        assert results[0].error is None
+        assert results[0].folder_name == "Music/Band"
+        assert results[0].transcript is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -812,10 +812,10 @@ class TestAudioTranscription:
         assert result is None
 
     def test_maybe_transcribe_invalid_transcriber_degrades(self) -> None:
-        """A transcriber missing generate() degrades to metadata-only."""
+        """A transcriber exposing neither transcribe() nor generate() degrades."""
         from file_organizer.core.dispatcher import _maybe_transcribe
 
-        bad = object()  # no .generate
+        bad = object()  # no .transcribe / .generate
         result = _maybe_transcribe(
             Path("/mock/a.mp3"),
             metadata=MagicMock(duration=10.0),
@@ -827,8 +827,7 @@ class TestAudioTranscription:
     def test_maybe_transcribe_over_cap_skips(self) -> None:
         from file_organizer.core.dispatcher import _maybe_transcribe
 
-        transcriber = MagicMock()
-        transcriber.generate.return_value = "should not be called"
+        transcriber = MagicMock(spec=["transcribe"])
         result = _maybe_transcribe(
             Path("/mock/long.mp3"),
             metadata=MagicMock(duration=900.0),
@@ -836,12 +835,34 @@ class TestAudioTranscription:
             max_transcribe_seconds=600.0,
         )
         assert result is None
-        transcriber.generate.assert_not_called()
+        transcriber.transcribe.assert_not_called()
 
-    def test_maybe_transcribe_success_returns_text(self) -> None:
+    def test_maybe_transcribe_uses_transcribe_api(self) -> None:
+        """The repo's AudioTranscriber (transcribe() -> TranscriptionResult) is used.
+
+        Regression for #1287 review: the guard previously required generate(),
+        rejecting the real Whisper transcriber and forcing metadata-only audio.
+        """
+        from types import SimpleNamespace
+
         from file_organizer.core.dispatcher import _maybe_transcribe
 
-        transcriber = MagicMock()
+        transcriber = MagicMock(spec=["transcribe"])
+        transcriber.transcribe.return_value = SimpleNamespace(text="hello from whisper")
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=10.0),
+            transcriber=transcriber,
+            max_transcribe_seconds=600.0,
+        )
+        assert result == "hello from whisper"
+        transcriber.transcribe.assert_called_once_with("/mock/a.mp3")
+
+    def test_maybe_transcribe_generate_duck_type_returns_text(self) -> None:
+        """A generate(path) -> str duck-type is still accepted as a fallback."""
+        from file_organizer.core.dispatcher import _maybe_transcribe
+
+        transcriber = MagicMock(spec=["generate"])
         transcriber.generate.return_value = "hello world"
         result = _maybe_transcribe(
             Path("/mock/a.mp3"),
@@ -856,8 +877,8 @@ class TestAudioTranscription:
         """A RuntimeError during transcription degrades, not aborts."""
         from file_organizer.core.dispatcher import _maybe_transcribe
 
-        transcriber = MagicMock()
-        transcriber.generate.side_effect = RuntimeError("decode failed")
+        transcriber = MagicMock(spec=["transcribe"])
+        transcriber.transcribe.side_effect = RuntimeError("decode failed")
         result = _maybe_transcribe(
             Path("/mock/a.mp3"),
             metadata=MagicMock(duration=10.0),
@@ -911,8 +932,10 @@ class TestAudioTranscription:
         mock_organizer_instance = MagicMock()
         mock_organizer_instance.generate_path.return_value = dest
 
-        transcriber = MagicMock()
-        transcriber.generate.return_value = "episode transcript text"
+        from types import SimpleNamespace
+
+        transcriber = MagicMock(spec=["transcribe"])
+        transcriber.transcribe.return_value = SimpleNamespace(text="episode transcript text")
 
         with (
             patch(_AUDIO_CLASSIFIER_TARGET, return_value=mock_classifier_instance),
@@ -961,8 +984,8 @@ class TestAudioTranscription:
         mock_organizer_instance = MagicMock()
         mock_organizer_instance.generate_path.return_value = dest
 
-        transcriber = MagicMock()
-        transcriber.generate.side_effect = RuntimeError("whisper crashed")
+        transcriber = MagicMock(spec=["transcribe"])
+        transcriber.transcribe.side_effect = RuntimeError("whisper crashed")
 
         with (
             patch(_AUDIO_CLASSIFIER_TARGET, return_value=mock_classifier_instance),

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -172,17 +172,22 @@ class TestConcurrencyFixes(unittest.TestCase):
         )
 
     def test_timeout_does_not_deadlock_with_queued_files(self) -> None:
-        """Test that timeout handling aborts queued work instead of deadlocking."""
+        """Timed-out tasks are abandoned; remaining files continue and terminate."""
+        # timeout=0.5s → saturation threshold = 2×0.5s = 1.0s.
+        # Task duration 0.8s keeps slow_3's max queue time (≈0.3s) well below 1.0s,
+        # so the saturation guard must NOT trigger — each task times out individually.
+        # Margins are deliberately wide (0.3s stuck-time vs 1.0s threshold) to
+        # absorb the thread-scheduling variance seen on macOS GitHub Actions runners.
         config = ParallelConfig(
             max_workers=1,
-            timeout_per_file=0.1,
+            timeout_per_file=0.5,
             retry_count=0,
         )
         processor = ParallelProcessor(config=config)
         paths = [Path("slow_1"), Path("slow_2"), Path("slow_3")]
 
         def very_slow_task(_path: Path) -> str:
-            threading.Event().wait(timeout=0.5)
+            threading.Event().wait(timeout=0.8)
             return "done"
 
         results = processor.process_batch(paths, very_slow_task)
@@ -190,20 +195,24 @@ class TestConcurrencyFixes(unittest.TestCase):
         self.assertEqual(results.total, 3)
         self.assertEqual(results.failed, 3)
         self.assertEqual(len(results.results), 3)
+        # Each file runs and times out individually — no cascade abort.
+        # With max_workers=1 and 3×0.5s timeouts, total is ~1.5s.
         self.assertLess(
             results.total_duration_ms,
-            700,
-            "Should abort queued/remaining work quickly after uncancellable timeout",
+            4000,
+            "Should terminate within reasonable time even with repeated timeouts",
         )
         errors = [str(item.error) for item in results.results]
-        self.assertTrue(any("Timed out" in err for err in errors))
-        self.assertTrue(any("Aborted because another task" in err for err in errors))
+        # Every file must report its own timeout, not a cascade-abort message.
+        self.assertTrue(all("Timed out" in err for err in errors))
 
     def test_uncancellable_timeout_is_not_retried(self) -> None:
-        """An uncancellable timed-out task should abort the batch without retries."""
+        """Timed-out tasks are non-retryable: each file runs exactly once."""
+        # timeout=0.5s keeps saturation threshold (1.0s) well above task duration (0.8s).
+        # Margins deliberately wide to absorb macOS GitHub Actions thread-scheduling variance.
         config = ParallelConfig(
             max_workers=1,
-            timeout_per_file=0.1,
+            timeout_per_file=0.5,
             retry_count=2,
         )
         processor = ParallelProcessor(config=config)
@@ -212,15 +221,101 @@ class TestConcurrencyFixes(unittest.TestCase):
         def very_slow_task(_path: Path) -> str:
             nonlocal call_count
             call_count += 1
-            threading.Event().wait(timeout=0.5)
+            threading.Event().wait(timeout=0.8)
             return "done"
 
-        results = processor.process_batch([Path("slow_1"), Path("slow_2")], very_slow_task)
+        paths = [Path("slow_1"), Path("slow_2")]
+        results = processor.process_batch(paths, very_slow_task)
 
-        self.assertEqual(call_count, 1)
+        # With retry_count=2, a retried file would be called up to 3 times.
+        # Each file should run exactly once (non_retryable prevents retry).
+        self.assertEqual(call_count, len(paths))
         self.assertEqual(results.failed, 2)
+        self.assertTrue(all("Timed out" in str(item.error) for item in results.results))
+
+    def test_saturated_pool_aborts_queued_tasks(self) -> None:
+        """Queued tasks abort when the pool is permanently saturated by hung tasks.
+
+        Uses genuinely infinite tasks (Event.wait() with no timeout) to simulate
+        worker threads that never complete.  The saturation guard should fire after
+        2 × timeout_per_file and fail remaining queued tasks without hanging.
+        """
+        stop_event = threading.Event()
+
+        config = ParallelConfig(
+            max_workers=1,
+            timeout_per_file=0.1,
+            retry_count=0,
+        )
+        processor = ParallelProcessor(config=config)
+        paths = [Path("hung_1"), Path("queued_2")]
+
+        def hung_task(_path: Path) -> str:
+            stop_event.wait()  # blocks until the event is set
+            return "done"
+
+        try:
+            results = processor.process_batch(paths, hung_task)
+        finally:
+            stop_event.set()  # unblock the hung thread so the pool shuts down
+
+        self.assertEqual(results.total, 2)
+        self.assertEqual(results.failed, 2)
+        # hung_1 should report a timeout; queued_2 must report pool saturation.
+        by_path = {r.path: str(r.error) for r in results.results}
         self.assertTrue(
-            any("could not be cancelled" in str(item.error) for item in results.results)
+            "Timed out" in by_path.get(Path("hung_1"), "")
+            or "saturated" in by_path.get(Path("hung_1"), ""),
+            f"hung_1 should have a timeout/saturation error, got: {by_path.get(Path('hung_1'))}",
+        )
+        self.assertIn(
+            "saturated",
+            by_path.get(Path("queued_2"), ""),
+            f"queued_2 must report pool saturation, got: {by_path.get(Path('queued_2'))}",
+        )
+
+    def test_saturated_pool_warning_includes_tuning_hint(self) -> None:
+        """#435: the saturation warning surfaces the tuning hint inline.
+
+        Operators don't discover ``--timeout-per-file`` / ``--workers``
+        until something breaks badly; the warning that fires when the
+        pool aborts must point at those knobs so the next run can be
+        tuned without a maintainer round-trip.
+        """
+        stop_event = threading.Event()
+        config = ParallelConfig(max_workers=1, timeout_per_file=0.1, retry_count=0)
+        processor = ParallelProcessor(config=config)
+
+        def hung_task(_path: Path) -> str:
+            stop_event.wait()
+            return "done"
+
+        captured: list[str] = []
+
+        def fake_warning(msg: str, *args: object, **_kw: object) -> None:
+            # stdlib logging-style: msg is a format string with %d / %s substitutions
+            try:
+                captured.append(msg % args)
+            except TypeError:
+                captured.append(msg)
+
+        from file_organizer.parallel import processor as processor_mod
+
+        with patch.object(processor_mod.logger, "warning", side_effect=fake_warning):
+            try:
+                processor.process_batch([Path("hung_1"), Path("queued_2")], hung_task)
+            finally:
+                stop_event.set()
+
+        saturated = [line for line in captured if "saturated" in line.lower()]
+        self.assertTrue(saturated, f"expected a saturation warning, got: {captured}")
+        self.assertTrue(
+            any("--timeout-per-file" in line for line in saturated),
+            f"saturation warning should mention --timeout-per-file: {saturated}",
+        )
+        self.assertTrue(
+            any("--workers" in line for line in saturated),
+            f"saturation warning should mention --workers: {saturated}",
         )
 
     def test_error_message_does_not_control_retry_policy(self) -> None:

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -274,6 +274,57 @@ class TestConcurrencyFixes(unittest.TestCase):
             f"queued_2 must report pool saturation, got: {by_path.get(Path('queued_2'))}",
         )
 
+    def test_retryable_saturation_survives_non_retryable_peer(self) -> None:
+        """#1287: a queued never-started saturation file (retryable) must still be
+        retried even when a non-retryable hung peer fails in the same attempt.
+
+        Old behaviour stopped on the first non-retryable failure before
+        collecting retryable ones, stranding the queued file as a failure
+        without ever running it — a residual cascade.
+        """
+        stop_event = threading.Event()
+        config = ParallelConfig(max_workers=1, timeout_per_file=0.1, retry_count=1)
+        processor = ParallelProcessor(config=config)
+
+        def task(path: Path) -> str:
+            if path.name == "hung_1":
+                stop_event.wait()  # never completes during the test
+            return "done"  # queued_2 succeeds once it actually runs (on retry)
+
+        try:
+            results = processor.process_batch([Path("hung_1"), Path("queued_2")], task)
+        finally:
+            stop_event.set()  # unblock the leaked thread so the pool shuts down
+
+        by_path = {r.path: r for r in results.results}
+        # The hung peer is a final failure (non-retryable)...
+        self.assertFalse(by_path[Path("hung_1")].success)
+        # ...but the queued file was retried alone and succeeded — not stranded.
+        self.assertTrue(
+            by_path[Path("queued_2")].success,
+            f"queued_2 should have been retried, got: {by_path[Path('queued_2')]}",
+        )
+
+    def test_timeout_result_records_elapsed_duration(self) -> None:
+        """#1287: a timed-out task records its elapsed duration (~timeout) rather
+        than the 0.0 default, so the dispatcher's fallback ``inference_ms`` (and
+        the p95/p99 sample) reflect the real worst-case latency of a hung call.
+        """
+        config = ParallelConfig(max_workers=1, timeout_per_file=0.2, retry_count=0)
+        processor = ParallelProcessor(config=config)
+
+        def very_slow_task(_path: Path) -> str:
+            threading.Event().wait(timeout=2.0)
+            return "done"
+
+        results = processor.process_batch([Path("slow")], very_slow_task)
+
+        self.assertEqual(results.failed, 1)
+        item = results.results[0]
+        self.assertIn("Timed out", str(item.error))
+        # Elapsed reflects the real wait (≈ timeout), not the 0.0 default.
+        self.assertGreaterEqual(item.duration_ms, config.timeout_per_file * 1000 * 0.5)
+
     def test_saturated_pool_warning_includes_tuning_hint(self) -> None:
         """#435: the saturation warning surfaces the tuning hint inline.
 

--- a/tests/parallel/test_processor.py
+++ b/tests/parallel/test_processor.py
@@ -7,6 +7,7 @@ callbacks, error handling, and graceful shutdown.
 """
 
 import threading
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -497,6 +498,89 @@ class TestShutdown(unittest.TestCase):
         """Test that shutdown can be called without error."""
         processor = ParallelProcessor()
         processor.shutdown()  # Should not raise
+
+
+class TestTimeoutRacePreservesResult(unittest.TestCase):
+    """When ``cancel()`` returns False and ``future.done()`` returns True, the
+    task actually completed in the race window — preserve its real result
+    instead of reporting a phantom timeout.
+    """
+
+    def test_race_window_preserves_successful_result(self) -> None:
+        from concurrent.futures import Future
+        from unittest.mock import MagicMock
+
+        from file_organizer.parallel.processor import ParallelProcessor
+        from file_organizer.parallel.result import FileResult
+
+        processor = ParallelProcessor(config=ParallelConfig(timeout_per_file=0.1))
+        # Construct a future that:
+        # 1. cancel() returns False (couldn't cancel — task already running)
+        # 2. done() returns True (the task ACTUALLY finished in the race window)
+        # 3. result() returns a real successful FileResult
+        finished_result = FileResult(path=Path("ok.txt"), success=True, result="real-output")
+        future: Future[FileResult] = MagicMock(spec=Future)
+        future.cancel.return_value = False
+        future.done.return_value = True
+        future.result.return_value = finished_result
+
+        pending = {future}
+        future_paths = {future: Path("ok.txt")}
+        # Backdate start so the timeout elapsed check fires.
+        future_started = {future: time.monotonic() - 1.0}
+        future_queued_at = {future: time.monotonic() - 1.0}
+
+        out = processor._handle_timeouts(
+            pending=pending,
+            future_paths=future_paths,
+            future_started=future_started,
+            future_queued_at=future_queued_at,
+            timeout=0.1,
+            poll_interval=0.05,
+            finalize_result=lambda r: r,
+        )
+        self.assertIsNotNone(out)
+        should_abort, needs_shutdown, results = out  # type: ignore[misc]
+        self.assertFalse(should_abort)
+        self.assertEqual(len(results), 1)
+        # The real successful result is preserved — NOT a timeout phantom.
+        self.assertTrue(results[0].success)
+        self.assertEqual(results[0].result, "real-output")
+
+    def test_race_window_preserves_exception(self) -> None:
+        from concurrent.futures import Future
+        from unittest.mock import MagicMock
+
+        from file_organizer.parallel.processor import ParallelProcessor
+        from file_organizer.parallel.result import FileResult
+
+        processor = ParallelProcessor(config=ParallelConfig(timeout_per_file=0.1))
+        future: Future[FileResult] = MagicMock(spec=Future)
+        future.cancel.return_value = False
+        future.done.return_value = True
+        # Task finished in the race window but raised — surface the
+        # actual exception text rather than a timeout phantom.
+        future.result.side_effect = RuntimeError("ollama 500")
+
+        pending = {future}
+        future_paths = {future: Path("boom.txt")}
+        future_started = {future: time.monotonic() - 1.0}
+        future_queued_at = {future: time.monotonic() - 1.0}
+
+        out = processor._handle_timeouts(
+            pending=pending,
+            future_paths=future_paths,
+            future_started=future_started,
+            future_queued_at=future_queued_at,
+            timeout=0.1,
+            poll_interval=0.05,
+            finalize_result=lambda r: r,
+        )
+        self.assertIsNotNone(out)
+        _, _, results = out  # type: ignore[misc]
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].success)
+        self.assertIn("ollama 500", results[0].error or "")
 
 
 if __name__ == "__main__":

--- a/tests/services/test_vision_fallback.py
+++ b/tests/services/test_vision_fallback.py
@@ -143,6 +143,28 @@ class TestComputeFallbackExifEndToEnd:
         assert result.folder == "Images/Photos/2025/11"
         assert result.filename == "DSC_0042"
 
+    def test_exif_datetime_only_drives_year_month_folder(self, tmp_path: Path) -> None:
+        """A JPEG carrying only the standard DateTime tag (no DateTimeOriginal)
+        still lands by EXIF date rather than degrading to filename (#1287 review)."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+        from PIL.ExifTags import TAGS
+
+        datetime_tag = next(k for k, v in TAGS.items() if v == "DateTime")
+        # Neutral filename (no date pattern) → filename path would be untagged,
+        # so an EXIF-dated folder unambiguously proves the DateTime tag was used.
+        img_path = tmp_path / "photo.jpg"
+        img = Image.new("RGB", (1, 1), color="blue")
+        exif = img.getexif()
+        exif[datetime_tag] = "2025:11:15 14:30:00"
+        img.save(img_path, "JPEG", exif=exif.tobytes())
+
+        result = compute_fallback(img_path)
+
+        assert result.source == "fallback_exif"
+        assert result.folder == "Images/Photos/2025/11"
+        assert result.filename == "photo"
+
     def test_image_without_exif_returns_none_from_exif(self, tmp_path: Path) -> None:
         """A bare image with no EXIF data → _from_exif returns None → filename path."""
         pytest.importorskip("PIL")

--- a/tests/services/test_vision_fallback.py
+++ b/tests/services/test_vision_fallback.py
@@ -1,0 +1,256 @@
+"""Tests for ``services.vision_fallback`` (#406 — degraded categorization).
+
+Covers the three resolution paths:
+  1. EXIF DateTime / DateTimeOriginal → ``Images/Photos/YYYY/MM/``
+  2. Filename pattern (Screenshot / IMG_YYYYMMDD)
+  3. Generic ``Images/Untagged/`` bucket
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from file_organizer.services.vision_fallback import FallbackResult, compute_fallback
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.integration]
+
+
+class TestComputeFallbackFilenamePatterns:
+    """When EXIF is unavailable, filename heuristics drive the placement."""
+
+    @patch("file_organizer.services.vision_fallback._from_exif", return_value=None)
+    def test_screenshot_pattern(self, _mock_exif, tmp_path: Path) -> None:
+        img = tmp_path / "Screenshot 2026-05-22 at 14.03.07.png"
+        img.write_bytes(b"")
+
+        result = compute_fallback(img)
+
+        assert isinstance(result, FallbackResult)
+        assert result.folder == "Images/Screenshots/2026"
+        assert result.filename == img.stem
+        assert result.source == "fallback_filename"
+
+    @patch("file_organizer.services.vision_fallback._from_exif", return_value=None)
+    def test_img_datestamp_pattern(self, _mock_exif, tmp_path: Path) -> None:
+        img = tmp_path / "IMG_20260522_140307.jpg"
+        img.write_bytes(b"")
+
+        result = compute_fallback(img)
+
+        assert result.folder == "Images/Photos/2026/05"
+        assert result.source == "fallback_filename"
+
+    @patch("file_organizer.services.vision_fallback._from_exif", return_value=None)
+    def test_pxl_datestamp_pattern(self, _mock_exif, tmp_path: Path) -> None:
+        # Google Pixel camera prefix
+        img = tmp_path / "PXL_20260601_093015.jpg"
+        img.write_bytes(b"")
+
+        result = compute_fallback(img)
+
+        assert result.folder == "Images/Photos/2026/06"
+        assert result.source == "fallback_filename"
+
+    @patch("file_organizer.services.vision_fallback._from_exif", return_value=None)
+    def test_unknown_filename_falls_to_untagged(self, _mock_exif, tmp_path: Path) -> None:
+        img = tmp_path / "random_photo_thing.png"
+        img.write_bytes(b"")
+
+        result = compute_fallback(img)
+
+        assert result.folder == "Images/Untagged"
+        assert result.filename == "random_photo_thing"
+        assert result.source == "fallback_filename"
+
+
+class TestComputeFallbackExif:
+    """When EXIF carries a DateTime, it takes priority over filename heuristics."""
+
+    @patch("file_organizer.services.vision_fallback._from_exif")
+    @patch("file_organizer.services.vision_fallback._from_filename", return_value=None)
+    def test_exif_datetime_wins(self, _mock_fname, mock_exif, tmp_path: Path) -> None:
+        mock_exif.return_value = FallbackResult(
+            folder="Images/Photos/2025/11",
+            filename="DSC_0042",
+            source="fallback_exif",
+        )
+
+        img = tmp_path / "DSC_0042.jpg"
+        img.write_bytes(b"")
+
+        result = compute_fallback(img)
+        assert result.source == "fallback_exif"
+        assert result.folder == "Images/Photos/2025/11"
+
+    @patch("file_organizer.services.vision_fallback._from_exif")
+    def test_exif_overrides_filename_screenshot(self, mock_exif, tmp_path: Path) -> None:
+        # A "Screenshot YYYY-MM-DD" filename has a filename match, but EXIF wins.
+        mock_exif.return_value = FallbackResult(
+            folder="Images/Photos/2024/01",
+            filename="Screenshot 2026-05-22",
+            source="fallback_exif",
+        )
+        img = tmp_path / "Screenshot 2026-05-22 at 14.03.07.png"
+        img.write_bytes(b"")
+
+        result = compute_fallback(img)
+        assert result.source == "fallback_exif"
+        assert result.folder == "Images/Photos/2024/01"
+
+    def test_pillow_unavailable_degrades_to_filename(self, tmp_path: Path) -> None:
+        """An ImportError on Pillow does not break the fallback path."""
+        img = tmp_path / "Screenshot 2026-05-22 at 14.03.07.png"
+        img.write_bytes(b"")
+
+        # The real _from_exif catches ImportError internally and returns None,
+        # so EXIF resolution silently degrades to filename matching.
+        with patch.dict("sys.modules", {"PIL": None}):
+            result = compute_fallback(img)
+
+        # Filename path still works
+        assert result.source == "fallback_filename"
+        assert result.folder == "Images/Screenshots/2026"
+
+
+class TestComputeFallbackExifEndToEnd:
+    """Exercise _from_exif with a real Pillow-encoded EXIF image (not mocked)."""
+
+    def _write_image_with_exif(self, path: Path, date_str: str) -> None:
+        """Create a 1x1 JPEG carrying DateTimeOriginal == date_str."""
+        from PIL import Image
+        from PIL.ExifTags import TAGS
+
+        # Find numeric tag IDs by name so we don't hardcode magic numbers.
+        date_tag = next(k for k, v in TAGS.items() if v == "DateTimeOriginal")
+
+        img = Image.new("RGB", (1, 1), color="red")
+        exif = img.getexif()
+        exif[date_tag] = date_str
+        img.save(path, "JPEG", exif=exif.tobytes())
+
+    def test_real_exif_drives_year_month_folder(self, tmp_path: Path) -> None:
+        """A JPEG carrying DateTimeOriginal=2025:11:15… lands in 2025/11."""
+        pytest.importorskip("PIL")
+        img = tmp_path / "DSC_0042.jpg"
+        self._write_image_with_exif(img, "2025:11:15 14:30:00")
+
+        result = compute_fallback(img)
+
+        assert result.source == "fallback_exif"
+        assert result.folder == "Images/Photos/2025/11"
+        assert result.filename == "DSC_0042"
+
+    def test_image_without_exif_returns_none_from_exif(self, tmp_path: Path) -> None:
+        """A bare image with no EXIF data → _from_exif returns None → filename path."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+
+        img_path = tmp_path / "Screenshot 2026-05-22 at 09.00.00.jpg"
+        Image.new("RGB", (1, 1)).save(img_path, "JPEG")  # no exif kwarg
+
+        result = compute_fallback(img_path)
+        assert result.source == "fallback_filename"
+        assert result.folder == "Images/Screenshots/2026"
+
+    def test_exif_with_empty_datetime_value_falls_through(self, tmp_path: Path) -> None:
+        """EXIF carries the DateTime tag but value is empty → falls through."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+        from PIL.ExifTags import TAGS
+
+        date_tag = next(k for k, v in TAGS.items() if v == "DateTimeOriginal")
+        img_path = tmp_path / "Screenshot 2026-05-22 at 09.00.00.jpg"
+        img = Image.new("RGB", (1, 1))
+        exif = img.getexif()
+        exif[date_tag] = ""  # empty string
+        img.save(img_path, "JPEG", exif=exif.tobytes())
+
+        result = compute_fallback(img_path)
+        # Filename path picks it up
+        assert result.source == "fallback_filename"
+        assert result.folder == "Images/Screenshots/2026"
+
+    def test_real_exif_malformed_date_falls_through(self, tmp_path: Path) -> None:
+        """An unparseable DateTimeOriginal string falls back to filename / untagged."""
+        pytest.importorskip("PIL")
+        img = tmp_path / "Screenshot 2024-07-04 at 09.30.00.png"
+        self._write_image_with_exif(img, "not-a-real-date")
+
+        # PNG won't actually round-trip EXIF via Pillow, but the function still
+        # reaches the parse path and returns None on ValueError.  Filename
+        # heuristic then catches the Screenshot pattern.
+        result = compute_fallback(img)
+        # Either EXIF succeeded (unlikely with this bogus date) or filename
+        # took over — both are acceptable; what we're guarding is "doesn't
+        # crash, returns a sane FallbackResult".
+        assert isinstance(result, FallbackResult)
+
+
+class TestDispatcherTimeoutFallbackIntegration:
+    """The dispatcher's timeout branch routes through compute_fallback (#406)."""
+
+    def test_timed_out_image_becomes_fallback_not_failure(self, tmp_path: Path) -> None:
+        """Vision timeout → ProcessedImage with source=fallback_*, no error."""
+        from unittest.mock import MagicMock
+
+        from file_organizer.core.dispatcher import process_image_files
+        from file_organizer.parallel.processor import FileResult
+
+        img = tmp_path / "Screenshot 2026-05-22 at 09.00.00.png"
+        img.write_bytes(b"")
+
+        # parallel_processor.process_batch_iter yields a single timed-out FileResult
+        timed_out = FileResult(
+            path=img,
+            success=False,
+            error="Timed out after 300.0s",
+            non_retryable=True,
+        )
+        mock_parallel = MagicMock()
+        mock_parallel.process_batch_iter.return_value = iter([timed_out])
+
+        mock_vision = MagicMock()
+        mock_console = MagicMock()
+
+        results = process_image_files([img], mock_vision, mock_parallel, mock_console)
+
+        assert len(results) == 1
+        result = results[0]
+        # Fallback placement, no error, source marker present
+        assert result.error is None or result.error == ""
+        assert result.folder_name == "Images/Screenshots/2026"
+        assert result.source == "fallback_filename"
+
+    def test_non_timeout_error_still_takes_failure_path(self, tmp_path: Path) -> None:
+        """A non-timeout failure (e.g. read error) is NOT rerouted to fallback."""
+        from unittest.mock import MagicMock
+
+        from file_organizer.core.dispatcher import ERROR_FALLBACK_FOLDER, process_image_files
+        from file_organizer.parallel.processor import FileResult
+
+        img = tmp_path / "broken.png"
+        img.write_bytes(b"")
+
+        read_error = FileResult(
+            path=img,
+            success=False,
+            error="PermissionError: [Errno 13] Permission denied",
+        )
+        mock_parallel = MagicMock()
+        mock_parallel.process_batch_iter.return_value = iter([read_error])
+        mock_vision = MagicMock()
+        mock_console = MagicMock()
+
+        results = process_image_files([img], mock_vision, mock_parallel, mock_console)
+
+        assert len(results) == 1
+        result = results[0]
+        # Real failure: error preserved, folder is the error bucket
+        assert result.error is not None
+        assert "Permission denied" in result.error
+        assert result.folder_name == ERROR_FALLBACK_FOLDER
+        # Default source unchanged
+        assert result.source == "vision"


### PR DESCRIPTION
Closes #1231 — Phase 4 (WP-4.1), epic #1221. **Targets the `epic/1221-phase-4` integration branch.**

## What

Faithful port of the fork's anti-cascade resilience: a single hung/slow/failed file must never abort or fail-out the whole batch.

## Changes

- **New `services/vision_fallback.py`** — `compute_fallback()` (EXIF→filename metadata categorization), `FallbackResult`, `FallbackSource`. Pillow EXIF read with an `ImportError` guard; no new deps.
- **`core/dispatcher.py`** — anti-cascade:
  - `process_image_files`: vision **timeouts** (`_is_timeout_error`) route through `compute_fallback` (categorized, not errored); worker-pool **saturation** aborts on never-started tasks (`non_retryable=False`) are queued and **retried sequentially** with a fresh single-worker `ParallelProcessor(max_workers=1, prefetch_depth=0, retry_count=0)` (inheriting `--timeout-per-file`) instead of being recorded as failures.
  - `process_audio_files`: best-effort transcription via `_maybe_transcribe` (+ `_to_transcription_result`) wired to this repo's `services/audio` (`AudioModel.generate`, `TranscriptionResult`), degrading to metadata-only on any recoverable failure.
- **`parallel/processor.py`** — the #370 timeout-cascade fix: per-task timeout handling (`future_queued_at` tracking, `_check_pool_saturation`, rewritten `_handle_timeouts`) that individually fails/abandons the offending task and emits the sentinels the dispatcher keys on (`"Timed out after Xs"`, `"Aborted: worker pool saturated"`) with `non_retryable`, instead of aborting the batch.
- **`services/vision_processor.py`** — `ProcessedImage.source` / `inference_ms` / `confidence` fields; `process_file` split into `_process_file_inner` wrapped with the existing `time_inference` to populate `inference_ms`.
- **`services/text_processor.py`** — `ProcessedFile.transcript` (audio anti-cascade deliverable).

## Out of scope (deliberate)

The summary-rendering consumers of the new fields (fork PRs #409 "Review recommended" UI, #410 p95/p99 observability) are **not** ported — `ProcessedImage.source/inference_ms/confidence` are populated but not yet rendered. Text-side `ProcessedFile.confidence`/`inference_ms` were intentionally not added (observability, not resilience). Resilience works end-to-end.

## Verification (local)

- Directly-affected suites (vision_fallback, dispatcher_core, parallel concurrency/processor): **94 passed**.
- Broader `tests/parallel` + `tests/services` + `tests/core`: **3517 passed, 7 skipped** — zero regressions. **+29 new tests.**
- `mypy` clean on all 4 changed src files; `ruff check`/`format` clean; test-quality guardrails (54) pass.
- 2 failures in `tests/integration/test_error_propagation.py` are **pre-existing** — verified identical on the `epic/1221-phase-4` base in a clean worktree, unrelated to this change.

## Notes for reviewers

- `parallel/processor.py` uses stdlib `logging` (matches the fork; a test patches `processor.logger.warning` and asserts %-style substitution — passes the G2 no-f-string guard). `core`/`services` keep loguru.
- Two existing tests in `tests/parallel/test_concurrency_fixes.py` that pinned the old cascade-abort behavior were replaced with the **fork's exact updated versions** (verified byte-identical), which assert the new anti-cascade behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_