### PR TITLE
fix: bundle PRs 1331-1335 — docs, markup, config, profile, daemon

### DIFF
--- a/src/file_organizer/cli/config_cli.py
+++ b/src/file_organizer/cli/config_cli.py
@@ -85,7 +85,19 @@ def config_edit(
         raise typer.Exit(code=1)
 
     mgr = ConfigManager()
-    cfg = mgr.load(profile=profile)
+    try:
+        cfg = mgr.load(profile=profile)
+    except Exception as exc:
+        from file_organizer.config.manager import UnsupportedConfigVersionError
+
+        if isinstance(exc, UnsupportedConfigVersionError):
+            console.print(
+                f"[red]Error: profile '{profile}' uses an unsupported config version "
+                f"and cannot be edited. Delete or migrate it first.[/red]\n"
+                f"[dim]Details: {exc}[/dim]"
+            )
+            raise typer.Exit(code=1) from exc
+        raise
 
     if text_model is not None:
         cfg.models.text_model = text_model

--- a/src/file_organizer/cli/config_cli.py
+++ b/src/file_organizer/cli/config_cli.py
@@ -85,19 +85,7 @@ def config_edit(
         raise typer.Exit(code=1)
 
     mgr = ConfigManager()
-    try:
-        cfg = mgr.load(profile=profile)
-    except Exception as exc:
-        from file_organizer.config.manager import UnsupportedConfigVersionError
-
-        if isinstance(exc, UnsupportedConfigVersionError):
-            console.print(
-                f"[red]Error: profile '{profile}' uses an unsupported config version "
-                f"and cannot be edited. Delete or migrate it first.[/red]\n"
-                f"[dim]Details: {exc}[/dim]"
-            )
-            raise typer.Exit(code=1) from exc
-        raise
+    cfg = mgr.load(profile=profile)
 
     if text_model is not None:
         cfg.models.text_model = text_model
@@ -110,5 +98,15 @@ def config_edit(
     if methodology is not None:
         cfg.default_methodology = methodology
 
-    mgr.save(cfg, profile=profile)
+    from file_organizer.config.manager import UnsupportedConfigVersionError
+
+    try:
+        mgr.save(cfg, profile=profile)
+    except UnsupportedConfigVersionError as exc:
+        console.print(
+            f"[red]Error: profile '{profile}' uses an unsupported config version "
+            f"and cannot be edited. Delete or migrate it first.[/red]\n"
+            f"[dim]Details: {exc}[/dim]"
+        )
+        raise typer.Exit(code=1) from exc
     console.print(f"[green]Saved profile '{profile}'[/green]")

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -528,6 +528,7 @@ def _register_profile_command() -> None:
             "Could not register 'fo profile' command: %s. "
             "The 'profile' sub-command will not be available.",
             exc,
+            exc_info=True,
         )
 
 

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -519,10 +519,16 @@ def _register_profile_command() -> None:
 
         typer_click_object = typer.main.get_group(app)
         typer_click_object.add_command(_profile_click_group, "profile")
-    except ImportError:
+    except ImportError as exc:
         # Profile module may fail to import if intelligence services
-        # are not installed; we degrade gracefully.
-        pass
+        # are not installed; degrade gracefully but log so operators can
+        # diagnose why `fo profile` is missing from the help output.
+        _logger = logging.getLogger(__name__)
+        _logger.warning(
+            "Could not register 'fo profile' command: %s. "
+            "The 'profile' sub-command will not be available.",
+            exc,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -616,7 +616,7 @@ class FileOrganizer:
                 transcriber = self._audio_model
             except ImportError as exc:
                 self.console.print(
-                    f"[yellow]--transcribe-audio requires the [media] extra: {exc}. "
+                    f"[yellow]--transcribe-audio requires the \\[media] extra: {exc}. "
                     "Falling back to metadata-only categorization.[/yellow]"
                 )
 

--- a/src/file_organizer/daemon/service.py
+++ b/src/file_organizer/daemon/service.py
@@ -152,6 +152,18 @@ class DaemonService:
             if self._thread is not None and not self._thread.is_alive():
                 self._thread = None
 
+            # PID-reuse guard (F2): if the in-process state looks clean but the
+            # on-disk PID file shows a live process (including a recycled PID
+            # matched by create_time), refuse to start rather than creating a
+            # second daemon writing to the same PID file.
+            if self.config.pid_file is not None and self._pid_manager.is_running(
+                self.config.pid_file
+            ):
+                raise RuntimeError(
+                    "Daemon is already running (stale PID file indicates a live process). "
+                    "Stop the existing daemon or remove the PID file and retry."
+                )
+
             self._stop_event.clear()
             self._started_event.clear()
             self._stopped_event.clear()
@@ -172,7 +184,9 @@ class DaemonService:
                 self._thread = None
                 raise
 
-        # Wait for the daemon to fully initialize
+        # Wait for the daemon to fully initialize.  _started_event is set by
+        # _background_run whether startup succeeded or failed, so this never
+        # blocks for the full timeout on early startup failures.
         self._started_event.wait(timeout=5.0)
 
     def stop(self) -> None:
@@ -280,6 +294,14 @@ class DaemonService:
             # Main event loop
             self._run_loop()
 
+        except Exception:
+            # Startup-failure safety: ensure start_background()'s wait() is
+            # unblocked even when initialization raises before _started_event
+            # is set.  Without this the caller blocks for the full 5-second
+            # timeout and has no indication that startup failed.
+            self._started_event.set()
+            logger.exception("Daemon startup failed")
+            raise
         finally:
             self._cleanup()
 

--- a/src/file_organizer/daemon/service.py
+++ b/src/file_organizer/daemon/service.py
@@ -82,6 +82,7 @@ class DaemonService:
         # ``_SIGNAL_LOG_MIN_INTERVAL_S`` so the log remains useful.
         self._last_signal_log_time = 0.0
         self._started_at: float | None = None
+        self._start_exception: BaseException | None = None
         self._files_processed: int = 0
         self._on_start_callback: Callable[[], None] | None = None
         self._on_stop_callback: Callable[[], None] | None = None
@@ -167,6 +168,7 @@ class DaemonService:
             self._stop_event.clear()
             self._started_event.clear()
             self._stopped_event.clear()
+            self._start_exception = None
 
             # Set _running = True while holding lock to prevent race condition
             # where two threads both pass the check above before _running is set
@@ -188,6 +190,16 @@ class DaemonService:
         # _background_run whether startup succeeded or failed, so this never
         # blocks for the full timeout on early startup failures.
         self._started_event.wait(timeout=5.0)
+
+        # _background_run records any startup exception in
+        # _start_exception before setting _started_event (see except
+        # clause below). Without re-raising here, callers (CLI/API) saw
+        # start_background() return normally even though the daemon
+        # thread had already died — a false success.
+        if self._start_exception is not None:
+            exc = self._start_exception
+            self._start_exception = None
+            raise RuntimeError("Daemon failed to start") from exc
 
     def stop(self) -> None:
         """Request a graceful shutdown of the daemon.
@@ -294,11 +306,22 @@ class DaemonService:
             # Main event loop
             self._run_loop()
 
-        except Exception:
+        except Exception as exc:
             # Startup-failure safety: ensure start_background()'s wait() is
             # unblocked even when initialization raises before _started_event
             # is set.  Without this the caller blocks for the full 5-second
-            # timeout and has no indication that startup failed.
+            # timeout and has no indication that startup failed. Recording
+            # the exception lets start_background() re-raise it instead of
+            # returning a false success.
+            #
+            # _running is cleared here (not just in the _cleanup() finally
+            # below) because _started_event.set() unblocks the caller's
+            # wait() immediately — without this, is_running could still
+            # read True for a brief window while _cleanup() is still
+            # running concurrently on this thread.
+            with self._lock:
+                self._running = False
+            self._start_exception = exc
             self._started_event.set()
             logger.exception("Daemon startup failed")
             raise

--- a/src/file_organizer/review_regressions/security.py
+++ b/src/file_organizer/review_regressions/security.py
@@ -168,7 +168,7 @@ def _resolve_path_names(tree: ast.AST) -> set[str]:
     * ``import <pkg>.api.utils as alias`` — module-alias form; adds the alias so
       that ``alias.resolve_path(...)`` is matched by the attribute branch of
       ``_is_resolve_path_call``.
-    * ``from <pkg>.api import file_organizer.utils [as alias]`` — package-level module import;
+    * ``from <pkg>.api import utils [as alias]`` — package-level module import;
       adds ``utils`` (or alias) so ``utils.resolve_path(...)`` is recognized.
     * ``def resolve_path(...)`` — locally re-implemented or re-defined; adds
       ``"resolve_path"`` so test fixtures and thin wrappers are covered.

--- a/tests/daemon/test_service.py
+++ b/tests/daemon/test_service.py
@@ -125,6 +125,25 @@ class TestDaemonLifecycle:
 
         assert daemon.is_running is True
 
+    def test_start_background_refuses_when_pid_file_shows_live_process(
+        self, daemon: DaemonService, pid_file: Path
+    ) -> None:
+        """If the on-disk PID file already points at a live process (e.g.
+        a prior daemon that crashed without cleaning up, or a still-running
+        one), start_background() must refuse rather than spawning a second
+        daemon that writes to the same PID file.
+
+        Uses this test process's own PID/create_time as the "live process"
+        the on-disk record points to, since it's guaranteed to be alive
+        for the duration of the test.
+        """
+        daemon._pid_manager.write_pid_record(pid_file, pid=os.getpid())
+
+        with pytest.raises(RuntimeError, match="stale PID file indicates a live process"):
+            daemon.start_background()
+
+        assert daemon.is_running is False
+
     def test_start_background_propagates_startup_failure(self, daemon: DaemonService) -> None:
         """If initialization in the background thread raises,
         start_background() must re-raise rather than returning a false

--- a/tests/daemon/test_service.py
+++ b/tests/daemon/test_service.py
@@ -125,6 +125,20 @@ class TestDaemonLifecycle:
 
         assert daemon.is_running is True
 
+    def test_start_background_propagates_startup_failure(self, daemon: DaemonService) -> None:
+        """If initialization in the background thread raises,
+        start_background() must re-raise rather than returning a false
+        success (regression: previously the caller only saw _started_event
+        get set and assumed the daemon was up).
+        """
+        from unittest.mock import patch
+
+        with patch.object(daemon, "_setup_default_tasks", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="Daemon failed to start"):
+                daemon.start_background()
+
+        assert daemon.is_running is False
+
     def test_repeated_restart_cycles_do_not_leave_scheduler_zombie(
         self,
         daemon: DaemonService,

--- a/tests/integration/test_cli_config.py
+++ b/tests/integration/test_cli_config.py
@@ -172,6 +172,7 @@ class TestConfigEdit:
         assert result.exit_code == 0
         assert "llama3.2:3b" in result.output
 
+    @pytest.mark.ci
     def test_config_edit_unsupported_version_exits_1_with_friendly_message(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/integration/test_cli_config.py
+++ b/tests/integration/test_cli_config.py
@@ -172,6 +172,30 @@ class TestConfigEdit:
         assert result.exit_code == 0
         assert "llama3.2:3b" in result.output
 
+    def test_config_edit_unsupported_version_exits_1_with_friendly_message(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Editing a profile written by a newer fo version must not crash
+        with a raw traceback. ``mgr.save()`` (not ``mgr.load()``) is what
+        raises ``UnsupportedConfigVersionError`` — ``load()`` degrades such
+        a profile to defaults instead of raising, so the guard has to wrap
+        the save call to actually intercept this error.
+        """
+        import yaml
+
+        monkeypatch.setattr("file_organizer.config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"profiles": {"default": {"version": "999.0", "profile_name": "default"}}}),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["config", "edit", "--text-model", "llama3.2:3b"])
+
+        assert result.exit_code == 1
+        assert "unsupported config version" in result.output.lower()
+        assert "Traceback" not in result.output
+
     def test_config_edit_custom_profile(self) -> None:
         result = runner.invoke(
             app,

--- a/tests/integration/test_cli_main_commands.py
+++ b/tests/integration/test_cli_main_commands.py
@@ -374,6 +374,7 @@ class TestEntryPoint:
         mock_close.assert_called_once_with(99)
         assert exc_info.value.code == 0
 
+    @pytest.mark.ci
     def test_register_profile_command_swallows_import_error(self) -> None:
         """A missing intelligence-service chain (ImportError) is silenced,
         not propagated — profile registration degrades gracefully. Setting


### PR DESCRIPTION
docs: fix _resolve_path_names docstring (PR #1335)
  - Third bullet had 'from <pkg>.api import file_organizer.utils' which is not valid Python syntax and doesn't match the actual predicate (alias.name == 'utils' when module.endswith('api')). Corrected to 'from <pkg>.api import utils [as alias]'.

fix(core): escape [media] Rich markup in transcribe-audio fallback (PR #1334)
  - self.console.print() in _process_audio_files() contained '[media]' as a bare Rich tag. Rich silently drops or raises MarkupError on unknown tags. Escaped to '\[media]' so the literal text is rendered.

fix(cli): catch UnsupportedConfigVersionError in 'fo config edit' (PR #1333)
  - config_edit() called mgr.load() with no error handling. A profile written by a newer version of fo raises UnsupportedConfigVersionError which propagated as a raw traceback. Now caught with a user-friendly '[red]Error:...[/red]' message and exit code 1, consistent with how the API router (routers/system.py:164) already handles this error.

fix(cli): log ImportError instead of silently swallowing it in
  _register_profile_command (PR #1332)
  - The bare 'pass' on ImportError made 'fo profile' silently disappear from help output with no diagnostics. Changed to logger.warning() so operators can diagnose missing profile registration via 'fo --log-level debug'.

fix(daemon): PID-reuse and startup-failure safety hardening (PR #1331)
  - start_background(): added on-disk PID-file liveness check via PidFileManager.is_running() before starting, catching the case where the in-process _running flag is False but a live process (possibly with a recycled PID) still owns the PID file.
  - _background_run(): wrapped body in try/except so any startup exception sets _started_event before propagating. Without this, start_background()'s wait(timeout=5.0) always blocked for the full 5 seconds on startup failure with no caller-visible signal.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CLI `config edit` experience with a clear, friendly error and exit code when a profile uses an unsupported config version (no raw traceback).
  * Prevent daemon startup when the configured PID file already points to a running process.
  * Daemon startup now fails fast and properly surfaces initialization failures.
  * Fixed terminal warning formatting so `[media]` displays literally.
  * Added a warning log when the `profile` CLI command can’t be registered.
* **Tests**
  * Added integration and daemon lifecycle test coverage for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
