### PR TITLE
test(pipeline): restore writer.py integration coverage floor after #1268

### DIFF
--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -365,8 +365,15 @@ class TestCopyFdXattrs:
 
 @pytest.mark.ci
 @pytest.mark.unit
+@pytest.mark.integration
 class TestWriterStage:
-    """Test WriterStage file copy operations."""
+    """Test WriterStage file copy operations.
+
+    Marked ``integration`` as well as ``unit``: these exercise the real
+    SafeDir filesystem copy path, so they carry ``writer.py``'s integration
+    coverage floor (the push-to-main Integration coverage gate measures only
+    ``-m integration``).
+    """
 
     def test_satisfies_protocol(self) -> None:
         assert isinstance(WriterStage(), PipelineStage)
@@ -425,6 +432,7 @@ class TestWriterStage:
 
 @pytest.mark.ci
 @pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir anchored write is POSIX-only")
 class TestWriterStageAnchored:
     """When ``context.output_root`` is set, the writer descends from it


### PR DESCRIPTION
## Summary

Fixes the **Integration coverage gate** failure on `main` introduced by #1268 (merged as `7e8c0a7`):

```
BELOW FLOOR: src/file_organizer/pipeline/stages/writer.py: 62.8% < 70% floor
```

### Root cause

#1268 refactored `pipeline/stages/writer.py` (new `_open_source_nofollow` / `_finish_copy` / `_copy_via_safedir` / `_copy_via_safedir_anchored` / `_write_destination` helpers + anchored branch). Its new tests — `TestWriterStage`, `TestWriterStageAnchored` — were marked `@pytest.mark.ci`/`unit` but **not** `@pytest.mark.integration`. The push-to-main **Integration coverage gate** measures `-m integration` only, so it never executed those tests, and writer.py's per-file integration coverage fell from above-floor to **62.8% < 70%**. The gate is **skipped on PRs** (runs only on push to `main`), so it passed PR CI and only failed post-merge.

(`safedir.py` was unaffected — its anchored tests were already `integration`-marked, so it stayed at 94%.)

### Fix

Add `@pytest.mark.integration` to the two real-filesystem writer copy test classes. They exercise the actual SafeDir copy path (anchored descent, symlinked-ancestor/leaf refusal, parent-rooted fallback, `copy2` metadata parity) against `tmp_path` with no extra dependencies — so `integration` is the **semantically correct** marker, not a workaround. With them counted, writer.py integration coverage rises to **~86%**, clearing the 70% floor (coverage is a union, so this can only raise it).

**No production code change** — test markers + a clarifying docstring only.

## Validation

- `python -m pytest tests/pipeline/test_stages.py -m integration --cov=file_organizer.pipeline.stages.writer` → writer.py **86%** (≥ 70% floor), 20 passed.
- `bash .claude/scripts/pre-commit-validation.sh` green; ruff clean.

## Note on prevention

This class of miss (per-file integration floor only enforced on push-to-main, invisible to PR CI) is exactly what the deferred **WP-6.2** `module_coverage_floor` rail is meant to surface earlier; this PR is the targeted fix for the immediate red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4urW7VLML2ReqxaHRc2Br)_