### PR TITLE
test: isolate CI shard regressions

### DIFF
--- a/tests/cli/test_cli_benchmark_coverage.py
+++ b/tests/cli/test_cli_benchmark_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -40,8 +41,9 @@ class TestBenchmarkErrors:
 
         assert result.exit_code in (1, 2)
 
-    def test_no_files_json(self, tmp_path: Path) -> None:
+    def test_no_files_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """No files found with JSON output."""
+        monkeypatch.setattr(logging, "raiseExceptions", False)
         app = _get_app()
         result = runner.invoke(app, ["benchmark", "run", str(tmp_path), "--json"])
         assert result.exit_code == 0
@@ -62,7 +64,8 @@ class TestBenchmarkErrors:
 class TestBenchmarkEvenIterations:
     """Covers median calculation for even number of iterations (line 138)."""
 
-    def test_even_iterations(self, tmp_path: Path) -> None:
+    def test_even_iterations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(logging, "raiseExceptions", False)
         app = _get_app()
         (tmp_path / "a.txt").write_text("hello")
 

--- a/tests/web/test_browse_folder_route.py
+++ b/tests/web/test_browse_folder_route.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
+from file_organizer.api.dependencies import get_setup_user
 from file_organizer.api.routers.setup import router as setup_router
 
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
@@ -32,6 +33,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.ci]
 @pytest.fixture()
 def client() -> TestClient:
     app = FastAPI()
+    app.dependency_overrides[get_setup_user] = lambda: None
     app.include_router(setup_router, prefix="/api")
     return TestClient(app, raise_server_exceptions=True)
 


### PR DESCRIPTION
## Summary
- Isolate `/api/setup/browse-folder` route tests from the real setup auth dependency so they do not try to open the default auth DB in CI.
- Keep benchmark JSON-output tests from failing when Python logging emits handler diagnostics into the captured CLI stream.

## RCA
CI run 28136848741 failed in two separate py3.11 shards:

- Shard 6: `tests/web/test_browse_folder_route.py` mounted the real setup router, so FastAPI resolved `get_setup_user`, which pulled in `get_db` and attempted to open `/home/runner/.config/file-organizer/auth.db`. The CI environment could not open that SQLite path, producing 8 `OperationalError` failures unrelated to folder-picker behavior.
- Shard 4: the benchmark command produced valid JSON, but a Python logging handler diagnostic (`I/O operation on closed file`) was appended to the `CliRunner` captured output, so `json.loads(result.output)` failed with `Extra data` in 2 tests.

## Changes
- Override `get_setup_user` in the browse-folder test app so the route tests remain focused on picker behavior and never touch the real auth DB.
- Use `monkeypatch` to set `logging.raiseExceptions = False` inside the two benchmark JSON tests, preventing logging handler diagnostics from corrupting JSON assertions while restoring the global afterward.

## Validation
- `pytest tests/cli/test_cli_benchmark_coverage.py::TestBenchmarkErrors::test_no_files_json tests/cli/test_cli_benchmark_coverage.py::TestBenchmarkEvenIterations::test_even_iterations tests/web/test_browse_folder_route.py -q --override-ini='addopts='`
- `.venv/bin/python -m pytest tests/cli/test_cli_benchmark_coverage.py::TestBenchmarkErrors::test_no_files_json tests/cli/test_cli_benchmark_coverage.py::TestBenchmarkEvenIterations::test_even_iterations tests/web/test_browse_folder_route.py -q --override-ini='addopts='`
- `pytest tests/cli tests/methodologies tests/ci tests/unit tests/plugins tests/tui tests/parallel tests/pipeline --strict-markers -m "not benchmark and not e2e" --timeout=30 -n=auto --override-ini='addopts='`
- `pytest tests/web --strict-markers -m "not benchmark and not e2e" --timeout=30 -n=auto --override-ini='addopts='`
- `git diff --check`

## Risk
Low. This only changes test isolation for the affected CI shards and does not alter production route or CLI behavior.

Fixes #1318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI benchmark test stability by handling logging-related exceptions during execution.
  * Added controlled dependency setup for the folder-browsing API test to make route behavior more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->