### PR TITLE
fix(cli): make 'fo profile' reachable through the real entry point

### DIFF
--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -512,17 +512,39 @@ def analytics(
 # module import time.  Typer wraps Click, so we register it just before app().
 
 
-def _register_profile_command() -> None:
-    """Lazily register the Click-based profile sub-command."""
+def _build_click_app() -> click.Group:
+    """Build the Click command tree exactly once, with ``profile`` attached.
+
+    ``typer.main.get_command(app)`` builds a brand-new Click group from
+    ``app``'s current registrations every time it's called — it never
+    mutates or caches anything on ``app`` itself. The previous
+    implementation called the lower-level ``get_group`` once just to
+    attach ``profile``, then discarded that instance; ``main()`` then
+    called ``app(standalone_mode=False)``, which calls ``get_command(app)``
+    again internally and builds a *second*, separate group that never saw
+    ``profile`` (#1328). Building the command tree exactly once here, and
+    having ``main()`` invoke this same returned object directly instead of
+    calling ``app(...)``, is what makes ``profile`` actually reachable.
+
+    Uses ``get_command`` rather than ``get_group`` so the
+    ``--install-completion`` / ``--show-completion`` options that
+    ``Typer.__call__`` normally adds via ``get_command`` are preserved.
+
+    Note: because ``main()`` invokes this returned ``click.Group`` directly
+    instead of going through ``Typer.__call__``, Typer's Rich-formatted
+    traceback handler is never armed — see the trade-off documented in
+    ``main()``'s docstring.
+    """
+    click_command = cast(click.Group, typer.main.get_command(app))
     try:
         from file_organizer.cli.profile import profile_command as _profile_click_group
 
-        typer_click_object = typer.main.get_group(app)
-        typer_click_object.add_command(_profile_click_group, "profile")
+        click_command.add_command(_profile_click_group, "profile")
     except ImportError:
         # Profile module may fail to import if intelligence services
         # are not installed; we degrade gracefully.
         pass
+    return click_command
 
 
 # ---------------------------------------------------------------------------
@@ -533,21 +555,36 @@ def _register_profile_command() -> None:
 def main() -> None:
     """Run the fo command-line application.
 
-    Registers the deferred profile command and invokes the Typer app with
-    ``standalone_mode=False`` so that ``KeyboardInterrupt`` and
-    ``BrokenPipeError`` propagate out of Click for our handlers to see — under
-    Click's default standalone mode the framework catches both internally and
-    our outer ``except`` clauses would never fire (codex review on PR #230).
+    Builds the Click command tree once (registering the deferred
+    ``profile`` command onto that exact instance — see
+    ``_build_click_app``) and invokes it with ``standalone_mode=False`` so
+    that ``KeyboardInterrupt`` and ``BrokenPipeError`` propagate out of
+    Click for our handlers to see — under Click's default standalone mode
+    the framework catches both internally and our outer ``except`` clauses
+    would never fire (codex review on PR #230).
 
     Exit codes:
         130 — user pressed Ctrl+C (POSIX SIGINT).
           0 — stdout consumer closed the pipe (e.g. ``fo ... | head``).
         Other typer/click exits propagate their own ``exit_code``.
+
+    Note: invoking the built ``click.Group`` directly — rather than calling
+    ``app(standalone_mode=False)`` as this used to do — means an exception
+    that escapes a command body uncaught (i.e. not one of the cases the
+    ``except`` clauses below already handle) renders as a plain Python
+    traceback instead of Typer's Rich-formatted one. ``Typer.__call__``
+    normally arms that formatting by installing ``sys.excepthook`` and
+    tagging the exception with a private ``DeveloperExceptionConfig``
+    attribute that ``typer.main.except_hook`` checks for; replicating it
+    here would mean depending on those private, version-coupled internals
+    for a purely cosmetic improvement on a "should never happen" path.
+    That trade-off was judged not worth it: this function's documented
+    contract is the exit-code behavior above, not traceback formatting.
     """
-    _register_profile_command()
+    click_app = _build_click_app()
 
     try:
-        app(standalone_mode=False)
+        click_app(standalone_mode=False)
     except (KeyboardInterrupt, click.exceptions.Abort):
         # Click converts KeyboardInterrupt → click.Abort under
         # standalone_mode=False; the bare KeyboardInterrupt branch covers

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -163,3 +163,44 @@ def test_preview_command_error(mock_organizer_cls, _mock_setup, tmp_path):
 
     assert result.exit_code == 1
     assert "Error: Bad input" in result.stdout
+
+
+def test_profile_command_registered_on_built_click_app():
+    """Regression test for #1328: `typer.main.get_command(app)` rebuilds a
+    fresh Click group from app's own registrations on every call and will
+    NEVER include `profile` — it's intentionally lazy-attached only by
+    `_build_click_app`, not registered globally on `app`, to avoid loading
+    the heavy intelligence-service import chain at module import time.
+    Asserting against a bare `get_command(app)` call would test the wrong
+    object; the real contract is that `_build_click_app()` — the function
+    `main()` actually invokes — returns a tree with `profile` attached.
+    """
+    from file_organizer.cli.main import _build_click_app
+
+    click_app = _build_click_app()
+    assert "profile" in click_app.commands
+
+
+def test_profile_reachable_via_cli_runner():
+    """End-to-end: invoking `profile --help` through the same object
+    main() calls must succeed, not fail with "No such command".
+
+    `_build_click_app()` returns a raw `click.Group` (the exact object
+    `main()` invokes), not a `Typer` instance. `typer.testing.CliRunner`
+    (the module-level `runner` used elsewhere in this file) always routes
+    its argument through `typer.main.get_command()` internally, which
+    expects `Typer`-only attributes (e.g. `_add_completion`) and raises
+    `AttributeError` on a bare `click.Group`. Use the plain
+    `click.testing.CliRunner` instead, matching the existing pattern in
+    `tests/cli/test_cli_profile.py` for invoking `profile_command`
+    directly.
+    """
+    from click.testing import CliRunner as ClickCliRunner
+
+    from file_organizer.cli.main import _build_click_app
+
+    click_app = _build_click_app()
+    click_runner = ClickCliRunner()
+    result = click_runner.invoke(click_app, ["profile", "--help"])
+    assert result.exit_code == 0
+    assert "profile" in result.output.lower()

--- a/tests/integration/test_cli_main_commands.py
+++ b/tests/integration/test_cli_main_commands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -275,35 +275,33 @@ class TestAnalyticsCommand:
 
 
 class TestEntryPoint:
-    """Tests for _register_profile_command and main() entry point."""
+    """Tests for _build_click_app and main() entry point."""
 
-    def test_register_profile_command_does_not_raise(self) -> None:
-        """_register_profile_command() runs without error (ImportError is silenced)."""
-        from file_organizer.cli.main import _register_profile_command
+    def test_build_click_app_does_not_raise(self) -> None:
+        """_build_click_app() runs without error (ImportError is silenced)."""
+        from file_organizer.cli.main import _build_click_app
 
-        _register_profile_command()  # should not raise
+        _build_click_app()  # should not raise
 
-    def test_main_calls_register_and_app(self) -> None:
-        """main() calls _register_profile_command then app()."""
-        from unittest.mock import patch
-
+    def test_main_calls_build_click_app_and_invokes_it(self) -> None:
+        """main() builds the click app once and invokes that exact object."""
         from file_organizer.cli.main import main
 
-        with (
-            patch("file_organizer.cli.main._register_profile_command") as mock_reg,
-            patch("file_organizer.cli.main.app") as mock_app,
-        ):
+        mock_click_app = MagicMock()
+        with patch(
+            "file_organizer.cli.main._build_click_app", return_value=mock_click_app
+        ) as mock_build:
             main()
-        mock_reg.assert_called_once()
-        mock_app.assert_called_once()
+        mock_build.assert_called_once()
+        mock_click_app.assert_called_once_with(standalone_mode=False)
 
     def test_main_keyboard_interrupt_exits_130(self) -> None:
-        """A bare KeyboardInterrupt from app() exits with code 130."""
+        """A bare KeyboardInterrupt from the click app exits with code 130."""
         from file_organizer.cli.main import main
 
+        mock_click_app = MagicMock(side_effect=KeyboardInterrupt)
         with (
-            patch("file_organizer.cli.main._register_profile_command"),
-            patch("file_organizer.cli.main.app", side_effect=KeyboardInterrupt),
+            patch("file_organizer.cli.main._build_click_app", return_value=mock_click_app),
             pytest.raises(SystemExit) as exc_info,
         ):
             main()
@@ -315,9 +313,9 @@ class TestEntryPoint:
 
         from file_organizer.cli.main import main
 
+        mock_click_app = MagicMock(side_effect=click.exceptions.Abort)
         with (
-            patch("file_organizer.cli.main._register_profile_command"),
-            patch("file_organizer.cli.main.app", side_effect=click.exceptions.Abort),
+            patch("file_organizer.cli.main._build_click_app", return_value=mock_click_app),
             pytest.raises(SystemExit) as exc_info,
         ):
             main()
@@ -330,9 +328,9 @@ class TestEntryPoint:
         from file_organizer.cli.main import main
 
         usage_error = click.exceptions.UsageError("bad usage")
+        mock_click_app = MagicMock(side_effect=usage_error)
         with (
-            patch("file_organizer.cli.main._register_profile_command"),
-            patch("file_organizer.cli.main.app", side_effect=usage_error),
+            patch("file_organizer.cli.main._build_click_app", return_value=mock_click_app),
             patch.object(usage_error, "show") as mock_show,
             pytest.raises(SystemExit) as exc_info,
         ):
@@ -346,9 +344,9 @@ class TestEntryPoint:
 
         from file_organizer.cli.main import main
 
+        mock_click_app = MagicMock(side_effect=click.exceptions.Exit(code=3))
         with (
-            patch("file_organizer.cli.main._register_profile_command"),
-            patch("file_organizer.cli.main.app", side_effect=click.exceptions.Exit(code=3)),
+            patch("file_organizer.cli.main._build_click_app", return_value=mock_click_app),
             pytest.raises(SystemExit) as exc_info,
         ):
             main()
@@ -360,9 +358,9 @@ class TestEntryPoint:
         doesn't repoint this pytest worker's real file descriptors."""
         from file_organizer.cli.main import main
 
+        mock_click_app = MagicMock(side_effect=BrokenPipeError)
         with (
-            patch("file_organizer.cli.main._register_profile_command"),
-            patch("file_organizer.cli.main.app", side_effect=BrokenPipeError),
+            patch("file_organizer.cli.main._build_click_app", return_value=mock_click_app),
             patch("os.open", return_value=99) as mock_open,
             patch("os.dup2") as mock_dup2,
             patch("os.close") as mock_close,
@@ -374,16 +372,16 @@ class TestEntryPoint:
         mock_close.assert_called_once_with(99)
         assert exc_info.value.code == 0
 
-    def test_register_profile_command_swallows_import_error(self) -> None:
+    def test_build_click_app_swallows_import_error(self) -> None:
         """A missing intelligence-service chain (ImportError) is silenced,
         not propagated — profile registration degrades gracefully. Setting
         the module to None in sys.modules forces the `import` statement
         itself to raise ImportError (mocking the attribute wouldn't: the
         `from X import Y` binding doesn't invoke anything to intercept)."""
-        from file_organizer.cli.main import _register_profile_command
+        from file_organizer.cli.main import _build_click_app
 
         with patch.dict("sys.modules", {"file_organizer.cli.profile": None}):
-            _register_profile_command()  # must not raise
+            _build_click_app()  # must not raise
 
     def test_tui_command_launches_run_tui(self) -> None:
         """`fo tui` delegates to file_organizer.tui.run_tui()."""


### PR DESCRIPTION
## Summary

Fixes #1328 — `fo profile` was registered onto a Click group that was immediately discarded, making it unreachable through the real `fo` entry point.

- `_register_profile_command()` called `typer.main.get_group(app)`, which builds a **brand-new** `LazyTyperGroup` from `app`'s current registrations every call. It attached `profile` to that throwaway instance, then discarded it.
- `main()` then called `app(standalone_mode=False)`, whose `Typer.__call__` calls `typer.main.get_command(app)` internally — rebuilding a **second**, separate group that never saw `profile`.
- Fix: replaced `_register_profile_command()` with `_build_click_app() -> click.Group`, which builds the command tree exactly once via `typer.main.get_command(app)` (not `get_group` — `get_command` additionally preserves the `--install-completion`/`--show-completion` flags), attaches `profile` to that one object, and returns it. `main()` now invokes that exact object instead of calling `app(...)`.
- Updated 8 pre-existing tests in `tests/integration/test_cli_main_commands.py::TestEntryPoint` that directly patched the now-removed `_register_profile_command` symbol — they would otherwise have broken on the rename, since they exist specifically to test `main()`'s entry-point behavior.
- Documented one narrow, intentional trade-off in `main()`'s docstring: invoking the built `click.Group` directly (instead of going through `Typer.__call__`) means a genuinely uncaught exception escaping a command body now renders as a plain Python traceback instead of Typer's Rich-formatted one. Restoring that would require depending on Typer's private `DeveloperExceptionConfig`/`except_hook` internals for a purely cosmetic improvement on a "should never happen" path — judged not worth the version-coupling risk, so it's documented instead of silently dropped.

## Test Plan

- [x] `tests/cli/test_main.py` — 2 new tests: `test_profile_command_registered_on_built_click_app`, `test_profile_reachable_via_cli_runner`
- [x] `tests/integration/test_cli_main_commands.py::TestEntryPoint` — 8 tests rewritten against the new `_build_click_app` contract, same coverage/intent preserved (one assertion strengthened)
- [x] `tests/cli/test_main.py tests/cli/test_cli_main.py tests/integration/test_cli_main_commands.py`: 97/97 passing
- [x] Broader sweep `tests/cli/ tests/integration/`: 7200/7200 passing
- [x] Manual check: `fo profile --help` now prints the profile sub-app's help text instead of `Error: No such command 'profile'` (reproduced the original bug via `git stash` to confirm)
- [x] `ruff check` / `mypy` clean on `cli/main.py`
- [x] `bash .claude/scripts/pre-commit-validation.sh` — passes except the same pre-existing, unrelated `mypy-changed` failure in `models/mlx_text_model.py`/`models/llama_cpp_text_model.py` seen on `main` (confirmed untouched by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)