### PR TITLE
docs: remove stale PR-agent rule reference

### DIFF
--- a/LOCAL_CI_PLAN.md
+++ b/LOCAL_CI_PLAN.md
@@ -146,14 +146,14 @@ artifact, not the x86_64 one GitHub ships. Use for test validation, not release 
 
 ## Phase 4 — Fix branch protection (do this or merges block forever)
 
-`main-branch-protection.md` lists required status checks. If hosted runners stop
+GitHub branch protection lists the required status checks. If hosted runners stop
 reporting, those checks never go green and **every merge is blocked**. Choose:
 
 - **If you self-host** (Phases 1–3 via self-hosted runners): checks still report —
   leave protection as is.
 - **If you gate purely locally**: remove the required-status-check rule and rely on
-  the `pre-push` hook + `make ci` as the gate. Update `main-branch-protection.md`
-  to match reality.
+  the `pre-push` hook + `make ci` as the gate. Update the repository's branch
+  protection settings to match reality.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaces the remaining reference to the deleted `main-branch-protection.md` PR-agent rule doc with direct GitHub branch protection wording.
- Confirms #1353 candidate PR automation/rule paths are absent and no stale references remain.

## Validation
- `pre-commit validate-config`
- Targeted stale-reference audit with `rg` for #1353 PR-agent scripts/rules/docs
- `PATH="/Users/rahul/Documents/Local-File-Organizer/.venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/rahul/.codex/tmp/arg0/codex-arg0SqBVqb:/Users/rahul/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/rahul/.antigravity-ide/antigravity-ide/bin:/Users/rahul/.antigravity/antigravity/bin:/Users/rahul/.pyenv/shims:/Users/rahul/.local/bin:/Applications/Codex.app/Contents/Resources" pre-commit run pymarkdown --files LOCAL_CI_PLAN.md`
- `git diff --check`

## Risk
Low. This is documentation-only and removes a reference to a deleted private agent planning/rule file.

## Notes
- `.venv/bin/pytest tests/docs -q --override-ini="addopts="` currently fails locally because this worktree has an unrelated unstaged deletion of `docs/assets/tui-demo.gif`, which breaks `docs/tui.md` link integrity. This PR does not touch that file.

Refs #1353