### PR TITLE
feat(cli): Entry-Point Streamlining & Desktop Consolidation (Epic #1184)

### DIFF
--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -39,12 +39,23 @@ collect_changed_files() {
   local untracked_files=()
 
   if git diff --cached --quiet; then
-    mapfile -t tracked_files < <(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
-    mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
+    tracked_files=()
+    while IFS= read -r line; do
+      tracked_files+=("$line")
+    done < <(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
+
+    untracked_files=()
+    while IFS= read -r line; do
+      untracked_files+=("$line")
+    done < <(git ls-files --others --exclude-standard)
+
     changed_files=("${tracked_files[@]}" "${untracked_files[@]}")
     changed_mode="working tree vs HEAD + untracked"
   else
-    mapfile -t changed_files < <(git diff --cached --name-only --diff-filter=ACMR)
+    changed_files=()
+    while IFS= read -r line; do
+      changed_files+=("$line")
+    done < <(git diff --cached --name-only --diff-filter=ACMR)
     changed_mode="staged diff"
   fi
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,4 +95,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
 
 # Default command: run the web API server (override port via FO_API_PORT env var)
 # Shell-form for env-var expansion; `exec` replaces sh so uvicorn is PID 1 (clean SIGTERM)
-CMD exec python -m uvicorn file_organizer.api:app --host 0.0.0.0 --port ${FO_API_PORT:-8000}
+CMD exec fo serve --host 0.0.0.0 --port ${FO_API_PORT:-8000}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -59,6 +59,4 @@ EXPOSE 8000
 EXPOSE 5678
 
 # Default command: run with live reload enabled
-CMD ["python", "-m", "uvicorn", "file_organizer.api:app", \
-     "--host", "0.0.0.0", "--port", "8000", "--reload", \
-     "--reload-dir", "/app/src"]
+CMD ["fo", "serve", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -75,6 +75,8 @@ File Organizer provides two equivalent entrypoints: `file-organizer` and the sho
 | `analyze` | Analyze a file and display AI-generated metadata |
 | `tui` | Launch the Terminal User Interface |
 | `serve` | Start the web UI server |
+| `desktop` | Launch the native desktop window application |
+| `docs` | Build or serve the project documentation |
 | `undo` | Undo the last file operation |
 | `redo` | Redo a previously undone operation |
 | `history` | Show operation history |
@@ -430,6 +432,40 @@ file-organizer serve --host 0.0.0.0 --port 9000
 ```
 
 Then open `http://localhost:8000/ui/` in your browser.
+
+## Desktop UI
+
+File Organizer includes a native desktop window application for managing files.
+
+### Launching the Desktop Application
+
+```bash
+# Launch with default settings
+file-organizer desktop
+
+# Specify custom window properties
+file-organizer desktop --title "My File Organizer" --width 1024 --height 768
+```
+
+## Project Documentation
+
+You can build or serve the local project documentation using the `docs` subcommand.
+
+### Serving Documentation Locally
+
+```bash
+# Start the local documentation server (localhost:8001)
+file-organizer docs
+
+# Specify custom host and port
+file-organizer docs --host 0.0.0.0 --port 9000
+```
+
+### Compiling Documentation to HTML
+
+```bash
+file-organizer docs --build
+```
 
 ## Configuration
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1517,7 +1517,7 @@ file-organizer autotag batch ~/Documents --pattern "*.pdf" --json
 
 ---
 
-## `file-organizer-desktop` — Native Desktop Window
+## `fo desktop` — Native Desktop Window
 
 Launch the File Organizer desktop application as a native OS window powered by
 pywebview.
@@ -1525,13 +1525,20 @@ pywebview.
 **Usage:**
 
 ```bash
-file-organizer-desktop
+file-organizer desktop [OPTIONS]
+# Or using the short alias:
+fo desktop [OPTIONS]
 ```
+
+**Options:**
+
+- `--title TEXT` — Window title bar text (default: `File Organizer`)
+- `--width INTEGER` — Initial window width in logical pixels (default: `1280`)
+- `--height INTEGER` — Initial window height in logical pixels (default: `800`)
 
 The command starts the FastAPI web UI on a random free port in a background
 thread, waits up to 10 seconds for the server to become ready, then opens a
-native OS window (WebKit on macOS, Edge WebView2 on Windows, WebKitGTK on
-Linux) pointing at the local server.
+native OS window pointing at the local server.
 
 The process exits cleanly when the window is closed; no background server is
 left running.
@@ -1542,17 +1549,57 @@ left running.
 - Ollama running with at least one model pulled
 - Linux: `sudo apt-get install -y libgirepository1.0-dev gir1.2-webkit2-4.1`
 
+!!! note
+    The legacy standalone `file-organizer-desktop` entry point is still supported as a backward-compatibility alias, but the unified `fo desktop` subcommand is preferred.
+
 **Examples:**
 
 ```bash
-# Start the desktop window
-file-organizer-desktop
+# Start the desktop window with default settings
+fo desktop
 
-# Start with Ollama running in the background
-ollama serve & file-organizer-desktop
+# Start with a custom title and window dimensions
+fo desktop --title "My Personal Organizer" --width 1024 --height 768
 ```
 
 See [Desktop App Guide](desktop-app.md) for full documentation.
+
+---
+
+## `fo docs` — Project Documentation
+
+Build or serve the local project documentation using mkdocs.
+
+**Usage:**
+
+```bash
+file-organizer docs [OPTIONS]
+# Or using the short alias:
+fo docs [OPTIONS]
+```
+
+**Options:**
+
+- `--build, -b` — Compile the documentation to HTML instead of starting the live-reload server (default: false)
+- `--host TEXT` — Bind address for the docs server (default: `127.0.0.1`)
+- `--port INTEGER` — Port number for the docs server (default: `8001`)
+
+**Prerequisites:**
+
+- `pip install "local-file-organizer[docs]"` (installs mkdocs + mkdocs-material)
+
+**Examples:**
+
+```bash
+# Start the live-reload documentation server at http://127.0.0.1:8001/
+fo docs
+
+# Start the server on a custom port and bind address
+fo docs --host 0.0.0.0 --port 9000
+
+# Build the static HTML documentation to the site/ directory
+fo docs --build
+```
 
 ---
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -43,7 +43,7 @@ chmod +x file-organizer-desktop-*
 
 ```bash
 pip install "local-file-organizer[desktop]"
-file-organizer-desktop
+file-organizer desktop  # Or the short alias: fo desktop
 ```
 
 ### Option C — Install from source
@@ -52,7 +52,7 @@ file-organizer-desktop
 git clone https://github.com/curdriceaurora/Local-File-Organizer.git
 cd Local-File-Organizer
 pip install -e ".[desktop]"
-file-organizer-desktop
+file-organizer desktop  # Or the short alias: fo desktop
 ```
 
 ## Prerequisites
@@ -74,7 +74,10 @@ Before launching the desktop app:
 
 ## First Launch
 
-When you run `file-organizer-desktop` for the first time:
+When you run `file-organizer desktop` (or `fo desktop`) for the first time:
+
+!!! note
+    The legacy standalone `file-organizer-desktop` command is retained as a backward-compatibility alias, but using the unified `fo desktop` subcommand is recommended.
 
 1. The app allocates a free local port (e.g. `http://127.0.0.1:54321`).
 2. The uvicorn server starts in the background (takes 1–3 seconds on first

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -28,6 +28,7 @@ pytest -k "backup or dedup"                     # Filter by name
 @pytest.mark.playwright    # Playwright browser smoke tests (require a running server)
 @pytest.mark.security      # Security hardening / regression tests (tests/security)
 @pytest.mark.extras        # Optional-dependency matrix tests (tests/extras)
+@pytest.mark.uses_setup_gate # Opts out of the autouse setup-gate bypass to exercise the real gate
 
 def test_example():
     pass

--- a/scripts/run-mypy-changed.sh
+++ b/scripts/run-mypy-changed.sh
@@ -21,7 +21,9 @@ if [ -z "$files" ]; then
   exit 0
 fi
 
-# Convert newline-separated files to a deduplicated array and run mypy safely
-mapfile -t files_sorted < <(printf '%s\n' "$files" | sort -u)
+files_sorted=()
+while IFS= read -r line; do
+  files_sorted+=("$line")
+done < <(printf '%s\n' "$files" | sort -u)
 MYPY=$(.venv/bin/mypy --version >/dev/null 2>&1 && echo .venv/bin/mypy || echo mypy)
 $MYPY -- "${files_sorted[@]}"

--- a/src/file_organizer/cli/lazy.py
+++ b/src/file_organizer/cli/lazy.py
@@ -60,7 +60,7 @@ class LazyCommandProxy(click.Group):
             if isinstance(obj, typer.Typer):
                 self._real_cmd = typer.main.get_group(obj)
             else:
-                self._real_cmd = typing.cast(click.Command, obj)
+                self._real_cmd = obj
         return self._real_cmd
 
     def invoke(self, ctx: click.Context) -> typing.Any:

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -62,6 +62,8 @@ _SETUP_GATE_ALLOWLIST: frozenset[str] = frozenset(
         "recover",
         "config",
         "hardware-info",
+        "desktop",
+        "docs",
     }
 )
 """Commands that work pre-setup. They're either bootstrap (`setup`,
@@ -261,6 +263,82 @@ def launch_tui() -> None:
     from file_organizer.tui import run_tui
 
     run_tui()
+
+
+@app.command(name="desktop")
+def launch_desktop(
+    title: str = typer.Option("File Organizer", help="Window title bar text."),
+    width: int = typer.Option(1280, help="Initial window width in logical pixels."),
+    height: int = typer.Option(800, help="Initial window height in logical pixels."),
+) -> None:
+    """Launch the native desktop window application."""
+    try:
+        from file_organizer.desktop.app import launch
+    except ImportError as exc:
+        console.print(
+            "[red]Error: pywebview is not installed.[/red]\n"
+            "Install it with: [bold]pip install 'file-organizer\\[desktop]'[/bold]"
+        )
+        raise typer.Exit(code=1) from exc
+
+    console.print(f"[bold]Launching Desktop UI[/bold] ({title})...")
+    try:
+        launch(title=title, width=width, height=height)
+    except Exception as exc:
+        console.print(f"[red]Error launching desktop: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+
+@app.command(name="docs")
+def docs_command(
+    build: bool = typer.Option(
+        False, "--build", "-b", help="Compile documentation to HTML instead of serving."
+    ),
+    host: str = typer.Option("127.0.0.1", help="Bind address for the docs server."),
+    port: int = typer.Option(8001, help="Port number for the docs server."),
+) -> None:
+    """Build or serve the project documentation."""
+    import shutil
+    import subprocess
+
+    mkdocs = shutil.which("mkdocs")
+    if not mkdocs:
+        console.print(
+            "[red]Error: mkdocs is not installed.[/red]\n"
+            "Install it with: [bold]pip install 'file-organizer\\[docs]'[/bold]"
+        )
+        raise typer.Exit(code=1)
+
+    # Resolve project root where mkdocs.yml is located
+    # src/file_organizer/cli/main.py is 3 levels deep in src/
+    project_root = Path(__file__).parents[3]
+    mkdocs_yml = project_root / "mkdocs.yml"
+    if not mkdocs_yml.exists():
+        # Fallback to current working directory
+        project_root = Path.cwd()
+        mkdocs_yml = project_root / "mkdocs.yml"
+        if not mkdocs_yml.exists():
+            console.print(
+                "[red]Error: mkdocs.yml not found. Please run this command from the project repository root.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+    if build:
+        console.print("[bold]Building documentation to HTML...[/bold]")
+        proc = subprocess.run([mkdocs, "build"], cwd=project_root)
+        if proc.returncode != 0:
+            console.print("[red]Error: Failed to build documentation.[/red]")
+            raise typer.Exit(code=1)
+        console.print(f"[green]Documentation built successfully in {project_root / 'site'}[/green]")
+    else:
+        console.print(f"[bold]Starting documentation server[/bold] at http://{host}:{port}/")
+        try:
+            subprocess.run(
+                [mkdocs, "serve", "--dev-addr", f"{host}:{port}"],
+                cwd=project_root,
+            )
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Documentation server stopped.[/yellow]")
 
 
 @app.command(name="hardware-info")

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -62,6 +62,7 @@ _SETUP_GATE_ALLOWLIST: frozenset[str] = frozenset(
         "recover",
         "config",
         "hardware-info",
+        "serve",
         "desktop",
         "docs",
     }
@@ -333,10 +334,13 @@ def docs_command(
     else:
         console.print(f"[bold]Starting documentation server[/bold] at http://{host}:{port}/")
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 [mkdocs, "serve", "--dev-addr", f"{host}:{port}"],
                 cwd=project_root,
             )
+            if proc.returncode != 0:
+                console.print("[red]Error: Documentation server failed.[/red]")
+                raise typer.Exit(code=proc.returncode)
         except KeyboardInterrupt:
             console.print("\n[yellow]Documentation server stopped.[/yellow]")
 
@@ -456,9 +460,10 @@ def history(
 
 
 @app.command()
-def recover(  # noqa: G3 (--journal is a read-only path; defaults to system state dir)
+def recover(
     journal: Path | None = typer.Option(
         None,
+        # --journal is a read-only path; defaults to system state dir.
         help="Override path to durable_move.journal (defaults to the user state dir).",
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),

--- a/tests/cli/test_entrypoints_consolidation.py
+++ b/tests/cli/test_entrypoints_consolidation.py
@@ -84,6 +84,16 @@ class TestDesktopSubcommand:
         assert result.exit_code == 1
         assert "Error launching desktop: Failed to allocate window" in result.output
 
+    def test_desktop_bypasses_setup_gate(self, mock_launch: MagicMock) -> None:
+        """Verify fo desktop is reachable before first-run setup completes."""
+        with patch(
+            "file_organizer.cli.organize._check_setup_completed",
+            side_effect=AssertionError("setup gate should not run for desktop"),
+        ):
+            result = runner.invoke(app, ["desktop"])
+        assert result.exit_code == 0
+        mock_launch.assert_called_once()
+
 
 class TestDocsSubcommand:
     """Verify 'fo docs' command behavior, build/serve modes, and validations."""
@@ -181,3 +191,14 @@ class TestDocsSubcommand:
             result = runner.invoke(app, ["docs"])
             assert result.exit_code == 0
             assert "Documentation server stopped" in result.output
+
+    def test_docs_bypasses_setup_gate(self, mock_shutil_which: MagicMock) -> None:
+        """Verify fo docs is reachable before first-run setup completes."""
+        mock_shutil_which.return_value = None
+        with patch(
+            "file_organizer.cli.organize._check_setup_completed",
+            side_effect=AssertionError("setup gate should not run for docs"),
+        ):
+            result = runner.invoke(app, ["docs"])
+        assert result.exit_code == 1
+        assert "mkdocs is not installed" in result.output

--- a/tests/cli/test_entrypoints_consolidation.py
+++ b/tests/cli/test_entrypoints_consolidation.py
@@ -11,6 +11,8 @@ from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
 
+pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
+
 runner = CliRunner()
 
 
@@ -155,3 +157,27 @@ class TestDocsSubcommand:
             mock_subprocess_run.assert_called_once()
             args = mock_subprocess_run.call_args[0][0]
             assert args == ["/usr/local/bin/mkdocs", "serve", "--dev-addr", "0.0.0.0:9000"]
+
+    def test_docs_command_serve_error(
+        self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
+    ) -> None:
+        """Verify fo docs reports an error when the serve process exits non-zero."""
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_subprocess_run.return_value.returncode = 1
+
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["docs"])
+            assert result.exit_code == 1
+            assert "Documentation server failed" in result.output
+
+    def test_docs_command_serve_keyboard_interrupt(
+        self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
+    ) -> None:
+        """Verify fo docs exits cleanly when the serve process is interrupted."""
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_subprocess_run.side_effect = KeyboardInterrupt
+
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["docs"])
+            assert result.exit_code == 0
+            assert "Documentation server stopped" in result.output

--- a/tests/cli/test_entrypoints_consolidation.py
+++ b/tests/cli/test_entrypoints_consolidation.py
@@ -1,0 +1,157 @@
+"""Tests for consolidated CLI entry points (desktop and docs subcommands)."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from file_organizer.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_launch() -> Generator[MagicMock, None, None]:
+    """Fixture to mock desktop.app.launch."""
+    with patch("file_organizer.desktop.app.launch") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_shutil_which() -> Generator[MagicMock, None, None]:
+    """Fixture to mock shutil.which."""
+    with patch("shutil.which") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_subprocess_run() -> Generator[MagicMock, None, None]:
+    """Fixture to mock subprocess.run."""
+    with patch("subprocess.run") as mock:
+        mock.return_value.returncode = 0
+        yield mock
+
+
+class TestDesktopSubcommand:
+    """Verify 'fo desktop' command behavior and error handling."""
+
+    def test_desktop_command_registered(self) -> None:
+        """Verify the desktop command is registered in the Typer app."""
+        result = runner.invoke(app, ["desktop", "--help"])
+        assert result.exit_code == 0
+        assert "Launch the native desktop window" in result.output
+
+    def test_desktop_command_success(self, mock_launch: MagicMock) -> None:
+        """Verify fo desktop successfully launches the window with custom options."""
+        result = runner.invoke(
+            app,
+            [
+                "desktop",
+                "--title",
+                "Custom Window Title",
+                "--width",
+                "1024",
+                "--height",
+                "768",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_launch.assert_called_once_with(
+            title="Custom Window Title",
+            width=1024,
+            height=768,
+        )
+
+    def test_desktop_command_import_error(self) -> None:
+        """Verify fo desktop prints a friendly error when pywebview is missing."""
+        # Simulate pywebview missing by patching the import block
+        with patch.dict("sys.modules", {"file_organizer.desktop.app": None}):
+            result = runner.invoke(app, ["desktop"])
+            assert result.exit_code == 1
+            assert "pywebview is not installed" in result.output
+            assert "pip install 'file-organizer[desktop]'" in result.output
+
+    def test_desktop_command_launch_error(self, mock_launch: MagicMock) -> None:
+        """Verify fo desktop handles launch failures gracefully."""
+        mock_launch.side_effect = RuntimeError("Failed to allocate window")
+        result = runner.invoke(app, ["desktop"])
+        assert result.exit_code == 1
+        assert "Error launching desktop: Failed to allocate window" in result.output
+
+
+class TestDocsSubcommand:
+    """Verify 'fo docs' command behavior, build/serve modes, and validations."""
+
+    def test_docs_command_registered(self) -> None:
+        """Verify the docs command is registered in the Typer app."""
+        result = runner.invoke(app, ["docs", "--help"])
+        assert result.exit_code == 0
+        assert "Build or serve the project documentation" in result.output
+
+    def test_docs_command_missing_mkdocs(self, mock_shutil_which: MagicMock) -> None:
+        """Verify fo docs exits cleanly and suggests installation if mkdocs is missing."""
+        mock_shutil_which.return_value = None
+        result = runner.invoke(app, ["docs"])
+        assert result.exit_code == 1
+        assert "mkdocs is not installed" in result.output
+        assert "pip install 'file-organizer[docs]'" in result.output
+
+    def test_docs_command_missing_config(
+        self, mock_shutil_which: MagicMock, tmp_path: Path
+    ) -> None:
+        """Verify fo docs fails gracefully if mkdocs.yml is not found."""
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+
+        # Run from a temporary directory without mkdocs.yml
+        with patch("pathlib.Path.exists", return_value=False):
+            result = runner.invoke(app, ["docs"])
+            assert result.exit_code == 1
+            assert "mkdocs.yml not found" in result.output
+
+    def test_docs_command_build_success(
+        self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
+    ) -> None:
+        """Verify fo docs --build compiles documentation to HTML."""
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+
+        # Mock mkdocs.yml presence check
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["docs", "--build"])
+            assert result.exit_code == 0
+            assert "Building documentation to HTML" in result.output
+            assert "Documentation built successfully" in result.output
+
+            mock_subprocess_run.assert_called_once()
+            args = mock_subprocess_run.call_args[0][0]
+            assert args == ["/usr/local/bin/mkdocs", "build"]
+
+    def test_docs_command_build_error(
+        self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
+    ) -> None:
+        """Verify fo docs --build handles compilation failure cleanly."""
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_subprocess_run.return_value.returncode = 1
+
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["docs", "--build"])
+            assert result.exit_code == 1
+            assert "Failed to build documentation" in result.output
+
+    def test_docs_command_serve_success(
+        self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
+    ) -> None:
+        """Verify fo docs serves documentation with default options."""
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["docs", "--host", "0.0.0.0", "--port", "9000"])
+            assert result.exit_code == 0
+            assert "Starting documentation server at http://0.0.0.0:9000/" in result.output
+
+            mock_subprocess_run.assert_called_once()
+            args = mock_subprocess_run.call_args[0][0]
+            assert args == ["/usr/local/bin/mkdocs", "serve", "--dev-addr", "0.0.0.0:9000"]

--- a/tests/cli/test_lazy.py
+++ b/tests/cli/test_lazy.py
@@ -1,0 +1,43 @@
+"""Tests for the lazy CLI command loading infrastructure."""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import click
+import pytest
+
+from file_organizer.cli.lazy import LazyCommandProxy
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
+
+
+def test_load_returns_non_typer_command_as_is() -> None:
+    """A LazyCommandProxy whose target attribute is a plain click.Command
+    (not a typer.Typer) is used directly, without conversion."""
+    real_command = click.Command(name="real", callback=lambda: None)
+    fake_module = types.SimpleNamespace(real_cmd=real_command)
+
+    proxy = LazyCommandProxy("real", "fake.module.path", "real_cmd", "help text")
+
+    with patch("importlib.import_module", return_value=fake_module) as mock_import:
+        loaded = proxy._load()
+
+    mock_import.assert_called_once_with("fake.module.path")
+    assert loaded is real_command
+
+
+def test_load_caches_result_across_calls() -> None:
+    """Subsequent _load() calls reuse the cached command without re-importing."""
+    real_command = click.Command(name="real", callback=lambda: None)
+    fake_module = types.SimpleNamespace(real_cmd=real_command)
+
+    proxy = LazyCommandProxy("real", "fake.module.path", "real_cmd", "help text")
+
+    with patch("importlib.import_module", return_value=fake_module) as mock_import:
+        first = proxy._load()
+        second = proxy._load()
+
+    mock_import.assert_called_once()
+    assert first is second is real_command


### PR DESCRIPTION
Consolidates all application entry points (native desktop window via `fo desktop` and project documentation server via `fo docs`) under the unified `fo` CLI. Both subcommands bypass the first-run setup gate so users can access help, guides, or the setup wizard pre-configuration. Production and development Dockerfiles are aligned to use the canonical `fo serve` entry point. Documentation is updated to reflect the new unified subcommands. Closes #1184, Closes #1185, Closes #1187, Closes #1189.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new top-level CLI commands for launching the desktop app and managing project documentation.
  * Improved the default app startup flow and added clearer version output and command handling.

* **Bug Fixes**
  * Made command startup and shutdown behavior more reliable, including better error handling and cleaner process exits.
  * Improved CLI recovery and analytics handling for more consistent results.

* **Documentation**
  * Expanded the user guide and CLI reference with updated desktop and documentation usage examples.
  * Added testing guidance for an additional setup-related test marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->