### PR TITLE
test(undo): harden remaining durable_move dir_move warning tests vs logging pollution

### DIFF
--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1700,8 +1700,7 @@ class TestSweepDirMoveHandling:
         # Disk state is whatever shutil.move left it — sweep doesn't
         # touch either path. We just verify the warning fired.
         assert any("dir_move entry" in r.getMessage() for r in records), (
-            f"warning must mention the dir_move entry; got "
-            f"{[r.getMessage() for r in records]}"
+            f"warning must mention the dir_move entry; got {[r.getMessage() for r in records]}"
         )
 
     def test_sweep_drops_dir_move_done_silently(self, tmp_path: Path) -> None:

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1678,9 +1678,7 @@ class TestSweepDirMoveHandling:
         # Disk state untouched.
         assert src.is_dir() and not dst.exists()
 
-    def test_sweep_drops_dir_move_started_with_warning(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_sweep_drops_dir_move_started_with_warning(self, tmp_path: Path) -> None:
         """A stranded ``dir_move`` started entry (move crashed) is
         dropped — sweep can't safely retry shutil.move. The warning
         prompts operator inspection of the on-disk state."""
@@ -1695,20 +1693,18 @@ class TestSweepDirMoveHandling:
             [{"op": "dir_move", "src": str(src), "dst": str(dst), "state": "started"}],
         )
 
-        with caplog.at_level("WARNING", logger="file_organizer.undo.durable_move"):
+        with _capture_durable_move_warnings() as records:
             sweep(journal)
         # Entry dropped (in-flight marker released).
         assert _read_journal(journal) == []
         # Disk state is whatever shutil.move left it — sweep doesn't
         # touch either path. We just verify the warning fired.
-        assert any("dir_move entry" in r.getMessage() for r in caplog.records), (
+        assert any("dir_move entry" in r.getMessage() for r in records), (
             f"warning must mention the dir_move entry; got "
-            f"{[r.getMessage() for r in caplog.records]}"
+            f"{[r.getMessage() for r in records]}"
         )
 
-    def test_sweep_drops_dir_move_done_silently(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_sweep_drops_dir_move_done_silently(self, tmp_path: Path) -> None:
         """§5.3 / §9.5 lock-in: ``dir_move done`` is dropped silently
         (no WARNING). Started entries warn so operators investigate
         the on-disk state; done entries are routine coordination
@@ -1724,7 +1720,7 @@ class TestSweepDirMoveHandling:
             [{"op": "dir_move", "src": str(src), "dst": str(dst), "state": "done"}],
         )
 
-        with caplog.at_level("WARNING", logger="file_organizer.undo.durable_move"):
+        with _capture_durable_move_warnings() as records:
             sweep(journal)
 
         assert _read_journal(journal) == []
@@ -1733,7 +1729,7 @@ class TestSweepDirMoveHandling:
         # subsystem warnings (if any) don't cause spurious failures.
         sweep_warnings = [
             r
-            for r in caplog.records
+            for r in records
             if r.levelname == "WARNING"
             and "dir_move" in r.getMessage()
             and r.name == "file_organizer.undo.durable_move"


### PR DESCRIPTION
## Summary

Follow-up to #1293 to get `main` CI fully green.

After #1293 merged, the main full-shard run on `86c02d2` showed the **integration gate now passes** (the floors re-baseline worked) — but `Test (shard 5, py3.12)` still failed on a **third** durable_move test with the *same* caplog-vs-xdist pollution bug the size-cap pair had:

```
FAILED tests/undo/test_durable_move.py::TestSweepDirMoveHandling::test_sweep_drops_dir_move_started_with_warning
  - AssertionError: warning must mention the dir_move entry; got []
```

`#1293` hardened the two size-cap tests but missed the two `dir_move` warning tests, which assert on `caplog.records`. A sibling shard-5 test leaks global logging state (`logging.disable()` / propagation), so under xdist `caplog` is empty even though the WARNING fires.

## Change

Convert both `TestSweepDirMoveHandling` warning tests to the `_capture_durable_move_warnings()` helper added in #1293 (attaches a handler directly to the `durable_move` logger and clears any global disable):

- `test_sweep_drops_dir_move_started_with_warning` — the positive assertion is now deterministic (was the CI failure).
- `test_sweep_drops_dir_move_done_silently` — the "done is silent" negative assertion was only *vacuously* true under pollution (empty `caplog`); now it's meaningful.

## Validation

- `grep` confirms no `caplog` usages remain in the file (only the helper's docstring).
- `TestSweepDirMoveHandling` + the size-cap pair pass under a simulated global `logging.disable(CRITICAL)` — the exact pollution that broke CI (6 passed). ruff clean.
- This was the *only* remaining failed job on the `86c02d2` main run, so this should take main fully green.

https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_