### PR TITLE
chore: make CI guardrails importable

### DIFF
--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -48,6 +48,24 @@ Add a new rule to the narrowest layer that can enforce it cleanly:
 
 Do not add new blocking policy directly to `scripts/dev/pre-commit-validation.sh`.
 
+### Importable Guardrail Modules
+
+Project-owned CI guardrail scripts live under `scripts/ci/guardrails/` and are
+importable as normal Python modules from `scripts.ci.guardrails`. Keep each
+module runnable as a script for pre-commit and CI, but write tests against the
+imported module:
+
+```python
+from scripts.ci.guardrails import check_example_guardrail
+
+
+def test_example(tmp_path: Path) -> None:
+    assert check_example_guardrail.check_file(tmp_path / "subject.py") == []
+```
+
+Avoid adding new `importlib.util.spec_from_file_location` loaders for
+`scripts/ci/guardrails` modules.
+
 ## API Compatibility Rule Index
 
 Issue `#813` adds allowlisted public-signature compatibility checks. These are
@@ -134,8 +152,10 @@ negative test case (`assert not predicate(...)`).
 | CI backstop | `tests/ci/test_predicate_negative_coverage.py` | On every CI run (full scan) |
 
 Shared logic lives in `scripts/ci/guardrails/check_predicate_negative_coverage.py`.
-The CI test imports from this script via `importlib`; the pre-commit hook runs
-it directly.  Update the script when new detector modules are added.
+The CI test imports it as
+`scripts.ci.guardrails.check_predicate_negative_coverage`; the pre-commit hook
+runs the same file directly. Update the script when new detector modules are
+added.
 
 | Detector module | Test file | Module stem in `_MODULE_TO_TEST` |
 |-----------------|-----------|----------------------------------|

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Project-owned utility scripts that are safe to import from tests."""

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI support scripts and guardrail runners."""

--- a/scripts/ci/guardrails/__init__.py
+++ b/scripts/ci/guardrails/__init__.py
@@ -1,0 +1,4 @@
+"""Importable CI guardrail checks.
+
+Each guardrail module also remains runnable as a script for pre-commit and CI.
+"""

--- a/tests/ci/test_check_called_attribute_assertion.py
+++ b/tests/ci/test_check_called_attribute_assertion.py
@@ -2,34 +2,13 @@
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 
+from scripts.ci.guardrails import check_called_attribute_assertion as checker
+
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
-
-_SCRIPT = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "ci"
-    / "guardrails"
-    / "check_called_attribute_assertion.py"
-)
-
-
-def _load_checker() -> ModuleType:
-    spec = importlib.util.spec_from_file_location(
-        "check_called_attribute_assertion_under_test", _SCRIPT
-    )
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-checker = _load_checker()
 
 
 def test_flags_assert_called(tmp_path: Path) -> None:

--- a/tests/ci/test_check_safedir_valueerror.py
+++ b/tests/ci/test_check_safedir_valueerror.py
@@ -2,32 +2,13 @@
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 
+from scripts.ci.guardrails import check_safedir_valueerror as checker
+
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
-
-_SCRIPT = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "ci"
-    / "guardrails"
-    / "check_safedir_valueerror.py"
-)
-
-
-def _load_checker() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("check_safedir_valueerror_under_test", _SCRIPT)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-checker = _load_checker()
 
 
 def test_flags_broad_except_around_open_child(tmp_path: Path) -> None:

--- a/tests/ci/test_check_textiowrapper_detach.py
+++ b/tests/ci/test_check_textiowrapper_detach.py
@@ -2,32 +2,13 @@
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 
+from scripts.ci.guardrails import check_textiowrapper_detach as checker
+
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
-
-_SCRIPT = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "ci"
-    / "guardrails"
-    / "check_textiowrapper_detach.py"
-)
-
-
-def _load_checker() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("check_textiowrapper_detach_under_test", _SCRIPT)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-checker = _load_checker()
 
 
 def test_flags_wrapper_without_detach(tmp_path: Path) -> None:

--- a/tests/ci/test_check_xdist_loadgroup.py
+++ b/tests/ci/test_check_xdist_loadgroup.py
@@ -2,32 +2,13 @@
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 
+from scripts.ci.guardrails import check_xdist_loadgroup as checker
+
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
-
-_SCRIPT = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "ci"
-    / "guardrails"
-    / "check_xdist_loadgroup.py"
-)
-
-
-def _load_checker() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("check_xdist_loadgroup_under_test", _SCRIPT)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-checker = _load_checker()
 
 
 def test_flags_getbasetemp_without_xdist_group(tmp_path: Path) -> None:

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -8,29 +8,14 @@ synthetic rails whose commands deterministically pass/fail.
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 
+from scripts.ci import ci_rails
+
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
-
-_RUNNER = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "ci_rails.py"
-
-
-def _load_runner() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("ci_rails_under_test", _RUNNER)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    # Register before exec so @dataclass can resolve the module via sys.modules.
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-ci_rails = _load_runner()
 
 # Commands that deterministically pass / fail via the test interpreter.
 _PASS = [sys.executable, "-c", "import sys; sys.exit(0)"]

--- a/tests/ci/test_predicate_negative_coverage.py
+++ b/tests/ci/test_predicate_negative_coverage.py
@@ -15,42 +15,17 @@ backstop that runs the full-scan path on every CI run.
 
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-
 import pytest
 
+from scripts.ci.guardrails import check_predicate_negative_coverage
+
 pytestmark = pytest.mark.ci
-
-_SCRIPT = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "ci"
-    / "guardrails"
-    / "check_predicate_negative_coverage.py"
-)
-
-
-def _load_checker():
-    """Load the shared hook script as a module; fail loudly if missing or malformed."""
-    spec = importlib.util.spec_from_file_location("check_predicate_negative_coverage", _SCRIPT)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(
-            f"Cannot load predicate coverage script — file not found or unreadable: {_SCRIPT}"
-        )
-    mod = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    except (SyntaxError, Exception) as exc:
-        raise RuntimeError(f"Failed to load predicate coverage script {_SCRIPT}: {exc}") from exc
-    return mod
 
 
 @pytest.mark.ci
 def test_all_predicates_have_negative_cases() -> None:
     """Every predicate in review_regressions/ must have a negative test case."""
-    checker = _load_checker()
-    missing = checker.check()
+    missing = check_predicate_negative_coverage.check()
     assert not missing, (
         "T10: These predicates are missing negative test cases\n"
         "(add `assert not <predicate_name>(...)` to the paired test file):\n"


### PR DESCRIPTION
## Summary
- Add package markers so `scripts.ci` and `scripts.ci.guardrails` can be imported from tests.
- Replace guardrail-specific `importlib.util.spec_from_file_location` loaders with normal imports.
- Document the import convention for future guardrail modules while preserving existing CLI/pre-commit paths.

## Validation
- `.venv/bin/pytest tests/ci/test_ci_rails_framework.py tests/ci/test_check_called_attribute_assertion.py tests/ci/test_check_safedir_valueerror.py tests/ci/test_check_textiowrapper_detach.py tests/ci/test_check_xdist_loadgroup.py tests/ci/test_predicate_negative_coverage.py -q --override-ini="addopts="`
- `.venv/bin/python scripts/ci/ci_rails.py`
- `.venv/bin/python -m ruff check scripts/__init__.py scripts/ci/__init__.py scripts/ci/guardrails/__init__.py tests/ci/test_ci_rails_framework.py tests/ci/test_check_called_attribute_assertion.py tests/ci/test_check_safedir_valueerror.py tests/ci/test_check_textiowrapper_detach.py tests/ci/test_check_xdist_loadgroup.py tests/ci/test_predicate_negative_coverage.py`
- `.venv/bin/pytest tests/ci -q --override-ini="addopts="`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --all-files`

## Risk
- Low. Runtime package code is untouched, and guardrails remain runnable through the same script paths used by `rails.toml`, pre-commit, and CI. The main risk is import path assumptions in tests, covered by the targeted and full `tests/ci` runs.

Fixes #1357