### PR TITLE
fix(ci): gate PRs on Python 3.12, integration floor, and shallow-checkout drift

### DIFF
--- a/.claude/scripts/check-threshold-drift.sh
+++ b/.claude/scripts/check-threshold-drift.sh
@@ -15,16 +15,37 @@ if [[ -z "$NEW_VAL" ]] || [[ -z "$OLD_VAL" ]] || [[ "$NEW_VAL" == "$OLD_VAL" ]];
   exit 0
 fi
 
-HITS=$(grep -rn "$OLD_VAL" \
+# Docs that use the old value outside what this check can reason about: a dated
+# historical snapshot (must keep the number it reported at the time) and a
+# meta-doc whose "95%" mentions are pedagogical examples, not state claims.
+# Excluded by path so the content-based matching below stays precise elsewhere.
+EXCLUDE_PATHS=(
+  "$REPO_ROOT/docs/testing/coverage-report.md"
+  "$REPO_ROOT/.claude/rules/documentation-generation-checklist.md"
+  "$REPO_ROOT/docs/superpowers/plans/2026-04-07-docstring-completion-and-ratchet.md"
+)
+
+HITS=$(grep -rnE "\b${OLD_VAL}\b" \
   "$REPO_ROOT/docs/" \
   "$REPO_ROOT/README.md" \
   "$REPO_ROOT/CONTRIBUTING.md" \
   "$REPO_ROOT/.claude/rules/" \
   "$REPO_ROOT/.github/" \
   2>/dev/null \
-  | grep -iE "cover|docstring|gate|threshold|fail.under" \
   | grep -v "^Binary" \
+  | awk -F: '
+      {
+        content = $0
+        sub(/^[^:]+:[^:]+:/, "", content)
+        lc = tolower(content)
+        if ((lc ~ /cover|gate|threshold|fail.under/) && (lc !~ /docstring|interrogate/)) print
+      }
+    ' \
   || true)
+
+for excluded in "${EXCLUDE_PATHS[@]}"; do
+  HITS=$(printf '%s\n' "$HITS" | grep -v "^${excluded}:" || true)
+done
 
 if [[ -n "$HITS" ]]; then
   printf "ERROR: Coverage threshold changed from %s%% to %s%% but stale references remain:\n" "$OLD_VAL" "$NEW_VAL"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -33,6 +33,7 @@ jobs:
           # fetch-depth: 0 so tests/ci guardrails can resolve origin/main for their
           # diff (shallow checkout leaves it unreachable, e.g. on epic/** branches).
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -29,6 +29,10 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v6
+        with:
+          # fetch-depth: 0 so tests/ci guardrails can resolve origin/main for their
+          # diff (shallow checkout leaves it unreachable, e.g. on epic/** branches).
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # fetch-depth: 0 is required so origin/main is resolvable —
+          # pre-commit runs the tests/ci guardrails, which diff against it.
+          fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           # fetch-depth: 0 is required so origin/main is resolvable —
           # pre-commit runs the tests/ci guardrails, which diff against it.
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
@@ -207,6 +208,7 @@ jobs:
           # fetch-depth: 0 so tests/ci guardrails can resolve origin/main for their
           # diff (shallow checkout leaves it unreachable, e.g. on epic/** branches).
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -199,6 +199,10 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v6
+        with:
+          # fetch-depth: 0 so tests/ci guardrails can resolve origin/main for their
+          # diff (shallow checkout leaves it unreachable, e.g. on epic/** branches).
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -458,7 +462,7 @@ jobs:
   test-integration:
     name: Integration coverage gate
     needs: changes
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ The `.actrc` file in the project root pins the Docker image and architecture aut
 **Rule**: each check lives in exactly one workflow.
 
 - `ci.yml` is the *fast-path gate*: runs on PRs and pushes to `main`.
-  - **PR test lane**: single Python 3.11 job, `ci` marker only (~2 400 tests), diff-coverage gate
+  - **PR test lane**: Python 3.11+3.12, `ci` marker only (~2 400 tests), diff-coverage gate
   - **Push to main**: 4 parallel shards × Python 3.11+3.12, each ~4 000 tests with
     `timeout-minutes: 20`; a separate `coverage-gate` job merges `.coverage` artifacts
     and enforces the 93% floor. Sharding prevents the GC-finaliser hang that occurred
@@ -369,7 +369,7 @@ pytest tests/playwright/ --override-ini='addopts='
 pytest tests/playwright/test_desktop_api_contract.py --override-ini='addopts='
 ```
 
-The `--override-ini='addopts='` flag is required to suppress the default `--cov-fail-under=95` coverage gate, which is not meaningful for a browser-driven test run targeting the UI layer.
+The `--override-ini='addopts='` flag is required to suppress the default `--cov-fail-under=93` coverage gate, which is not meaningful for a browser-driven test run targeting the UI layer.
 
 ---
 

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -338,7 +338,7 @@ GitHub Actions runs automated checks on every PR and push to main:
 
 **Main Branch Pushes:**
 - Full test suite passes (`pytest`)
-- Coverage must be ≥ 95% (code) and ≥ 95% (docstrings) — both gates must pass
+- Coverage must be ≥ 93% (code) and ≥ 95% (docstrings) — both gates must pass
 - Linting must pass (ruff and markdownlint)
 - Type checking must pass (mypy)
 

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -41,7 +41,7 @@ def test_example():
 - **API Module**: 92% code coverage ✅
 - **Services**: 82% code coverage ✅
 - **Models**: 90% code coverage ✅
-- **CI Gate**: 95% minimum (coverage requirement, enforced on main pushes)
+- **CI Gate**: 93% minimum (coverage requirement, enforced on main pushes)
 
 ### Coverage Targets by Module
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,7 +336,8 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html",
     "--cov-report=xml",
-    "--cov-fail-under=95",
+    # Matches the unit coverage-gate job's enforced floor (ci.yml: coverage report --fail-under=93).
+    "--cov-fail-under=93",
     "--timeout=30",
     # Branch coverage baseline (integration tests only):
     # Measured 2026-03-21 via measure-integration-coverage.sh: TOTAL ~49%

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -51,9 +51,14 @@ def _make_app(allowed_paths: list[str]) -> TestClient:
         """Override dependency to return test settings."""
         return settings
 
-    from file_organizer.api.dependencies import get_settings
+    from file_organizer.api.dependencies import AnonymousUser, get_current_active_user, get_settings
 
     app.dependency_overrides[get_settings] = override_settings
+    # search's router depends on get_current_active_user, which (via
+    # get_current_user) resolves a real get_db session even when
+    # auth_enabled=False. Override it directly so these tests don't touch
+    # the default auth.db location (flaky if its parent dir doesn't exist).
+    app.dependency_overrides[get_current_active_user] = lambda: AnonymousUser()
     return TestClient(app)
 
 

--- a/tests/api/test_search_router.py
+++ b/tests/api/test_search_router.py
@@ -498,7 +498,9 @@ class TestSearchAuthEnforcement:
 
     def test_search_unauthenticated_fails(self, tmp_path: Path) -> None:
         """Test search endpoint without active user override fails with 401."""
-        settings = ApiSettings(environment="test", auth_enabled=True)
+        settings = ApiSettings(
+            environment="test", auth_enabled=True, auth_db_path=str(tmp_path / "auth.db")
+        )
         app = FastAPI()
         setup_exception_handlers(app)
         app.dependency_overrides[get_settings] = lambda: settings

--- a/tests/ci/test_optional_dep_guards.py
+++ b/tests/ci/test_optional_dep_guards.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import ast
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -183,9 +184,15 @@ def _git_changed_test_files() -> list[Path]:
     guardrail. Outside CI (local dev, possibly without a configured
     ``origin`` remote) the silent fallback below is intentional.
     """
+    git_bin = shutil.which("git")
+    if git_bin is None:
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.fail("git executable not found on PATH in CI.")
+        return []
+
     if os.environ.get("GITHUB_ACTIONS") == "true":
         verify = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", "origin/main"],
+            [git_bin, "rev-parse", "--verify", "--quiet", "origin/main"],
             capture_output=True,
             text=True,
             cwd=FO_ROOT,
@@ -199,14 +206,14 @@ def _git_changed_test_files() -> list[Path]:
 
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            [git_bin, "diff", "--name-only", "origin/main...HEAD"],
             capture_output=True,
             text=True,
             cwd=FO_ROOT,
         )
         if not result.stdout.strip():
             result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
+                [git_bin, "diff", "--name-only", "HEAD"],
                 capture_output=True,
                 text=True,
                 cwd=FO_ROOT,

--- a/tests/ci/test_optional_dep_guards.py
+++ b/tests/ci/test_optional_dep_guards.py
@@ -26,6 +26,7 @@ violations are resolved.
 from __future__ import annotations
 
 import ast
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -174,7 +175,28 @@ def _find_unguarded_optional_imports(
 
 
 def _git_changed_test_files() -> list[Path]:
-    """Return test files modified relative to main (diff-based subset)."""
+    """Return test files modified relative to main (diff-based subset).
+
+    In CI, a shallow checkout can leave ``origin/main`` unresolvable, which
+    would otherwise silently collapse the diff to empty and skip every
+    violation. Fail loudly in that case rather than degrade to a no-op
+    guardrail. Outside CI (local dev, possibly without a configured
+    ``origin`` remote) the silent fallback below is intentional.
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        verify = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", "origin/main"],
+            capture_output=True,
+            text=True,
+            cwd=FO_ROOT,
+        )
+        if verify.returncode != 0:
+            pytest.fail(
+                "origin/main is not resolvable in CI (likely a shallow checkout) — "
+                "this guardrail would silently no-op instead of checking changed files. "
+                "Ensure the checkout step uses fetch-depth: 0."
+            )
+
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", "origin/main...HEAD"],

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import ast
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -76,9 +77,15 @@ def _git_changed_test_files() -> list[Path]:
     guardrail. Outside CI (local dev, possibly without a configured
     ``origin`` remote) the silent fallback below is intentional.
     """
+    git_bin = shutil.which("git")
+    if git_bin is None:
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.fail("git executable not found on PATH in CI.")
+        return []
+
     if os.environ.get("GITHUB_ACTIONS") == "true":
         verify = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", "origin/main"],
+            [git_bin, "rev-parse", "--verify", "--quiet", "origin/main"],
             capture_output=True,
             text=True,
             cwd=FO_ROOT,
@@ -92,14 +99,14 @@ def _git_changed_test_files() -> list[Path]:
 
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            [git_bin, "diff", "--name-only", "origin/main...HEAD"],
             capture_output=True,
             text=True,
             cwd=FO_ROOT,
         )
         if not result.stdout.strip():
             result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
+                [git_bin, "diff", "--name-only", "HEAD"],
                 capture_output=True,
                 text=True,
                 cwd=FO_ROOT,

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -32,6 +32,7 @@ Guardrail 4 is diff-based until a full-suite clean-up is done.
 from __future__ import annotations
 
 import ast
+import os
 import subprocess
 from pathlib import Path
 
@@ -68,7 +69,27 @@ def _git_changed_test_files() -> list[Path]:
     Used for guardrails that have known pre-existing violations in the full
     suite.  Only files touched in the current branch are checked, preventing
     failures on historical code while blocking new violations.
+
+    In CI, a shallow checkout can leave ``origin/main`` unresolvable, which
+    would otherwise silently collapse the diff to empty and skip every
+    violation. Fail loudly in that case rather than degrade to a no-op
+    guardrail. Outside CI (local dev, possibly without a configured
+    ``origin`` remote) the silent fallback below is intentional.
     """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        verify = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", "origin/main"],
+            capture_output=True,
+            text=True,
+            cwd=FO_ROOT,
+        )
+        if verify.returncode != 0:
+            pytest.fail(
+                "origin/main is not resolvable in CI (likely a shallow checkout) — "
+                "this guardrail would silently no-op instead of checking changed files. "
+                "Ensure the checkout step uses fetch-depth: 0."
+            )
+
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", "origin/main...HEAD"],

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -162,11 +162,11 @@ class TestCIWorkflow:
         """Verify the split PR/push test structure uses correct Python versions.
 
         ci.yml uses two separate jobs:
-        - 'test': PR-only, Python 3.11 only (fast feedback, ~2 400 tests)
+        - 'test': PR-only, Python 3.11+3.12 (~2 400 tests, ci marker)
         - 'test-full': push-only, 6 shards x Python 3.11+3.12 (~17 000 tests)
 
-        This replaces the old single 'test' job that used a conditional matrix
-        expression and timed out due to GC pressure with 17 000 tests/2 workers.
+        Both jobs cover 3.12 directly on PRs rather than waiting until after
+        merge (or the daily ci-full.yml run) to catch version-specific issues.
         """
         jobs = workflow.get("jobs", {})
 
@@ -179,12 +179,12 @@ class TestCIWorkflow:
             "'test' job must have if: github.event_name == 'pull_request'"
         )
 
-        # Must use Python 3.11 only (speed; 3.12 is covered by test-full)
+        # Must run both Python versions so 3.12 is validated on every PR
         strategy = test_job.get("strategy", {})
         matrix = strategy.get("matrix", {})
         python_versions = matrix.get("python-version", [])
-        assert python_versions == ["3.11"], (
-            f"'test' (PR) job must use [\"3.11\"] only, got {python_versions}"
+        assert set(python_versions) == {"3.11", "3.12"}, (
+            f"'test' (PR) job must include both 3.11 and 3.12, got {python_versions}"
         )
 
         # Must have a timeout to prevent indefinite hangs

--- a/tests/integration/test_api_integrations_workflow.py
+++ b/tests/integration/test_api_integrations_workflow.py
@@ -190,6 +190,7 @@ def test_integrations_reject_invalid_paths_and_names(
 def test_integrations_settings_reject_invalid_filename_in_command_output_path(
     integrations_client: TestClient, tmp_path: Path
 ) -> None:
+    """Reject a vscode command_output_path that resolves to a directory traversal."""
     invalid_filename = integrations_client.post(
         "/api/v1/integrations/vscode/settings",
         json={"settings": {"command_output_path": str(tmp_path) + "/.."}},
@@ -214,6 +215,7 @@ def test_integrations_settings_reject_invalid_subdir_values(
     subdir_value: object,
     message_fragment: str,
 ) -> None:
+    """Reject malformed obsidian attachments_subdir values with a matching error message."""
     response = integrations_client.post(
         "/api/v1/integrations/obsidian/settings",
         json={"settings": {"attachments_subdir": subdir_value}},
@@ -230,6 +232,7 @@ def test_integrations_settings_reject_invalid_subdir_values(
 
 
 def _obsidian_integration(vault: Path, **subdir_overrides: str) -> ObsidianIntegration:
+    """Build an ObsidianIntegration configured against the given vault path."""
     settings: dict[str, object] = {
         "vault_path": str(vault),
         "attachments_subdir": "Attachments",
@@ -246,38 +249,47 @@ def _obsidian_integration(vault: Path, **subdir_overrides: str) -> ObsidianInteg
 
 
 class TestObsidianIntegrationBranches:
+    """Branch coverage for ObsidianIntegration's auth, path-validation, and send_file logic."""
+
     def test_init_coerces_integration_type_to_desktop_app(self, tmp_path: Path) -> None:
+        """Constructing an Obsidian integration always coerces its type to DESKTOP_APP."""
         integration = _obsidian_integration(tmp_path / "vault")
         assert integration.config.integration_type is IntegrationType.DESKTOP_APP
 
     def test_validate_auth_none_returns_true(self, tmp_path: Path) -> None:
+        """auth_method="none" always validates successfully."""
         integration = _obsidian_integration(tmp_path / "vault")
         integration.config.auth_method = "none"
         assert asyncio.run(integration.validate_auth()) is True
 
     def test_validate_auth_api_key_present_returns_true(self, tmp_path: Path) -> None:
+        """auth_method="api_key" validates when an api_key setting is present."""
         integration = _obsidian_integration(tmp_path / "vault")
         integration.config.auth_method = "api_key"
         integration.config.settings["api_key"] = "secret-key"
         assert asyncio.run(integration.validate_auth()) is True
 
     def test_validate_auth_api_key_missing_returns_false(self, tmp_path: Path) -> None:
+        """auth_method="api_key" fails validation when no api_key setting is configured."""
         integration = _obsidian_integration(tmp_path / "vault")
         integration.config.auth_method = "api_key"
         assert asyncio.run(integration.validate_auth()) is False
 
     def test_validate_auth_unsupported_method_returns_false(self, tmp_path: Path) -> None:
+        """An unsupported auth_method fails validation."""
         integration = _obsidian_integration(tmp_path / "vault")
         integration.config.auth_method = "oauth"
         assert asyncio.run(integration.validate_auth()) is False
 
     def test_send_file_returns_false_when_vault_missing(self, tmp_path: Path) -> None:
+        """send_file fails when the configured vault directory does not exist."""
         source = tmp_path / "source.txt"
         source.write_text("content", encoding="utf-8")
         integration = _obsidian_integration(tmp_path / "missing-vault")
         assert asyncio.run(integration.send_file(str(source))) is False
 
     def test_send_file_returns_false_when_auth_fails(self, tmp_path: Path) -> None:
+        """send_file fails when auth validation fails before any file is copied."""
         vault = tmp_path / "vault"
         vault.mkdir()
         source = tmp_path / "source.txt"
@@ -287,6 +299,7 @@ class TestObsidianIntegrationBranches:
         assert asyncio.run(integration.send_file(str(source))) is False
 
     def test_send_file_returns_false_when_source_missing(self, tmp_path: Path) -> None:
+        """send_file fails when the source file does not exist."""
         vault = tmp_path / "vault"
         vault.mkdir()
         integration = _obsidian_integration(vault)
@@ -304,6 +317,7 @@ class TestObsidianIntegrationBranches:
     def test_send_file_rejects_invalid_attachments_subdir(
         self, tmp_path: Path, subdir_overrides: dict[str, str]
     ) -> None:
+        """send_file rejects vaults configured with a malformed attachments_subdir."""
         vault = tmp_path / "vault"
         vault.mkdir()
         source = tmp_path / "source.txt"
@@ -312,6 +326,7 @@ class TestObsidianIntegrationBranches:
         assert asyncio.run(integration.send_file(str(source))) is False
 
     def test_send_file_rejects_attachments_dir_escaping_vault(self, tmp_path: Path) -> None:
+        """send_file rejects an Attachments directory that symlinks outside the vault."""
         vault = tmp_path / "vault"
         vault.mkdir()
         outside = tmp_path / "outside"
@@ -323,6 +338,7 @@ class TestObsidianIntegrationBranches:
         assert asyncio.run(integration.send_file(str(source))) is False
 
     def test_send_file_rejects_destination_escaping_vault(self, tmp_path: Path) -> None:
+        """send_file rejects when the attachment destination symlinks outside the vault."""
         vault = tmp_path / "vault"
         attachments = vault / "Attachments"
         attachments.mkdir(parents=True)
@@ -335,6 +351,7 @@ class TestObsidianIntegrationBranches:
         assert asyncio.run(integration.send_file(str(source))) is False
 
     def test_send_file_rejects_notes_dir_escaping_vault(self, tmp_path: Path) -> None:
+        """send_file rejects a Notes directory that symlinks outside the vault."""
         vault = tmp_path / "vault"
         vault.mkdir()
         outside = tmp_path / "outside"
@@ -346,6 +363,7 @@ class TestObsidianIntegrationBranches:
         assert asyncio.run(integration.send_file(str(source))) is False
 
     def test_send_file_rejects_note_path_escaping_vault(self, tmp_path: Path) -> None:
+        """send_file rejects when the generated note path symlinks outside the vault."""
         vault = tmp_path / "vault"
         notes = vault / "Notes"
         notes.mkdir(parents=True)

--- a/tests/integration/test_api_integrations_workflow.py
+++ b/tests/integration/test_api_integrations_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -14,6 +15,7 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_current_active_user, get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
 from file_organizer.api.routers.integrations import router
+from file_organizer.integrations import IntegrationConfig, IntegrationType, ObsidianIntegration
 
 pytestmark = pytest.mark.integration
 
@@ -183,3 +185,174 @@ def test_integrations_reject_invalid_paths_and_names(
         "/api/v1/integrations/unknown/connect",
     )
     assert missing_integration.status_code == 404
+
+
+def test_integrations_settings_reject_invalid_filename_in_command_output_path(
+    integrations_client: TestClient, tmp_path: Path
+) -> None:
+    invalid_filename = integrations_client.post(
+        "/api/v1/integrations/vscode/settings",
+        json={"settings": {"command_output_path": str(tmp_path) + "/.."}},
+    )
+    assert invalid_filename.status_code == 400
+    assert invalid_filename.json()["error"] == "invalid_filename"
+
+
+@pytest.mark.parametrize(
+    ("subdir_value", "message_fragment"),
+    [
+        (123, "must be a string"),
+        ("   ", "cannot be empty"),
+        ("a//b", "empty path segments"),
+        ("a\\\\b", "empty path segments"),
+        ("C:\\folder", "must be a relative path"),
+        ("../escape", "path traversal"),
+    ],
+)
+def test_integrations_settings_reject_invalid_subdir_values(
+    integrations_client: TestClient,
+    subdir_value: object,
+    message_fragment: str,
+) -> None:
+    response = integrations_client.post(
+        "/api/v1/integrations/obsidian/settings",
+        json={"settings": {"attachments_subdir": subdir_value}},
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "invalid_settings"
+    assert message_fragment in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# ObsidianIntegration adapter — auth and path-validation branch coverage
+# ---------------------------------------------------------------------------
+
+
+def _obsidian_integration(vault: Path, **subdir_overrides: str) -> ObsidianIntegration:
+    settings: dict[str, object] = {
+        "vault_path": str(vault),
+        "attachments_subdir": "Attachments",
+        "notes_subdir": "Notes",
+    }
+    settings.update(subdir_overrides)
+    return ObsidianIntegration(
+        IntegrationConfig(
+            name="obsidian",
+            integration_type=IntegrationType.EDITOR,
+            settings=settings,
+        )
+    )
+
+
+class TestObsidianIntegrationBranches:
+    def test_init_coerces_integration_type_to_desktop_app(self, tmp_path: Path) -> None:
+        integration = _obsidian_integration(tmp_path / "vault")
+        assert integration.config.integration_type is IntegrationType.DESKTOP_APP
+
+    def test_validate_auth_none_returns_true(self, tmp_path: Path) -> None:
+        integration = _obsidian_integration(tmp_path / "vault")
+        integration.config.auth_method = "none"
+        assert asyncio.run(integration.validate_auth()) is True
+
+    def test_validate_auth_api_key_present_returns_true(self, tmp_path: Path) -> None:
+        integration = _obsidian_integration(tmp_path / "vault")
+        integration.config.auth_method = "api_key"
+        integration.config.settings["api_key"] = "secret-key"
+        assert asyncio.run(integration.validate_auth()) is True
+
+    def test_validate_auth_api_key_missing_returns_false(self, tmp_path: Path) -> None:
+        integration = _obsidian_integration(tmp_path / "vault")
+        integration.config.auth_method = "api_key"
+        assert asyncio.run(integration.validate_auth()) is False
+
+    def test_validate_auth_unsupported_method_returns_false(self, tmp_path: Path) -> None:
+        integration = _obsidian_integration(tmp_path / "vault")
+        integration.config.auth_method = "oauth"
+        assert asyncio.run(integration.validate_auth()) is False
+
+    def test_send_file_returns_false_when_vault_missing(self, tmp_path: Path) -> None:
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        integration = _obsidian_integration(tmp_path / "missing-vault")
+        assert asyncio.run(integration.send_file(str(source))) is False
+
+    def test_send_file_returns_false_when_auth_fails(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        integration = _obsidian_integration(vault)
+        integration.config.auth_method = "api_key"
+        assert asyncio.run(integration.send_file(str(source))) is False
+
+    def test_send_file_returns_false_when_source_missing(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        integration = _obsidian_integration(vault)
+        assert asyncio.run(integration.send_file(str(tmp_path / "nope.txt"))) is False
+
+    @pytest.mark.parametrize(
+        "subdir_overrides",
+        [
+            {"attachments_subdir": ""},
+            {"attachments_subdir": "a//b"},
+            {"attachments_subdir": "a\\\\b"},
+            {"attachments_subdir": "../escape"},
+        ],
+    )
+    def test_send_file_rejects_invalid_attachments_subdir(
+        self, tmp_path: Path, subdir_overrides: dict[str, str]
+    ) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        integration = _obsidian_integration(vault, **subdir_overrides)
+        assert asyncio.run(integration.send_file(str(source))) is False
+
+    def test_send_file_rejects_attachments_dir_escaping_vault(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (vault / "Attachments").symlink_to(outside, target_is_directory=True)
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        integration = _obsidian_integration(vault)
+        assert asyncio.run(integration.send_file(str(source))) is False
+
+    def test_send_file_rejects_destination_escaping_vault(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        attachments = vault / "Attachments"
+        attachments.mkdir(parents=True)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("outside-content", encoding="utf-8")
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        (attachments / source.name).symlink_to(outside)
+        integration = _obsidian_integration(vault)
+        assert asyncio.run(integration.send_file(str(source))) is False
+
+    def test_send_file_rejects_notes_dir_escaping_vault(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (vault / "Notes").symlink_to(outside, target_is_directory=True)
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        integration = _obsidian_integration(vault)
+        assert asyncio.run(integration.send_file(str(source))) is False
+
+    def test_send_file_rejects_note_path_escaping_vault(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        notes = vault / "Notes"
+        notes.mkdir(parents=True)
+        outside = tmp_path / "outside.md"
+        outside.write_text("outside-note", encoding="utf-8")
+        source = tmp_path / "source.txt"
+        source.write_text("content", encoding="utf-8")
+        (notes / f"{source.stem}.md").symlink_to(outside)
+        integration = _obsidian_integration(vault)
+        assert asyncio.run(integration.send_file(str(source))) is False

--- a/tests/integration/test_api_routers.py
+++ b/tests/integration/test_api_routers.py
@@ -51,6 +51,7 @@ def analyze_client(api_settings: ApiSettings) -> TestClient:
 
 @pytest.fixture()
 def daemon_client(api_settings: ApiSettings) -> TestClient:
+    """Build a TestClient wired to the daemon router with overridden settings."""
     app = FastAPI()
     app.dependency_overrides[get_settings] = lambda: api_settings
     setup_exception_handlers(app)

--- a/tests/integration/test_api_routers.py
+++ b/tests/integration/test_api_routers.py
@@ -50,8 +50,9 @@ def analyze_client(api_settings: ApiSettings) -> TestClient:
 
 
 @pytest.fixture()
-def daemon_client() -> TestClient:
+def daemon_client(api_settings: ApiSettings) -> TestClient:
     app = FastAPI()
+    app.dependency_overrides[get_settings] = lambda: api_settings
     setup_exception_handlers(app)
     app.include_router(daemon_router)
     return TestClient(app, raise_server_exceptions=False)

--- a/tests/integration/test_plugins_api_endpoints.py
+++ b/tests/integration/test_plugins_api_endpoints.py
@@ -503,6 +503,7 @@ class TestPluginHookManager:
             _validate_callback_url("http:///path")
 
     def test_default_http_client_factory_returns_httpx_client(self) -> None:
+        """The default HTTP client factory returns an httpx.Client with redirects disabled."""
         import httpx
 
         from file_organizer.plugins.api.hooks import _default_http_client_factory
@@ -515,6 +516,7 @@ class TestPluginHookManager:
             client.close()
 
     def test_validate_callback_url_raises_on_netloc_without_hostname(self) -> None:
+        """A callback URL with no parseable hostname is rejected."""
         from file_organizer.plugins.api.hooks import _validate_callback_url
 
         with pytest.raises(ValueError, match="valid host"):
@@ -522,6 +524,7 @@ class TestPluginHookManager:
 
     @pytest.mark.parametrize("host", ["localhost", "localhost.localdomain"])
     def test_validate_callback_url_raises_on_localhost(self, host: str) -> None:
+        """Callback URLs pointing at localhost (by name) are rejected."""
         from file_organizer.plugins.api.hooks import _validate_callback_url
 
         with pytest.raises(ValueError, match="not allowed"):
@@ -530,11 +533,13 @@ class TestPluginHookManager:
     def test_validate_callback_url_raises_when_host_unresolvable_at_dispatch(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A host that fails DNS resolution at dispatch time is rejected, not allowed through."""
         import socket
 
         from file_organizer.plugins.api import hooks as hooks_module
 
         def _raise_gaierror(*_args: object, **_kwargs: object) -> list[object]:
+            """Simulate a DNS resolution failure."""
             raise socket.gaierror("name resolution failed")
 
         monkeypatch.setattr(hooks_module.socket, "getaddrinfo", _raise_gaierror)
@@ -547,9 +552,11 @@ class TestPluginHookManager:
     def test_validate_callback_url_skips_unparsable_resolved_address(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A resolved address that isn't a parseable IP is skipped rather than rejected."""
         from file_organizer.plugins.api import hooks as hooks_module
 
         def _fake_getaddrinfo(*_args: object, **_kwargs: object) -> list[tuple]:
+            """Return a resolved address that isn't a valid IP literal."""
             return [(2, 1, 6, "", ("not-an-ip-address", 0))]
 
         monkeypatch.setattr(hooks_module.socket, "getaddrinfo", _fake_getaddrinfo)
@@ -568,6 +575,7 @@ class TestPluginHookManager:
         ],
     )
     def test_reject_unsafe_ip_blocks_each_category(self, ip_str: str, match: str) -> None:
+        """_reject_unsafe_ip blocks loopback, unspecified, private, reserved, and multicast IPs."""
         import ipaddress
 
         from file_organizer.plugins.api.hooks import _reject_unsafe_ip
@@ -576,6 +584,7 @@ class TestPluginHookManager:
             _reject_unsafe_ip(ipaddress.ip_address(ip_str), ip_str)
 
     def test_reject_unsafe_ip_blocks_link_local_independently_of_private_flag(self) -> None:
+        """The is_link_local branch blocks an address even when is_private is False."""
         # Real-world link-local ranges (169.254.0.0/16, fe80::/10) are also flagged
         # is_private by ipaddress, so that check always fires first. Use a double to
         # exercise the is_link_local branch on its own as defense-in-depth coverage.
@@ -590,6 +599,7 @@ class TestPluginHookManager:
             _reject_unsafe_ip(fake_ip, "169.254.1.1")
 
     def test_reject_unsafe_ip_allows_public_address(self) -> None:
+        """A genuinely public IP address passes without raising."""
         import ipaddress
 
         from file_organizer.plugins.api.hooks import _reject_unsafe_ip
@@ -597,6 +607,7 @@ class TestPluginHookManager:
         _reject_unsafe_ip(ipaddress.ip_address("8.8.8.8"), "8.8.8.8")
 
     def test_reject_unsafe_ip_blocks_metadata_ip_string_explicitly(self) -> None:
+        """The cloud metadata service IP is blocked by string match even if otherwise public."""
         import ipaddress
 
         from file_organizer.plugins.api.hooks import _reject_unsafe_ip
@@ -605,6 +616,7 @@ class TestPluginHookManager:
             _reject_unsafe_ip(ipaddress.ip_address("8.8.8.8"), "169.254.169.254")
 
     def test_unregister_local_hook_removes_callback(self) -> None:
+        """Unregistering a local hook callback stops it from receiving future events."""
         from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 
         manager = PluginHookManager()
@@ -616,6 +628,7 @@ class TestPluginHookManager:
         assert received == []
 
     def test_register_webhook_iterates_past_non_matching_entries(self) -> None:
+        """Registering a webhook scans past existing non-matching entries to add a new one."""
         from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 
         manager = PluginHookManager()
@@ -632,6 +645,7 @@ class TestPluginHookManager:
         assert len(manager.list_webhooks(event=HookEvent.FILE_SCANNED)) == 3
 
     def test_unregister_webhook_no_match_returns_false(self) -> None:
+        """Unregistering a webhook with no matching registration returns False."""
         from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 
         manager = PluginHookManager()
@@ -645,6 +659,7 @@ class TestPluginHookManager:
         assert len(manager.list_webhooks(event=HookEvent.FILE_SCANNED)) == 1
 
     def test_unregister_webhook_keeps_remaining_registrations(self) -> None:
+        """Unregistering one webhook leaves other registrations for the same event intact."""
         from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 
         manager = PluginHookManager()
@@ -665,12 +680,14 @@ class TestPluginHookManager:
     def test_trigger_event_blocks_dispatch_when_host_unresolvable(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """trigger_event reports an SSRF-prevention error when the webhook host can't resolve."""
         import socket
 
         from file_organizer.plugins.api import hooks as hooks_module
         from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 
         def _raise_gaierror(*_args: object, **_kwargs: object) -> list[object]:
+            """Simulate a DNS resolution failure."""
             raise socket.gaierror("name resolution failed")
 
         monkeypatch.setattr(hooks_module.socket, "getaddrinfo", _raise_gaierror)
@@ -688,23 +705,31 @@ class TestPluginHookManager:
         assert results[0].error.startswith("SSRF Prevention:")
 
     def test_trigger_event_success_includes_secret_header(self) -> None:
+        """A successful webhook dispatch includes the configured secret in the request header."""
         from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 
         captured: dict[str, object] = {}
 
         class _FakeResponse:
+            """Minimal httpx.Response double reporting a successful POST."""
+
             status_code = 200
             is_success = True
             text = ""
 
         class _FakeClient:
+            """Minimal httpx.Client double that records the dispatched request."""
+
             def __enter__(self) -> _FakeClient:
+                """Support use as a context manager, matching httpx.Client."""
                 return self
 
             def __exit__(self, *_args: object) -> bool:
+                """Support use as a context manager, matching httpx.Client."""
                 return False
 
             def post(self, url: str, *, json: dict, headers: dict, timeout: float) -> _FakeResponse:
+                """Record the request URL and headers, then return a fake success response."""
                 captured["url"] = url
                 captured["headers"] = headers
                 return _FakeResponse()

--- a/tests/integration/test_plugins_api_endpoints.py
+++ b/tests/integration/test_plugins_api_endpoints.py
@@ -501,3 +501,224 @@ class TestPluginHookManager:
 
         with pytest.raises(ValueError, match="host"):
             _validate_callback_url("http:///path")
+
+    def test_default_http_client_factory_returns_httpx_client(self) -> None:
+        import httpx
+
+        from file_organizer.plugins.api.hooks import _default_http_client_factory
+
+        client = _default_http_client_factory()
+        try:
+            assert isinstance(client, httpx.Client)
+            assert client.follow_redirects is False
+        finally:
+            client.close()
+
+    def test_validate_callback_url_raises_on_netloc_without_hostname(self) -> None:
+        from file_organizer.plugins.api.hooks import _validate_callback_url
+
+        with pytest.raises(ValueError, match="valid host"):
+            _validate_callback_url("http://:9999/path")
+
+    @pytest.mark.parametrize("host", ["localhost", "localhost.localdomain"])
+    def test_validate_callback_url_raises_on_localhost(self, host: str) -> None:
+        from file_organizer.plugins.api.hooks import _validate_callback_url
+
+        with pytest.raises(ValueError, match="not allowed"):
+            _validate_callback_url(f"http://{host}/hook")
+
+    def test_validate_callback_url_raises_when_host_unresolvable_at_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import socket
+
+        from file_organizer.plugins.api import hooks as hooks_module
+
+        def _raise_gaierror(*_args: object, **_kwargs: object) -> list[object]:
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(hooks_module.socket, "getaddrinfo", _raise_gaierror)
+
+        with pytest.raises(ValueError, match="must resolve before dispatch"):
+            hooks_module._validate_callback_url(
+                "http://nonexistent.example/hook", allow_unresolved_host=False
+            )
+
+    def test_validate_callback_url_skips_unparsable_resolved_address(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from file_organizer.plugins.api import hooks as hooks_module
+
+        def _fake_getaddrinfo(*_args: object, **_kwargs: object) -> list[tuple]:
+            return [(2, 1, 6, "", ("not-an-ip-address", 0))]
+
+        monkeypatch.setattr(hooks_module.socket, "getaddrinfo", _fake_getaddrinfo)
+
+        result = hooks_module._validate_callback_url("http://example.com/hook")
+        assert result == "http://example.com/hook"
+
+    @pytest.mark.parametrize(
+        ("ip_str", "match"),
+        [
+            ("127.0.0.1", "Loopback"),
+            ("0.0.0.0", "Unspecified"),
+            ("10.0.0.1", "Private"),
+            ("200::1", "Reserved"),
+            ("224.0.0.1", "Multicast"),
+        ],
+    )
+    def test_reject_unsafe_ip_blocks_each_category(self, ip_str: str, match: str) -> None:
+        import ipaddress
+
+        from file_organizer.plugins.api.hooks import _reject_unsafe_ip
+
+        with pytest.raises(ValueError, match=match):
+            _reject_unsafe_ip(ipaddress.ip_address(ip_str), ip_str)
+
+    def test_reject_unsafe_ip_blocks_link_local_independently_of_private_flag(self) -> None:
+        # Real-world link-local ranges (169.254.0.0/16, fe80::/10) are also flagged
+        # is_private by ipaddress, so that check always fires first. Use a double to
+        # exercise the is_link_local branch on its own as defense-in-depth coverage.
+        from file_organizer.plugins.api.hooks import _reject_unsafe_ip
+
+        fake_ip = MagicMock()
+        fake_ip.is_loopback = False
+        fake_ip.is_unspecified = False
+        fake_ip.is_private = False
+        fake_ip.is_link_local = True
+        with pytest.raises(ValueError, match="Link-local"):
+            _reject_unsafe_ip(fake_ip, "169.254.1.1")
+
+    def test_reject_unsafe_ip_allows_public_address(self) -> None:
+        import ipaddress
+
+        from file_organizer.plugins.api.hooks import _reject_unsafe_ip
+
+        _reject_unsafe_ip(ipaddress.ip_address("8.8.8.8"), "8.8.8.8")
+
+    def test_reject_unsafe_ip_blocks_metadata_ip_string_explicitly(self) -> None:
+        import ipaddress
+
+        from file_organizer.plugins.api.hooks import _reject_unsafe_ip
+
+        with pytest.raises(ValueError, match="Metadata service"):
+            _reject_unsafe_ip(ipaddress.ip_address("8.8.8.8"), "169.254.169.254")
+
+    def test_unregister_local_hook_removes_callback(self) -> None:
+        from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
+
+        manager = PluginHookManager()
+        received: list[dict] = []
+        callback = lambda payload: received.append(payload)  # noqa: E731
+        manager.register_local_hook(HookEvent.FILE_SCANNED, callback)
+        manager.unregister_local_hook(HookEvent.FILE_SCANNED, callback)
+        manager.trigger_local_hooks(HookEvent.FILE_SCANNED, {"file": "a.txt"})
+        assert received == []
+
+    def test_register_webhook_iterates_past_non_matching_entries(self) -> None:
+        from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
+
+        manager = PluginHookManager()
+        manager.register_webhook(
+            plugin_id="p1", event=HookEvent.FILE_SCANNED, callback_url="http://a.com/1"
+        )
+        manager.register_webhook(
+            plugin_id="p2", event=HookEvent.FILE_SCANNED, callback_url="http://b.com/2"
+        )
+        _, created = manager.register_webhook(
+            plugin_id="p3", event=HookEvent.FILE_SCANNED, callback_url="http://c.com/3"
+        )
+        assert created is True
+        assert len(manager.list_webhooks(event=HookEvent.FILE_SCANNED)) == 3
+
+    def test_unregister_webhook_no_match_returns_false(self) -> None:
+        from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
+
+        manager = PluginHookManager()
+        manager.register_webhook(
+            plugin_id="p1", event=HookEvent.FILE_SCANNED, callback_url="http://a.com/1"
+        )
+        removed = manager.unregister_webhook(
+            plugin_id="p2", event=HookEvent.FILE_SCANNED, callback_url="http://a.com/1"
+        )
+        assert removed is False
+        assert len(manager.list_webhooks(event=HookEvent.FILE_SCANNED)) == 1
+
+    def test_unregister_webhook_keeps_remaining_registrations(self) -> None:
+        from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
+
+        manager = PluginHookManager()
+        manager.register_webhook(
+            plugin_id="p1", event=HookEvent.FILE_SCANNED, callback_url="http://a.com/1"
+        )
+        manager.register_webhook(
+            plugin_id="p2", event=HookEvent.FILE_SCANNED, callback_url="http://b.com/2"
+        )
+        removed = manager.unregister_webhook(
+            plugin_id="p1", event=HookEvent.FILE_SCANNED, callback_url="http://a.com/1"
+        )
+        assert removed is True
+        remaining = manager.list_webhooks(event=HookEvent.FILE_SCANNED)
+        assert len(remaining) == 1
+        assert remaining[0].plugin_id == "p2"
+
+    def test_trigger_event_blocks_dispatch_when_host_unresolvable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import socket
+
+        from file_organizer.plugins.api import hooks as hooks_module
+        from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
+
+        def _raise_gaierror(*_args: object, **_kwargs: object) -> list[object]:
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(hooks_module.socket, "getaddrinfo", _raise_gaierror)
+
+        manager = PluginHookManager()
+        manager.register_webhook(
+            plugin_id="p",
+            event=HookEvent.FILE_SCANNED,
+            callback_url="http://nonexistent.example/hook",
+        )
+        results = manager.trigger_event(HookEvent.FILE_SCANNED, {})
+        assert len(results) == 1
+        assert results[0].delivered is False
+        assert results[0].error is not None
+        assert results[0].error.startswith("SSRF Prevention:")
+
+    def test_trigger_event_success_includes_secret_header(self) -> None:
+        from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
+
+        captured: dict[str, object] = {}
+
+        class _FakeResponse:
+            status_code = 200
+            is_success = True
+            text = ""
+
+        class _FakeClient:
+            def __enter__(self) -> _FakeClient:
+                return self
+
+            def __exit__(self, *_args: object) -> bool:
+                return False
+
+            def post(self, url: str, *, json: dict, headers: dict, timeout: float) -> _FakeResponse:
+                captured["url"] = url
+                captured["headers"] = headers
+                return _FakeResponse()
+
+        manager = PluginHookManager(http_client_factory=lambda: _FakeClient())
+        manager.register_webhook(
+            plugin_id="p",
+            event=HookEvent.FILE_ORGANIZED,
+            callback_url="http://8.8.8.8:9999/hook",
+            secret="topsecret",
+        )
+        results = manager.trigger_event(HookEvent.FILE_ORGANIZED, {"k": "v"})
+        assert len(results) == 1
+        assert results[0].delivered is True
+        assert results[0].status_code == 200
+        assert results[0].error is None
+        assert captured["headers"]["X-Plugin-Secret"] == "topsecret"


### PR DESCRIPTION
## Summary

Implements the unplanned, verified, low-risk fixes from a CI/coverage/guardrail review (full disposition table below). Each item was independently re-verified against the actual code/workflows before being included — see "Deferred" section for items already tracked under in-flight work packages.

### Fixed

1. **PR test matrix only covered Python 3.11** — `test` job in `ci.yml` now runs `["3.11", "3.12"]`. Previously 3.12-only regressions only surfaced post-merge (`test-full`) or on the daily `ci-full.yml` cron.
2. **Integration coverage floor never gated PRs** — `test-integration`'s `if:` now also runs on `pull_request` (was push-to-main only), so the 72% combined + per-file integration floors block the PR directly instead of breaking `main` after merge.
3. **Local `pytest --cov-fail-under=95` didn't match CI's actual gate (93%)** — fixed in `pyproject.toml`, with a comment pointing at the `coverage-gate` job it now matches. Previously a clean local run in the 93–95% coverage band could fail locally when CI would have passed.
4. **Diff-based guardrails silently no-op under shallow checkout** — `tests/ci/test_test_quality_guardrails.py` and `tests/ci/test_optional_dep_guards.py`'s `_git_changed_test_files()` collapsed to an empty diff (skipping every violation) when `origin/main` was unresolvable, e.g. on `epic/**` push jobs with a shallow checkout. Now `pytest.fail()`s loudly under `GITHUB_ACTIONS=true` instead of degrading to a no-op. Also added `fetch-depth: 0` to `test-full` (ci.yml) and `test-linux-full` (ci-full.yml) checkout steps so `origin/main` is actually resolvable.

### Cascading fixes required by the above

- `tests/ci/test_workflows.py::test_ci_uses_python_312` asserted the PR job uses `["3.11"]` only — this guardrail existed specifically to lock in the old (now intentionally changed) design, so it's updated to assert `{"3.11", "3.12"}`.
- 3 stale doc references to the old 95% code-coverage figure: `CONTRIBUTING.md`, `docs/developer/testing.md`, `docs/testing/testing-strategy.md`. Also updated `CONTRIBUTING.md`'s "single Python 3.11 job" PR-lane description.
- **Bug fix in `check-threshold-drift.sh`** (the pre-commit hook that caught the stale-doc-reference issue above): its keyword filter was matching against `grep -rn`'s `path:line:` prefix rather than line content, so any file whose *path* contained a tracked keyword (e.g. `coverage-report.md`, `docstring-completion-and-ratchet.md`) had every digit-match flagged regardless of actual content — and it didn't distinguish the code-coverage gate from the unrelated, unchanged docstring gate (`interrogate`, still 95%) when both happen to share a number. Fixed both, and added 3 explicit, commented path exclusions for a dated historical snapshot (`coverage-report.md`) and two docs whose "95%" mentions are pedagogical/forward-looking rather than current-state claims. Regression-tested: reverted one of the doc fixes locally and confirmed the hardened hook still catches it before re-applying.

### Deferred (already tracked, not duplicated here)

| Finding | Tracked under |
|---|---|
| No per-file **unit** coverage floors (only integration has them) | WP-6.2 (`check_module_coverage_floor.py`) |
| `mypy` scope limited to `src/file_organizer/models/` | WP-6.4 (`mypy-on-all-src`) |
| Diff-based guardrails scoped to changed files, not full suite | WP-6.2 (`select_tests_for_changes.py` rework) |
| `security.yml` silences `pip-audit`/`bandit` (`continue-on-error`) | WP-6.3 (accepted-risk allowlist, gates *after* the allowlist mechanism lands — hard-gating now would preempt that design) |

### Skipped (verified, not worth the diff noise)

- Loose root-level `tests/test_*.py` files (64 files) — cosmetic, no functional risk; flagged separately as issue #1313.
- Playwright tests silently skipped if the package goes missing — checked `conftest.py`; already fails loud (pytest exits 5, "no tests collected") if the import ever failed in the dedicated Playwright job.

### Known local-verification gap

`pre-commit run --all-files` can't fully execute in this sandbox (no network access to clone the two GitHub-hosted hook repos: `pre-commit/pre-commit-hooks` and `jackdewinter/pymarkdown`). I manually replicated every `language: system` hook against the diff (ruff check/format, codespell, absolute-path/f-string/build-artifact checks, `check-threshold-drift.sh`, `interrogate`, `deptry`) plus the equivalent of the network-hosted hooks (EOF newline / trailing whitespace via direct grep, YAML/TOML syntax via `yaml.safe_load`/`tomllib`, markdown lint via a locally-installed `pymarkdownlnt`). All passed. CI itself should run the real hooks with full network access.

## Test plan

- [x] `python3 -m pytest tests/ci -q --no-cov --override-ini="addopts="` — 522 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` on all modified Python files
- [x] `interrogate -v src/ --fail-under 95 -q` — docstring gate unaffected
- [x] `codespell` on all modified files
- [x] `deptry src/` — no dependency issues
- [x] `pymarkdownlnt scan` on the 3 modified `.md` files
- [x] YAML (`yaml.safe_load`) / TOML (`tomllib`) syntax validation on modified workflow/config files
- [x] Manual EOF-newline / trailing-whitespace check on all modified files
- [x] Simulated a shallow-clone + `GITHUB_ACTIONS=true` scenario to confirm the hardened `_git_changed_test_files()` actually fails loudly instead of silently no-op'ing
- [x] Regression-tested `check-threshold-drift.sh`'s fix by reverting one doc fix and confirming the hook still flags it


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdk3ShAMUeX6TZRTQ297RY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Python version testing to include 3.12 alongside 3.11
  * Enhanced test isolation and dependency handling
  * Added comprehensive integration tests for third-party service support
  * Improved CI safety checks for git history resolution

* **Chores**
  * Updated code coverage enforcement threshold to 93%
  * Updated contributor documentation and testing guidelines
  * Improved CI/CD git fetch configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->