### PR TITLE
test: fix flaky and platform-specific test failures on macOS/Windows

### DIFF
--- a/tests/cli/test_organize_path_validation.py
+++ b/tests/cli/test_organize_path_validation.py
@@ -62,7 +62,8 @@ def test_organize_output_inside_input_is_bad_parameter(tmp_path: Path) -> None:
     out_dir = in_dir / "sorted"
     result = runner.invoke(app, ["organize", str(in_dir), str(out_dir)])
     assert result.exit_code == 2
-    assert "inside the input" in result.output.lower()
+    out = result.output.lower()
+    assert "inside" in out and "input" in out
 
 
 def test_organize_input_inside_output_is_bad_parameter(tmp_path: Path) -> None:
@@ -71,7 +72,8 @@ def test_organize_input_inside_output_is_bad_parameter(tmp_path: Path) -> None:
     in_dir.mkdir(parents=True)
     result = runner.invoke(app, ["organize", str(in_dir), str(out_dir)])
     assert result.exit_code == 2
-    assert "inside the output" in result.output.lower()
+    out = result.output.lower()
+    assert "inside" in out and "output" in out
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="symlink loop is POSIX-focused")

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -867,7 +867,7 @@ class TestAudioTranscription:
         assert result is whisper_result
         assert result.text == "hello from whisper"
         assert result.segments == whisper_result.segments
-        transcriber.transcribe.assert_called_once_with("/mock/a.mp3")
+        transcriber.transcribe.assert_called_once_with(str(Path("/mock/a.mp3")))
 
     def test_maybe_transcribe_incomplete_object_synthesizes_result(self) -> None:
         """A text-bearing object lacking .segments/.duration is wrapped, not passed through.
@@ -937,7 +937,7 @@ class TestAudioTranscription:
         assert isinstance(result, TranscriptionResult)
         assert result.text == "hello world"
         assert result.segments == []
-        transcriber.generate.assert_called_once_with("/mock/a.mp3")
+        transcriber.generate.assert_called_once_with(str(Path("/mock/a.mp3")))
 
     def test_maybe_transcribe_recoverable_error_degrades(self) -> None:
         """A RuntimeError during transcription degrades, not aborts."""

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -582,7 +582,6 @@ class TestConcurrencyFixes(unittest.TestCase):
             return real_wait(fs, *args, **kwargs)
 
         def short_task(_path: Path) -> str:
-            threading.Event().wait(timeout=0.02)
             return "ok"
 
         with patch("file_organizer.parallel.processor.wait", side_effect=tracked_wait):

--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -313,7 +313,7 @@ class TestCopyFdXattrs:
         def _raise(_fd: int) -> list[str]:
             raise OSError(_errno.ENOTSUP, "unsupported")
 
-        monkeypatch.setattr(w.os, "listxattr", _raise)
+        monkeypatch.setattr(w.os, "listxattr", _raise, raising=False)
         w._copy_fd_xattrs(0, 1)  # swallowed, no raise
 
     def test_listxattr_other_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -324,7 +324,7 @@ class TestCopyFdXattrs:
         def _raise(_fd: int) -> list[str]:
             raise OSError(_errno.EIO, "io error")
 
-        monkeypatch.setattr(w.os, "listxattr", _raise)
+        monkeypatch.setattr(w.os, "listxattr", _raise, raising=False)
         with pytest.raises(OSError, match="io error"):
             w._copy_fd_xattrs(0, 1)
 
@@ -333,13 +333,13 @@ class TestCopyFdXattrs:
 
         from file_organizer.pipeline.stages import writer as w
 
-        monkeypatch.setattr(w.os, "listxattr", lambda _fd: ["user.x"])
-        monkeypatch.setattr(w.os, "getxattr", lambda _fd, _name: b"v")
+        monkeypatch.setattr(w.os, "listxattr", lambda _fd: ["user.x"], raising=False)
+        monkeypatch.setattr(w.os, "getxattr", lambda _fd, _name: b"v", raising=False)
 
         def _raise(_fd: int, _name: str, _value: bytes) -> None:
             raise OSError(_errno.EPERM, "denied")
 
-        monkeypatch.setattr(w.os, "setxattr", _raise)
+        monkeypatch.setattr(w.os, "setxattr", _raise, raising=False)
         w._copy_fd_xattrs(0, 1)  # swallowed
 
     def test_setxattr_other_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -347,13 +347,13 @@ class TestCopyFdXattrs:
 
         from file_organizer.pipeline.stages import writer as w
 
-        monkeypatch.setattr(w.os, "listxattr", lambda _fd: ["user.x"])
-        monkeypatch.setattr(w.os, "getxattr", lambda _fd, _name: b"v")
+        monkeypatch.setattr(w.os, "listxattr", lambda _fd: ["user.x"], raising=False)
+        monkeypatch.setattr(w.os, "getxattr", lambda _fd, _name: b"v", raising=False)
 
         def _raise(_fd: int, _name: str, _value: bytes) -> None:
             raise OSError(_errno.EIO, "io error")
 
-        monkeypatch.setattr(w.os, "setxattr", _raise)
+        monkeypatch.setattr(w.os, "setxattr", _raise, raising=False)
         with pytest.raises(OSError, match="io error"):
             w._copy_fd_xattrs(0, 1)
 

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -3347,10 +3347,27 @@ class TestWriterProtocolV2:
                 events.append(("journal_started", str(j)))
             return real_locked_append(j, payload)
 
+        import json
+
+        real_append_durable = dm_mod.append_durable
+
+        def tracking_append_durable(j, text):  # type: ignore[no-untyped-def]
+            try:
+                payload = json.loads(text)
+                if payload.get("state") == "started":
+                    events.append(("journal_started", str(j)))
+            except Exception:
+                pass
+            return real_append_durable(j, text)
+
         monkeypatch.setattr("file_organizer.undo.durable_move.os.open", tracking_open)
         monkeypatch.setattr(
             "file_organizer.undo.durable_move._append_journal_line_locked",
             tracking_locked_append,
+        )
+        monkeypatch.setattr(
+            "file_organizer.undo.durable_move.append_durable",
+            tracking_append_durable,
         )
 
         dm_mod.durable_move(src, dst, journal=journal)


### PR DESCRIPTION
## Description

This PR resolves multiple platform-specific and flaky test failures on macOS and Windows CI runs (observed in run [27897719865](https://github.com/curdriceaurora/Local-File-Organizer/actions/runs/27897719865)). 

Summary of changes:
1. **CLI Validation Tests (`tests/cli/test_organize_path_validation.py`)**: Split assertions on nested path error boxes into individual keyword checks (`"inside"`, `"input"`, `"output"`) rather than contiguous strings. This prevents test failures caused by Rich console panel text wrapping under different console widths.
2. **Parallel Processing Tests (`tests/parallel/test_concurrency_fixes.py`)**: Removed a `threading.Event().wait(timeout=0.02)` sleep from `short_task` to make the task return instantly. This prevents timing-dependent failures/timeouts on CPU-contended CI runners.
3. **Pipeline Stage Tests (`tests/pipeline/test_stages.py`)**: Configured `raising=False` on `monkeypatch.setattr` calls for `os.listxattr`, `os.getxattr`, and `os.setxattr` so that they do not fail with `AttributeError` on environments that lack native support for POSIX extended attributes.
4. **Integration & Dispatcher Tests (`tests/integration/test_dispatcher_core.py`)**: Updated mock assertions for path arguments to check against `str(Path("/mock/a.mp3"))` instead of hardcoded UNIX-style strings, resolving Windows backslash (`\`) separator mismatches.
5. **Durable Move Tests (`tests/undo/test_durable_move.py`)**: Mocked and tracked `append_durable` alongside `_append_journal_line_locked` to record the `"started"` journal state event on non-POSIX/Windows systems.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The modified test suites were validated locally:

```bash
uv run pytest tests/cli/test_organize_path_validation.py tests/parallel/test_concurrency_fixes.py tests/pipeline/test_stages.py tests/integration/test_dispatcher_core.py tests/undo/test_durable_move.py --override-ini="addopts="