### PR TITLE
chore: enforce passing CI rails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -210,13 +210,12 @@ repos:
         files: ^(src/|pyproject\.toml)
 
       # ----------------------------------------------------------------
-      # CI-rail framework (WP-0.1, #1222) — advisory runner.
-      # Runs the rails declared in scripts/ci/rails.toml. The registry is empty
-      # until WP-6.x adds rails, so this is a no-op (exit 0) today. Advisory
-      # rails warn but never block; enforce rails block.
+      # CI-rail framework (WP-0.1, #1222) — advisory/enforced runner.
+      # Runs the rails declared in scripts/ci/rails.toml. Advisory rails warn
+      # but never block; enforce rails block.
       # ----------------------------------------------------------------
       - id: ci-rails
-        name: ci rails (advisory framework)
+        name: ci rails
         entry: python scripts/ci/ci_rails.py
         language: system
         always_run: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,11 +41,9 @@ project-specific AST checks layered on top of both.
 
 The rails below are AST-based static checks run via
 `scripts/ci/ci_rails.py` (registry: `scripts/ci/rails.toml`),
-either as a pre-commit hook or in CI. All rails are currently
-**advisory** (they print violations but do not fail the build) because
-the codebase has a substantial backlog of pre-existing violations from
-before each rail existed. Issue #1356 tracks the advisory-to-enforce
-follow-up.
+either as a pre-commit hook or in CI. Rails with no current violations
+are **enforced**; rails with pre-existing violation backlogs remain
+**advisory** until their cleanup issues are resolved.
 
 | Rail | What it flags | Status |
 |---|---|---|
@@ -56,10 +54,10 @@ follow-up.
 | `test-hardcoded-paths` | Hardcoded absolute paths in tests (use `tmp_path`) | advisory |
 | `test-separator-paths` | Hardcoded path separators in `Path(...)` calls in tests | advisory |
 | `pytest-raises-hygiene` | `pytest.raises()` without a `match=` regex on a generic/built-in exception | advisory |
-| `safedir-valueerror` | A broad `except Exception`/bare `except` around a `SafeDir` call that doesn't re-raise or catch `ValueError` explicitly | advisory |
-| `textiowrapper-detach` | An `io.TextIOWrapper` that is never `.detach()`-ed before going out of scope (use-after-close risk on the wrapped buffer/fd) | advisory |
+| `safedir-valueerror` | A broad `except Exception`/bare `except` around a `SafeDir` call that doesn't re-raise or catch `ValueError` explicitly | enforced |
+| `textiowrapper-detach` | An `io.TextIOWrapper` that is never `.detach()`-ed before going out of scope (use-after-close risk on the wrapped buffer/fd) | enforced |
 | `called-attribute-assertion` | Weak `assert mock.called` / bare `assert mock.call_count` test assertions | advisory |
-| `xdist-loadgroup` | A test using the xdist-wide `tmp_path_factory.getbasetemp()` without an `xdist_group` marker | advisory |
+| `xdist-loadgroup` | A test using the xdist-wide `tmp_path_factory.getbasetemp()` without an `xdist_group` marker | enforced |
 
 Per-file coverage floors (`check-integration-floors.py` for the
 integration suite, `check_module_coverage_floor.py` for the unit suite)
@@ -97,12 +95,12 @@ Supply-chain scanning (run in `.github/workflows/security.yml`):
   ratchet baseline (see `pyproject.toml`, "WP-6.4 ratchet baseline").
   New files get full enforcement; the 41 existing ones are fixed
   incrementally — remove an entry as its file is cleaned up.
-- **Most lint rails above are advisory, not enforced.** Each has a
-  pre-existing violation count in the hundreds (e.g. `test-separator-paths`
-  had 1310 at last count) that predates the rail's existence. Flipping
-  a rail to `enforce` requires first reducing its violation count to
-  zero (or to an explicitly accepted/`noqa`-tagged remainder). Issue
-  #1356 tracks those decisions.
+- **Most lint rails above are advisory, not enforced.** Each advisory
+  rail still has pre-existing violations that predate the rail's
+  enforcement. Flipping a rail to `enforce` requires first reducing its
+  violation count to zero (or to an explicitly accepted/`noqa`-tagged
+  remainder). The remaining advisory rails are tracked individually in
+  #1363 through #1370.
 
 ## Reporting a Vulnerability
 

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -57,13 +57,13 @@ description = "Ensures pytest.raises on generic/built-in exceptions specifies a 
 [[rail]]
 name = "safedir-valueerror"
 command = ["python", "scripts/ci/guardrails/check_safedir_valueerror.py"]
-mode = "advisory"
+mode = "enforce"
 description = "Flags broad except blocks that swallow SafeDir's path-safety ValueError (WP-6.1)."
 
 [[rail]]
 name = "textiowrapper-detach"
 command = ["python", "scripts/ci/guardrails/check_textiowrapper_detach.py"]
-mode = "advisory"
+mode = "enforce"
 description = "Flags io.TextIOWrapper instances that are never detach()-ed before going out of scope (WP-6.1)."
 
 [[rail]]
@@ -75,5 +75,5 @@ description = "Flags weak `assert mock.called` / bare `assert mock.call_count` t
 [[rail]]
 name = "xdist-loadgroup"
 command = ["python", "scripts/ci/guardrails/check_xdist_loadgroup.py"]
-mode = "advisory"
+mode = "enforce"
 description = "Reminds to mark tests sharing xdist-wide temp state with xdist_group (WP-6.2)."

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -143,20 +143,19 @@ def test_list_is_noop_exit_zero(tmp_path: Path) -> None:
 
 
 def test_repo_registry_loads_registered_rails() -> None:
-    """The checked-in registry loads all registered rails, and they must be advisory in this phase."""
+    """The checked-in registry loads all registered rails with the expected enforcement modes."""
     rails = ci_rails.load_rails(ci_rails.DEFAULT_REGISTRY)
-    assert {rail.name for rail in rails} == {
-        "safedir-required",
-        "atomic-write",
-        "cli-path-validation",
-        "defusedxml-fallback",
-        "test-hardcoded-paths",
-        "test-separator-paths",
-        "pytest-raises-hygiene",
-        "safedir-valueerror",
-        "textiowrapper-detach",
-        "called-attribute-assertion",
-        "xdist-loadgroup",
+    expected_modes = {
+        "safedir-required": "advisory",
+        "atomic-write": "advisory",
+        "cli-path-validation": "advisory",
+        "defusedxml-fallback": "advisory",
+        "test-hardcoded-paths": "advisory",
+        "test-separator-paths": "advisory",
+        "pytest-raises-hygiene": "advisory",
+        "safedir-valueerror": "enforce",
+        "textiowrapper-detach": "enforce",
+        "called-attribute-assertion": "advisory",
+        "xdist-loadgroup": "enforce",
     }
-    for rail in rails:
-        assert rail.mode == "advisory"
+    assert {rail.name: rail.mode for rail in rails} == expected_modes


### PR DESCRIPTION
## Summary
- Enforce the three CI rails that currently pass: `safedir-valueerror`, `textiowrapper-detach`, and `xdist-loadgroup`.
- Keep the remaining failing rails advisory and tracked individually in #1363 through #1370.
- Update SECURITY.md, the pre-commit hook label, and the CI rail registry test to reflect the mixed advisory/enforced state.

## Validation
- `.venv/bin/python scripts/ci/guardrails/check_safedir_valueerror.py`
- `.venv/bin/python scripts/ci/guardrails/check_textiowrapper_detach.py`
- `.venv/bin/python scripts/ci/guardrails/check_xdist_loadgroup.py`
- `.venv/bin/python scripts/ci/ci_rails.py`
- `pre-commit validate-config`
- `.venv/bin/pytest tests/ci -q --override-ini="addopts="`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --all-files`

## Risk
- Low. This changes enforcement only for rails that currently report no violations. The noisy rails remain advisory and non-blocking while their cleanup issues are handled separately.

Fixes #1356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Several CI lint rails now fail builds when violated instead of only warning, helping catch issues earlier.
  * Updated the rail status information so the current enforcement level is clearer and more accurate.
* **Documentation**
  * Clarified which lint rails are enforced versus advisory and simplified the guidance for when a rail becomes enforced.
* **Chores**
  * Cleaned up the CI rail label and related comments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->