### PR TITLE
docs: fix _resolve_path_names docstring to match actual matching behavior

### DIFF
--- a/src/file_organizer/review_regressions/security.py
+++ b/src/file_organizer/review_regressions/security.py
@@ -168,7 +168,7 @@ def _resolve_path_names(tree: ast.AST) -> set[str]:
     * ``import <pkg>.api.utils as alias`` — module-alias form; adds the alias so
       that ``alias.resolve_path(...)`` is matched by the attribute branch of
       ``_is_resolve_path_call``.
-    * ``from <pkg>.api import file_organizer.utils [as alias]`` — package-level module import;
+    * ``from <pkg>.api import utils [as alias]`` — package-level module import;
       adds ``utils`` (or alias) so ``utils.resolve_path(...)`` is recognized.
     * ``def resolve_path(...)`` — locally re-implemented or re-defined; adds
       ``"resolve_path"`` so test fixtures and thin wrappers are covered.


### PR DESCRIPTION
## Summary

Fixes #1326 — the docstring for `_resolve_path_names` in `src/file_organizer/review_regressions/security.py` claimed support for `from <pkg>.api import file_organizer.utils [as alias]`, which is both invalid Python syntax (`from`-import names must be plain identifiers, not dotted paths) and doesn't match the implementation, which checks a bare name (`alias.name == "utils"`).

Corrected the one bullet to `from <pkg>.api import utils [as alias]`, matching the actual code. Nothing else in the file changed — docstring-only, no behavior change.

## Test Plan

- [x] `tests/unit/review_regressions/test_security_detectors.py tests/integration/test_review_regressions_security.py`: 132/132 passing, unchanged
- [x] `ruff check` clean
- [x] `bash .claude/scripts/pre-commit-validation.sh` — passes except the same pre-existing, unrelated `mypy-changed` failure in `models/mlx_text_model.py`/`models/llama_cpp_text_model.py` seen on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)