### PR TITLE
fix: guard empty-array expansions in pre-commit-validation.sh for bash 3.2

### DIFF
--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -49,7 +49,16 @@ collect_changed_files() {
       untracked_files+=("$line")
     done < <(git ls-files --others --exclude-standard)
 
-    changed_files=("${tracked_files[@]}" "${untracked_files[@]}")
+    # Guard against bash <4.4 "unbound variable" on "${arr[@]}" when arr is
+    # empty under `set -u` (e.g. macOS system bash 3.2). ${#arr[@]} is always
+    # safe to read, even for an empty/unset array.
+    changed_files=()
+    if ((${#tracked_files[@]})); then
+      changed_files+=("${tracked_files[@]}")
+    fi
+    if ((${#untracked_files[@]})); then
+      changed_files+=("${untracked_files[@]}")
+    fi
     changed_mode="working tree vs HEAD + untracked"
   else
     changed_files=()
@@ -66,7 +75,11 @@ echo "Pre-PR Guardrail Validation"
 echo "==========================="
 echo "Branch: $(git branch --show-current)"
 echo ""
-print_files "$changed_mode" "${changed_files[@]}"
+if ((${#changed_files[@]})); then
+  print_files "$changed_mode" "${changed_files[@]}"
+else
+  print_files "$changed_mode"
+fi
 echo ""
 
 run_step "Validate pre-commit configuration" pre-commit validate-config


### PR DESCRIPTION
## Summary
- `collect_changed_files()` in `.claude/scripts/pre-commit-validation.sh` expanded `"${untracked_files[@]}"` unconditionally under `set -u`. On bash <4.4 (e.g. macOS system bash 3.2, since no Homebrew bash is installed), expanding an empty array with `${arr[@]}` under strict mode throws `unbound variable`, killing the script immediately whenever there are no untracked files.
- Guarded every expansion of a possibly-empty array (`tracked_files`, `untracked_files`, and the later `changed_files` passed to `print_files`) by checking `${#arr[@]}` (always safe to read) before expanding with `[@]`.

## Test plan
- [x] Ran the affected header logic standalone with the current repo state (one modified tracked file, zero untracked files) — prints the file list correctly, no crash.
- [x] Ran again with an untracked file present — both tracked and untracked files are listed correctly.
- [x] Ran again on a fully clean tree (no tracked diff, no untracked files) — prints `(none)` instead of crashing.
- [ ] Full `bash .claude/scripts/pre-commit-validation.sh` run on actual bash 3.2 (not available in this sandbox; logic verified via the guard pattern which is version-agnostic).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq2Dbm9GgPDNsxJhj2dFTR)_