### PR TITLE
fix(core): escape [media] Rich markup in transcribe-audio fallback

### DIFF
--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -21,6 +21,7 @@ from typing import Any, ClassVar
 
 from loguru import logger
 from rich.console import Console
+from rich.markup import escape
 
 from file_organizer.core import dispatcher, display, file_ops, initializer
 from file_organizer.core.types import (
@@ -616,8 +617,9 @@ class FileOrganizer:
                 transcriber = self._audio_model
             except ImportError as exc:
                 self.console.print(
-                    f"[yellow]--transcribe-audio requires the [media] extra: {exc}. "
-                    "Falling back to metadata-only categorization.[/yellow]"
+                    rf"[yellow]--transcribe-audio requires the \[media] extra: "
+                    f"{escape(str(exc))}. Falling back to metadata-only "
+                    "categorization.[/yellow]"
                 )
 
         return dispatcher.process_audio_files(

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -179,6 +179,41 @@ class TestFileOrganizer:
         assert mock_fallback.call_args.args[0] == [image]
 
 
+@pytest.mark.unit
+@pytest.mark.ci
+def test_transcribe_audio_import_error_renders_media_extra_literally(
+    text_config: ModelConfig, vision_config: ModelConfig
+) -> None:
+    """#1325: the [media] extra name (both the hard-coded literal and the
+    one inside the ImportError text) must render as literal text in the
+    fallback message, not be silently swallowed as unparseable Rich markup
+    style.
+    """
+    from rich.console import Console
+
+    organizer = FileOrganizer(
+        text_model_config=text_config,
+        vision_model_config=vision_config,
+        dry_run=True,
+        use_hardlinks=False,
+        transcribe_audio=True,
+    )
+    # width=200: comfortably wider than the ~145-char rendered message so it
+    # stays on one line under Rich's normal word-wrapping (no soft_wrap
+    # needed in production code; see #1325 follow-up).
+    organizer.console = Console(record=True, width=200)
+
+    with (
+        patch("file_organizer.services.audio.transcriber._FASTER_WHISPER_AVAILABLE", False),
+        patch("file_organizer.core.dispatcher.process_audio_files", return_value=[]),
+    ):
+        organizer._process_audio_files([])
+
+    output = organizer.console.export_text()
+    assert output.count("[media]") == 2
+    assert "Falling back to metadata-only categorization" in output
+
+
 # ---------------------------------------------------------------------------
 # file_ops module tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1325 — the `ImportError` fallback for `--transcribe-audio` in `FileOrganizer._process_audio_files` printed a message containing two unescaped literal `[media]` occurrences (one hard-coded, one embedded in the `ImportError` text itself: `"faster_whisper is not installed (the [media] extra)"`). Rich's `Console.print` parses `[media]` as a markup style tag; since `media` isn't a valid style, both occurrences were silently dropped from the rendered output.

**Note on the original issue's framing:** the issue title says this "crashes." That doesn't reproduce against this repo's pinned Rich version (13.9.4) — verified directly, it doesn't raise, it silently swallows the bracketed text instead. Still a real bug (a corrupted/confusing message defeats the point of a graceful-degradation warning), just not literally a crash on this Rich version.

- Added `from rich.markup import escape`.
- Escaped the hard-coded literal as `\[media]` and wrapped the interpolated exception text as `escape(str(exc))` — both are needed; escaping only one leaves the bug in place via the other.
- (A review round caught and reverted an over-broad `soft_wrap=True` addition that was added to make a test pass — it would have disabled Rich's word-wrap *and cropping* in production, risking ungraceful overflow on narrow real terminals. Fixed the test instead by widening its `Console` width so the message fits without wrapping in the test specifically, leaving production wrapping behavior untouched.)

## Test Plan

- [x] `tests/core/test_organizer.py` — new `test_transcribe_audio_import_error_renders_media_extra_literally`: asserts both `[media]` occurrences render literally
- [x] `tests/core/test_organizer.py tests/core/test_organizer_coverage.py`: 40/40 passing
- [x] Broader sweep (`tests/core/`, `tests/integration/test_core_organizer_batch3.py`, `tests/integration/test_organizer_integration.py`, `tests/services/audio/`): 734/734 passing
- [x] Manually verified at multiple console widths (40/80/100/140/200) that the message word-wraps normally on narrow terminals and renders both `[media]` occurrences literally regardless of width
- [x] `ruff check` clean on both touched files
- [x] `bash .claude/scripts/pre-commit-validation.sh` — passes except the same pre-existing, unrelated `mypy-changed` failure in `models/mlx_text_model.py`/`models/llama_cpp_text_model.py` seen on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio transcription fallback messages so missing optional media support is shown as plain text instead of being interpreted as formatting.
  * Ensured the metadata-only fallback message remains readable in console output.

* **Tests**
  * Added coverage for the audio transcription fallback path to verify the message is displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->