### PR TITLE
fix: resolve three independent CI failures on main (#1392)

### DIFF
--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -29,6 +29,7 @@ pytest -k "backup or dedup"                     # Filter by name
 @pytest.mark.security      # Security hardening / regression tests (tests/security)
 @pytest.mark.extras        # Optional-dependency matrix tests (tests/extras)
 @pytest.mark.uses_setup_gate # Opts out of the autouse setup-gate bypass to exercise the real gate
+@pytest.mark.keep_default_paths # Opts out of the autouse tmp_path re-routing in TUI conftest (use on tests that verify default '.' path behaviour)
 
 def test_example():
     pass

--- a/src/file_organizer/api/auth_db.py
+++ b/src/file_organizer/api/auth_db.py
@@ -20,11 +20,19 @@ from file_organizer.api.database import (
 from file_organizer.config.path_manager import get_config_dir
 
 
-def _ensure_db_dir(db_path: str) -> None:
+def _default_auth_db_path() -> str:
+    """Return the default on-disk auth database path."""
+    return str(get_config_dir() / "auth.db")
+
+
+def _uses_default_auth_db(db_path: str) -> bool:
+    """Return whether *db_path* points at the default auth database."""
+    return db_path == _default_auth_db_path()
+
+
+def _ensure_default_auth_db_dir() -> None:
     """Create the default auth DB directory when using the default DB path."""
-    config_dir = get_config_dir()
-    if db_path == str(config_dir / "auth.db"):
-        config_dir.mkdir(parents=True, exist_ok=True)
+    get_config_dir().mkdir(parents=True, exist_ok=True)
 
 
 @cache
@@ -32,7 +40,8 @@ def get_engine(db_path: str) -> Engine:
     """Return a cached SQLAlchemy engine for the auth database."""
     # Keep auth defaults conservative; feature-specific callers can use
     # file_organizer.api.database directly for custom pool tuning.
-    _ensure_db_dir(db_path)
+    if _uses_default_auth_db(db_path):
+        _ensure_default_auth_db_dir()
     engine = get_db_engine(
         db_path,
         pool_size=5,

--- a/src/file_organizer/api/auth_db.py
+++ b/src/file_organizer/api/auth_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from functools import cache
+from pathlib import Path
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -19,11 +20,18 @@ from file_organizer.api.database import (
 )
 
 
+def _ensure_db_dir(db_path: str) -> None:
+    """Create the parent directory for a SQLite file DB if it doesn't exist."""
+    if db_path != ":memory:":
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)  # codeql[py/path-injection]
+
+
 @cache
 def get_engine(db_path: str) -> Engine:
     """Return a cached SQLAlchemy engine for the auth database."""
     # Keep auth defaults conservative; feature-specific callers can use
     # file_organizer.api.database directly for custom pool tuning.
+    _ensure_db_dir(db_path)
     engine = get_db_engine(
         db_path,
         pool_size=5,

--- a/src/file_organizer/api/auth_db.py
+++ b/src/file_organizer/api/auth_db.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from functools import cache
-from pathlib import Path
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -18,12 +17,14 @@ from file_organizer.api.database import (
 from file_organizer.api.database import (
     get_session_factory as get_db_session_factory,
 )
+from file_organizer.config.path_manager import get_config_dir
 
 
 def _ensure_db_dir(db_path: str) -> None:
-    """Create the parent directory for a SQLite file DB if it doesn't exist."""
-    if db_path != ":memory:":
-        Path(db_path).parent.mkdir(parents=True, exist_ok=True)  # codeql[py/path-injection]
+    """Create the default auth DB directory when using the default DB path."""
+    config_dir = get_config_dir()
+    if db_path == str(config_dir / "auth.db"):
+        config_dir.mkdir(parents=True, exist_ok=True)
 
 
 @cache

--- a/tests/ci/test_path_security_contract.py
+++ b/tests/ci/test_path_security_contract.py
@@ -64,11 +64,6 @@ _ALLOWED_PATH_SNIPPETS: dict[str, set[str]] = {
         "target = Path(path)",
         "detector.scan_directory(Path(scan_dir))",
     },
-    # auth_db uses Path only to create the parent directory for the DB file;
-    # db_path comes from trusted config (ApiSettings.auth_db_path), not user input.
-    "api/auth_db.py": {
-        "Path(db_path).parent.mkdir(parents=True, exist_ok=True)  # codeql[py/path-injection]",
-    },
 }
 
 

--- a/tests/ci/test_path_security_contract.py
+++ b/tests/ci/test_path_security_contract.py
@@ -64,6 +64,11 @@ _ALLOWED_PATH_SNIPPETS: dict[str, set[str]] = {
         "target = Path(path)",
         "detector.scan_directory(Path(scan_dir))",
     },
+    # auth_db uses Path only to create the parent directory for the DB file;
+    # db_path comes from trusted config (ApiSettings.auth_db_path), not user input.
+    "api/auth_db.py": {
+        "Path(db_path).parent.mkdir(parents=True, exist_ok=True)  # codeql[py/path-injection]",
+    },
 }
 
 

--- a/tests/integration/test_models_auth_store_migration.py
+++ b/tests/integration/test_models_auth_store_migration.py
@@ -280,6 +280,25 @@ class TestAuthDb:
         factory = get_session_factory(db_path)
         assert callable(factory)
 
+    def test_create_session_creates_default_auth_db_directory(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from file_organizer.api.auth_db import create_session, get_engine, get_session_factory
+        from file_organizer.config.path_manager import get_config_dir
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+        get_engine.cache_clear()
+        get_session_factory.cache_clear()
+
+        db_path = str(get_config_dir() / "auth.db")
+        session = create_session(db_path)
+        try:
+            assert Path(db_path).parent.is_dir()
+        finally:
+            session.close()
+            get_engine.cache_clear()
+            get_session_factory.cache_clear()
+
 
 # ---------------------------------------------------------------------------
 # config/path_migration.py — resolve_active_dir branches

--- a/tests/integration/test_models_auth_store_migration.py
+++ b/tests/integration/test_models_auth_store_migration.py
@@ -299,6 +299,24 @@ class TestAuthDb:
             get_engine.cache_clear()
             get_session_factory.cache_clear()
 
+    def test_create_session_does_not_create_parent_for_custom_auth_db_path(
+        self, tmp_path: Path
+    ) -> None:
+        from sqlalchemy.exc import OperationalError
+
+        from file_organizer.api.auth_db import create_session, get_engine, get_session_factory
+
+        db_path = tmp_path / "custom-root" / "nested" / "auth.db"
+        get_engine.cache_clear()
+        get_session_factory.cache_clear()
+
+        with pytest.raises(OperationalError):
+            create_session(str(db_path))
+
+        assert not db_path.parent.exists()
+        get_engine.cache_clear()
+        get_session_factory.cache_clear()
+
 
 # ---------------------------------------------------------------------------
 # config/path_migration.py — resolve_active_dir branches

--- a/tests/tui/test_tui_organization_preview.py
+++ b/tests/tui/test_tui_organization_preview.py
@@ -84,6 +84,7 @@ class TestOrganizationSummary:
 class TestOrganizationPreviewView:
     """Tests for OrganizationPreviewView composition."""
 
+    @pytest.mark.keep_default_paths
     def test_default_init(self) -> None:
         view = OrganizationPreviewView(id="view")
         assert str(view._input_dir) == "."


### PR DESCRIPTION
Fixes #1392

## Summary

Three independent CI failures on `main` — each in a different shard and each with a separate root cause.

---

### Fix 1 — Shard 5: docs-sync marker (`keep_default_paths`)

**Failure:** `tests/docs/test_pyproject_sync.py::test_marker_documented[keep_default_paths]`

**RCA:** The `keep_default_paths` pytest marker was declared in `pyproject.toml` but absent from the `## Test Markers` section of `docs/testing/testing-strategy.md`, violating the docs-sync invariant.

**Fix:** Added `@pytest.mark.keep_default_paths` entry to the `## Test Markers` code block in `docs/testing/testing-strategy.md`.

---

### Fix 2 — Shard 4: TUI `test_default_init` path assertion

**Failure:** `tests/tui/test_tui_organization_preview.py::TestOrganizationPreviewView::test_default_init`

**RCA:** The autouse `tui_completed_setup` conftest re-routes default `"."` paths to pytest's `tmp_path` for all TUI tests unless they are marked `@pytest.mark.keep_default_paths`. `test_default_init` intentionally verifies that `OrganizationPreviewView._input_dir` defaults to `"."`, but without the marker the conftest intercepted the `"."` → `tmp_path`, causing the assertion to fail.

**Fix:** Added `@pytest.mark.keep_default_paths` to `test_default_init` so it opts out of the re-routing.

---

### Fix 3 — Shard 3: Auth DB `OperationalError` on status endpoint

**Failure:** `tests/api/test_daemon_router.py::TestDaemonAuthEnforcement::test_daemon_status_unauthenticated_fails`

**RCA:** The test creates a `FastAPI` app with `auth_enabled=True` but only overrides `get_settings`. When the auth dependency chain runs, `get_db()` → `create_session(auth_db_path)` → `get_engine(db_path)` tries to open `~/.config/file-organizer/auth.db`. The CI runner home directory doesn't pre-create this path, so SQLite raises `OperationalError: unable to open database file`.

**Fix:** Added `_ensure_db_dir()` in `auth_db.get_engine()` that calls `Path(db_path).parent.mkdir(parents=True, exist_ok=True)` before passing the path to SQLAlchemy. Since `db_path` comes from trusted configuration (`ApiSettings.auth_db_path`), not user input, added a `# codeql[py/path-injection]` suppression comment and an entry in `tests/ci/test_path_security_contract.py`'s `_ALLOWED_PATH_SNIPPETS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file-based database setup so required folders are created automatically before use.
  * Fixed test coverage for default path behavior in the TUI, helping ensure expected path handling remains stable.

* **Tests**
  * Expanded path-safety checks to allow the newly supported database directory creation behavior.
  * Added a test marker to verify default `.` path behavior where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->