### PR TITLE
fix(pipeline): close retired stages on stop to prevent fd leak (#1286)

### DIFF
--- a/src/file_organizer/pipeline/orchestrator.py
+++ b/src/file_organizer/pipeline/orchestrator.py
@@ -274,7 +274,14 @@ class PipelineOrchestrator:
             # (``_stages_closed``): their close() already ran, so re-queuing them
             # would double-close on the next stop().
             if not self._stages_closed:
-                self._retired_stages.extend(self._stages)
+                # Only retire stages actually being dropped. A stage carried
+                # over into the new list (e.g. ``[a]`` -> ``set_stages([a, b])``)
+                # stays current and must NOT also be queued for close, or its
+                # close() would run twice on stop() — once via the retired loop
+                # and once via the current-stages loop (#1289 review). Compare
+                # by identity since stages need not be hashable/comparable.
+                retained_ids = {id(s) for s in stages}
+                self._retired_stages.extend(s for s in self._stages if id(s) not in retained_ids)
             self._stages = list(stages)
             # Newly installed stages may hold their own fds; allow stop() to
             # close them even if a previous stage list was already closed

--- a/src/file_organizer/pipeline/orchestrator.py
+++ b/src/file_organizer/pipeline/orchestrator.py
@@ -283,6 +283,12 @@ class PipelineOrchestrator:
                 retained_ids = {id(s) for s in stages}
                 self._retired_stages.extend(s for s in self._stages if id(s) not in retained_ids)
             self._stages = list(stages)
+            # Purge any reinstalled stage from the retired list: a stage that was
+            # dropped earlier and is now present in the new list is current
+            # again, so it must be closed via the current-stages loop only, not
+            # also via the retired loop (e.g. [a] -> [b] -> [a]) (#1289 review).
+            current_ids = {id(s) for s in self._stages}
+            self._retired_stages = [s for s in self._retired_stages if id(s) not in current_ids]
             # Newly installed stages may hold their own fds; allow stop() to
             # close them even if a previous stage list was already closed
             # (e.g. batch → set_stages → batch without start()) (#1285 review).

--- a/src/file_organizer/pipeline/orchestrator.py
+++ b/src/file_organizer/pipeline/orchestrator.py
@@ -185,6 +185,11 @@ class PipelineOrchestrator:
         self.stats = PipelineStats()
         self._stats_lock = threading.Lock()
         self._stages: list[PipelineStage] = list(stages) if stages else []
+        # Stages retired by ``set_stages()`` while still potentially holding open
+        # resources (e.g. SafeDir fds). They become unreachable from
+        # ``self._stages`` but their ``close()`` must still run, so track them
+        # here and close them in ``stop()`` alongside the current stages (#1286).
+        self._retired_stages: list[PipelineStage] = []
 
         self._prefetch_depth = max(0, prefetch_depth)
         self._prefetch_stages = max(0, prefetch_stages)
@@ -261,6 +266,15 @@ class PipelineOrchestrator:
             stages: New ordered list of pipeline stages.
         """
         with self._lock:
+            # Preserve the outgoing stages so their close() is not lost: once
+            # replaced they are unreachable from self._stages, but they may hold
+            # open fds. stop() closes them (under the same drain-safety as the
+            # current stages) and then clears the retired list (#1286).
+            # Skip retiring when the outgoing stages were already closed
+            # (``_stages_closed``): their close() already ran, so re-queuing them
+            # would double-close on the next stop().
+            if not self._stages_closed:
+                self._retired_stages.extend(self._stages)
             self._stages = list(stages)
             # Newly installed stages may hold their own fds; allow stop() to
             # close them even if a previous stage list was already closed
@@ -368,7 +382,26 @@ class PipelineOrchestrator:
         that do not define ``close()`` (this repo's stages currently hold no
         fds). Idempotent via ``_stages_closed`` so a repeated ``stop()`` does
         not double-close; ``start()`` resets the guard for a reused orchestrator.
+
+        Retired stages (replaced via ``set_stages()`` while still holding open
+        resources) are closed here too and then cleared, so their ``close()`` is
+        not lost when they fall out of ``self._stages`` (#1286). This runs only
+        when the caller deemed it safe to close (the watch-worker drain
+        succeeded), so retired stages are never closed out from under a worker
+        that might still be using them — a timed-out drain leaves them in
+        ``_retired_stages`` for a later ``stop()``.
         """
+        # Close retired stages first, then drop them. This is gated by the same
+        # drain check as the current stages (the caller only invokes us when
+        # ``safe_to_close``), and clearing the list keeps a repeated ``stop()``
+        # from double-closing them.
+        for stage in self._retired_stages:
+            close_fn = getattr(stage, "close", None)
+            if close_fn is not None:
+                with contextlib.suppress(Exception):
+                    close_fn()
+        self._retired_stages.clear()
+
         if self._stages_closed:
             return
         self._stages_closed = True

--- a/tests/pipeline/test_orchestrator_watch_loop.py
+++ b/tests/pipeline/test_orchestrator_watch_loop.py
@@ -503,6 +503,37 @@ class TestWatchLoopExecutor:
         assert sorted(closed) == ["a", "b"]
         assert closed.count("a") == 1
 
+    def test_reinstalled_stage_closed_once(self):
+        """A stage dropped then reinstalled before stop() is closed only once.
+
+        Regression for #1289: set_stages([a]) -> set_stages([b]) retires `a`;
+        set_stages([a]) reinstalls it as current. Without purging it from the
+        retired list, stop() would close `a` twice (retired loop + current loop).
+        """
+        closed: list[str] = []
+
+        class _ClosableStage:
+            def __init__(self, label: str) -> None:
+                self.name = label
+                self._label = label
+
+            def process(self, context):  # pragma: no cover - not invoked here
+                return context
+
+            def close(self) -> None:
+                closed.append(self._label)
+
+        orch = self._make_orchestrator()
+        a = _ClosableStage("a")
+        orch.set_stages([a])
+        orch.set_stages([_ClosableStage("b")])  # `a` retired
+        orch.set_stages([a])  # `a` reinstalled — must be purged from retired
+
+        orch.stop()
+        # `a` closed once (current), `b` once (retired) — `a` not double-closed.
+        assert sorted(closed) == ["a", "b"]
+        assert closed.count("a") == 1
+
     def test_second_stop_does_not_double_close_retired_stages(self):
         """A repeated stop() does not re-close retired stages (list cleared).
 

--- a/tests/pipeline/test_orchestrator_watch_loop.py
+++ b/tests/pipeline/test_orchestrator_watch_loop.py
@@ -471,6 +471,38 @@ class TestWatchLoopExecutor:
         # Both the retired (a) and the current (b) stage are closed.
         assert sorted(closed) == ["a", "b"]
 
+    def test_set_stages_carryover_stage_closed_once(self):
+        """A stage carried over into the replacement list is closed only once.
+
+        Regression for #1289: set_stages([a]) then set_stages([a, b]) (extend /
+        reorder) must NOT retire `a` — it stays a current stage. Retiring it
+        anyway would close it twice on stop() (retired loop + current loop).
+        Only stages actually dropped from the new list are retired.
+        """
+        closed: list[str] = []
+
+        class _ClosableStage:
+            def __init__(self, label: str) -> None:
+                self.name = label
+                self._label = label
+
+            def process(self, context):  # pragma: no cover - not invoked here
+                return context
+
+            def close(self) -> None:
+                closed.append(self._label)
+
+        orch = self._make_orchestrator()
+        a = _ClosableStage("a")
+        orch.set_stages([a])
+        # Extend: `a` is carried over (stays current), `b` is added.
+        orch.set_stages([a, _ClosableStage("b")])
+
+        orch.stop()
+        # `a` is closed exactly once (not double-closed); `b` once.
+        assert sorted(closed) == ["a", "b"]
+        assert closed.count("a") == 1
+
     def test_second_stop_does_not_double_close_retired_stages(self):
         """A repeated stop() does not re-close retired stages (list cleared).
 

--- a/tests/pipeline/test_orchestrator_watch_loop.py
+++ b/tests/pipeline/test_orchestrator_watch_loop.py
@@ -440,3 +440,106 @@ class TestWatchLoopExecutor:
         orch.set_stages([_ClosableStage()])
         orch.stop()
         assert closed == ["close", "close"]
+
+    def test_stop_closes_retired_stages_replaced_via_set_stages(self):
+        """A stage retired by set_stages() is still closed on a later stop().
+
+        Regression for #1286: _close_stages() iterates only self._stages, so a
+        stage replaced via set_stages() before any close became unreachable and
+        leaked its fd. Retired stages must be tracked and closed by stop().
+        """
+        closed: list[str] = []
+
+        class _ClosableStage:
+            def __init__(self, label: str) -> None:
+                self.name = label
+                self._label = label
+
+            def process(self, context):  # pragma: no cover - not invoked here
+                return context
+
+            def close(self) -> None:
+                closed.append(self._label)
+
+        orch = self._make_orchestrator()
+        # Stage A is installed (and "used") but never closed before replacement.
+        orch.set_stages([_ClosableStage("a")])
+        # Replace with stage B at runtime: A is retired and must not be lost.
+        orch.set_stages([_ClosableStage("b")])
+
+        orch.stop()
+        # Both the retired (a) and the current (b) stage are closed.
+        assert sorted(closed) == ["a", "b"]
+
+    def test_second_stop_does_not_double_close_retired_stages(self):
+        """A repeated stop() does not re-close retired stages (list cleared).
+
+        Regression for #1286: clearing _retired_stages after a successful close
+        is what keeps a second stop() from double-closing a retired stage.
+        """
+        closed: list[str] = []
+
+        class _ClosableStage:
+            def __init__(self, label: str) -> None:
+                self.name = label
+                self._label = label
+
+            def process(self, context):  # pragma: no cover - not invoked here
+                return context
+
+            def close(self) -> None:
+                closed.append(self._label)
+
+        orch = self._make_orchestrator()
+        orch.set_stages([_ClosableStage("a")])
+        orch.set_stages([_ClosableStage("b")])
+
+        orch.stop()
+        assert sorted(closed) == ["a", "b"]
+
+        # Second stop() must not re-close the already-closed retired stage.
+        orch.stop()
+        assert sorted(closed) == ["a", "b"]
+
+    def test_stop_skips_retired_stage_close_when_drain_times_out(self):
+        """Retired stages are NOT closed while a watch worker is still live.
+
+        Regression for #1286: retired-stage closing must obey the same drain
+        safety as current-stage closing. When the drain times out (a worker is
+        still inside stage.process()), closing a retired stage's fd could race
+        the live worker, so the close loop — including retired stages — is
+        skipped and they remain queued for a later stop().
+        """
+        closed: list[str] = []
+
+        class _ClosableStage:
+            def __init__(self, label: str) -> None:
+                self.name = label
+                self._label = label
+
+            def process(self, context):  # pragma: no cover - not invoked here
+                return context
+
+            def close(self) -> None:
+                closed.append(self._label)
+
+        orch = self._make_orchestrator()
+        orch.set_stages([_ClosableStage("a")])
+        orch.set_stages([_ClosableStage("b")])  # retire "a"
+        orch._running = True
+        orch._watch_thread = MagicMock()
+        # Simulate a still-running worker by registering a pending future.
+        orch._watch_futures.add(MagicMock())
+
+        # Patch the drain to report the worker as not finished within timeout.
+        with patch(
+            "file_organizer.pipeline.orchestrator.futures_wait",
+            return_value=(set(), {object()}),
+        ) as mock_wait:
+            orch.stop()
+
+        mock_wait.assert_called_once()
+        # Neither the current nor the retired stage was closed during the race.
+        assert closed == []
+        # The retired stage stays queued for a future stop() that drains cleanly.
+        assert len(orch._retired_stages) == 1


### PR DESCRIPTION
Closes #1286 — WP-4.3 follow-up (deferred from PR #1285 review). Targets `epic/1221-phase-4`.

## Problem
`PipelineOrchestrator._close_stages()` (added in WP-4.3) only iterates the **current** `self._stages`. When `set_stages()` replaces the stage list at runtime, the **retired** stage objects become unreachable, so a closable retired stage's `close()` is never called and its fd leaks (e.g. batch with stage A → `set_stages([B])` → `stop()` closes only B; A's fd leaks).

## Fix
- `__init__`: add `self._retired_stages: list[PipelineStage] = []`.
- `set_stages()`: under the existing `self._lock`, append the outgoing stages to `_retired_stages` **before** replacing them — but skip retiring when `_stages_closed` is already `True` (those stages' `close()` already ran, so re-queuing would double-close). The retire-check runs before the existing `_stages_closed = False` reset.
- `_close_stages()`: close every retired stage (same `getattr(stage, "close", None)` + `contextlib.suppress(Exception)` pattern), then `clear()` the list. This inherits the existing **drain-safety**: `_close_stages()` is only invoked from `stop()` when the watch-worker drain succeeded (`safe_to_close`), so retired stages are never closed out from under a still-live worker — a timed-out drain leaves them queued for a later `stop()`. Clearing the list keeps a repeated `stop()` from double-closing.

A stage is only ever in `self._stages` **or** `self._retired_stages` (never both), so the two close loops never double-close the same object.

## Tests
- `tests/pipeline/` — **319 passed** (all existing unchanged + 3 new).
- New: `test_stop_closes_retired_stages_replaced_via_set_stages`, `test_second_stop_does_not_double_close_retired_stages`, `test_stop_skips_retired_stage_close_when_drain_times_out` (patches `futures_wait` to report a not-done future → retired stages not closed).
- The existing `test_set_stages_resets_close_guard` passes **unchanged** (the `_stages_closed` retire-guard prevents the double-close it would otherwise have hit).
- Guardrails (54) pass; `mypy` clean on `orchestrator.py` (the 5 reported errors are pre-existing in `watcher/monitor.py`, transitively imported); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_