### PR TITLE
fix(cli): catch UnsupportedConfigVersionError in 'fo config edit'

### DIFF
--- a/src/file_organizer/cli/config_cli.py
+++ b/src/file_organizer/cli/config_cli.py
@@ -58,6 +58,7 @@ def config_edit(
 ) -> None:
     """Edit a configuration profile."""
     from file_organizer.config import ConfigManager
+    from file_organizer.config.manager import UnsupportedConfigVersionError
     from file_organizer.utils.cli_errors import format_validation_error
 
     _VALID_DEVICES = {"auto", "cpu", "cuda", "mps", "metal"}
@@ -98,5 +99,13 @@ def config_edit(
     if methodology is not None:
         cfg.default_methodology = methodology
 
-    mgr.save(cfg, profile=profile)
+    try:
+        mgr.save(cfg, profile=profile)
+    except UnsupportedConfigVersionError as exc:
+        # The on-disk profile uses an unsupported schema version; saving
+        # would overwrite it with defaults. Refuse with a clean message
+        # instead of a raw traceback (#1324) — mirrors the same exception
+        # being handled the same way in api/routers/system.py.
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
     console.print(f"[green]Saved profile '{profile}'[/green]")

--- a/tests/cli/test_config_cli.py
+++ b/tests/cli/test_config_cli.py
@@ -1,0 +1,32 @@
+"""Tests for the config CLI sub-app (config_cli.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from file_organizer.cli.main import app
+from file_organizer.config.manager import UnsupportedConfigVersionError
+
+runner = CliRunner()
+
+
+class TestConfigEdit:
+    """Tests for `fo config edit`."""
+
+    @patch("file_organizer.config.ConfigManager")
+    def test_edit_unsupported_version_prints_friendly_error_and_exits_1(
+        self, mock_cm_cls: MagicMock
+    ) -> None:
+        """ConfigManager.save() raising UnsupportedConfigVersionError must
+        produce a clean error message + exit code 1, not a raw traceback."""
+        mock_mgr = MagicMock()
+        mock_cm_cls.return_value = mock_mgr
+        mock_mgr.save.side_effect = UnsupportedConfigVersionError("default", "99.0")
+
+        result = runner.invoke(app, ["config", "edit", "--text-model", "gpt-x"])
+
+        assert result.exit_code == 1
+        assert "unsupported" in result.output.lower()
+        assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary

Fixes #1324 — `ConfigManager.save()` raises `UnsupportedConfigVersionError` (a `RuntimeError` subclass) when the on-disk profile has an unsupported schema version and `force=False`, to avoid silently clobbering it with defaults. `config_cli.py`'s `config_edit` called `mgr.save(...)` with no try/except, and `main()`'s top-level handler in `cli/main.py` only catches Click's own exception types plus `BrokenPipeError`/`KeyboardInterrupt`/`Abort` — not `RuntimeError`. Net effect: editing a profile with a newer-than-supported schema version crashed with a full Python traceback instead of a clean message + exit code 1.

- Wrapped `mgr.save(cfg, profile=profile)` in `try/except UnsupportedConfigVersionError`, printing a clean error and exiting with code 1.
- Mirrors the identical exception already being handled the same way in `api/routers/system.py`.
- Confirmed `typer.Exit` is a subclass of `click.exceptions.Exit`, so it's caught correctly by `main()`'s existing handler.
- Confirmed scope: grepped all of `src/file_organizer/cli/*.py` for other unguarded `.save()` calls — `config_edit` is the only CLI call site affected.

## Test Plan

- [x] `tests/cli/test_config_cli.py` (new) — `test_edit_unsupported_version_prints_friendly_error_and_exits_1`: exit code 1, friendly "unsupported" message, no traceback in output
- [x] `tests/cli/test_config_cli.py tests/cli/test_cli_main.py`: 50/50 passing
- [x] `tests/cli/test_cli_config.py tests/cli/test_cli_config_integration.py tests/cli/test_config_validation_hints.py`: 27/27 passing, including the pre-existing success-path tests (confirms the happy path is untouched)
- [x] `ruff check` / `mypy` clean on `config_cli.py`
- [x] `bash .claude/scripts/pre-commit-validation.sh` — passes except the same pre-existing, unrelated `mypy-changed` failure in `models/mlx_text_model.py`/`models/llama_cpp_text_model.py` seen on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)