### PR TITLE
fix(daemon): PID-reuse and startup-failure safety hardening

### DIFF
--- a/src/file_organizer/cli/daemon.py
+++ b/src/file_organizer/cli/daemon.py
@@ -115,6 +115,16 @@ def stop() -> None:
         console.print("[yellow]Could not read PID from file.[/yellow]")
         mgr.remove_pid(_DEFAULT_PID_FILE)
         raise typer.Exit(code=1)
+
+    if not mgr.is_running(_DEFAULT_PID_FILE):
+        # F2 (#1323, finding 1): is_running() already detects PID
+        # recycling via create_time comparison. Without this check, a
+        # stale PID file whose PID was reused by an unrelated process
+        # would cause SIGTERM to land on that unrelated process.
+        console.print("[yellow]Stale PID file — daemon is not running.[/yellow]")
+        mgr.remove_pid(_DEFAULT_PID_FILE)
+        raise typer.Exit(code=0)
+
     pid = record.pid
 
     console.print(f"Sending SIGTERM to PID {pid}...")

--- a/src/file_organizer/daemon/pid.py
+++ b/src/file_organizer/daemon/pid.py
@@ -342,25 +342,35 @@ class PidFileManager:
                 if isinstance(raw_pid, bool) or not isinstance(raw_pid, int):
                     raise TypeError(f"pid field must be int, got {type(raw_pid).__name__}")
                 pid = raw_pid
+                if pid <= 0:
+                    # F2 hardening (#1323): pid 0 signals the whole process
+                    # group via os.kill; negative values signal a process
+                    # group by id on POSIX. Either is corrupt input here.
+                    raise ValueError(f"pid must be a positive integer, got {pid}")
                 ct_raw = data.get("create_time")
                 if ct_raw is None:
-                    create_time: float | None = None
-                else:
-                    # Codex P2: reject non-finite ``create_time`` values
-                    # (NaN, +Inf, -Inf). ``float("nan")`` parses cleanly
-                    # from JSON strings like ``"nan"`` or from a
-                    # malformed numeric literal, but propagating NaN
-                    # into ``is_running`` silently defeats the F2
-                    # recycling check: ``abs(actual - NaN) > tolerance``
-                    # is ALWAYS False (any comparison with NaN is
-                    # False), so a recycled PID would be reported as
-                    # the original daemon. Inf makes the subtraction
-                    # overflow and the comparison either always True
-                    # (False-positive recycling mismatch) or NaN again.
-                    # Treat any non-finite value as corrupt.
-                    create_time = float(ct_raw)
-                    if not math.isfinite(create_time):
-                        raise ValueError(f"create_time must be finite, got {create_time!r}")
+                    # F2 hardening (#1323): a JSON record (it has a "pid"
+                    # key) without create_time is malformed/truncated, not
+                    # legacy. Only the plain-integer branch below is
+                    # allowed to produce create_time=None — silently
+                    # downgrading a JSON record to liveness-only here would
+                    # defeat the PID-recycling check it's supposed to back.
+                    raise ValueError("JSON pid record is missing the required 'create_time' field")
+                # Codex P2: reject non-finite ``create_time`` values
+                # (NaN, +Inf, -Inf). ``float("nan")`` parses cleanly
+                # from JSON strings like ``"nan"`` or from a
+                # malformed numeric literal, but propagating NaN
+                # into ``is_running`` silently defeats the F2
+                # recycling check: ``abs(actual - NaN) > tolerance``
+                # is ALWAYS False (any comparison with NaN is
+                # False), so a recycled PID would be reported as
+                # the original daemon. Inf makes the subtraction
+                # overflow and the comparison either always True
+                # (False-positive recycling mismatch) or NaN again.
+                # Treat any non-finite value as corrupt.
+                create_time = float(ct_raw)
+                if not math.isfinite(create_time):
+                    raise ValueError(f"create_time must be finite, got {create_time!r}")
                 return PidRecord(pid=pid, create_time=create_time)
         except (json.JSONDecodeError, ValueError, TypeError) as exc:
             # Distinguish "valid JSON with malformed pid field" from
@@ -375,10 +385,15 @@ class PidFileManager:
 
         # Fall through to legacy integer format.
         try:
-            return PidRecord(pid=int(content), create_time=None)
+            legacy_pid = int(content)
         except ValueError:
             logger.warning("PID file %s contains unparsable content", pid_file)
             return None
+        if legacy_pid <= 0:
+            # F2 hardening (#1323): same pid<=0 rule as the JSON branch.
+            logger.warning("PID file %s contains non-positive PID %d", pid_file, legacy_pid)
+            return None
+        return PidRecord(pid=legacy_pid, create_time=None)
 
     def is_running(self, pid_file: Path) -> bool:
         """Check whether the process recorded in a PID file is alive.

--- a/src/file_organizer/daemon/service.py
+++ b/src/file_organizer/daemon/service.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 # the rest of the log. 1.0s keeps the signal actionable without flooding.
 _SIGNAL_LOG_MIN_INTERVAL_S = 1.0
 
+# Timeout for joining the background thread after a startup failure, so
+# start_background() doesn't raise while _cleanup() is still tearing the
+# daemon down (#1323, finding 4). Module-level so tests can shrink it via
+# monkeypatch instead of waiting out the real timeout.
+_STARTUP_JOIN_TIMEOUT_S = 10.0
+
 
 class DaemonService:
     """Long-running daemon that watches directories and organizes files.
@@ -82,6 +88,13 @@ class DaemonService:
         # ``_SIGNAL_LOG_MIN_INTERVAL_S`` so the log remains useful.
         self._last_signal_log_time = 0.0
         self._started_at: float | None = None
+        # Narrowly typed to Exception (not BaseException): only the
+        # ``except Exception`` clause in ``_background_run`` assigns here,
+        # so the annotation reflects what is actually captured. A
+        # BaseException subtype (SystemExit, KeyboardInterrupt) raised
+        # during startup is NOT recorded here and will NOT be re-raised by
+        # start_background() — see that method's docstring.
+        self._startup_error: Exception | None = None
         self._files_processed: int = 0
         self._on_start_callback: Callable[[], None] | None = None
         self._on_stop_callback: Callable[[], None] | None = None
@@ -145,6 +158,18 @@ class DaemonService:
 
         Raises:
             RuntimeError: If the daemon is already running.
+            Exception: Whatever the background thread raised while
+                writing the PID file, setting up tasks, or starting the
+                scheduler — startup failures are re-raised here rather
+                than left silently swallowed in the background thread
+                (#1323, finding 4). Does NOT cover the ``on_start``
+                callback: that is invoked inside its own pre-existing
+                ``try/except Exception`` that logs and swallows on
+                failure (a broken on_start callback should not abort the
+                daemon), so callback failures are never re-raised here.
+                Also does not cover BaseException subtypes (e.g.
+                ``SystemExit``, ``KeyboardInterrupt``) raised during
+                startup — only ``Exception`` subclasses are captured.
         """
         with self._lock:
             if self._running or (self._thread is not None and self._thread.is_alive()):
@@ -155,6 +180,7 @@ class DaemonService:
             self._stop_event.clear()
             self._started_event.clear()
             self._stopped_event.clear()
+            self._startup_error = None
 
             # Set _running = True while holding lock to prevent race condition
             # where two threads both pass the check above before _running is set
@@ -174,6 +200,33 @@ class DaemonService:
 
         # Wait for the daemon to fully initialize
         self._started_event.wait(timeout=5.0)
+
+        if self._startup_error is not None:
+            error = self._startup_error
+            self._startup_error = None
+            # The background thread sets _started_event from inside the
+            # inner `finally` *before* unwinding through the outer
+            # `finally` (`_cleanup()`), so cleanup may still be in flight
+            # here. Join it so `is_running` is reliably False and the PID
+            # file is gone by the time this raises — callers must not
+            # observe a half-torn-down daemon after the exception.
+            if self._thread is not None:
+                self._thread.join(timeout=_STARTUP_JOIN_TIMEOUT_S)
+                if self._thread.is_alive():
+                    # Cleanup is still running past the timeout (e.g. a
+                    # slow on_stop callback or scheduler shutdown). Do NOT
+                    # discard the thread handle — leave it set so the
+                    # is_alive() guard at the top of this method and
+                    # stop()'s own join() can still detect/wait for it.
+                    logger.warning(
+                        "Background thread still alive %.1fs after startup "
+                        "failure; cleanup is still in progress. The PID "
+                        "file or running flag may not have cleared yet.",
+                        _STARTUP_JOIN_TIMEOUT_S,
+                    )
+                else:
+                    self._thread = None
+            raise error
 
     def stop(self) -> None:
         """Request a graceful shutdown of the daemon.
@@ -254,28 +307,41 @@ class DaemonService:
         """
         logger.info("Starting daemon service (background)")
         self._started_at = time.monotonic()
+        self._startup_error = None
 
         try:
-            # Write PID file — F2 record format (pid + create_time) so
-            # ``is_running`` can detect PID recycling after crash.
-            if self.config.pid_file is not None:
-                self._pid_manager.write_pid_record(self.config.pid_file)
+            try:
+                # Write PID file — F2 record format (pid + create_time) so
+                # ``is_running`` can detect PID recycling after crash.
+                if self.config.pid_file is not None:
+                    self._pid_manager.write_pid_record(self.config.pid_file)
 
-            # Set up default periodic tasks
-            self._setup_default_tasks()
+                # Set up default periodic tasks
+                self._setup_default_tasks()
 
-            # Start the scheduler in background
-            self._scheduler.run_in_background()
+                # Start the scheduler in background
+                self._scheduler.run_in_background()
 
-            # Fire on_start callback
-            if self._on_start_callback is not None:
-                try:
-                    self._on_start_callback()
-                except Exception:
-                    logger.exception("on_start callback failed")
-
-            # Signal that startup is complete
-            self._started_event.set()
+                # Fire on_start callback
+                if self._on_start_callback is not None:
+                    try:
+                        self._on_start_callback()
+                    except Exception:
+                        logger.exception("on_start callback failed")
+            except Exception as exc:
+                # F4 hardening (#1323, finding 4): startup failed before the
+                # daemon was actually usable. Record it so start_background()
+                # re-raises instead of returning as if startup succeeded —
+                # the thread dying silently here would otherwise leave no
+                # PID file and no running daemon, with the caller none the
+                # wiser.
+                self._startup_error = exc
+                return
+            finally:
+                # Signal that startup is complete (success OR failure) —
+                # start_background() is waiting on this event and must not
+                # block for the full timeout on a fast failure.
+                self._started_event.set()
 
             # Main event loop
             self._run_loop()

--- a/tests/cli/test_cli_daemon.py
+++ b/tests/cli/test_cli_daemon.py
@@ -103,6 +103,30 @@ class TestDaemonStop:
     @patch("file_organizer.cli.daemon.os.kill")
     @patch("file_organizer.cli.daemon._DEFAULT_PID_FILE")
     @patch("file_organizer.daemon.pid.PidFileManager")
+    def test_stop_stale_pid_file_does_not_signal(
+        self,
+        mock_pid_cls: MagicMock,
+        mock_pid_file: MagicMock,
+        mock_kill: MagicMock,
+    ) -> None:
+        """If the daemon already exited and the OS recycled its PID for
+        an unrelated process, stop must not signal that process."""
+        mock_pid_file.exists.return_value = True
+        mock_mgr = MagicMock()
+        mock_pid_cls.return_value = mock_mgr
+        mock_mgr.read_pid_record.return_value = PidRecord(pid=12345, create_time=1700000000.0)
+        mock_mgr.is_running.return_value = False
+
+        result = runner.invoke(app, ["daemon", "stop"])
+
+        assert result.exit_code == 0
+        assert "not running" in result.output.lower() or "stale" in result.output.lower()
+        mock_kill.assert_not_called()
+        mock_mgr.remove_pid.assert_called_once()
+
+    @patch("file_organizer.cli.daemon.os.kill")
+    @patch("file_organizer.cli.daemon._DEFAULT_PID_FILE")
+    @patch("file_organizer.daemon.pid.PidFileManager")
     def test_stop_success(
         self,
         mock_pid_cls: MagicMock,

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -266,6 +266,46 @@ class TestPidRecord:
         pid_file.write_text('{"pid": 12345, "create_time": -Infinity}')
         assert pid_manager.read_pid_record(pid_file) is None
 
+    def test_read_pid_record_rejects_zero_json_pid(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """pid=0 in a JSON record would make os.kill target the entire
+        process group instead of one process — must be rejected."""
+        pid_file.write_text(json.dumps({"pid": 0, "create_time": 1.0}))
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_read_pid_record_rejects_negative_json_pid(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """A negative pid targets a process group by id on POSIX —
+        must be rejected, not passed through to os.kill."""
+        pid_file.write_text(json.dumps({"pid": -7, "create_time": 1.0}))
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_read_pid_record_rejects_zero_legacy_pid(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """Same rule applies to the legacy plain-integer file format."""
+        pid_file.write_text("0")
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_read_pid_record_rejects_negative_legacy_pid(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        pid_file.write_text("-7")
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_read_pid_record_rejects_json_missing_create_time(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """A JSON record (has a 'pid' key) without 'create_time' is
+        malformed/truncated, not legacy — only the plain-integer format
+        is allowed to produce create_time=None. Falling back to
+        liveness-only mode here would silently defeat PID-recycling
+        protection for a record that claims to be in the F2 format."""
+        pid_file.write_text(json.dumps({"pid": 12345}))
+        assert pid_manager.read_pid_record(pid_file) is None
+
     def test_is_running_nan_create_time_does_not_bypass_recycling_check(
         self, pid_manager: PidFileManager, pid_file: Path
     ) -> None:

--- a/tests/daemon/test_service.py
+++ b/tests/daemon/test_service.py
@@ -342,3 +342,91 @@ class TestSignalHandling:
             assert len(data) > 0
 
         svc._running = False
+
+
+class TestStartupFailurePropagation:
+    """F-hardening (#1323, finding 4): start_background() must surface
+    startup failures to the caller instead of returning as if the
+    daemon started successfully."""
+
+    def test_start_background_raises_when_pid_write_fails(
+        self, daemon: DaemonService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(self: object, pid_file: Path, pid: int | None = None) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("file_organizer.daemon.pid.PidFileManager.write_pid_record", _boom)
+
+        with pytest.raises(OSError, match="disk full"):
+            daemon.start_background()
+
+        assert daemon.is_running is False
+
+    def test_start_background_raises_on_later_stage_failure(
+        self, daemon: DaemonService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure AFTER the PID write (e.g. scheduler startup) must
+        still be captured and re-raised — proving the broad try/except
+        covers more than just the first statement in the startup block.
+        """
+
+        def _boom() -> None:
+            raise RuntimeError("scheduler exploded")
+
+        monkeypatch.setattr(daemon._scheduler, "run_in_background", _boom)
+
+        with pytest.raises(RuntimeError, match="scheduler exploded"):
+            daemon.start_background()
+
+        assert daemon.is_running is False
+
+    def test_start_background_still_raises_when_cleanup_outlives_join(
+        self, daemon: DaemonService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If _cleanup() (e.g. a slow on_stop callback) outlives the join
+        timeout, start_background() must still raise the captured startup
+        error promptly rather than blocking forever or swallowing it.
+
+        Uses a tiny monkeypatched join timeout so this test runs fast
+        instead of waiting out the real 10s timeout.
+        """
+        import file_organizer.daemon.service as service_module
+
+        monkeypatch.setattr(service_module, "_STARTUP_JOIN_TIMEOUT_S", 0.05)
+
+        cleanup_release = threading.Event()
+
+        def _slow_on_stop() -> None:
+            # Block past the shrunk join timeout, simulating a slow
+            # on_stop_callback/scheduler shutdown still in flight.
+            cleanup_release.wait(timeout=2.0)
+
+        daemon.on_stop(_slow_on_stop)
+
+        def _boom() -> None:
+            raise RuntimeError("startup exploded")
+
+        monkeypatch.setattr(daemon._scheduler, "run_in_background", _boom)
+
+        try:
+            start = time.monotonic()
+            with pytest.raises(RuntimeError, match="startup exploded"):
+                daemon.start_background()
+            elapsed = time.monotonic() - start
+
+            # Must return promptly (bounded by the shrunk timeout), not
+            # block for the real 10s default or forever.
+            assert elapsed < 2.0
+
+            # The thread handle must be preserved (not discarded) while
+            # cleanup is still in flight, so callers retain the ability
+            # to detect/wait for it later.
+            assert daemon._thread is not None
+            assert daemon._thread.is_alive()
+        finally:
+            # Unblock the stalled cleanup so the background thread can
+            # finish and the test doesn't leak a running thread.
+            cleanup_release.set()
+            if daemon._thread is not None:
+                daemon._thread.join(timeout=5.0)
+                daemon._thread = None

--- a/tests/integration/test_cli_daemon.py
+++ b/tests/integration/test_cli_daemon.py
@@ -410,6 +410,7 @@ class TestJSONPidFileCLIBoundary:
         with (
             patch("file_organizer.cli.daemon._DEFAULT_PID_FILE", pid_file),
             patch("os.kill", side_effect=ProcessLookupError()),
+            patch("file_organizer.daemon.pid.PidFileManager.is_running", return_value=True),
         ):
             result = runner.invoke(app, ["daemon", "stop"])
 
@@ -432,6 +433,7 @@ class TestJSONPidFileCLIBoundary:
         with (
             patch("file_organizer.cli.daemon._DEFAULT_PID_FILE", pid_file),
             patch("os.kill", side_effect=ProcessLookupError()),
+            patch("file_organizer.daemon.pid.PidFileManager.is_running", return_value=True),
         ):
             result = runner.invoke(app, ["daemon", "stop"])
 


### PR DESCRIPTION
## Summary

Fixes #1323 — four related daemon PID/startup safety gaps flagged by CodeRabbit on PR #1321's review (filed separately since none of these files were touched by that PR's actual diff).

- **`cli/daemon.py` `stop()`**: now checks `PidFileManager.is_running()` before sending `SIGTERM`. Without this, a stale PID file whose PID was recycled by the OS for an unrelated process would cause `daemon stop` to signal that unrelated process instead of detecting the stale file.
- **`daemon/pid.py` `read_pid_record()`**: rejects non-positive PIDs (`0`/negative) in both the JSON and legacy plain-integer formats — `os.kill(0, ...)` signals an entire process group, and negative PIDs signal a process group by id on POSIX.
- **`daemon/pid.py` `read_pid_record()`**: a JSON record (identified by a `"pid"` key) missing `create_time` is now treated as corrupt rather than silently downgraded to legacy liveness-only mode, which was quietly defeating the PID-recycling protection the JSON format exists for.
- **`daemon/service.py` `start_background()`**: background-thread startup failures (e.g. `write_pid_record` raising) are now captured and re-raised to the caller instead of `start_background()` returning normally after a timeout as if the daemon had started, with no PID file and no running daemon. Includes correct handling of the case where cleanup outlives the join timeout (the thread handle is preserved with a warning rather than silently discarded).
- A follow-up fixup updates two pre-existing integration tests (`TestJSONPidFileCLIBoundary`) whose fake/non-running sentinel PIDs now correctly trip the new `is_running()` check before reaching the code path they were written to exercise.

Each fix was implemented test-first, and independently reviewed for spec compliance and code quality (two rounds for the `start_background()` change, after the first round caught a join-timeout edge case and a `BaseException`-vs-`Exception` typing gap — both fixed and re-verified).

## Test Plan

- [x] `tests/daemon/test_pid.py` — 5 new tests for non-positive PID / missing create_time rejection, 41/41 passing
- [x] `tests/cli/test_cli_daemon.py` — new `test_stop_stale_pid_file_does_not_signal`, 14/14 passing
- [x] `tests/daemon/test_service.py` — new `TestStartupFailurePropagation` (3 tests: PID-write failure, later-stage failure, join-timeout degradation), 25/25 passing
- [x] `tests/integration/test_cli_daemon.py` — fixed up, 21/21 passing
- [x] Full affected surface (`tests/daemon/`, `tests/cli/test_cli_daemon*.py`, `tests/integration/test_cli_daemon.py`, `tests/integration/test_daemon_service_and_autotag_cli.py`, `tests/integration/test_events_health_and_daemon_pid.py`, `tests/api/test_daemon_router.py`): 297/297 passing
- [x] `ruff check` / `mypy` clean on all touched files
- [x] `bash .claude/scripts/pre-commit-validation.sh` — passes except a pre-existing, unrelated `mypy-changed` failure in `models/mlx_text_model.py`/`models/llama_cpp_text_model.py` (confirmed byte-identical to `main`, untouched by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon stop handling so stale PID files are detected and cleaned up without trying to stop a non-running process.
  * Strengthened PID file validation to reject invalid, non-positive, or malformed entries and avoid unsafe reuse of stale process IDs.
  * Background startup failures are now surfaced to the caller more reliably, with cleanup handled in a bounded amount of time.

* **Tests**
  * Added coverage for stale PID cleanup, PID validation edge cases, and startup failure propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->