### PR TITLE
refactor(cli): migrate all CLI modules to Annotated typer syntax (#1339)

### DIFF
--- a/src/file_organizer/cli/api.py
+++ b/src/file_organizer/cli/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
     from file_organizer.client.exceptions import ClientError
@@ -62,9 +62,9 @@ def _print_json(payload: object) -> None:
 
 @api_app.command("health")
 def health(
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
-    as_json: bool = typer.Option(False, "--json", help="Print JSON output."),
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """Check API health."""
     client, ClientError = _build_client(
@@ -87,16 +87,15 @@ def health(
 
 @api_app.command("login")
 def login(
-    username: str = typer.Option(..., prompt=True, help="Username."),
-    password: str = typer.Option(..., prompt=True, hide_input=True, help="Password."),
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
-    save_to: Path | None = typer.Option(
-        None,
-        "--save-token",
-        help="Optional path to save token JSON.",
-    ),
-    as_json: bool = typer.Option(False, "--json", help="Print JSON output."),
+    username: Annotated[str, typer.Option(prompt=True, help="Username.")],
+    password: Annotated[str, typer.Option(prompt=True, hide_input=True, help="Password.")],
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    save_to: Annotated[
+        Path | None,
+        typer.Option("--save-token", help="Optional path to save token JSON."),
+    ] = None,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """Authenticate and print/store access tokens."""
     client, ClientError = _build_client(
@@ -123,10 +122,10 @@ def login(
 
 @api_app.command("me")
 def me(
-    token: str = typer.Option(..., "--token", help="Bearer token."),
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
-    as_json: bool = typer.Option(False, "--json", help="Print JSON output."),
+    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """Show authenticated user info."""
     client, ClientError = _build_client(
@@ -149,10 +148,10 @@ def me(
 
 @api_app.command("logout")
 def logout(
-    token: str = typer.Option(..., "--token", help="Bearer token."),
-    refresh_token: str = typer.Option(..., "--refresh-token", help="Refresh token to revoke."),
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
+    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
+    refresh_token: Annotated[str, typer.Option("--refresh-token", help="Refresh token to revoke.")],
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
 ) -> None:
     """Revoke the current access/refresh token pair."""
     client, ClientError = _build_client(
@@ -170,14 +169,14 @@ def logout(
 
 @api_app.command("files")
 def files_list(
-    path: str = typer.Argument(..., help="Directory to list."),
-    token: str = typer.Option(..., "--token", help="Bearer token."),
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    recursive: bool = typer.Option(False, help="Include nested files."),
-    include_hidden: bool = typer.Option(False, help="Include hidden files."),
-    limit: int = typer.Option(100, min=1, max=500, help="Maximum rows."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
-    as_json: bool = typer.Option(False, "--json", help="Print JSON output."),
+    path: Annotated[str, typer.Argument(help="Directory to list.")],
+    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    recursive: Annotated[bool, typer.Option(help="Include nested files.")] = False,
+    include_hidden: Annotated[bool, typer.Option(help="Include hidden files.")] = False,
+    limit: Annotated[int, typer.Option(min=1, max=500, help="Maximum rows.")] = 100,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """List files via the API client."""
     client, ClientError = _build_client(
@@ -209,11 +208,11 @@ def files_list(
 
 @api_app.command("system-status")
 def system_status(
-    path: str = typer.Argument(".", help="Path to inspect."),
-    token: str = typer.Option(..., "--token", help="Bearer token."),
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
-    as_json: bool = typer.Option(False, "--json", help="Print JSON output."),
+    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
+    path: Annotated[str, typer.Argument(help="Path to inspect.")] = ".",
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """Show system status from the API."""
     client, ClientError = _build_client(
@@ -236,13 +235,13 @@ def system_status(
 
 @api_app.command("system-stats")
 def system_stats(
-    path: str = typer.Argument(".", help="Directory to analyze."),
-    token: str = typer.Option(..., "--token", help="Bearer token."),
-    base_url: str = typer.Option("http://localhost:8000", help="API base URL."),
-    max_depth: int | None = typer.Option(None, min=1, help="Optional max depth."),
-    use_cache: bool = typer.Option(True, help="Use server-side cache."),
-    timeout: float = typer.Option(30.0, help="Request timeout in seconds."),
-    as_json: bool = typer.Option(False, "--json", help="Print JSON output."),
+    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
+    path: Annotated[str, typer.Argument(help="Directory to analyze.")] = ".",
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    max_depth: Annotated[int | None, typer.Option(min=1, help="Optional max depth.")] = None,
+    use_cache: Annotated[bool, typer.Option(help="Use server-side cache.")] = True,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """Show storage analytics stats from the API."""
     client, ClientError = _build_client(

--- a/src/file_organizer/cli/autotag_v2.py
+++ b/src/file_organizer/cli/autotag_v2.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
@@ -35,10 +35,12 @@ logger = logging.getLogger(__name__)
 
 @autotag_app.command()
 def suggest(
-    directory: Path = typer.Argument(..., help="Directory containing files to tag."),
-    top_n: int = typer.Option(10, "--top-n", "-n", help="Max suggestions per file."),
-    min_confidence: float = typer.Option(40.0, "--min-confidence", help="Minimum confidence %."),
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
+    directory: Annotated[Path, typer.Argument(help="Directory containing files to tag.")],
+    top_n: Annotated[int, typer.Option("--top-n", "-n", help="Max suggestions per file.")] = 10,
+    min_confidence: Annotated[
+        float, typer.Option("--min-confidence", help="Minimum confidence %.")
+    ] = 40.0,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
 ) -> None:
     """Suggest tags for files in a directory."""
     from file_organizer.services.auto_tagging import AutoTaggingService
@@ -111,8 +113,8 @@ def suggest(
 
 @autotag_app.command()
 def apply(
-    file_path: Path = typer.Argument(..., help="File to tag."),
-    tags: list[str] = typer.Argument(..., help="Tags to apply."),
+    file_path: Annotated[Path, typer.Argument(help="File to tag.")],
+    tags: Annotated[list[str], typer.Argument(help="Tags to apply.")],
 ) -> None:
     """Apply tags to a file."""
     from file_organizer.services.auto_tagging import AutoTaggingService
@@ -134,7 +136,7 @@ def apply(
 
 @autotag_app.command()
 def popular(
-    limit: int = typer.Option(20, "--limit", "-n", help="Number of tags to show."),
+    limit: Annotated[int, typer.Option("--limit", "-n", help="Number of tags to show.")] = 20,
 ) -> None:
     """Show most popular tags."""
     from file_organizer.services.auto_tagging import AutoTaggingService
@@ -163,8 +165,8 @@ def popular(
 
 @autotag_app.command()
 def recent(
-    days: int = typer.Option(30, "--days", help="Days to look back."),
-    limit: int = typer.Option(20, "--limit", "-n", help="Number of tags to show."),
+    days: Annotated[int, typer.Option("--days", help="Days to look back.")] = 30,
+    limit: Annotated[int, typer.Option("--limit", "-n", help="Number of tags to show.")] = 20,
 ) -> None:
     """Show recently used tags."""
     from file_organizer.services.auto_tagging import AutoTaggingService
@@ -192,10 +194,10 @@ def recent(
 
 @autotag_app.command()
 def batch(
-    directory: Path = typer.Argument(..., help="Directory to process."),
-    pattern: str = typer.Option("*", help="File pattern."),
-    recursive: bool = typer.Option(True, "--recursive/--no-recursive"),
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
+    directory: Annotated[Path, typer.Argument(help="Directory to process.")],
+    pattern: Annotated[str, typer.Option(help="File pattern.")] = "*",
+    recursive: Annotated[bool, typer.Option("--recursive/--no-recursive")] = True,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
 ) -> None:
     """Batch tag suggestion for directory."""
     from file_organizer.services.auto_tagging import AutoTaggingService

--- a/src/file_organizer/cli/benchmark.py
+++ b/src/file_organizer/cli/benchmark.py
@@ -21,7 +21,7 @@ import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Annotated, Any, TypedDict, cast
 
 import typer
 
@@ -1135,53 +1135,59 @@ def _validate_compare_path(compare_path: Path | None) -> Path | None:
 
 @benchmark_app.command()
 def run(
-    input_path: Path = typer.Argument(
-        Path("tests/fixtures/"),
-        help="Path to files to benchmark.",
-    ),
-    iterations: int = typer.Option(
-        10,
-        "--iterations",
-        "-i",
-        help="Number of measured iterations to run (excluding warmup). Total runs = warmup + iterations.",
-        min=1,
-    ),
-    warmup: int = typer.Option(
-        3,
-        "--warmup",
-        "-w",
-        help="Warmup iterations excluded from statistics.",
-        min=0,
-    ),
-    suite: str = typer.Option(
-        "io",
-        "--suite",
-        "-s",
-        help=(
-            "Benchmark suite to run (io, text, vision, audio, pipeline, e2e). "
-            "Each suite executes a dedicated runner."
+    input_path: Annotated[
+        Path,
+        typer.Argument(help="Path to files to benchmark."),
+    ] = Path("tests/fixtures/"),
+    iterations: Annotated[
+        int,
+        typer.Option(
+            "--iterations",
+            "-i",
+            help="Number of measured iterations to run (excluding warmup). Total runs = warmup + iterations.",
+            min=1,
         ),
-    ),
-    json_output: bool = typer.Option(
-        False,
-        "--json",
-        help="Output results as JSON.",
-    ),
-    compare_path: Path | None = typer.Option(
-        None,
-        "--compare",
-        help="Path to baseline JSON file for regression comparison.",
-    ),
-    transcribe_smoke: bool = typer.Option(
-        False,
-        "--transcribe-smoke",
-        help=(
-            "Run AudioModel.generate() on one candidate file as an "
-            "end-to-end smoke test. Only meaningful with --suite audio. "
-            "Requires the [media] extra. Off by default to keep "
-            "benchmark runs fast."
+    ] = 10,
+    warmup: Annotated[
+        int,
+        typer.Option(
+            "--warmup",
+            "-w",
+            help="Warmup iterations excluded from statistics.",
+            min=0,
         ),
-    ),
+    ] = 3,
+    suite: Annotated[
+        str,
+        typer.Option(
+            "--suite",
+            "-s",
+            help=(
+                "Benchmark suite to run (io, text, vision, audio, pipeline, e2e). "
+                "Each suite executes a dedicated runner."
+            ),
+        ),
+    ] = "io",
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output results as JSON."),
+    ] = False,
+    compare_path: Annotated[
+        Path | None,
+        typer.Option("--compare", help="Path to baseline JSON file for regression comparison."),
+    ] = None,
+    transcribe_smoke: Annotated[
+        bool,
+        typer.Option(
+            "--transcribe-smoke",
+            help=(
+                "Run AudioModel.generate() on one candidate file as an "
+                "end-to-end smoke test. Only meaningful with --suite audio. "
+                "Requires the [media] extra. Off by default to keep "
+                "benchmark runs fast."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Run a performance benchmark with statistical output.
 

--- a/src/file_organizer/cli/config_cli.py
+++ b/src/file_organizer/cli/config_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import typer
 from rich.console import Console
 
@@ -12,7 +14,7 @@ config_app = typer.Typer(help="Configuration management.")
 
 @config_app.command(name="show")
 def config_show(
-    profile: str = typer.Option("default", help="Profile name."),
+    profile: Annotated[str, typer.Option(help="Profile name.")] = "default",
 ) -> None:
     """Show current configuration."""
     from file_organizer.config import ConfigManager
@@ -49,12 +51,16 @@ def config_list() -> None:
 
 @config_app.command(name="edit")
 def config_edit(
-    profile: str = typer.Option("default", help="Profile name to edit."),
-    text_model: str | None = typer.Option(None, help="Set text model name."),
-    vision_model: str | None = typer.Option(None, help="Set vision model name."),
-    temperature: float | None = typer.Option(None, help="Set temperature (0.0-1.0)."),
-    device: str | None = typer.Option(None, help="Set device (auto, cpu, cuda, mps, metal)."),
-    methodology: str | None = typer.Option(None, help="Set default methodology (none, para, jd)."),
+    profile: Annotated[str, typer.Option(help="Profile name to edit.")] = "default",
+    text_model: Annotated[str | None, typer.Option(help="Set text model name.")] = None,
+    vision_model: Annotated[str | None, typer.Option(help="Set vision model name.")] = None,
+    temperature: Annotated[float | None, typer.Option(help="Set temperature (0.0-1.0).")] = None,
+    device: Annotated[
+        str | None, typer.Option(help="Set device (auto, cpu, cuda, mps, metal).")
+    ] = None,
+    methodology: Annotated[
+        str | None, typer.Option(help="Set default methodology (none, para, jd).")
+    ] = None,
 ) -> None:
     """Edit a configuration profile."""
     from file_organizer.config import ConfigManager

--- a/src/file_organizer/cli/copilot.py
+++ b/src/file_organizer/cli/copilot.py
@@ -7,6 +7,7 @@ commands to the copilot engine.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -23,16 +24,18 @@ console = Console()
 
 @copilot_app.command(name="chat")
 def copilot_chat(
-    message: str | None = typer.Argument(
-        None,
-        help="Single message to send (omit for interactive REPL).",
-    ),
-    directory: str | None = typer.Option(
-        None,
-        "--dir",
-        "-d",
-        help="Working directory for file operations.",
-    ),
+    message: Annotated[
+        str | None,
+        typer.Argument(help="Single message to send (omit for interactive REPL)."),
+    ] = None,
+    directory: Annotated[
+        str | None,
+        typer.Option(
+            "--dir",
+            "-d",
+            help="Working directory for file operations.",
+        ),
+    ] = None,
 ) -> None:
     """Chat with the file-organisation copilot.
 

--- a/src/file_organizer/cli/daemon.py
+++ b/src/file_organizer/cli/daemon.py
@@ -10,7 +10,7 @@ import os
 import signal
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Annotated, Any, cast
 
 import typer
 from rich.console import Console
@@ -34,19 +34,25 @@ _DEFAULT_PID_FILE = _DEFAULT_PID_DIR / "daemon.pid"
 
 @daemon_app.command()
 def start(
-    watch_dir: Path | None = typer.Option(
-        None, "--watch-dir", "-w", help="Directory to watch for new files."
-    ),
-    output_dir: Path | None = typer.Option(
-        None, "--output-dir", "-o", help="Destination directory for organized files."
-    ),
-    foreground: bool = typer.Option(
-        False, "--foreground", "-f", help="Run in the foreground (blocking)."
-    ),
-    poll_interval: float = typer.Option(
-        1.0, "--poll-interval", help="Seconds between file-system polls."
-    ),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without moving files."),
+    watch_dir: Annotated[
+        Path | None,
+        typer.Option("--watch-dir", "-w", help="Directory to watch for new files."),
+    ] = None,
+    output_dir: Annotated[
+        Path | None,
+        typer.Option("--output-dir", "-o", help="Destination directory for organized files."),
+    ] = None,
+    foreground: Annotated[
+        bool,
+        typer.Option("--foreground", "-f", help="Run in the foreground (blocking)."),
+    ] = False,
+    poll_interval: Annotated[
+        float,
+        typer.Option("--poll-interval", help="Seconds between file-system polls."),
+    ] = 1.0,
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview changes without moving files.")
+    ] = False,
 ) -> None:
     """Start the background file organization daemon."""
     from file_organizer.daemon.config import DaemonConfig
@@ -160,8 +166,10 @@ def status() -> None:
 
 @daemon_app.command()
 def watch(
-    watch_dir: Path = typer.Argument(..., help="Directory to watch for file events."),
-    poll_interval: float = typer.Option(1.0, "--poll-interval", help="Seconds between polls."),
+    watch_dir: Annotated[Path, typer.Argument(help="Directory to watch for file events.")],
+    poll_interval: Annotated[
+        float, typer.Option("--poll-interval", help="Seconds between polls.")
+    ] = 1.0,
 ) -> None:
     """Watch a directory and stream file events (Ctrl+C to stop)."""
     from file_organizer.watcher.config import WatcherConfig
@@ -193,9 +201,11 @@ def watch(
 
 @daemon_app.command()
 def process(
-    input_dir: Path = typer.Argument(..., help="Directory containing files to process."),
-    output_dir: Path = typer.Argument(..., help="Destination directory for organized files."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without moving files."),
+    input_dir: Annotated[Path, typer.Argument(help="Directory containing files to process.")],
+    output_dir: Annotated[Path, typer.Argument(help="Destination directory for organized files.")],
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview changes without moving files.")
+    ] = False,
 ) -> None:
     """One-shot: organize files and display a summary."""
     from file_organizer.core.organizer import FileOrganizer

--- a/src/file_organizer/cli/dedupe_v2.py
+++ b/src/file_organizer/cli/dedupe_v2.py
@@ -12,7 +12,7 @@ Epic D / D4).
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
+from typing import Annotated, Any, cast
 
 import typer
 from rich.console import Console
@@ -121,30 +121,38 @@ def _hidden_files_will_be_scanned(directory: Path, *, include_hidden: bool) -> b
 
 @dedupe_app.command()
 def scan(
-    directory: Path = typer.Argument(..., help="Directory to scan for duplicates."),
-    algorithm: str = typer.Option("sha256", help="Hash algorithm (md5, sha256)."),
-    recursive: bool = typer.Option(True, help="Scan subdirectories."),
-    min_size: int = typer.Option(0, help="Minimum file size in bytes."),
-    max_size: int | None = typer.Option(None, help="Maximum file size in bytes."),
-    include: str | None = typer.Option(None, help="Comma-separated glob include patterns."),
-    exclude: str | None = typer.Option(None, help="Comma-separated glob exclude patterns."),
-    include_hidden: bool = typer.Option(
-        False,
-        "--include-hidden",
-        help=(
-            "Include dotfiles and files under hidden directories "
-            "(.env, .ssh, .config). Off by default — hidden paths often "
-            "contain credentials."
+    directory: Annotated[Path, typer.Argument(help="Directory to scan for duplicates.")],
+    algorithm: Annotated[str, typer.Option(help="Hash algorithm (md5, sha256).")] = "sha256",
+    recursive: Annotated[bool, typer.Option(help="Scan subdirectories.")] = True,
+    min_size: Annotated[int, typer.Option(help="Minimum file size in bytes.")] = 0,
+    max_size: Annotated[int | None, typer.Option(help="Maximum file size in bytes.")] = None,
+    include: Annotated[
+        str | None, typer.Option(help="Comma-separated glob include patterns.")
+    ] = None,
+    exclude: Annotated[
+        str | None, typer.Option(help="Comma-separated glob exclude patterns.")
+    ] = None,
+    include_hidden: Annotated[
+        bool,
+        typer.Option(
+            "--include-hidden",
+            help=(
+                "Include dotfiles and files under hidden directories "
+                "(.env, .ssh, .config). Off by default — hidden paths often "
+                "contain credentials."
+            ),
         ),
-    ),
-    output_format: str = typer.Option(
-        "rich",
-        "--format",
-        "-f",
-        help=_FORMAT_HELP,
-        case_sensitive=False,
-        callback=_validate_format,
-    ),
+    ] = False,
+    output_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            "-f",
+            help=_FORMAT_HELP,
+            case_sensitive=False,
+            callback=_validate_format,
+        ),
+    ] = "rich",
 ) -> None:
     """Scan a directory and display duplicate file groups."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
@@ -179,34 +187,38 @@ def scan(
 
 @dedupe_app.command()
 def resolve(
-    directory: Path = typer.Argument(..., help="Directory to scan for duplicates."),
-    strategy: str = typer.Option(
-        "manual",
-        help="Resolution strategy (manual, oldest, newest, largest, smallest).",
-    ),
-    algorithm: str = typer.Option("sha256", help="Hash algorithm."),
-    recursive: bool = typer.Option(True, help="Scan subdirectories."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without deleting."),
-    min_size: int = typer.Option(0, help="Minimum file size in bytes."),
-    max_size: int | None = typer.Option(None, help="Maximum file size in bytes."),
-    include: str | None = typer.Option(None, help="Comma-separated include patterns."),
-    exclude: str | None = typer.Option(None, help="Comma-separated exclude patterns."),
-    include_hidden: bool = typer.Option(
-        False,
-        "--include-hidden",
-        help=(
-            "Include dotfiles / hidden directories. Off by default; when "
-            "on, a confirmation prompt appears before any deletion."
+    directory: Annotated[Path, typer.Argument(help="Directory to scan for duplicates.")],
+    strategy: Annotated[
+        str,
+        typer.Option(help="Resolution strategy (manual, oldest, newest, largest, smallest)."),
+    ] = "manual",
+    algorithm: Annotated[str, typer.Option(help="Hash algorithm.")] = "sha256",
+    recursive: Annotated[bool, typer.Option(help="Scan subdirectories.")] = True,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview without deleting.")] = False,
+    min_size: Annotated[int, typer.Option(help="Minimum file size in bytes.")] = 0,
+    max_size: Annotated[int | None, typer.Option(help="Maximum file size in bytes.")] = None,
+    include: Annotated[str | None, typer.Option(help="Comma-separated include patterns.")] = None,
+    exclude: Annotated[str | None, typer.Option(help="Comma-separated exclude patterns.")] = None,
+    include_hidden: Annotated[
+        bool,
+        typer.Option(
+            "--include-hidden",
+            help=(
+                "Include dotfiles / hidden directories. Off by default; when "
+                "on, a confirmation prompt appears before any deletion."
+            ),
         ),
-    ),
-    output_format: str = typer.Option(
-        "rich",
-        "--format",
-        "-f",
-        help=_FORMAT_HELP,
-        case_sensitive=False,
-        callback=_validate_format,
-    ),
+    ] = False,
+    output_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            "-f",
+            help=_FORMAT_HELP,
+            case_sensitive=False,
+            callback=_validate_format,
+        ),
+    ] = "rich",
 ) -> None:
     """Scan and resolve duplicates using a strategy."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
@@ -285,22 +297,26 @@ def resolve(
 
 @dedupe_app.command()
 def report(
-    directory: Path = typer.Argument(..., help="Directory to scan."),
-    algorithm: str = typer.Option("sha256", help="Hash algorithm."),
-    recursive: bool = typer.Option(True, help="Scan subdirectories."),
-    include_hidden: bool = typer.Option(
-        False,
-        "--include-hidden",
-        help="Include dotfiles and files under hidden directories in the report.",
-    ),
-    output_format: str = typer.Option(
-        "rich",
-        "--format",
-        "-f",
-        help=_FORMAT_HELP,
-        case_sensitive=False,
-        callback=_validate_format,
-    ),
+    directory: Annotated[Path, typer.Argument(help="Directory to scan.")],
+    algorithm: Annotated[str, typer.Option(help="Hash algorithm.")] = "sha256",
+    recursive: Annotated[bool, typer.Option(help="Scan subdirectories.")] = True,
+    include_hidden: Annotated[
+        bool,
+        typer.Option(
+            "--include-hidden",
+            help="Include dotfiles and files under hidden directories in the report.",
+        ),
+    ] = False,
+    output_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            "-f",
+            help=_FORMAT_HELP,
+            case_sensitive=False,
+            callback=_validate_format,
+        ),
+    ] = "rich",
 ) -> None:
     """Scan and display a summary report of duplicates."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)

--- a/src/file_organizer/cli/doctor.py
+++ b/src/file_organizer/cli/doctor.py
@@ -11,7 +11,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
@@ -335,24 +335,24 @@ def install_groups(groups: set[str]) -> None:
 
 
 def doctor(
-    path: Path = typer.Argument(
-        ...,
-        help="Directory path to scan for file types.",
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
-        resolve_path=True,
-    ),
-    install: bool = typer.Option(
-        False,
-        "--install",
-        help="Automatically install recommended dependency groups.",
-    ),
-    json_output: bool = typer.Option(
-        False,
-        "--json",
-        help="Output as JSON.",
-    ),
+    path: Annotated[
+        Path,
+        typer.Argument(
+            help="Directory path to scan for file types.",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
+    ],
+    install: Annotated[
+        bool,
+        typer.Option("--install", help="Automatically install recommended dependency groups."),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output as JSON."),
+    ] = False,
 ) -> None:
     """Scan directory for file types and recommend optional dependencies.
 

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Annotated, Any, cast
 
 import click
 import typer
@@ -77,29 +77,38 @@ files first."""
 @app.callback()
 def main_callback(
     ctx: typer.Context,
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without executing."),
-    json_output: bool = typer.Option(False, "--json", help="Output results as JSON."),
-    yes: bool = typer.Option(False, "--yes", "-y", help="Auto-confirm all prompts."),
-    interactive: bool = typer.Option(
-        True, "--interactive/--no-interactive", help="Toggle interactive prompts."
-    ),
-    debug: bool = typer.Option(
-        False,
-        "--debug",
-        help=(
-            "Enable verbose logging and surface tracebacks on errors. "
-            "Required for filing useful beta bug reports."
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Enable verbose output.")
+    ] = False,
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview changes without executing.")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output results as JSON.")] = False,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Auto-confirm all prompts.")] = False,
+    interactive: Annotated[
+        bool,
+        typer.Option("--interactive/--no-interactive", help="Toggle interactive prompts."),
+    ] = True,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            "--debug",
+            help=(
+                "Enable verbose logging and surface tracebacks on errors. "
+                "Required for filing useful beta bug reports."
+            ),
         ),
-    ),
-    version_flag: bool = typer.Option(
-        False,
-        "--version",
-        "-V",
-        callback=_version_callback,
-        is_eager=True,
-        help="Show the application version and exit.",
-    ),
+    ] = False,
+    version_flag: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-V",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show the application version and exit.",
+        ),
+    ] = False,
 ) -> None:
     """Initialize global CLI state and perform startup bookkeeping.
 
@@ -222,10 +231,10 @@ def version() -> None:
 
 @app.command()
 def serve(
-    host: str = typer.Option("0.0.0.0", help="Bind address."),
-    port: int = typer.Option(8000, help="Port number."),
-    reload: bool = typer.Option(False, help="Auto-reload on code changes."),
-    workers: int = typer.Option(1, help="Number of worker processes."),
+    host: Annotated[str, typer.Option(help="Bind address.")] = "0.0.0.0",
+    port: Annotated[int, typer.Option(help="Port number.")] = 8000,
+    reload: Annotated[bool, typer.Option(help="Auto-reload on code changes.")] = False,
+    workers: Annotated[int, typer.Option(help="Number of worker processes.")] = 1,
 ) -> None:
     """Start the File Organizer web server and API."""
     try:
@@ -268,9 +277,9 @@ def launch_tui() -> None:
 
 @app.command(name="desktop")
 def launch_desktop(
-    title: str = typer.Option("File Organizer", help="Window title bar text."),
-    width: int = typer.Option(1280, help="Initial window width in logical pixels."),
-    height: int = typer.Option(800, help="Initial window height in logical pixels."),
+    title: Annotated[str, typer.Option(help="Window title bar text.")] = "File Organizer",
+    width: Annotated[int, typer.Option(help="Initial window width in logical pixels.")] = 1280,
+    height: Annotated[int, typer.Option(help="Initial window height in logical pixels.")] = 800,
 ) -> None:
     """Launch the native desktop window application."""
     try:
@@ -292,11 +301,12 @@ def launch_desktop(
 
 @app.command(name="docs")
 def docs_command(
-    build: bool = typer.Option(
-        False, "--build", "-b", help="Compile documentation to HTML instead of serving."
-    ),
-    host: str = typer.Option("127.0.0.1", help="Bind address for the docs server."),
-    port: int = typer.Option(8001, help="Port number for the docs server."),
+    build: Annotated[
+        bool,
+        typer.Option("--build", "-b", help="Compile documentation to HTML instead of serving."),
+    ] = False,
+    host: Annotated[str, typer.Option(help="Bind address for the docs server.")] = "127.0.0.1",
+    port: Annotated[int, typer.Option(help="Port number for the docs server.")] = 8001,
 ) -> None:
     """Build or serve the project documentation."""
     import shutil
@@ -347,7 +357,7 @@ def docs_command(
 
 @app.command(name="hardware-info")
 def hardware_info(
-    json_out: bool = typer.Option(False, "--json", help="Output as JSON."),
+    json_out: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
 ) -> None:
     """Print the current machine's hardware profile to the console.
 
@@ -391,10 +401,10 @@ def hardware_info(
 
 @app.command()
 def undo(
-    operation_id: int | None = typer.Option(None, help="Specific operation ID to undo."),
-    transaction_id: str | None = typer.Option(None, help="Transaction ID to undo."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without executing."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+    operation_id: Annotated[int | None, typer.Option(help="Specific operation ID to undo.")] = None,
+    transaction_id: Annotated[str | None, typer.Option(help="Transaction ID to undo.")] = None,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview without executing.")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
 ) -> None:
     """Undo previously recorded file operations.
 
@@ -417,9 +427,9 @@ def undo(
 
 @app.command()
 def redo(
-    operation_id: int | None = typer.Option(None, help="Specific operation ID to redo."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without executing."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+    operation_id: Annotated[int | None, typer.Option(help="Specific operation ID to redo.")] = None,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview without executing.")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
 ) -> None:
     """Redo previously recorded file operations.
 
@@ -440,11 +450,11 @@ def redo(
 
 @app.command()
 def history(
-    limit: int = typer.Option(10, help="Maximum number of operations to show."),
-    operation_type: str | None = typer.Option(None, "--type", help="Filter by type."),
-    status: str | None = typer.Option(None, help="Filter by status."),
-    stats: bool = typer.Option(False, help="Show statistics."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+    limit: Annotated[int, typer.Option(help="Maximum number of operations to show.")] = 10,
+    operation_type: Annotated[str | None, typer.Option("--type", help="Filter by type.")] = None,
+    status: Annotated[str | None, typer.Option(help="Filter by status.")] = None,
+    stats: Annotated[bool, typer.Option(help="Show statistics.")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
 ) -> None:
     """View operation history."""
     from file_organizer.cli.undo_redo import history_command as _history
@@ -461,12 +471,13 @@ def history(
 
 @app.command()
 def recover(
-    journal: Path | None = typer.Option(
-        None,
-        # --journal is a read-only path; defaults to system state dir.
-        help="Override path to durable_move.journal (defaults to the user state dir).",
-    ),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+    journal: Annotated[
+        Path | None,
+        typer.Option(
+            help="Override path to durable_move.journal (defaults to the user state dir)."
+        ),
+    ] = None,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
 ) -> None:
     """Preview pending durable_move recovery actions without executing them.
 
@@ -483,8 +494,8 @@ def recover(
 
 @app.command()
 def analytics(
-    directory: Path | None = typer.Argument(None, help="Directory to analyze."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+    directory: Annotated[Path | None, typer.Argument(help="Directory to analyze.")] = None,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
 ) -> None:
     """Display storage analytics dashboard."""
     from file_organizer.cli.analytics import analytics_command

--- a/src/file_organizer/cli/marketplace.py
+++ b/src/file_organizer/cli/marketplace.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
     from file_organizer.plugins.marketplace import MarketplaceService, PluginPackage
@@ -55,10 +55,14 @@ def _render_plugins(items: list[PluginPackage]) -> None:
 
 @marketplace_app.command("list")
 def list_plugins(
-    page: int = typer.Option(1, "--page", "-p", min=1, help="Page number."),
-    per_page: int = typer.Option(20, "--per-page", min=1, max=100, help="Results per page."),
-    category: str | None = typer.Option(None, "--category", "-c", help="Filter by category."),
-    tags: list[str] | None = typer.Option(None, "--tag", "-t", help="Filter by tags."),
+    page: Annotated[int, typer.Option("--page", "-p", min=1, help="Page number.")] = 1,
+    per_page: Annotated[
+        int, typer.Option("--per-page", min=1, max=100, help="Results per page.")
+    ] = 20,
+    category: Annotated[
+        str | None, typer.Option("--category", "-c", help="Filter by category.")
+    ] = None,
+    tags: Annotated[list[str] | None, typer.Option("--tag", "-t", help="Filter by tags.")] = None,
 ) -> None:
     """List available plugins."""
     from file_organizer.plugins.marketplace import MarketplaceError
@@ -79,9 +83,11 @@ def list_plugins(
 
 @marketplace_app.command("search")
 def search_plugins(
-    query: str = typer.Argument(..., help="Search query."),
-    category: str | None = typer.Option(None, "--category", "-c", help="Filter by category."),
-    tags: list[str] | None = typer.Option(None, "--tag", "-t", help="Filter by tags."),
+    query: Annotated[str, typer.Argument(help="Search query.")],
+    category: Annotated[
+        str | None, typer.Option("--category", "-c", help="Filter by category.")
+    ] = None,
+    tags: Annotated[list[str] | None, typer.Option("--tag", "-t", help="Filter by tags.")] = None,
 ) -> None:
     """Search marketplace plugins."""
     from file_organizer.plugins.marketplace import MarketplaceError
@@ -103,8 +109,10 @@ def search_plugins(
 
 @marketplace_app.command("info")
 def plugin_info(
-    name: str = typer.Argument(..., help="Plugin name."),
-    version: str | None = typer.Option(None, "--version", "-v", help="Specific version."),
+    name: Annotated[str, typer.Argument(help="Plugin name.")],
+    version: Annotated[
+        str | None, typer.Option("--version", "-v", help="Specific version.")
+    ] = None,
 ) -> None:
     """Show detailed plugin metadata."""
     from file_organizer.plugins.marketplace import MarketplaceError
@@ -132,8 +140,10 @@ def plugin_info(
 
 @marketplace_app.command("install")
 def install_plugin(
-    name: str = typer.Argument(..., help="Plugin name."),
-    version: str | None = typer.Option(None, "--version", "-v", help="Specific version."),
+    name: Annotated[str, typer.Argument(help="Plugin name.")],
+    version: Annotated[
+        str | None, typer.Option("--version", "-v", help="Specific version.")
+    ] = None,
 ) -> None:
     """Install a plugin from marketplace."""
     from file_organizer.plugins.marketplace import MarketplaceError
@@ -148,7 +158,7 @@ def install_plugin(
 
 @marketplace_app.command("uninstall")
 def uninstall_plugin(
-    name: str = typer.Argument(..., help="Plugin name."),
+    name: Annotated[str, typer.Argument(help="Plugin name.")],
 ) -> None:
     """Uninstall a marketplace plugin."""
     from file_organizer.plugins.marketplace import MarketplaceError
@@ -163,7 +173,7 @@ def uninstall_plugin(
 
 @marketplace_app.command("update")
 def update_plugin(
-    name: str = typer.Argument(..., help="Plugin name."),
+    name: Annotated[str, typer.Argument(help="Plugin name.")],
 ) -> None:
     """Update an installed plugin."""
     from file_organizer.plugins.marketplace import MarketplaceError
@@ -220,11 +230,11 @@ def available_updates() -> None:
 
 @marketplace_app.command("review")
 def add_review(
-    name: str = typer.Argument(..., help="Plugin name.", metavar="PLUGIN_NAME"),
-    user: str = typer.Option(..., "--user", help="Reviewer ID."),
-    rating: int = typer.Option(..., "--rating", min=1, max=5, help="Rating from 1 to 5."),
-    title: str = typer.Option(..., "--title", help="Review title."),
-    content: str = typer.Option(..., "--content", help="Review text."),
+    name: Annotated[str, typer.Argument(help="Plugin name.", metavar="PLUGIN_NAME")],
+    user: Annotated[str, typer.Option("--user", help="Reviewer ID.")],
+    rating: Annotated[int, typer.Option("--rating", min=1, max=5, help="Rating from 1 to 5.")],
+    title: Annotated[str, typer.Option("--title", help="Review title.")],
+    content: Annotated[str, typer.Option("--content", help="Review text.")],
 ) -> None:
     """Add or update a plugin review."""
     from file_organizer.plugins.marketplace import MarketplaceError, PluginReview

--- a/src/file_organizer/cli/models_cli.py
+++ b/src/file_organizer/cli/models_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import typer
 from rich.console import Console
 
@@ -12,9 +14,10 @@ model_app = typer.Typer(help="AI model management.")
 
 @model_app.command(name="list")
 def model_list(
-    type_filter: str | None = typer.Option(
-        None, "--type", help="Filter by model type (text, vision, audio)."
-    ),
+    type_filter: Annotated[
+        str | None,
+        typer.Option("--type", help="Filter by model type (text, vision, audio)."),
+    ] = None,
 ) -> None:
     """List available AI models with install status."""
     from file_organizer.models.model_manager import ModelManager
@@ -25,9 +28,10 @@ def model_list(
 
 @model_app.command(name="pull")
 def model_pull(
-    name: str = typer.Argument(
-        ..., help="Model name to download (e.g. qwen2.5:3b-instruct-q4_K_M)."
-    ),
+    name: Annotated[
+        str,
+        typer.Argument(help="Model name to download (e.g. qwen2.5:3b-instruct-q4_K_M)."),
+    ],
 ) -> None:
     """Download an AI model via Ollama."""
     from file_organizer.models.model_manager import ModelManager

--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -74,59 +75,69 @@ def _resolve_parallel_settings(
 
 
 def organize(
-    input_dir: Path = typer.Argument(..., help="Directory containing files to organize."),
-    output_dir: Path = typer.Argument(..., help="Destination directory for organized files."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without moving files."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
-    max_workers: int | None = typer.Option(
-        None,
-        "--max-workers",
-        min=1,
-        help="Maximum number of parallel workers for file processing.",
-    ),
-    sequential: bool = typer.Option(
-        False,
-        "--sequential",
-        help="Force single-worker sequential processing.",
-    ),
-    no_vision: bool = typer.Option(
-        False,
-        "--no-vision",
-        "--text-only",
-        help="Disable vision model usage and organize images by extension fallback.",
-    ),
-    prefetch_depth: int = typer.Option(
-        2,
-        "--prefetch-depth",
-        min=0,
-        help=(
-            "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
-            "uses strictly sequential submission)."
+    input_dir: Annotated[Path, typer.Argument(help="Directory containing files to organize.")],
+    output_dir: Annotated[Path, typer.Argument(help="Destination directory for organized files.")],
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview without moving files.")
+    ] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
+    max_workers: Annotated[
+        int | None,
+        typer.Option(
+            "--max-workers",
+            min=1,
+            help="Maximum number of parallel workers for file processing.",
         ),
-    ),
-    no_prefetch: bool = typer.Option(
-        False,
-        "--no-prefetch",
-        help="Backward-compatible alias for --prefetch-depth 0.",
-    ),
-    transcribe_audio: bool = typer.Option(
-        False,
-        "--transcribe-audio",
-        help=(
-            "Transcribe audio files (requires the [media] extra) and use the "
-            "transcript for content-aware categorization. Off by default — "
-            "transcription is the expensive operation in the audio pipeline."
+    ] = None,
+    sequential: Annotated[
+        bool,
+        typer.Option("--sequential", help="Force single-worker sequential processing."),
+    ] = False,
+    no_vision: Annotated[
+        bool,
+        typer.Option(
+            "--no-vision",
+            "--text-only",
+            help="Disable vision model usage and organize images by extension fallback.",
         ),
-    ),
-    max_transcribe_seconds: float = typer.Option(
-        600.0,
-        "--max-transcribe-seconds",
-        min=0.0,
-        help=(
-            "Skip transcription for audio files longer than this (seconds). "
-            "Default: 600 (10 min). Set to 0 to disable the cap entirely."
+    ] = False,
+    prefetch_depth: Annotated[
+        int,
+        typer.Option(
+            "--prefetch-depth",
+            min=0,
+            help=(
+                "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
+                "uses strictly sequential submission)."
+            ),
         ),
-    ),
+    ] = 2,
+    no_prefetch: Annotated[
+        bool,
+        typer.Option("--no-prefetch", help="Backward-compatible alias for --prefetch-depth 0."),
+    ] = False,
+    transcribe_audio: Annotated[
+        bool,
+        typer.Option(
+            "--transcribe-audio",
+            help=(
+                "Transcribe audio files (requires the [media] extra) and use the "
+                "transcript for content-aware categorization. Off by default — "
+                "transcription is the expensive operation in the audio pipeline."
+            ),
+        ),
+    ] = False,
+    max_transcribe_seconds: Annotated[
+        float,
+        typer.Option(
+            "--max-transcribe-seconds",
+            min=0.0,
+            help=(
+                "Skip transcription for audio files longer than this (seconds). "
+                "Default: 600 (10 min). Set to 0 to disable the cap entirely."
+            ),
+        ),
+    ] = 600.0,
 ) -> None:
     """Organize files in a directory using AI models."""
     # First-run setup gate now lives in `cli.main.main_callback` and runs
@@ -177,55 +188,63 @@ def organize(
 
 
 def preview(
-    input_dir: Path = typer.Argument(..., help="Directory to preview."),
-    max_workers: int | None = typer.Option(
-        None,
-        "--max-workers",
-        min=1,
-        help="Maximum number of parallel workers for file processing.",
-    ),
-    sequential: bool = typer.Option(
-        False,
-        "--sequential",
-        help="Force single-worker sequential processing.",
-    ),
-    no_vision: bool = typer.Option(
-        False,
-        "--no-vision",
-        "--text-only",
-        help="Disable vision model usage and organize images by extension fallback.",
-    ),
-    prefetch_depth: int = typer.Option(
-        2,
-        "--prefetch-depth",
-        min=0,
-        help=(
-            "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
-            "uses strictly sequential submission)."
+    input_dir: Annotated[Path, typer.Argument(help="Directory to preview.")],
+    max_workers: Annotated[
+        int | None,
+        typer.Option(
+            "--max-workers",
+            min=1,
+            help="Maximum number of parallel workers for file processing.",
         ),
-    ),
-    no_prefetch: bool = typer.Option(
-        False,
-        "--no-prefetch",
-        help="Backward-compatible alias for --prefetch-depth 0.",
-    ),
-    transcribe_audio: bool = typer.Option(
-        False,
-        "--transcribe-audio",
-        help=(
-            "Transcribe audio files (requires the [media] extra) and use the "
-            "transcript for content-aware categorization. Off by default."
+    ] = None,
+    sequential: Annotated[
+        bool,
+        typer.Option("--sequential", help="Force single-worker sequential processing."),
+    ] = False,
+    no_vision: Annotated[
+        bool,
+        typer.Option(
+            "--no-vision",
+            "--text-only",
+            help="Disable vision model usage and organize images by extension fallback.",
         ),
-    ),
-    max_transcribe_seconds: float = typer.Option(
-        600.0,
-        "--max-transcribe-seconds",
-        min=0.0,
-        help=(
-            "Skip transcription for audio files longer than this (seconds). "
-            "Default: 600 (10 min). Set to 0 to disable the cap entirely."
+    ] = False,
+    prefetch_depth: Annotated[
+        int,
+        typer.Option(
+            "--prefetch-depth",
+            min=0,
+            help=(
+                "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
+                "uses strictly sequential submission)."
+            ),
         ),
-    ),
+    ] = 2,
+    no_prefetch: Annotated[
+        bool,
+        typer.Option("--no-prefetch", help="Backward-compatible alias for --prefetch-depth 0."),
+    ] = False,
+    transcribe_audio: Annotated[
+        bool,
+        typer.Option(
+            "--transcribe-audio",
+            help=(
+                "Transcribe audio files (requires the [media] extra) and use the "
+                "transcript for content-aware categorization. Off by default."
+            ),
+        ),
+    ] = False,
+    max_transcribe_seconds: Annotated[
+        float,
+        typer.Option(
+            "--max-transcribe-seconds",
+            min=0.0,
+            help=(
+                "Skip transcription for audio files longer than this (seconds). "
+                "Default: 600 (10 min). Set to 0 to disable the cap entirely."
+            ),
+        ),
+    ] = 600.0,
 ) -> None:
     """Preview how files would be organized (dry-run)."""
     # Setup gate moved to `cli.main.main_callback` (Step 3).

--- a/src/file_organizer/cli/rules.py
+++ b/src/file_organizer/cli/rules.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -27,7 +28,7 @@ console = Console()
 
 @rules_app.command(name="list")
 def rules_list(
-    rule_set: str = typer.Option("default", "--set", "-s", help="Rule set name."),
+    rule_set: Annotated[str, typer.Option("--set", "-s", help="Rule set name.")] = "default",
 ) -> None:
     """List all rules in a rule set."""
     from file_organizer.services.copilot.rules import RuleManager
@@ -79,20 +80,27 @@ def rules_sets() -> None:
 
 @rules_app.command(name="add")
 def rules_add(
-    name: str = typer.Argument(..., help="Rule name."),
-    extension: str | None = typer.Option(
-        None, "--ext", help="File extension filter (e.g. '.pdf,.docx')."
-    ),
-    pattern: str | None = typer.Option(None, "--pattern", help="Filename glob pattern."),
-    action: str = typer.Option(
-        "move",
-        "--action",
-        "-a",
-        help="Action type (move, rename, tag, categorize, archive, copy, delete).",
-    ),
-    destination: str = typer.Option("", "--dest", "-d", help="Destination path or pattern."),
-    priority: int = typer.Option(0, "--priority", "-p", help="Rule priority (higher = first)."),
-    rule_set: str = typer.Option("default", "--set", "-s", help="Target rule set."),
+    name: Annotated[str, typer.Argument(help="Rule name.")],
+    extension: Annotated[
+        str | None,
+        typer.Option("--ext", help="File extension filter (e.g. '.pdf,.docx')."),
+    ] = None,
+    pattern: Annotated[str | None, typer.Option("--pattern", help="Filename glob pattern.")] = None,
+    action: Annotated[
+        str,
+        typer.Option(
+            "--action",
+            "-a",
+            help="Action type (move, rename, tag, categorize, archive, copy, delete).",
+        ),
+    ] = "move",
+    destination: Annotated[
+        str, typer.Option("--dest", "-d", help="Destination path or pattern.")
+    ] = "",
+    priority: Annotated[
+        int, typer.Option("--priority", "-p", help="Rule priority (higher = first).")
+    ] = 0,
+    rule_set: Annotated[str, typer.Option("--set", "-s", help="Target rule set.")] = "default",
 ) -> None:
     """Add a new rule to a rule set."""
     from file_organizer.services.copilot.rules.models import (
@@ -131,8 +139,8 @@ def rules_add(
 
 @rules_app.command(name="remove")
 def rules_remove(
-    name: str = typer.Argument(..., help="Rule name to remove."),
-    rule_set: str = typer.Option("default", "--set", "-s", help="Target rule set."),
+    name: Annotated[str, typer.Argument(help="Rule name to remove.")],
+    rule_set: Annotated[str, typer.Option("--set", "-s", help="Target rule set.")] = "default",
 ) -> None:
     """Remove a rule from a rule set."""
     from file_organizer.services.copilot.rules import RuleManager
@@ -146,8 +154,8 @@ def rules_remove(
 
 @rules_app.command(name="toggle")
 def rules_toggle(
-    name: str = typer.Argument(..., help="Rule name to toggle."),
-    rule_set: str = typer.Option("default", "--set", "-s", help="Target rule set."),
+    name: Annotated[str, typer.Argument(help="Rule name to toggle.")],
+    rule_set: Annotated[str, typer.Option("--set", "-s", help="Target rule set.")] = "default",
 ) -> None:
     """Toggle a rule's enabled/disabled state."""
     from file_organizer.services.copilot.rules import RuleManager
@@ -163,12 +171,12 @@ def rules_toggle(
 
 @rules_app.command(name="preview")
 def rules_preview(
-    directory: Path = typer.Argument(..., help="Directory to preview against."),
-    rule_set: str = typer.Option("default", "--set", "-s", help="Rule set to evaluate."),
-    recursive: bool = typer.Option(
-        True, "--recursive/--no-recursive", help="Recurse into subdirectories."
-    ),
-    max_files: int = typer.Option(500, "--max-files", help="Maximum files to scan."),
+    directory: Annotated[Path, typer.Argument(help="Directory to preview against.")],
+    rule_set: Annotated[str, typer.Option("--set", "-s", help="Rule set to evaluate.")] = "default",
+    recursive: Annotated[
+        bool, typer.Option("--recursive/--no-recursive", help="Recurse into subdirectories.")
+    ] = True,
+    max_files: Annotated[int, typer.Option("--max-files", help="Maximum files to scan.")] = 500,
 ) -> None:
     """Preview what rules would do (dry-run)."""
     from file_organizer.services.copilot.rules import PreviewEngine, RuleManager
@@ -209,8 +217,8 @@ def rules_preview(
 
 @rules_app.command(name="export")
 def rules_export(
-    rule_set: str = typer.Option("default", "--set", "-s", help="Rule set to export."),
-    output: Path | None = typer.Option(None, "--output", "-o", help="Output file path."),
+    rule_set: Annotated[str, typer.Option("--set", "-s", help="Rule set to export.")] = "default",
+    output: Annotated[Path | None, typer.Option("--output", "-o", help="Output file path.")] = None,
 ) -> None:
     """Export a rule set to YAML."""
     import yaml
@@ -261,8 +269,10 @@ def rules_export(
 
 @rules_app.command(name="import")
 def rules_import(
-    file: Path = typer.Argument(..., help="YAML file to import."),
-    rule_set: str | None = typer.Option(None, "--set", "-s", help="Override rule set name."),
+    file: Annotated[Path, typer.Argument(help="YAML file to import.")],
+    rule_set: Annotated[
+        str | None, typer.Option("--set", "-s", help="Override rule set name.")
+    ] = None,
 ) -> None:
     """Import a rule set from a YAML file."""
     import yaml

--- a/src/file_organizer/cli/setup.py
+++ b/src/file_organizer/cli/setup.py
@@ -1,8 +1,8 @@
 """Setup wizard CLI sub-app."""
 
 from __future__ import annotations
-from typing import Annotated
 
+from typing import Annotated
 
 import typer
 from rich.panel import Panel
@@ -16,20 +16,16 @@ setup_app = typer.Typer(help="Interactive setup wizard for first-run configurati
 
 @setup_app.command(name="run")
 def setup_run(  # noqa: C901
-    mode: Annotated[str, typer.Option(
-        "--mode",
-        "-m",
-        help="Setup mode: quick-start or power-user.",
-    )] = "quick-start",
-    profile: Annotated[str, typer.Option(
-        "--profile", 
-        "-p", 
-        help="Profile name."
-    )] = "default",
-    dry_run: Annotated[bool, typer.Option(
-        "--dry-run", 
-        help="Preview without saving."
-    )] = False,
+    mode: Annotated[
+        str,
+        typer.Option(
+            "--mode",
+            "-m",
+            help="Setup mode: quick-start or power-user.",
+        ),
+    ] = "quick-start",
+    profile: Annotated[str, typer.Option("--profile", "-p", help="Profile name.")] = "default",
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview without saving.")] = False,
 ) -> None:
     """Run the setup wizard to configure File Organizer.
 

--- a/src/file_organizer/cli/suggest.py
+++ b/src/file_organizer/cli/suggest.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
@@ -53,11 +53,13 @@ def _collect_files(directory: Path) -> list[Path]:
 
 @suggest_app.command()
 def files(
-    directory: Path = typer.Argument(..., help="Directory to generate suggestions for."),
-    min_confidence: float = typer.Option(40.0, help="Minimum confidence threshold (0-100)."),
-    max_results: int = typer.Option(50, help="Maximum number of suggestions."),
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Alias for preview mode."),
+    directory: Annotated[Path, typer.Argument(help="Directory to generate suggestions for.")],
+    min_confidence: Annotated[
+        float, typer.Option(help="Minimum confidence threshold (0-100).")
+    ] = 40.0,
+    max_results: Annotated[int, typer.Option(help="Maximum number of suggestions.")] = 50,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Alias for preview mode.")] = False,
 ) -> None:
     """Generate organisation suggestions for files in a directory."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
@@ -119,10 +121,12 @@ def files(
 
 @suggest_app.command()
 def apply(
-    directory: Path = typer.Argument(..., help="Directory to organise."),
-    min_confidence: float = typer.Option(60.0, help="Minimum confidence for auto-apply."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without changes."),
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
+    directory: Annotated[Path, typer.Argument(help="Directory to organise.")],
+    min_confidence: Annotated[
+        float, typer.Option(help="Minimum confidence for auto-apply.")
+    ] = 60.0,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview without changes.")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
 ) -> None:
     """Generate suggestions and apply them (with confirmation)."""
     from file_organizer.cli.interactive import confirm_action
@@ -181,8 +185,8 @@ def apply(
 
 @suggest_app.command()
 def patterns(
-    directory: Path = typer.Argument(..., help="Directory to analyze."),
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
+    directory: Annotated[Path, typer.Argument(help="Directory to analyze.")],
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
 ) -> None:
     """Detect and display naming/structure patterns in a directory."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)

--- a/src/file_organizer/cli/update.py
+++ b/src/file_organizer/cli/update.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import typer
 from rich.console import Console
 
@@ -15,16 +17,14 @@ console = Console()
 
 @update_app.command(name="check")
 def update_check(
-    repo: str = typer.Option(
-        "curdriceaurora/fo-core",
-        "--repo",
-        help="GitHub repository to check.",
-    ),
-    include_prerelease: bool = typer.Option(
-        False,
-        "--pre",
-        help="Include pre-release versions.",
-    ),
+    repo: Annotated[
+        str,
+        typer.Option("--repo", help="GitHub repository to check."),
+    ] = "curdriceaurora/fo-core",
+    include_prerelease: Annotated[
+        bool,
+        typer.Option("--pre", help="Include pre-release versions."),
+    ] = False,
 ) -> None:
     """Check if a newer version is available."""
     from file_organizer.updater import UpdateManager
@@ -47,17 +47,15 @@ def update_check(
 
 @update_app.command(name="install")
 def update_install(
-    dry_run: bool = typer.Option(False, "--dry-run", help="Download but don't install."),
-    repo: str = typer.Option(
-        "curdriceaurora/fo-core",
-        "--repo",
-        help="GitHub repository.",
-    ),
-    include_prerelease: bool = typer.Option(
-        False,
-        "--pre",
-        help="Include pre-release versions.",
-    ),
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Download but don't install.")] = False,
+    repo: Annotated[
+        str,
+        typer.Option("--repo", help="GitHub repository."),
+    ] = "curdriceaurora/fo-core",
+    include_prerelease: Annotated[
+        bool,
+        typer.Option("--pre", help="Include pre-release versions."),
+    ] = False,
 ) -> None:
     """Download and install the latest update."""
     from file_organizer.updater import UpdateManager

--- a/src/file_organizer/cli/utilities.py
+++ b/src/file_organizer/cli/utilities.py
@@ -7,6 +7,7 @@ import os
 import time
 import warnings
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -334,22 +335,26 @@ def _do_default_search(
 
 
 def search(
-    query: str = typer.Argument(..., help="Search query (glob pattern or keyword)."),
-    directory: Path = typer.Argument(".", help="Directory to search in.", exists=False),
-    type_filter: str | None = typer.Option(
-        None,
-        "--type",
-        "-t",
-        help="Filter by type: text, image, video, audio, archive.",
-    ),
-    limit: int = typer.Option(50, "--limit", "-n", help="Max results to show."),
-    recursive: bool = typer.Option(True, help="Search subdirectories."),
-    json_out: bool = typer.Option(False, "--json", help="Output as JSON array."),
-    semantic: bool = typer.Option(
-        False,
-        "--semantic",
-        help="Use hybrid BM25+vector semantic search instead of filename matching.",
-    ),
+    query: Annotated[str, typer.Argument(help="Search query (glob pattern or keyword).")],
+    directory: Annotated[Path, typer.Argument(help="Directory to search in.")] = Path("."),
+    type_filter: Annotated[
+        str | None,
+        typer.Option(
+            "--type",
+            "-t",
+            help="Filter by type: text, image, video, audio, archive.",
+        ),
+    ] = None,
+    limit: Annotated[int, typer.Option("--limit", "-n", help="Max results to show.")] = 50,
+    recursive: Annotated[bool, typer.Option(help="Search subdirectories.")] = True,
+    json_out: Annotated[bool, typer.Option("--json", help="Output as JSON array.")] = False,
+    semantic: Annotated[
+        bool,
+        typer.Option(
+            "--semantic",
+            help="Use hybrid BM25+vector semantic search instead of filename matching.",
+        ),
+    ] = False,
 ) -> None:
     """Search for files by name pattern with optional type filtering."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
@@ -369,9 +374,11 @@ def search(
 
 
 def analyze(
-    file_path: Path = typer.Argument(..., help="File to analyze."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show additional details."),
-    json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
+    file_path: Annotated[Path, typer.Argument(help="File to analyze.")],
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Show additional details.")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
 ) -> None:
     """Analyze a file using AI and show description, category, and confidence."""
     from file_organizer.services.analyzer import (


### PR DESCRIPTION
## Summary

Closes #1339.

Migrates all 17 CLI modules from the legacy `param: type = typer.Option(default, ...)` pattern to the modern `param: Annotated[type, typer.Option(...)] = default` style, eliminating the class of Typer `OptionInfo` type-leak bug fixed in PR #1306 across the entire CLI surface.

## Validation

- `ruff check src/file_organizer/cli/`: ✅ all clean  
- CLI smoke test (`fo --help`): ✅  
- `tests/cli/`: ✅ 1062 passed, 0 failed  
- diff-cover: ✅ 100% (17 changed lines, 0 missing)