### PR TITLE
fix: resolve the two pre-existing CI shard failures (web sub-routers + recover docs)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -368,6 +368,47 @@ file-organizer redo [OPTIONS]
 
 ---
 
+### `recover`
+
+Replay or sweep the durable-move journal to recover interrupted cross-device moves.
+
+A crash midway through a cross-device rollback move can leave the durable-move
+JSONL journal with unfinished `started`/`copied` entries (and possibly orphan
+files on disk). This command runs the same reconciliation `sweep` performs
+automatically on the next run, exposed explicitly so an operator can trigger it
+on demand.
+
+**Usage:**
+
+```bash
+file-organizer recover [OPTIONS]
+```
+
+**Options:**
+- `--journal PATH` — Path to the durable-move journal. Defaults to the shared undo journal.
+- `--dry-run` — Report planned recovery actions without mutating the journal or disk.
+
+**Examples:**
+
+```bash
+# Sweep the default journal
+file-organizer recover
+
+# Preview what recovery would do, without touching disk
+file-organizer recover --dry-run
+
+# Recover from a specific journal file
+file-organizer recover --journal /path/to/durable_move.jsonl
+```
+
+**Behavior notes:**
+
+- `--dry-run` calls the same `plan_recovery_actions` planner the real sweep uses, so the preview can never drift from the actual run.
+- If the journal does not exist or has no entries, the command reports that there is nothing to recover and exits successfully.
+- Transient filesystem errors during the sweep (permissions, disk full) surface as a clean error message, not a stack trace.
+
+---
+
 ### `history`
 
 View operation history.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -374,9 +374,9 @@ Replay or sweep the durable-move journal to recover interrupted cross-device mov
 
 A crash midway through a cross-device rollback move can leave the durable-move
 JSONL journal with unfinished `started`/`copied` entries (and possibly orphan
-files on disk). This command runs the same reconciliation `sweep` performs
-automatically on the next run, exposed explicitly so an operator can trigger it
-on demand.
+files on disk). Reconciliation is **not** automatic — run this command on demand
+(for example, after a crash) to sweep the journal and complete or roll back the
+interrupted moves.
 
 **Usage:**
 

--- a/tests/web/test_router.py
+++ b/tests/web/test_router.py
@@ -79,39 +79,29 @@ class TestHomeRoute:
         assert "/ui/setup" in response.headers["location"]
 
 
-def _mounted_app_paths() -> list[str]:
-    """Concrete route paths after mounting the web router as the app does.
-
-    Starlette 1.3 (#1282) no longer surfaces included sub-router paths on a bare
-    ``APIRouter.routes`` (it only shows ``/``), so inspecting ``router.routes``
-    directly is unreliable. Mount the router into a fresh ``FastAPI`` app at
-    ``/ui`` (mirroring the real app) and read the assembled, flattened routes —
-    a runtime-faithful assertion of sub-router inclusion.
-    """
-    app = FastAPI()
-    app.include_router(router, prefix="/ui")
-    return [route.path for route in app.routes if hasattr(route, "path")]
-
-
 class TestSubRouterInclusion:
     """Verify that sub-routers are included (and reachable) under ``/ui``.
 
-    Asserts exact base-route membership (not substring) so an unrelated path
-    like ``/ui/files-legacy`` can't satisfy the guard (Copilot/CodeRabbit #1283).
-    Each sub-router exposes a concrete base route at ``/ui/<name>``.
+    Asserts each sub-router's concrete base route at ``/ui/<name>`` is reachable
+    by issuing a real request through a mounted ``TestClient`` — the same runtime
+    mechanism ``TestHomeRoute`` uses (and which passes in CI). A registered route
+    responds (here ``200``); an *unincluded* sub-router would yield ``404``.
+
+    This replaces the earlier ``app.routes`` introspection, which was fragile
+    across FastAPI/Starlette versions (included sub-router paths are not reliably
+    surfaced on a flattened ``app.routes`` under Starlette 1.3+, #1282) and broke
+    nondeterministically under xdist. Targeting the *exact* base path keeps the
+    guard precise: an unrelated path like ``/ui/files-legacy`` still 404s, so it
+    can't satisfy the check (Copilot/CodeRabbit #1283).
     """
 
-    def test_files_router_routes_present(self):
-        assert "/ui/files" in set(_mounted_app_paths())
-
-    def test_organize_router_routes_present(self):
-        assert "/ui/organize" in set(_mounted_app_paths())
-
-    def test_profile_router_routes_present(self):
-        assert "/ui/profile" in set(_mounted_app_paths())
-
-    def test_settings_router_routes_present(self):
-        assert "/ui/settings" in set(_mounted_app_paths())
-
-    def test_marketplace_router_routes_present(self):
-        assert "/ui/marketplace" in set(_mounted_app_paths())
+    @pytest.mark.parametrize(
+        "base_path",
+        ["/ui/files", "/ui/organize", "/ui/profile", "/ui/settings", "/ui/marketplace"],
+    )
+    def test_sub_router_base_route_reachable(self, client, base_path):
+        status = client.get(base_path).status_code
+        assert status != 404, (
+            f"{base_path} returned 404 — its sub-router is not included under /ui "
+            f"(expected the route to be registered and reachable)"
+        )

--- a/tests/web/test_router.py
+++ b/tests/web/test_router.py
@@ -99,7 +99,13 @@ class TestSubRouterInclusion:
         "base_path",
         ["/ui/files", "/ui/organize", "/ui/profile", "/ui/settings", "/ui/marketplace"],
     )
-    def test_sub_router_base_route_reachable(self, client, base_path):
+    def test_sub_router_base_route_reachable(self, client, base_path, tmp_path, monkeypatch):
+        # ``/ui/marketplace`` instantiates ``MarketplaceService``, which creates
+        # its home dir and writes ``metadata.json`` under ``FO_MARKETPLACE_HOME``
+        # (defaulting to the real user config dir). Redirect it into ``tmp_path``
+        # so this route-inclusion check stays hermetic and doesn't 500 on
+        # read-only config homes.
+        monkeypatch.setenv("FO_MARKETPLACE_HOME", str(tmp_path / "marketplace"))
         status = client.get(base_path).status_code
         # Require a success/redirect status (not merely "not 404"): a registered
         # but broken route returning 500/503 should fail this reachability guard,

--- a/tests/web/test_router.py
+++ b/tests/web/test_router.py
@@ -101,7 +101,10 @@ class TestSubRouterInclusion:
     )
     def test_sub_router_base_route_reachable(self, client, base_path):
         status = client.get(base_path).status_code
-        assert status != 404, (
-            f"{base_path} returned 404 — its sub-router is not included under /ui "
-            f"(expected the route to be registered and reachable)"
+        # Require a success/redirect status (not merely "not 404"): a registered
+        # but broken route returning 500/503 should fail this reachability guard,
+        # while a missing sub-router (404) still fails as before.
+        assert 200 <= status < 400, (
+            f"{base_path} returned unexpected status {status} — expected a reachable "
+            f"GET route under /ui (404 => sub-router not included; 5xx => route broken)"
         )


### PR DESCRIPTION
## Summary

Fixes the two long-standing `main` CI failures that were scoped out of the Phase 4 PR (#1291) as "not Phase 4's job". Both are now green.

### Shard 6 — `tests/web/test_router.py::TestSubRouterInclusion::*` (5 failures)

The five sub-router checks built a fresh `FastAPI()` app, mounted the web router under `/ui`, and introspected the **flattened `app.routes`** to assert `/ui/<name>` membership.

Under CI's FastAPI/Starlette combination (`starlette ~=1.3`, the version the lock resolves), included sub-router paths are **not reliably surfaced on a flattened `app.routes`** — so the membership checks failed, even though the routes are fully mounted and reachable. The smoking gun: `TestHomeRoute` (same file), which exercises the router through a real `TestClient`, **passed in the same CI runs** that failed these five.

**Fix:** assert runtime **reachability** via `TestClient` instead of route introspection — `GET /ui/<name>` and require a non-404. This:
- uses the exact mechanism `TestHomeRoute` already uses (proven to work in CI),
- tests the real contract ("sub-routers are included **and reachable** under `/ui`"),
- stays precise — targeting the exact base path means an unrelated `/ui/files-legacy` still 404s (Copilot/CodeRabbit #1283),
- removes the fragile `_mounted_app_paths` introspection helper.

### Shard 5 — `tests/docs/test_cli_docs_accuracy.py::test_commands_exist` (1 failure)

The `recover` command (`fo recover`, #1248) was registered in the CLI (`main.py`) but undocumented. Added a `recover` section to `docs/cli-reference.md` documenting `--journal` and `--dry-run`, mirroring the surrounding `undo`/`redo` sections.

## Validation

- `tests/web/test_router.py` + `tests/docs/test_cli_docs_accuracy.py` — pass (incl. under `starlette 1.3.1` + `fastapi 0.135.1`, the CI-locked versions)
- Full `tests/web` + `tests/docs` under `-n=auto` xdist (CI-style): **816 passed, 1 xfailed**
- `ruff` clean on the changed test; `pymarkdown -c .pymarkdown.json` clean on the doc

## Notes

- No source/behavior changes — this is a test-robustness fix plus a docs addition. The web routes were always functional; only the test's introspection method was version-fragile.

https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CLI reference documentation for the `recover` command, including usage syntax, available options, example invocations, and behavior notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->