### PR TITLE
docs: update pip-audit gate reference

### DIFF
--- a/.github/accepted-risks.yml
+++ b/.github/accepted-risks.yml
@@ -1,4 +1,4 @@
-# Accepted risk allowlist for .claude/scripts/pip_audit_gate.py (WP-6.3, #1242).
+# Accepted risk allowlist for scripts/security/pip_audit_gate.py (WP-6.3, #1242).
 #
 # Each entry suppresses ONE pip-audit finding (matched by package name +
 # vulnerability id) from failing the gate. Every entry MUST have a


### PR DESCRIPTION
## Summary
- Updates the accepted-risk allowlist header to reference the promoted pip-audit gate at `scripts/security/pip_audit_gate.py`.
- Confirms #1352's moved coverage/security/dev script references no longer point at `.claude/scripts`, `.claude/hooks/tdd-gate.sh`, or `.claude/bin/docker-compose-*`.

## Validation
- `pre-commit validate-config`
- `.venv/bin/pytest tests/ci -q --override-ini="addopts="` (699 passed, 1 skipped)
- Targeted moved-path audit with `rg` for stale #1352 `.claude` script/hook/docker references

## Risk
Low. This is a comment-only documentation/reference correction for the already-promoted security script.

Refs #1352