### PR TITLE
fix(parallel,core): saturation-guard precision + preserve transcription segments (#1288)

### DIFF
--- a/src/file_organizer/core/dispatcher.py
+++ b/src/file_organizer/core/dispatcher.py
@@ -38,8 +38,20 @@ def _maybe_transcribe(
     metadata: AudioMetadata,
     transcriber: Any | None,
     max_transcribe_seconds: float | None,
-) -> str | None:
-    """Return a transcript when a transcriber is set and duration is within cap.
+) -> Any | None:
+    """Return a transcription *result* when a transcriber is set and within cap.
+
+    The returned object is the classifier-ready ``TranscriptionResult`` (with
+    ``.text`` **and** ``.segments``) rather than a bare string, so the
+    classifier's segment-based heuristics (speaker count, narrative length —
+    see ``AudioClassifier._score_from_transcription``) receive the real
+    segments instead of an empty list (#1288).
+
+    - For the repo's ``AudioTranscriber.transcribe() -> TranscriptionResult``
+      path, the result is returned as-is (segments intact).
+    - For the ``generate(path) -> str`` duck-type fallback (text only), a
+      segment-less ``TranscriptionResult`` is synthesized via
+      ``_to_transcription_result`` so callers always get a uniform object.
 
     Returns ``None`` for any of:
     - No transcriber configured (the default; metadata-only categorization).
@@ -48,6 +60,7 @@ def _maybe_transcribe(
     - The transcriber raises a recoverable exception (FileNotFound,
       RuntimeError, ImportError); we degrade to metadata-only categorization
       rather than aborting the entire organize batch on a single bad file.
+    - The produced transcript is empty/missing.
     """
     if transcriber is None:
         return None
@@ -79,12 +92,23 @@ def _maybe_transcribe(
         return None
     try:
         if callable(transcribe_fn):
-            # Repo's AudioTranscriber returns a TranscriptionResult (.text);
-            # a duck-typed transcribe() may already return a str.
+            # Repo's AudioTranscriber returns a TranscriptionResult (.text +
+            # .segments). Preserve it whole so the classifier's segment
+            # heuristics run. A duck-typed transcribe() may instead return a
+            # bare str — synthesize a segment-less result for uniformity.
             result = transcribe_fn(str(audio_path))
-            text = getattr(result, "text", result)
+            if isinstance(result, str):
+                return _to_transcription_result(result, metadata)
+            text = getattr(result, "text", None)
+            if text is None or not str(text):
+                return None
+            return result
         elif callable(generate_fn):
+            # generate() yields text only; wrap into a segment-less result.
             text = generate_fn(str(audio_path))
+            if text is None:
+                return None
+            return _to_transcription_result(str(text), metadata)
         else:  # pragma: no cover - guarded above
             return None
     except (FileNotFoundError, OSError, ValueError, RuntimeError, ImportError) as exc:
@@ -97,12 +121,6 @@ def _maybe_transcribe(
         # metadata-only categorization on any recoverable failure.
         logger.warning("Audio transcription failed for {}: {}", audio_path.name, exc)
         return None
-    if text is None:
-        return None
-    # ``transcriber`` is typed as ``Any`` so mypy can't see the return type;
-    # cast to str to satisfy the no-any-return gate. AudioTranscriber yields a
-    # TranscriptionResult.text (str) and AudioModel.generate returns str.
-    return str(text)
 
 
 def _to_transcription_result(transcript: str | None, metadata: AudioMetadata) -> Any:
@@ -459,13 +477,19 @@ def process_audio_files(
             # Transcribe FIRST so the result can influence classification.
             # Otherwise the user pays transcription cost and gets the same
             # metadata-only folder routing — defeating the transcribe path.
-            transcript = _maybe_transcribe(
+            #
+            # _maybe_transcribe now returns the full TranscriptionResult (with
+            # .segments intact) so the classifier's segment-based heuristics run
+            # (#1288). The ProcessedFile.transcript field stays a plain str, so
+            # we project ``.text`` off the result for storage while passing the
+            # whole object to classify().
+            transcription = _maybe_transcribe(
                 audio_path,
                 metadata=metadata,
                 transcriber=transcriber,
                 max_transcribe_seconds=max_transcribe_seconds,
             )
-            transcription = _to_transcription_result(transcript, metadata)
+            transcript = getattr(transcription, "text", None) if transcription is not None else None
             classification = classifier.classify(metadata, transcription=transcription)
             dest_path = organizer.generate_path(classification.audio_type, metadata)
 

--- a/src/file_organizer/core/dispatcher.py
+++ b/src/file_organizer/core/dispatcher.py
@@ -102,7 +102,15 @@ def _maybe_transcribe(
             text = getattr(result, "text", None)
             if text is None or not str(text):
                 return None
-            return result
+            # Only pass the object straight through if it's classify-ready:
+            # AudioClassifier.classify() reads .segments and .duration. A
+            # text-bearing object lacking those (e.g. a SimpleNamespace adapter
+            # or a partial stub) would raise AttributeError downstream, so wrap
+            # its text into a proper segment-less TranscriptionResult instead
+            # (#1290 review). Genuine TranscriptionResults keep their segments.
+            if hasattr(result, "segments") and hasattr(result, "duration"):
+                return result
+            return _to_transcription_result(str(text), metadata)
         elif callable(generate_fn):
             # generate() yields text only; wrap into a segment-less result.
             text = generate_fn(str(audio_path))

--- a/src/file_organizer/parallel/processor.py
+++ b/src/file_organizer/parallel/processor.py
@@ -337,6 +337,18 @@ class ParallelProcessor:
                 path = future_paths.pop(future)
                 future_started.pop(future, None)
                 future_queued_at.pop(future, None)
+                # A healthy completion means the pool just made progress: a
+                # worker slot is now free for queued work. Reset the
+                # saturation-detection clock for every still-pending future so
+                # the 2×timeout guard only fires after *continuous* no-progress
+                # (all slots blocked by hung/abandoned work). Without this, a
+                # degraded-but-progressing pool (max_workers slowly draining a
+                # backlog) could age a queued future past 2×timeout and
+                # false-positive as saturated, mass-failing files that would
+                # have completed (#1288).
+                _progress_at = time.monotonic()
+                for _remaining in pending:
+                    future_queued_at[_remaining] = _progress_at
                 yield finalize_result(self._collect_result(future, path))
                 submit_round_of_work()
 

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -851,7 +851,11 @@ class TestAudioTranscription:
         from file_organizer.core.dispatcher import _maybe_transcribe
 
         transcriber = MagicMock(spec=["transcribe"])
-        whisper_result = SimpleNamespace(text="hello from whisper", segments=[object()])
+        # A classify-ready result (has .text, .segments AND .duration — the
+        # attributes AudioClassifier.classify() reads).
+        whisper_result = SimpleNamespace(
+            text="hello from whisper", segments=[object()], duration=10.0
+        )
         transcriber.transcribe.return_value = whisper_result
         result = _maybe_transcribe(
             Path("/mock/a.mp3"),
@@ -859,11 +863,38 @@ class TestAudioTranscription:
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
         )
-        # Returned object is the TranscriptionResult as-is, segments intact.
+        # Returned object is the result as-is, segments intact.
         assert result is whisper_result
         assert result.text == "hello from whisper"
         assert result.segments == whisper_result.segments
         transcriber.transcribe.assert_called_once_with("/mock/a.mp3")
+
+    def test_maybe_transcribe_incomplete_object_synthesizes_result(self) -> None:
+        """A text-bearing object lacking .segments/.duration is wrapped, not passed through.
+
+        Regression for #1290 review: classify() reads .segments and .duration, so
+        a partial adapter (e.g. SimpleNamespace(text=...)) must be wrapped into a
+        proper TranscriptionResult or it would raise AttributeError downstream.
+        """
+        from types import SimpleNamespace
+
+        from file_organizer.core.dispatcher import _maybe_transcribe
+        from file_organizer.services.audio.transcriber import TranscriptionResult
+
+        transcriber = MagicMock(spec=["transcribe"])
+        # Has .text but NOT .segments/.duration — not classify-ready.
+        transcriber.transcribe.return_value = SimpleNamespace(text="partial adapter")
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=12.0),
+            transcriber=transcriber,
+            max_transcribe_seconds=600.0,
+        )
+        # Wrapped into a classify-ready TranscriptionResult (segment-less).
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "partial adapter"
+        assert result.segments == []
+        assert result.duration == 12.0
 
     def test_maybe_transcribe_transcribe_api_str_return_synthesizes_result(self) -> None:
         """A duck-typed transcribe() returning a bare str is wrapped uniformly.
@@ -973,8 +1004,10 @@ class TestAudioTranscription:
         # can prove segments survive the dispatcher → classifier handoff (#1288).
         fake_segments = [SimpleNamespace(start=0.0, end=1.0, text="hi")]
         transcriber = MagicMock(spec=["transcribe"])
+        # Classify-ready shape (.text, .segments AND .duration) so the object is
+        # passed through with segments intact rather than wrapped (#1290 review).
         transcriber.transcribe.return_value = SimpleNamespace(
-            text="episode transcript text", segments=fake_segments
+            text="episode transcript text", segments=fake_segments, duration=30.0
         )
 
         with (

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -842,25 +842,58 @@ class TestAudioTranscription:
 
         Regression for #1287 review: the guard previously required generate(),
         rejecting the real Whisper transcriber and forcing metadata-only audio.
+
+        #1288: the full result object is returned (not just ``.text``) so the
+        classifier's segment heuristics survive.
         """
         from types import SimpleNamespace
 
         from file_organizer.core.dispatcher import _maybe_transcribe
 
         transcriber = MagicMock(spec=["transcribe"])
-        transcriber.transcribe.return_value = SimpleNamespace(text="hello from whisper")
+        whisper_result = SimpleNamespace(text="hello from whisper", segments=[object()])
+        transcriber.transcribe.return_value = whisper_result
         result = _maybe_transcribe(
             Path("/mock/a.mp3"),
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
         )
-        assert result == "hello from whisper"
+        # Returned object is the TranscriptionResult as-is, segments intact.
+        assert result is whisper_result
+        assert result.text == "hello from whisper"
+        assert result.segments == whisper_result.segments
         transcriber.transcribe.assert_called_once_with("/mock/a.mp3")
 
-    def test_maybe_transcribe_generate_duck_type_returns_text(self) -> None:
-        """A generate(path) -> str duck-type is still accepted as a fallback."""
+    def test_maybe_transcribe_transcribe_api_str_return_synthesizes_result(self) -> None:
+        """A duck-typed transcribe() returning a bare str is wrapped uniformly.
+
+        #1288: callers always get a TranscriptionResult-shaped object with
+        ``.text`` and (empty) ``.segments``, never a raw string.
+        """
         from file_organizer.core.dispatcher import _maybe_transcribe
+        from file_organizer.services.audio.transcriber import TranscriptionResult
+
+        transcriber = MagicMock(spec=["transcribe"])
+        transcriber.transcribe.return_value = "plain text only"
+        result = _maybe_transcribe(
+            Path("/mock/a.mp3"),
+            metadata=MagicMock(duration=10.0),
+            transcriber=transcriber,
+            max_transcribe_seconds=600.0,
+        )
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "plain text only"
+        assert result.segments == []
+
+    def test_maybe_transcribe_generate_duck_type_returns_text(self) -> None:
+        """A generate(path) -> str duck-type is still accepted as a fallback.
+
+        #1288: the text is wrapped into a segment-less TranscriptionResult so
+        the return type is uniform with the transcribe() path.
+        """
+        from file_organizer.core.dispatcher import _maybe_transcribe
+        from file_organizer.services.audio.transcriber import TranscriptionResult
 
         transcriber = MagicMock(spec=["generate"])
         transcriber.generate.return_value = "hello world"
@@ -870,7 +903,9 @@ class TestAudioTranscription:
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
         )
-        assert result == "hello world"
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "hello world"
+        assert result.segments == []
         transcriber.generate.assert_called_once_with("/mock/a.mp3")
 
     def test_maybe_transcribe_recoverable_error_degrades(self) -> None:
@@ -934,8 +969,13 @@ class TestAudioTranscription:
 
         from types import SimpleNamespace
 
+        # Real TranscriptionResult-shaped object with non-empty segments so we
+        # can prove segments survive the dispatcher → classifier handoff (#1288).
+        fake_segments = [SimpleNamespace(start=0.0, end=1.0, text="hi")]
         transcriber = MagicMock(spec=["transcribe"])
-        transcriber.transcribe.return_value = SimpleNamespace(text="episode transcript text")
+        transcriber.transcribe.return_value = SimpleNamespace(
+            text="episode transcript text", segments=fake_segments
+        )
 
         with (
             patch(_AUDIO_CLASSIFIER_TARGET, return_value=mock_classifier_instance),
@@ -949,11 +989,14 @@ class TestAudioTranscription:
             )
 
         assert len(results) == 1
+        # transcript field stays a plain str projected from result.text.
         assert results[0].transcript == "episode transcript text"
-        # The classifier received a TranscriptionResult (not None).
+        # The classifier received the full TranscriptionResult (not None) with
+        # the real segments intact — not a rebuilt empty-segment stand-in.
         _, kwargs = mock_classifier_instance.classify.call_args
         assert kwargs["transcription"] is not None
         assert kwargs["transcription"].text == "episode transcript text"
+        assert kwargs["transcription"].segments == fake_segments
 
     def test_process_audio_transcription_failure_does_not_fail_file(self) -> None:
         """A transcription failure degrades to metadata-only — file still classified."""

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -274,6 +274,94 @@ class TestConcurrencyFixes(unittest.TestCase):
             f"queued_2 must report pool saturation, got: {by_path.get(Path('queued_2'))}",
         )
 
+    def test_slow_progressing_pool_does_not_trip_saturation(self) -> None:
+        """#1288: a degraded-but-progressing pool must not false-trip saturation.
+
+        With ``max_workers=1`` and several tasks that each complete just under
+        ``timeout_per_file``, later files sit queued while earlier ones drain
+        sequentially. A queued file's wall-clock age can exceed 2×timeout even
+        though the pool is making steady progress. The saturation guard must
+        measure *continuous no-progress* time — reset on every healthy
+        completion — so it does NOT fire here and ALL files complete.
+        """
+        timeout = 0.2
+        config = ParallelConfig(
+            max_workers=1,
+            timeout_per_file=timeout,
+            retry_count=0,
+        )
+        processor = ParallelProcessor(config=config)
+        # Six files drained one-at-a-time: total ≈ 6 × 0.1s = 0.6s. Without the
+        # per-completion reset, the last queued file would age well past
+        # 2×timeout (0.4s) and false-trip saturation before it ever runs.
+        paths = [Path(f"slow_progress_{i}") for i in range(6)]
+
+        def slow_but_completes(_path: Path) -> str:
+            # Completes in ~half the timeout, so each task is healthy.
+            threading.Event().wait(timeout=timeout * 0.5)
+            return "ok"
+
+        results = processor.process_batch(paths, slow_but_completes)
+
+        self.assertEqual(results.total, len(paths))
+        self.assertEqual(
+            results.succeeded,
+            len(paths),
+            f"all files should complete on a progressing pool, got: "
+            f"{[(str(r.path), r.success, r.error) for r in results.results]}",
+        )
+        self.assertEqual(results.failed, 0)
+        self.assertFalse(
+            any("saturated" in str(r.error) for r in results.results),
+            "a steadily-progressing pool must not report saturation",
+        )
+
+    def test_saturation_guard_keys_off_recent_queue_time(self) -> None:
+        """#1288 (unit): ``_check_pool_saturation`` keys off ``future_queued_at``.
+
+        A never-started queued future whose ``future_queued_at`` was *recently*
+        refreshed (as the main loop does on every healthy completion) must NOT
+        be flagged as saturated, even though it has technically existed for a
+        long time. This pins the contract that the reset on healthy completion
+        relies on: saturation is measured from the last refreshed queue time,
+        not absolute age.
+        """
+        config = ParallelConfig(max_workers=1, timeout_per_file=0.1, retry_count=0)
+        processor = ParallelProcessor(config=config)
+
+        never_started = MagicMock()
+        never_started.running.return_value = False
+
+        pending = {never_started}
+        future_paths = {never_started: Path("queued")}
+        future_started: dict[object, float | None] = {never_started: None}
+        now = time.monotonic()
+        # Simulate a clock that was just refreshed by a healthy completion.
+        future_queued_at = {never_started: now}
+
+        result = processor._check_pool_saturation(
+            pending,  # type: ignore[arg-type]
+            future_paths,  # type: ignore[arg-type]
+            future_started,  # type: ignore[arg-type]
+            future_queued_at,  # type: ignore[arg-type]
+            config.timeout_per_file,
+            lambda r: r,
+        )
+        self.assertIsNone(result, "recently-refreshed queue time must not trip saturation")
+
+        # Conversely, an un-refreshed clock older than 2×timeout DOES trip it,
+        # proving the reset is what prevents the false positive.
+        future_queued_at[never_started] = now - (config.timeout_per_file * 2 + 1.0)
+        stale_result = processor._check_pool_saturation(
+            pending,  # type: ignore[arg-type]
+            future_paths,  # type: ignore[arg-type]
+            future_started,  # type: ignore[arg-type]
+            future_queued_at,  # type: ignore[arg-type]
+            config.timeout_per_file,
+            lambda r: r,
+        )
+        self.assertIsNotNone(stale_result, "stale queue time beyond 2×timeout must trip saturation")
+
     def test_retryable_saturation_survives_non_retryable_peer(self) -> None:
         """#1287: a queued never-started saturation file (retryable) must still be
         retried even when a non-retryable hung peer fails in the same attempt.


### PR DESCRIPTION
Closes #1288 — WP-4.1 follow-up (deferred from PR #1287 review). Targets `epic/1221-phase-4`. Two independent fixes.

## Fix 1 — Saturation-guard precision (`parallel/processor.py`)
The 2×timeout saturation guard aborted **all** pending futures when one never-started queued future aged past 2×timeout, even on a degraded-but-**progressing** pool (e.g. `max_workers=1` slowly draining a backlog) — false-failing files that would have completed.

Extend the existing queue-clock reset (previously only on the abandoned-task path) to **healthy completions**: when a task finishes and a result is collected in the main loop, refresh `future_queued_at` for every still-pending future. Saturation now measures **continuous** no-progress time and fires only when the pool makes zero progress for 2×timeout (all slots genuinely blocked by hung/abandoned work). Genuinely-hung tasks never complete, so they never reset the clock — true-saturation detection is preserved. The reset is O(pending) per completion (pending is bounded by the concurrency window, not total files).

## Fix 2 — Preserve transcription segments (`core/dispatcher.py`)
`_maybe_transcribe` collapsed the `TranscriptionResult` to `.text`, and `_to_transcription_result` rebuilt one with `segments=[]`, so `AudioClassifier._score_from_transcription`'s segment-based heuristics (speaker count, narrative length) never ran.

`_maybe_transcribe` now returns the full classifier-ready `TranscriptionResult`: the repo's `AudioTranscriber.transcribe()` result is passed through whole (segments intact); a `generate()`/`transcribe()` that returns a bare `str` is wrapped into a segment-less result via `_to_transcription_result` for a uniform return. `process_audio_files` projects `.text` into the still-`str` `ProcessedFile.transcript` and passes the **whole object** to `classify(transcription=...)`, so real segments reach the classifier. All prior behavior preserved (None when no transcriber / over the duration cap / recoverable error / empty transcript).

## Verification (local)
- `tests/parallel/` + `tests/integration/test_dispatcher_core.py` + `tests/services/` — **3384 passed, 7 skipped** (zero regressions).
- New: `test_slow_progressing_pool_does_not_trip_saturation` (functional, stable across reruns), `test_saturation_guard_keys_off_recent_queue_time` (predicate unit test); updated/added transcription tests asserting the full object + segments reach `classify()` (`...transcription.segments == fake_segments`).
- Existing genuinely-hung saturation tests still pass (no completions → clock never resets → saturation fires as before).
- Guardrails (54) pass; `mypy` clean on both changed files (the 14 reported errors are pre-existing in transitively-imported modules); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_