### PR TITLE
Tech debt: remediate test-hardcoded-paths CI rail (closes #1367)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
       # Use tmp_path fixture in tests; ConfigManager in source.
       # Note: expanduser() is intentionally allowed — it is the correct
       # way to resolve home-directory paths throughout the codebase.
-      # Only checks added lines that are not pure comments.
+      # Only checks added lines that are not pure comments or have noqa exemption.
       # ----------------------------------------------------------------
       - id: no-absolute-paths
         name: no absolute paths in Python files (G1)
         entry: >
-          bash -c "git diff --cached -- '*.py' | grep -E '^\+.*(/tmp/|/Users/|/home/)' | grep -v '^+++' | grep -vE '^\+\s*#' && echo 'ERROR: hardcoded path in Python — use tmp_path fixture or ConfigManager' && exit 1 || exit 0"
+          bash -c "git diff --cached -- '*.py' | grep -E '^\+.*(/tmp/|/Users/|/home/)' | grep -v '^+++' | grep -vE '^\+\s*#' | grep -v 'noqa: test-hardcoded-paths' && echo 'ERROR: hardcoded path in Python — use tmp_path fixture or ConfigManager' && exit 1 || exit 0"
         language: system
         pass_filenames: false
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,7 @@ are **enforced**; rails with pre-existing violation backlogs remain
 | `atomic-write` | Raw file-write operations bypassing `atomic_write()` | enforced |
 | `cli-path-validation` | A CLI command's `Path` parameter not wrapped in `resolve_cli_path()` | enforced |
 | `defusedxml-fallback` | Importing from stdlib `xml` instead of `defusedxml` | enforced |
-| `test-hardcoded-paths` | Hardcoded absolute paths in tests (use `tmp_path`) | advisory |
+| `test-hardcoded-paths` | Hardcoded absolute paths in tests (use `tmp_path`) | enforced |
 | `test-separator-paths` | Hardcoded path separators in `Path(...)` calls in tests | advisory |
 | `pytest-raises-hygiene` | `pytest.raises()` without a `match=` regex on a generic/built-in exception | advisory |
 | `safedir-valueerror` | A broad `except Exception`/bare `except` around a `SafeDir` call that doesn't re-raise or catch `ValueError` explicitly | enforced |
@@ -95,12 +95,11 @@ Supply-chain scanning (run in `.github/workflows/security.yml`):
   ratchet baseline (see `pyproject.toml`, "WP-6.4 ratchet baseline").
   New files get full enforcement; the 41 existing ones are fixed
   incrementally — remove an entry as its file is cleaned up.
-- **Three lint rails above are still advisory.** The remaining advisory
-  rails (`test-hardcoded-paths`, `test-separator-paths`, and
-  `pytest-raises-hygiene`) each have pre-existing violations that
-  predate enforcement. Flipping a rail to `enforce` requires first
-  reducing its violation count to zero (or to an explicitly
-  accepted/`noqa`-tagged remainder).
+- **Two lint rails above are still advisory.** The remaining advisory
+  rails (`test-separator-paths` and `pytest-raises-hygiene`) each have
+  pre-existing violations that predate enforcement. Flipping a rail to
+  `enforce` requires first reducing its violation count to zero (or to an
+  explicitly accepted/`noqa`-tagged remainder).
 
 ## Reporting a Vulnerability
 

--- a/scripts/ci/guardrails/check_test_hardcoded_paths.py
+++ b/scripts/ci/guardrails/check_test_hardcoded_paths.py
@@ -40,7 +40,7 @@ class TestHardcodedPathVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support targeted noqa override only (bare # noqa does not suppress)
+            # Support targeted override only (requires specific code like noqa: test-hardcoded-paths)
             if "noqa: test-hardcoded-paths" in line_content:
                 return
             self.violations.append((lineno, message, line_content.strip()))

--- a/scripts/ci/guardrails/check_test_hardcoded_paths.py
+++ b/scripts/ci/guardrails/check_test_hardcoded_paths.py
@@ -40,8 +40,8 @@ class TestHardcodedPathVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support noqa override
-            if "noqa: test-hardcoded-paths" in line_content or "noqa" in line_content:
+            # Support targeted noqa override only (bare # noqa does not suppress)
+            if "noqa: test-hardcoded-paths" in line_content:
                 return
             self.violations.append((lineno, message, line_content.strip()))
 

--- a/scripts/ci/guardrails/check_test_hardcoded_paths.py
+++ b/scripts/ci/guardrails/check_test_hardcoded_paths.py
@@ -41,8 +41,11 @@ class TestHardcodedPathVisitor(ast.NodeVisitor):
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
             # Support targeted override only (requires specific code like noqa: test-hardcoded-paths)
-            if "noqa: test-hardcoded-paths" in line_content:
-                return
+            # Extract only the comment part (after #) to avoid false positives from string literals
+            if "#" in line_content:
+                comment = line_content.split("#", 1)[1]
+                if "noqa: test-hardcoded-paths" in comment:
+                    return
             self.violations.append((lineno, message, line_content.strip()))
 
 

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -39,7 +39,7 @@ description = "Enforces using defusedxml instead of standard library xml (WP-6.1
 [[rail]]
 name = "test-hardcoded-paths"
 command = ["python", "scripts/ci/guardrails/check_test_hardcoded_paths.py"]
-mode = "advisory"
+mode = "enforce"
 description = "Flags hardcoded absolute system paths in tests, promoting tmp_path instead (WP-6.2)."
 
 [[rail]]

--- a/tests/api/test_analyze_router.py
+++ b/tests/api/test_analyze_router.py
@@ -23,7 +23,7 @@ def _build_app() -> tuple[FastAPI, TestClient]:
     settings = ApiSettings(
         environment="test",
         auth_enabled=False,
-        allowed_paths=["/tmp"],
+        allowed_paths=["/tmp"],  # noqa: test-hardcoded-paths
         auth_jwt_secret="test-secret",
         rate_limit_enabled=False,
     )

--- a/tests/api/test_api_server_config.py
+++ b/tests/api/test_api_server_config.py
@@ -209,7 +209,7 @@ class TestLoadSettings:
     def test_env_allowed_paths(self, monkeypatch):
         monkeypatch.setenv("FO_API_ALLOWED_PATHS", "/tmp,/home")
         settings = load_settings()
-        assert settings.allowed_paths == ["/tmp", "/home"]
+        assert settings.allowed_paths == ["/tmp", "/home"]  # noqa: test-hardcoded-paths
 
     def test_env_ws_ping_interval_valid(self, monkeypatch):
         monkeypatch.setenv("FO_API_WS_PING_INTERVAL", "15")
@@ -237,9 +237,9 @@ class TestLoadSettings:
         assert settings.auth_enabled is False
 
     def test_env_auth_db_path(self, monkeypatch):
-        monkeypatch.setenv("FO_API_AUTH_DB_PATH", "/tmp/auth.db")
+        monkeypatch.setenv("FO_API_AUTH_DB_PATH", "/tmp/auth.db")  # noqa: test-hardcoded-paths
         settings = load_settings()
-        assert settings.auth_db_path == "/tmp/auth.db"
+        assert settings.auth_db_path == "/tmp/auth.db"  # noqa: test-hardcoded-paths
 
     def test_env_auth_jwt_secret(self, monkeypatch):
         monkeypatch.setenv("FO_API_AUTH_JWT_SECRET", "my-secret-key")
@@ -531,7 +531,7 @@ class TestLoadSettings:
         assert settings.port == 7777
 
     def test_yaml_config_missing_path(self, monkeypatch):
-        monkeypatch.setenv("FO_API_CONFIG_PATH", "/tmp/nonexistent_config_12345.yaml")
+        monkeypatch.setenv("FO_API_CONFIG_PATH", "/tmp/nonexistent_config_12345.yaml")  # noqa: test-hardcoded-paths
         settings = load_settings()
         # Should fall back to defaults
         assert settings.app_name == "File Organizer API"

--- a/tests/api/test_api_utils_coverage.py
+++ b/tests/api/test_api_utils_coverage.py
@@ -19,17 +19,17 @@ class TestResolvePath:
 
     def test_no_allowed_paths(self) -> None:
         with pytest.raises(ApiError) as exc_info:
-            resolve_path("/tmp/test", allowed_paths=None)
+            resolve_path("/tmp/test", allowed_paths=None)  # noqa: test-hardcoded-paths
         assert exc_info.value.status_code == 403
 
     def test_empty_allowed_paths(self) -> None:
         with pytest.raises(ApiError) as exc_info:
-            resolve_path("/tmp/test", allowed_paths=[])
+            resolve_path("/tmp/test", allowed_paths=[])  # noqa: test-hardcoded-paths
         assert exc_info.value.status_code == 403
 
     def test_path_outside_roots(self, tmp_path: Path) -> None:
         with pytest.raises(ApiError) as exc_info:
-            resolve_path("/etc/passwd", allowed_paths=[str(tmp_path)])
+            resolve_path("/etc/passwd", allowed_paths=[str(tmp_path)])  # noqa: test-hardcoded-paths
         assert exc_info.value.status_code == 403
 
     def test_path_inside_root(self, tmp_path: Path) -> None:
@@ -44,7 +44,7 @@ class TestResolvePath:
             patch("os.path.commonpath", side_effect=ValueError("different drives")),
             pytest.raises(ApiError) as exc_info,
         ):
-            resolve_path("/tmp/test", allowed_paths=["/other/path"])
+            resolve_path("/tmp/test", allowed_paths=["/other/path"])  # noqa: test-hardcoded-paths
         assert exc_info.value.status_code == 403
 
 
@@ -52,13 +52,13 @@ class TestIsHidden:
     """Covers is_hidden."""
 
     def test_hidden_file(self) -> None:
-        assert is_hidden(Path("/home/user/.config"))
+        assert is_hidden(Path("/home/user/.config"))  # noqa: test-hardcoded-paths
 
     def test_non_hidden_file(self) -> None:
-        assert not is_hidden(Path("/home/user/documents/file.txt"))
+        assert not is_hidden(Path("/home/user/documents/file.txt"))  # noqa: test-hardcoded-paths
 
     def test_hidden_parent(self) -> None:
-        assert is_hidden(Path("/home/user/.hidden/file.txt"))
+        assert is_hidden(Path("/home/user/.hidden/file.txt"))  # noqa: test-hardcoded-paths
 
 
 class TestFileInfoFromPath:

--- a/tests/api/test_database.py
+++ b/tests/api/test_database.py
@@ -41,7 +41,7 @@ class TestResolveDatabaseUrl:
         assert result == "sqlite+pysqlite:///data/app.db"
 
     def test_absolute_path(self):
-        result = resolve_database_url("/tmp/app.db")
+        result = resolve_database_url("/tmp/app.db")  # noqa: test-hardcoded-paths
         assert result == "sqlite+pysqlite:////tmp/app.db"
 
     def test_backslash_normalized(self):

--- a/tests/api/test_db_models.py
+++ b/tests/api/test_db_models.py
@@ -46,11 +46,11 @@ class TestWorkspaceModel:
             id="ws-1",
             name="Test",
             owner_id="user-1",
-            root_path="/tmp/test",
+            root_path="/tmp/test",  # noqa: test-hardcoded-paths
         )
         assert ws.name == "Test"
         assert ws.owner_id == "user-1"
-        assert ws.root_path == "/tmp/test"
+        assert ws.root_path == "/tmp/test"  # noqa: test-hardcoded-paths
         assert ws.description is None
 
     def test_repr(self):

--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -211,16 +211,16 @@ class TestPreviewDuplicates:
             hash_value="abc123",
             files=[
                 DedupeFileInfo(
-                    path="/tmp/z-last.txt",
+                    path="/tmp/z-last.txt",  # noqa: test-hardcoded-paths
                     size=100,
                     modified=same_time,
-                    accessed=same_time,  # noqa: test-hardcoded-paths
+                    accessed=same_time,
                 ),
                 DedupeFileInfo(
-                    path="/tmp/a-first.txt",
+                    path="/tmp/a-first.txt",  # noqa: test-hardcoded-paths
                     size=100,
                     modified=same_time,
-                    accessed=same_time,  # noqa: test-hardcoded-paths
+                    accessed=same_time,
                 ),
             ],
             total_size=200,

--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -211,10 +211,16 @@ class TestPreviewDuplicates:
             hash_value="abc123",
             files=[
                 DedupeFileInfo(
-                    path="/tmp/z-last.txt", size=100, modified=same_time, accessed=same_time  # noqa: test-hardcoded-paths
+                    path="/tmp/z-last.txt",
+                    size=100,
+                    modified=same_time,
+                    accessed=same_time,  # noqa: test-hardcoded-paths
                 ),
                 DedupeFileInfo(
-                    path="/tmp/a-first.txt", size=100, modified=same_time, accessed=same_time  # noqa: test-hardcoded-paths
+                    path="/tmp/a-first.txt",
+                    size=100,
+                    modified=same_time,
+                    accessed=same_time,  # noqa: test-hardcoded-paths
                 ),
             ],
             total_size=200,

--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -58,14 +58,14 @@ def _make_mock_index(groups: dict | None = None, stats: dict | None = None):
         # Default: one group with 2 duplicate files
         now = datetime(2025, 1, 1, tzinfo=UTC)
         fm1 = FileMetadata(
-            path=Path("/tmp/a.txt"),
+            path=Path("/tmp/a.txt"),  # noqa: test-hardcoded-paths
             size=100,
             modified_time=now,
             accessed_time=now,
             hash_value="abc123",
         )
         fm2 = FileMetadata(
-            path=Path("/tmp/b.txt"),
+            path=Path("/tmp/b.txt"),  # noqa: test-hardcoded-paths
             size=100,
             modified_time=now,
             accessed_time=now,
@@ -193,8 +193,8 @@ class TestPreviewDuplicates:
         group = DedupeGroup(
             hash_value="abc123",
             files=[
-                DedupeFileInfo(path="/tmp/newer.txt", size=100, modified=newer, accessed=newer),
-                DedupeFileInfo(path="/tmp/older.txt", size=100, modified=older, accessed=older),
+                DedupeFileInfo(path="/tmp/newer.txt", size=100, modified=newer, accessed=newer),  # noqa: test-hardcoded-paths
+                DedupeFileInfo(path="/tmp/older.txt", size=100, modified=older, accessed=older),  # noqa: test-hardcoded-paths
             ],
             total_size=200,
             wasted_space=100,
@@ -202,8 +202,8 @@ class TestPreviewDuplicates:
 
         preview = _preview([group])
 
-        assert preview[0].keep == "/tmp/older.txt"
-        assert preview[0].remove == ["/tmp/newer.txt"]
+        assert preview[0].keep == "/tmp/older.txt"  # noqa: test-hardcoded-paths
+        assert preview[0].remove == ["/tmp/newer.txt"]  # noqa: test-hardcoded-paths
 
     def test_preview_breaks_equal_mtime_ties_by_path(self) -> None:
         same_time = datetime(2024, 1, 1, tzinfo=UTC)
@@ -211,10 +211,10 @@ class TestPreviewDuplicates:
             hash_value="abc123",
             files=[
                 DedupeFileInfo(
-                    path="/tmp/z-last.txt", size=100, modified=same_time, accessed=same_time
+                    path="/tmp/z-last.txt", size=100, modified=same_time, accessed=same_time  # noqa: test-hardcoded-paths
                 ),
                 DedupeFileInfo(
-                    path="/tmp/a-first.txt", size=100, modified=same_time, accessed=same_time
+                    path="/tmp/a-first.txt", size=100, modified=same_time, accessed=same_time  # noqa: test-hardcoded-paths
                 ),
             ],
             total_size=200,
@@ -223,8 +223,8 @@ class TestPreviewDuplicates:
 
         preview = _preview([group])
 
-        assert preview[0].keep == "/tmp/a-first.txt"
-        assert preview[0].remove == ["/tmp/z-last.txt"]
+        assert preview[0].keep == "/tmp/a-first.txt"  # noqa: test-hardcoded-paths
+        assert preview[0].remove == ["/tmp/z-last.txt"]  # noqa: test-hardcoded-paths
 
     @patch("file_organizer.api.routers.dedupe.DuplicateDetector")
     def test_preview_success(self, mock_detector_cls, tmp_path: Path) -> None:

--- a/tests/api/test_integrations_router.py
+++ b/tests/api/test_integrations_router.py
@@ -167,7 +167,7 @@ class TestUpdateIntegrationSettings:
         mock_manager.get.return_value = MagicMock()
 
         # Path outside allowed_paths should be rejected
-        payload = {"settings": {"vault_path": "/etc/passwd"}}
+        payload = {"settings": {"vault_path": "/etc/passwd"}}  # noqa: test-hardcoded-paths
 
         _, client = _build_app(tmp_path, mock_integration_manager=mock_manager)
         resp = client.post("/api/v1/integrations/obsidian/settings", json=payload)
@@ -302,7 +302,7 @@ class TestSendFileToIntegration:
         mock_manager = MagicMock()
         mock_manager.get.return_value = MagicMock()
 
-        payload = {"path": "/etc/passwd", "metadata": {}}
+        payload = {"path": "/etc/passwd", "metadata": {}}  # noqa: test-hardcoded-paths
 
         _, client = _build_app(tmp_path, mock_integration_manager=mock_manager)
         resp = client.post("/api/v1/integrations/obsidian/send", json=payload)
@@ -468,7 +468,7 @@ class TestSubdirValidation:
     @pytest.mark.parametrize(
         "subdir_val",
         [
-            "/tmp/outside",
+            "/tmp/outside",  # noqa: test-hardcoded-paths
             "../outside",
             "a//b",
             "a\\\\b",

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -109,7 +109,7 @@ class TestResolvePath:
         allowed = tmp_path / "allowed"
         allowed.mkdir()
         with pytest.raises(ApiError) as exc_info:
-            resolve_path(r"C:\Windows\System32", allowed_paths=[str(allowed)])
+            resolve_path(r"C:\Windows\System32", allowed_paths=[str(allowed)])  # noqa: test-hardcoded-paths
         assert exc_info.value.status_code == 403
         assert exc_info.value.error == "path_not_allowed"
 

--- a/tests/api/test_workspace_repo.py
+++ b/tests/api/test_workspace_repo.py
@@ -19,7 +19,7 @@ class TestWorkspaceRepositoryCreate:
     def test_create_minimal(self):
         session = MagicMock(spec=Session)
 
-        WorkspaceRepository.create(session, "My Workspace", "user-1", "/home/user/docs")
+        WorkspaceRepository.create(session, "My Workspace", "user-1", "/home/user/docs")  # noqa: test-hardcoded-paths
 
         session.add.assert_called_once()
         session.flush.assert_called_once()
@@ -27,7 +27,7 @@ class TestWorkspaceRepositoryCreate:
         assert isinstance(added, Workspace)
         assert added.name == "My Workspace"
         assert added.owner_id == "user-1"
-        assert added.root_path == "/home/user/docs"
+        assert added.root_path == "/home/user/docs"  # noqa: test-hardcoded-paths
         assert added.description is None
 
     def test_create_with_description(self):

--- a/tests/ci/test_check_test_hardcoded_paths.py
+++ b/tests/ci/test_check_test_hardcoded_paths.py
@@ -1,0 +1,126 @@
+"""Tests for the WP-6.2 test-hardcoded-paths CI rail."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.guardrails import check_test_hardcoded_paths as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def test_flags_unix_home_path(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text('path = Path("/home/user/documents")\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "/home/user/documents" in violations[0][1]  # noqa: test-hardcoded-paths
+
+
+def test_flags_tmp_path_literal(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text('result = do_thing(Path("/tmp/test.txt"))\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "/tmp/test.txt" in violations[0][1]  # noqa: test-hardcoded-paths
+
+
+def test_flags_users_path(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text('assert result == "/Users/someone/Documents"\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "/Users/someone/Documents" in violations[0][1]  # noqa: test-hardcoded-paths
+
+
+def test_flags_windows_absolute_path(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text('path = Path("C:\\\\Users\\\\test\\\\file.txt")\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "C:\\" in violations[0][1]  # noqa: test-hardcoded-paths
+
+
+def test_flags_etc_path(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text('assert is_hidden(Path("/etc/passwd"))\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "exempt.py"
+    src.write_text(
+        'path = Path("/home/user/docs")  # noqa: test-hardcoded-paths\n', encoding="utf-8"
+    )
+    assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text('path = Path("/home/user/docs")  # noqa\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_unrelated_noqa_code_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "other.py"
+    src.write_text('path = Path("/home/user/docs")  # noqa: E501\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_relative_path_not_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "ok.py"
+    src.write_text('path = Path("relative/path/to/file.txt")\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_url_like_path_not_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "ok.py"
+    src.write_text('url = "/api/v1/users"\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_non_path_root_not_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "ok.py"
+    src.write_text('url = "/some/relative-ish/path"\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_multiple_violations_reported(tmp_path: Path) -> None:
+    src = tmp_path / "multi.py"
+    src.write_text(
+        'a = Path("/tmp/a.txt")\nb = Path("/home/user/b.txt")\n', encoding="utf-8"
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 2
+
+
+def test_multiple_violations_one_suppressed(tmp_path: Path) -> None:
+    src = tmp_path / "mixed.py"
+    src.write_text(
+        'a = Path("/tmp/a.txt")  # noqa: test-hardcoded-paths\nb = Path("/home/user/b.txt")\n',
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "/home/user/b.txt" in violations[0][1]  # noqa: test-hardcoded-paths
+
+
+def test_syntax_error_returns_empty(tmp_path: Path) -> None:
+    src = tmp_path / "broken.py"
+    src.write_text("def bad_syntax(:\n", encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_check_file_returns_line_number(tmp_path: Path) -> None:
+    src = tmp_path / "lineno.py"
+    src.write_text('x = 1\ny = Path("/tmp/foo.txt")\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    lineno, msg, line = violations[0]
+    assert lineno == 2
+    assert "/tmp/foo.txt" in msg  # noqa: test-hardcoded-paths

--- a/tests/ci/test_check_test_hardcoded_paths.py
+++ b/tests/ci/test_check_test_hardcoded_paths.py
@@ -50,6 +50,18 @@ def test_flags_etc_path(tmp_path: Path) -> None:
     assert len(violations) == 1
 
 
+def test_string_literal_noqa_directive_does_not_suppress(tmp_path: Path) -> None:
+    """Verify that 'noqa: test-hardcoded-paths' inside string literal doesn't suppress violation."""
+    src = tmp_path / "string_literal_false_positive.py"
+    src.write_text(  # noqa: test-hardcoded-paths
+        'msg = "some text with noqa: test-hardcoded-paths in it"\npath = Path("/tmp/test")\n',
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "/tmp/test" in violations[0][1]  # noqa: test-hardcoded-paths
+
+
 def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
     src = tmp_path / "exempt.py"
     src.write_text(

--- a/tests/ci/test_check_test_hardcoded_paths.py
+++ b/tests/ci/test_check_test_hardcoded_paths.py
@@ -92,9 +92,7 @@ def test_non_path_root_not_flagged(tmp_path: Path) -> None:
 
 def test_multiple_violations_reported(tmp_path: Path) -> None:
     src = tmp_path / "multi.py"
-    src.write_text(
-        'a = Path("/tmp/a.txt")\nb = Path("/home/user/b.txt")\n', encoding="utf-8"
-    )
+    src.write_text('a = Path("/tmp/a.txt")\nb = Path("/home/user/b.txt")\n', encoding="utf-8")
     violations = checker.check_file(src)
     assert len(violations) == 2
 

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -135,7 +135,7 @@ def test_repo_registry_loads_registered_rails() -> None:
         "atomic-write": "enforce",
         "cli-path-validation": "enforce",
         "defusedxml-fallback": "enforce",
-        "test-hardcoded-paths": "advisory",
+        "test-hardcoded-paths": "enforce",
         "test-separator-paths": "advisory",
         "pytest-raises-hygiene": "advisory",
         "safedir-valueerror": "enforce",

--- a/tests/ci/test_docker_config.py
+++ b/tests/ci/test_docker_config.py
@@ -87,7 +87,7 @@ class TestDockerfileStructure:
 
     def test_dockerfile_installs_to_opt_venv(self, dockerfile_content: str) -> None:
         """Verify dependencies are installed into /opt/venv."""
-        assert "/opt/venv" in dockerfile_content, "Dependencies should be installed to /opt/venv"
+        assert "/opt/venv" in dockerfile_content, "Dependencies should be installed to /opt/venv"  # noqa: test-hardcoded-paths
 
     def test_dockerfile_runtime_installs_ffmpeg(self, dockerfile_content: str) -> None:
         """Verify runtime stage installs ffmpeg."""

--- a/tests/ci/test_pr92_review_fixes.py
+++ b/tests/ci/test_pr92_review_fixes.py
@@ -104,7 +104,7 @@ class TestPARAKeywordMatching:
     def test_evaluate_with_word_boundaries(self):
         """Test full evaluate() uses word boundary matching."""
         # Path with "projection" should not match "project" keyword
-        test_path = Path("/home/user/projection_analysis/data.txt")
+        test_path = Path("/home/user/projection_analysis/data.txt")  # noqa: test-hardcoded-paths
 
         result = self.heuristic.evaluate(test_path)
 
@@ -126,14 +126,14 @@ class TestTemporalHeuristicOldYearDetection:
     def test_contains_old_year_detects_old_paths(self):
         """Test _contains_old_year() detects old years."""
         old_year = self.current_year - 4  # 4 years ago
-        path_str = f"/home/user/Projects/{old_year}/report.pdf"
+        path_str = f"/home/user/Projects/{old_year}/report.pdf"  # noqa: test-hardcoded-paths
 
         result = self.heuristic._contains_old_year(path_str, self.current_year)
         assert result is True
 
     def test_contains_old_year_doesnt_flag_current_year(self):
         """Test _contains_old_year() doesn't flag current year."""
-        path_str = f"/home/user/Projects/{self.current_year}/report.pdf"
+        path_str = f"/home/user/Projects/{self.current_year}/report.pdf"  # noqa: test-hardcoded-paths
 
         result = self.heuristic._contains_old_year(path_str, self.current_year)
         assert result is False
@@ -141,7 +141,7 @@ class TestTemporalHeuristicOldYearDetection:
     def test_contains_old_year_doesnt_flag_recent_years(self):
         """Test _contains_old_year() doesn't flag recent years."""
         recent_year = self.current_year - 2  # Within 3-year threshold
-        path_str = f"/home/user/Projects/{recent_year}/report.pdf"
+        path_str = f"/home/user/Projects/{recent_year}/report.pdf"  # noqa: test-hardcoded-paths
 
         result = self.heuristic._contains_old_year(path_str, self.current_year)
         assert result is False
@@ -149,7 +149,7 @@ class TestTemporalHeuristicOldYearDetection:
     def test_contains_old_year_respects_threshold(self):
         """Test _contains_old_year() respects threshold parameter."""
         year_5_ago = self.current_year - 5
-        path_str = f"/home/user/Projects/{year_5_ago}/report.pdf"
+        path_str = f"/home/user/Projects/{year_5_ago}/report.pdf"  # noqa: test-hardcoded-paths
 
         # With threshold=3, 5 years ago is old
         assert (
@@ -167,7 +167,7 @@ class TestTemporalHeuristicOldYearDetection:
         """Test _contains_old_year() uses word boundaries."""
         # Year embedded in larger number should not match
         old_year = self.current_year - 4
-        path_with_embedded_year = f"/home/user/file{old_year}123.txt"
+        path_with_embedded_year = f"/home/user/file{old_year}123.txt"  # noqa: test-hardcoded-paths
 
         result = self.heuristic._contains_old_year(path_with_embedded_year, self.current_year)
 

--- a/tests/cli/test_cli_api_coverage.py
+++ b/tests/cli/test_cli_api_coverage.py
@@ -104,7 +104,7 @@ class TestApiFiles:
         with patch("file_organizer.cli.api._build_client", return_value=(client, err_cls)):
             result = runner.invoke(
                 api_app,
-                ["files", "/tmp", "--token", "fake-token"],
+                ["files", "/tmp", "--token", "fake-token"],  # noqa: test-hardcoded-paths
             )
 
         assert result.exit_code == 1

--- a/tests/cli/test_cli_autotag.py
+++ b/tests/cli/test_cli_autotag.py
@@ -138,7 +138,11 @@ class TestHandleAutotagCommand:
 
     def test_route_batch(self, mock_service):
         args = Namespace(
-            autotag_command="batch", directory="/tmp", pattern="*", recursive=False, output=None  # noqa: test-hardcoded-paths
+            autotag_command="batch",
+            directory="/tmp",
+            pattern="*",
+            recursive=False,
+            output=None,  # noqa: test-hardcoded-paths
         )
         with patch("file_organizer.cli.autotag.AutoTaggingService", return_value=mock_service):
             with patch("file_organizer.cli.autotag.handle_batch") as mock_handler:

--- a/tests/cli/test_cli_autotag.py
+++ b/tests/cli/test_cli_autotag.py
@@ -138,7 +138,7 @@ class TestHandleAutotagCommand:
 
     def test_route_batch(self, mock_service):
         args = Namespace(
-            autotag_command="batch", directory="/tmp", pattern="*", recursive=False, output=None
+            autotag_command="batch", directory="/tmp", pattern="*", recursive=False, output=None  # noqa: test-hardcoded-paths
         )
         with patch("file_organizer.cli.autotag.AutoTaggingService", return_value=mock_service):
             with patch("file_organizer.cli.autotag.handle_batch") as mock_handler:

--- a/tests/cli/test_cli_autotag.py
+++ b/tests/cli/test_cli_autotag.py
@@ -139,10 +139,10 @@ class TestHandleAutotagCommand:
     def test_route_batch(self, mock_service):
         args = Namespace(
             autotag_command="batch",
-            directory="/tmp",
+            directory="/tmp",  # noqa: test-hardcoded-paths
             pattern="*",
             recursive=False,
-            output=None,  # noqa: test-hardcoded-paths
+            output=None,
         )
         with patch("file_organizer.cli.autotag.AutoTaggingService", return_value=mock_service):
             with patch("file_organizer.cli.autotag.handle_batch") as mock_handler:

--- a/tests/cli/test_cli_dedupe.py
+++ b/tests/cli/test_cli_dedupe.py
@@ -800,7 +800,7 @@ class TestDedupeCommandDuplicates:
         mock_detector.get_duplicate_groups.return_value = {"hash1": grp}
 
         mock_bkp = MagicMock()
-        mock_bkp.create_backup.return_value = Path("/tmp/backup")
+        mock_bkp.create_backup.return_value = Path("/tmp/backup")  # noqa: test-hardcoded-paths
 
         with (
             patch(_DETECTOR_PATH, return_value=mock_detector),
@@ -828,7 +828,7 @@ class TestDedupeCommandDuplicates:
         # Make the second file's path a MagicMock so unlink() raises
         grp.files[1].path = MagicMock()
         grp.files[1].path.unlink.side_effect = PermissionError("denied")
-        grp.files[1].path.__str__ = lambda self: "/tmp/b.txt"
+        grp.files[1].path.__str__ = lambda self: "/tmp/b.txt"  # noqa: test-hardcoded-paths
 
         mock_detector = MagicMock()
         mock_detector.scan_directory.return_value = None

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -462,7 +462,7 @@ class TestRulesPreview:
         mock_mgr.load_rule_set.return_value = rs
 
         with patch(_RULE_MGR_PATH, return_value=mock_mgr):
-            result = runner.invoke(rules_app, ["preview", "/tmp"])
+            result = runner.invoke(rules_app, ["preview", "/tmp"])  # noqa: test-hardcoded-paths
         assert result.exit_code == 0
         assert "No enabled rules" in result.output
 

--- a/tests/cli/test_cli_suggest.py
+++ b/tests/cli/test_cli_suggest.py
@@ -33,8 +33,8 @@ def mock_engine_with_suggestions():
     suggestion = MagicMock()
     suggestion.suggestion_id = "s1"
     suggestion.suggestion_type = _MockSuggestionType.MOVE
-    suggestion.file_path = Path("/tmp/doc.txt")
-    suggestion.target_path = Path("/tmp/Documents/doc.txt")
+    suggestion.file_path = Path("/tmp/doc.txt")  # noqa: test-hardcoded-paths
+    suggestion.target_path = Path("/tmp/Documents/doc.txt")  # noqa: test-hardcoded-paths
     suggestion.confidence = 75.0
     suggestion.reasoning = "Matches document pattern"
     suggestion.new_name = None

--- a/tests/cli/test_entrypoints_consolidation.py
+++ b/tests/cli/test_entrypoints_consolidation.py
@@ -116,7 +116,7 @@ class TestDocsSubcommand:
         self, mock_shutil_which: MagicMock, tmp_path: Path
     ) -> None:
         """Verify fo docs fails gracefully if mkdocs.yml is not found."""
-        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"  # noqa: test-hardcoded-paths
 
         # Run from a temporary directory without mkdocs.yml
         with patch("pathlib.Path.exists", return_value=False):
@@ -128,7 +128,7 @@ class TestDocsSubcommand:
         self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
     ) -> None:
         """Verify fo docs --build compiles documentation to HTML."""
-        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"  # noqa: test-hardcoded-paths
 
         # Mock mkdocs.yml presence check
         with patch("pathlib.Path.exists", return_value=True):
@@ -139,13 +139,13 @@ class TestDocsSubcommand:
 
             mock_subprocess_run.assert_called_once()
             args = mock_subprocess_run.call_args[0][0]
-            assert args == ["/usr/local/bin/mkdocs", "build"]
+            assert args == ["/usr/local/bin/mkdocs", "build"]  # noqa: test-hardcoded-paths
 
     def test_docs_command_build_error(
         self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
     ) -> None:
         """Verify fo docs --build handles compilation failure cleanly."""
-        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"  # noqa: test-hardcoded-paths
         mock_subprocess_run.return_value.returncode = 1
 
         with patch("pathlib.Path.exists", return_value=True):
@@ -157,7 +157,7 @@ class TestDocsSubcommand:
         self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
     ) -> None:
         """Verify fo docs serves documentation with default options."""
-        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"  # noqa: test-hardcoded-paths
 
         with patch("pathlib.Path.exists", return_value=True):
             result = runner.invoke(app, ["docs", "--host", "0.0.0.0", "--port", "9000"])
@@ -166,13 +166,13 @@ class TestDocsSubcommand:
 
             mock_subprocess_run.assert_called_once()
             args = mock_subprocess_run.call_args[0][0]
-            assert args == ["/usr/local/bin/mkdocs", "serve", "--dev-addr", "0.0.0.0:9000"]
+            assert args == ["/usr/local/bin/mkdocs", "serve", "--dev-addr", "0.0.0.0:9000"]  # noqa: test-hardcoded-paths
 
     def test_docs_command_serve_error(
         self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
     ) -> None:
         """Verify fo docs reports an error when the serve process exits non-zero."""
-        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"  # noqa: test-hardcoded-paths
         mock_subprocess_run.return_value.returncode = 1
 
         with patch("pathlib.Path.exists", return_value=True):
@@ -184,7 +184,7 @@ class TestDocsSubcommand:
         self, mock_shutil_which: MagicMock, mock_subprocess_run: MagicMock
     ) -> None:
         """Verify fo docs exits cleanly when the serve process is interrupted."""
-        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"
+        mock_shutil_which.return_value = "/usr/local/bin/mkdocs"  # noqa: test-hardcoded-paths
         mock_subprocess_run.side_effect = KeyboardInterrupt
 
         with patch("pathlib.Path.exists", return_value=True):

--- a/tests/client/test_async_client_coverage.py
+++ b/tests/client/test_async_client_coverage.py
@@ -371,31 +371,31 @@ class TestAsyncClientDedupe:
     async def test_dedupe_scan(self):
         """Test dedupe scan."""
         client = AsyncFileOrganizerClient()
-        resp = _ok({"path": "/tmp", "duplicates": [], "stats": {"total": 0}})
+        resp = _ok({"path": "/tmp", "duplicates": [], "stats": {"total": 0}})  # noqa: test-hardcoded-paths
         client._client = AsyncMock()
         client._client.post = AsyncMock(return_value=resp)
 
-        result = await client.dedupe_scan("/tmp", max_file_size=1000)
-        assert result.path == "/tmp"
+        result = await client.dedupe_scan("/tmp", max_file_size=1000)  # noqa: test-hardcoded-paths
+        assert result.path == "/tmp"  # noqa: test-hardcoded-paths
 
     async def test_dedupe_preview(self):
         """Test dedupe preview."""
         client = AsyncFileOrganizerClient()
-        resp = _ok({"path": "/tmp", "preview": [], "stats": {"total": 0}})
+        resp = _ok({"path": "/tmp", "preview": [], "stats": {"total": 0}})  # noqa: test-hardcoded-paths
         client._client = AsyncMock()
         client._client.post = AsyncMock(return_value=resp)
 
-        result = await client.dedupe_preview("/tmp")
-        assert result.path == "/tmp"
+        result = await client.dedupe_preview("/tmp")  # noqa: test-hardcoded-paths
+        assert result.path == "/tmp"  # noqa: test-hardcoded-paths
 
     async def test_dedupe_execute(self):
         """Test dedupe execute."""
         client = AsyncFileOrganizerClient()
-        resp = _ok({"path": "/tmp", "removed": [], "dry_run": True, "stats": {"total": 0}})
+        resp = _ok({"path": "/tmp", "removed": [], "dry_run": True, "stats": {"total": 0}})  # noqa: test-hardcoded-paths
         client._client = AsyncMock()
         client._client.post = AsyncMock(return_value=resp)
 
-        result = await client.dedupe_execute("/tmp")
+        result = await client.dedupe_execute("/tmp")  # noqa: test-hardcoded-paths
         assert result.dry_run is True
 
 

--- a/tests/client/test_client_coverage.py
+++ b/tests/client/test_client_coverage.py
@@ -215,7 +215,7 @@ class TestSyncClientFiles:
         resp = _mock_response(200, {"items": [], "total": 0, "skip": 0, "limit": 100})
         client._client.get = MagicMock(return_value=resp)
 
-        result = client.list_files("/tmp", file_type="pdf")
+        result = client.list_files("/tmp", file_type="pdf")  # noqa: test-hardcoded-paths
         assert hasattr(result, "items")
         client.close()
 

--- a/tests/client/test_client_models.py
+++ b/tests/client/test_client_models.py
@@ -38,7 +38,7 @@ _NOW_STR = "2026-01-15T10:30:00Z"
 def _file_info_data(**overrides):
     """Return a minimal valid dict for FileInfo."""
     base = {
-        "path": "/tmp/test.txt",
+        "path": "/tmp/test.txt",  # noqa: test-hardcoded-paths
         "name": "test.txt",
         "size": 1024,
         "created": _NOW_STR,
@@ -111,7 +111,7 @@ class TestHealthResponse:
 class TestFileInfo:
     def test_valid_construction(self):
         fi = FileInfo(**_file_info_data())
-        assert fi.path == "/tmp/test.txt"
+        assert fi.path == "/tmp/test.txt"  # noqa: test-hardcoded-paths
         assert fi.name == "test.txt"
         assert fi.size == 1024
         assert fi.file_type == "text"
@@ -190,13 +190,13 @@ class TestFileListResponse:
 class TestFileContentResponse:
     def test_valid_construction(self):
         resp = FileContentResponse(
-            path="/tmp/f.txt",
+            path="/tmp/f.txt",  # noqa: test-hardcoded-paths
             content="hello",
             encoding="utf-8",
             truncated=False,
             size=5,
         )
-        assert resp.path == "/tmp/f.txt"
+        assert resp.path == "/tmp/f.txt"  # noqa: test-hardcoded-paths
         assert resp.content == "hello"
         assert resp.encoding == "utf-8"
         assert resp.truncated is False
@@ -274,11 +274,11 @@ class TestDeleteFileResponse:
 class TestScanResponse:
     def test_valid_construction(self):
         resp = ScanResponse(
-            input_dir="/home/user/docs",
+            input_dir="/home/user/docs",  # noqa: test-hardcoded-paths
             total_files=42,
             counts={"pdf": 10, "txt": 32},
         )
-        assert resp.input_dir == "/home/user/docs"
+        assert resp.input_dir == "/home/user/docs"  # noqa: test-hardcoded-paths
         assert resp.total_files == 42
         assert resp.counts == {"pdf": 10, "txt": 32}
 

--- a/tests/config/test_config_manager_coverage.py
+++ b/tests/config/test_config_manager_coverage.py
@@ -204,12 +204,12 @@ class TestConfigManagerModuleDelegation:
         mgr = ConfigManager()
         cfg = AppConfig(
             daemon={
-                "watch_directories": ["/tmp/a"],
-                "output_directory": "/tmp/out",
+                "watch_directories": ["/tmp/a"],  # noqa: test-hardcoded-paths
+                "output_directory": "/tmp/out",  # noqa: test-hardcoded-paths
             }
         )
         result = mgr.to_daemon_config(cfg)
-        assert Path("/tmp/a") in result.watch_directories
+        assert Path("/tmp/a") in result.watch_directories  # noqa: test-hardcoded-paths
 
     def test_config_to_dict_includes_overrides(self):
         mgr = ConfigManager()

--- a/tests/core/test_compatibility.py
+++ b/tests/core/test_compatibility.py
@@ -444,7 +444,7 @@ class TestIsinstanceTupleForm:
 
     def test_isinstance_path_types(self) -> None:
         """isinstance with Path types should work."""
-        p = Path("/tmp/test")
+        p = Path("/tmp/test")  # noqa: test-hardcoded-paths
         assert isinstance(p, (str, Path))
         assert not isinstance(42, (str, Path))
 

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -100,9 +100,9 @@ class TestDeploymentConfigValidation:
 
     def test_string_data_directory_converted_to_path(self) -> None:
         """Verify string data_directory is converted to Path."""
-        config = DeploymentConfig(data_directory="/tmp/test")  # type: ignore[arg-type]
+        config = DeploymentConfig(data_directory="/tmp/test")  # type: ignore[arg-type]  # noqa: test-hardcoded-paths
         assert isinstance(config.data_directory, Path)
-        assert config.data_directory == Path("/tmp/test")
+        assert config.data_directory == Path("/tmp/test")  # noqa: test-hardcoded-paths
 
     def test_all_valid_environments_accepted(self) -> None:
         """Verify all defined valid environments are accepted."""

--- a/tests/deploy/test_health.py
+++ b/tests/deploy/test_health.py
@@ -22,7 +22,7 @@ def dev_config() -> DeploymentConfig:
     return DeploymentConfig(
         environment="dev",
         redis_url="redis://localhost:6379/0",
-        data_directory=Path("/tmp/fo-test-data"),
+        data_directory=Path("/tmp/fo-test-data"),  # noqa: test-hardcoded-paths
     )
 
 

--- a/tests/desktop/test_desktop_api_browse.py
+++ b/tests/desktop/test_desktop_api_browse.py
@@ -36,13 +36,13 @@ class TestDesktopAPIBrowseDirectory:
         """browse_directory() must return the first element of the result tuple."""
         from file_organizer.desktop.app import DesktopAPI
 
-        mock_webview, _ = self._make_mock_webview(("/Users/rahul/Documents",))
+        mock_webview, _ = self._make_mock_webview(("/Users/testuser/Documents",))  # noqa: test-hardcoded-paths
 
         with patch.dict("sys.modules", {"webview": mock_webview}):
             api = DesktopAPI()
             result = api.browse_directory()
 
-        assert result == "/Users/rahul/Documents"
+        assert result == "/Users/testuser/Documents"  # noqa: test-hardcoded-paths
 
     def test_calls_folder_dialog_constant(self) -> None:
         """Must call create_file_dialog with FOLDER_DIALOG, not a file dialog."""

--- a/tests/events/test_pubsub.py
+++ b/tests/events/test_pubsub.py
@@ -136,7 +136,7 @@ class TestPubSubPublish:
         self, pubsub: PubSubManager, mock_manager: MagicMock
     ) -> None:
         """publish() returns the Redis message ID."""
-        msg_id = pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        msg_id = pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         assert msg_id == "1234567890-0"
         assert pubsub.publish_count == 1
 
@@ -144,7 +144,7 @@ class TestPubSubPublish:
         self, pubsub: PubSubManager, mock_manager: MagicMock
     ) -> None:
         """publish() writes to the correct Redis stream."""
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         mock_manager.publish.assert_called_once()
         call_args = mock_manager.publish.call_args
         # publish is called with positional args: (stream_name, event_data)
@@ -154,21 +154,21 @@ class TestPubSubPublish:
         """publish() invokes matching handlers synchronously."""
         handler = MagicMock()
         pubsub.subscribe("file.created", handler)
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         handler.assert_called_once()
 
     def test_publish_dispatches_to_wildcard_handler(self, pubsub: PubSubManager) -> None:
         """Wildcard subscribers receive matching events."""
         handler = MagicMock()
         pubsub.subscribe("file.*", handler)
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         handler.assert_called_once()
 
     def test_publish_does_not_dispatch_to_non_matching(self, pubsub: PubSubManager) -> None:
         """Non-matching handlers are not invoked."""
         handler = MagicMock()
         pubsub.subscribe("scan.*", handler)
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         handler.assert_not_called()
 
     def test_publish_with_filter_passes(self, pubsub: PubSubManager) -> None:
@@ -198,7 +198,7 @@ class TestPubSubPublish:
         h1, h2 = MagicMock(), MagicMock()
         pubsub.subscribe("file.created", h1)
         pubsub.subscribe("file.*", h2)
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         h1.assert_called_once()
         h2.assert_called_once()
 
@@ -208,7 +208,7 @@ class TestPubSubPublish:
         h2 = MagicMock()
         pubsub.subscribe("file.created", h1)
         pubsub.subscribe("file.created", h2)
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         h1.assert_called_once()
         h2.assert_called_once()
 
@@ -217,7 +217,7 @@ class TestPubSubPublish:
     ) -> None:
         """When Redis publish fails, returns None."""
         mock_manager.publish.return_value = None
-        msg_id = pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        msg_id = pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         assert msg_id is None
         assert pubsub.publish_count == 0
 
@@ -239,7 +239,7 @@ class TestPubSubPublish:
         handler = MagicMock()
         pubsub.subscribe("file.created", handler)
         pubsub.unsubscribe("file.created", handler)
-        pubsub.publish("file.created", {"path": "/tmp/f.txt"})
+        pubsub.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         handler.assert_not_called()
 
 
@@ -262,7 +262,7 @@ class TestPubSubMiddleware:
         pipeline = MiddlewarePipeline()
         pipeline.add(CancelMiddleware())
         ps = PubSubManager(stream_manager=mock_manager, pipeline=pipeline)
-        result = ps.publish("file.created", {"path": "/tmp/f.txt"})
+        result = ps.publish("file.created", {"path": "/tmp/f.txt"})  # noqa: test-hardcoded-paths
         assert result is None
         mock_manager.publish.assert_not_called()
 

--- a/tests/history/test_db_models.py
+++ b/tests/history/test_db_models.py
@@ -96,7 +96,7 @@ class TestWorkspaceModel:
         ws = Workspace(
             name="My Workspace",
             owner_id=user.id,
-            root_path="/tmp/ws",
+            root_path="/tmp/ws",  # noqa: test-hardcoded-paths
         )
         db_session.add(ws)
         db_session.flush()
@@ -104,7 +104,7 @@ class TestWorkspaceModel:
         assert ws.id is not None
         assert ws.name == "My Workspace"
         assert ws.owner_id == user.id
-        assert ws.root_path == "/tmp/ws"
+        assert ws.root_path == "/tmp/ws"  # noqa: test-hardcoded-paths
         assert ws.is_active is True
         assert ws.description is None
         assert isinstance(ws.created_at, datetime)
@@ -114,7 +114,7 @@ class TestWorkspaceModel:
         ws = Workspace(
             name="Described",
             owner_id=user.id,
-            root_path="/tmp/desc",
+            root_path="/tmp/desc",  # noqa: test-hardcoded-paths
             description="A test workspace",
         )
         db_session.add(ws)
@@ -122,13 +122,13 @@ class TestWorkspaceModel:
         assert ws.description == "A test workspace"
 
     def test_workspace_requires_name(self, db_session: Session, user: User) -> None:
-        ws = Workspace(owner_id=user.id, root_path="/tmp/bad")
+        ws = Workspace(owner_id=user.id, root_path="/tmp/bad")  # noqa: test-hardcoded-paths
         db_session.add(ws)
         with pytest.raises(IntegrityError):
             db_session.flush()
 
     def test_workspace_requires_owner(self, db_session: Session) -> None:
-        ws = Workspace(name="orphan", root_path="/tmp/bad")
+        ws = Workspace(name="orphan", root_path="/tmp/bad")  # noqa: test-hardcoded-paths
         db_session.add(ws)
         with pytest.raises(IntegrityError):
             db_session.flush()
@@ -140,7 +140,7 @@ class TestWorkspaceModel:
             db_session.flush()
 
     def test_workspace_repr(self, db_session: Session, user: User) -> None:
-        ws = Workspace(name="repr-test", owner_id=user.id, root_path="/tmp/r")
+        ws = Workspace(name="repr-test", owner_id=user.id, root_path="/tmp/r")  # noqa: test-hardcoded-paths
         db_session.add(ws)
         db_session.flush()
         assert "repr-test" in repr(ws)
@@ -149,7 +149,7 @@ class TestWorkspaceModel:
         ws = Workspace(
             name="bad-fk",
             owner_id="nonexistent-user-id",
-            root_path="/tmp/fk",
+            root_path="/tmp/fk",  # noqa: test-hardcoded-paths
         )
         db_session.add(ws)
         # SQLite does not enforce FK by default; we still verify the row is created.
@@ -414,13 +414,13 @@ class TestFileMetadataModel:
     """Tests for the FileMetadata model."""
 
     def test_create_file_metadata(self, db_session: Session, user: User) -> None:
-        workspace = Workspace(name="ws-meta", owner_id=user.id, root_path="/tmp/ws-meta")
+        workspace = Workspace(name="ws-meta", owner_id=user.id, root_path="/tmp/ws-meta")  # noqa: test-hardcoded-paths
         db_session.add(workspace)
         db_session.flush()
 
         row = FileMetadata(
             workspace_id=workspace.id,
-            path="/tmp/ws-meta/docs/file.txt",
+            path="/tmp/ws-meta/docs/file.txt",  # noqa: test-hardcoded-paths
             relative_path="docs/file.txt",
             name="file.txt",
             size_bytes=123,
@@ -435,13 +435,13 @@ class TestFileMetadataModel:
         assert row.size_bytes == 123
 
     def test_file_metadata_unique_workspace_path(self, db_session: Session, user: User) -> None:
-        workspace = Workspace(name="ws-meta-uq", owner_id=user.id, root_path="/tmp/ws-meta-uq")
+        workspace = Workspace(name="ws-meta-uq", owner_id=user.id, root_path="/tmp/ws-meta-uq")  # noqa: test-hardcoded-paths
         db_session.add(workspace)
         db_session.flush()
 
         one = FileMetadata(
             workspace_id=workspace.id,
-            path="/tmp/ws-meta-uq/file.txt",
+            path="/tmp/ws-meta-uq/file.txt",  # noqa: test-hardcoded-paths
             relative_path="file.txt",
             name="file.txt",
             size_bytes=10,
@@ -451,7 +451,7 @@ class TestFileMetadataModel:
 
         two = FileMetadata(
             workspace_id=workspace.id,
-            path="/tmp/ws-meta-uq/file.txt",
+            path="/tmp/ws-meta-uq/file.txt",  # noqa: test-hardcoded-paths
             relative_path="file.txt",
             name="file.txt",
             size_bytes=11,

--- a/tests/history/test_history_models.py
+++ b/tests/history/test_history_models.py
@@ -219,7 +219,7 @@ class TestOperation:
         op = Operation(
             operation_type=OperationType.DELETE,
             timestamp=now,
-            source_path=Path("/tmp/gone.txt"),
+            source_path=Path("/tmp/gone.txt"),  # noqa: test-hardcoded-paths
             status=OperationStatus.FAILED,
             error_message="Permission denied",
         )

--- a/tests/history/test_repositories.py
+++ b/tests/history/test_repositories.py
@@ -106,7 +106,10 @@ class TestWorkspaceRepository:
 
     def test_get_by_id(self, db_session: Session, user: User) -> None:
         ws = WorkspaceRepository.create(
-            db_session, name="Find Me", owner_id=user.id, root_path="/tmp/find"  # noqa: test-hardcoded-paths
+            db_session,
+            name="Find Me",
+            owner_id=user.id,
+            root_path="/tmp/find",  # noqa: test-hardcoded-paths
         )
         found = WorkspaceRepository.get_by_id(db_session, ws.id)
         assert found is not None

--- a/tests/history/test_repositories.py
+++ b/tests/history/test_repositories.py
@@ -85,13 +85,13 @@ class TestWorkspaceRepository:
             db_session,
             name="Test WS",
             owner_id=user.id,
-            root_path="/tmp/test",
+            root_path="/tmp/test",  # noqa: test-hardcoded-paths
             description="desc",
         )
         assert ws.id is not None
         assert ws.name == "Test WS"
         assert ws.owner_id == user.id
-        assert ws.root_path == "/tmp/test"
+        assert ws.root_path == "/tmp/test"  # noqa: test-hardcoded-paths
         assert ws.description == "desc"
         assert ws.is_active is True
 
@@ -100,13 +100,13 @@ class TestWorkspaceRepository:
             db_session,
             name="NoDesc",
             owner_id=user.id,
-            root_path="/tmp/nd",
+            root_path="/tmp/nd",  # noqa: test-hardcoded-paths
         )
         assert ws.description is None
 
     def test_get_by_id(self, db_session: Session, user: User) -> None:
         ws = WorkspaceRepository.create(
-            db_session, name="Find Me", owner_id=user.id, root_path="/tmp/find"
+            db_session, name="Find Me", owner_id=user.id, root_path="/tmp/find"  # noqa: test-hardcoded-paths
         )
         found = WorkspaceRepository.get_by_id(db_session, ws.id)
         assert found is not None
@@ -502,13 +502,13 @@ class TestFileMetadataRepository:
             db_session,
             name="meta-ws",
             owner_id=user.id,
-            root_path="/tmp/meta-ws",
+            root_path="/tmp/meta-ws",  # noqa: test-hardcoded-paths
         )
         cache = InMemoryCache()
         row = FileMetadataRepository.upsert(
             db_session,
             workspace_id=ws.id,
-            path="/tmp/meta-ws/docs/a.txt",
+            path="/tmp/meta-ws/docs/a.txt",  # noqa: test-hardcoded-paths
             relative_path="docs/a.txt",
             name="a.txt",
             size_bytes=5,
@@ -536,12 +536,12 @@ class TestFileMetadataRepository:
             db_session,
             name="meta-ws-stale-cache",
             owner_id=user.id,
-            root_path="/tmp/meta-ws-stale",
+            root_path="/tmp/meta-ws-stale",  # noqa: test-hardcoded-paths
         )
         row = FileMetadataRepository.upsert(
             db_session,
             workspace_id=ws.id,
-            path="/tmp/meta-ws-stale/a.txt",
+            path="/tmp/meta-ws-stale/a.txt",  # noqa: test-hardcoded-paths
             relative_path="a.txt",
             name="a.txt",
             size_bytes=123,
@@ -570,12 +570,12 @@ class TestFileMetadataRepository:
             db_session,
             name="meta-ws-2",
             owner_id=user.id,
-            root_path="/tmp/meta-ws-2",
+            root_path="/tmp/meta-ws-2",  # noqa: test-hardcoded-paths
         )
         first = FileMetadataRepository.upsert(
             db_session,
             workspace_id=ws.id,
-            path="/tmp/meta-ws-2/a.txt",
+            path="/tmp/meta-ws-2/a.txt",  # noqa: test-hardcoded-paths
             relative_path="a.txt",
             name="a.txt",
             size_bytes=10,
@@ -583,7 +583,7 @@ class TestFileMetadataRepository:
         second = FileMetadataRepository.upsert(
             db_session,
             workspace_id=ws.id,
-            path="/tmp/meta-ws-2/a.txt",
+            path="/tmp/meta-ws-2/a.txt",  # noqa: test-hardcoded-paths
             relative_path="a.txt",
             name="a.txt",
             size_bytes=22,
@@ -598,12 +598,12 @@ class TestFileMetadataRepository:
             db_session,
             name="meta-ws-3",
             owner_id=user.id,
-            root_path="/tmp/meta-ws-3",
+            root_path="/tmp/meta-ws-3",  # noqa: test-hardcoded-paths
         )
         FileMetadataRepository.upsert(
             db_session,
             workspace_id=ws.id,
-            path="/tmp/meta-ws-3/a.txt",
+            path="/tmp/meta-ws-3/a.txt",  # noqa: test-hardcoded-paths
             relative_path="a.txt",
             name="a.txt",
             size_bytes=1,
@@ -611,7 +611,7 @@ class TestFileMetadataRepository:
         FileMetadataRepository.upsert(
             db_session,
             workspace_id=ws.id,
-            path="/tmp/meta-ws-3/b.txt",
+            path="/tmp/meta-ws-3/b.txt",  # noqa: test-hardcoded-paths
             relative_path="b.txt",
             name="b.txt",
             size_bytes=2,

--- a/tests/infrastructure/test_coverage_infrastructure.py
+++ b/tests/infrastructure/test_coverage_infrastructure.py
@@ -2604,7 +2604,7 @@ class TestPARARulesEngine:
         from file_organizer.methodologies.para.rules.engine import EvaluationContext
 
         ctx = EvaluationContext(
-            file_path=Path("/home/user/doc.pdf"),
+            file_path=Path("/home/user/doc.pdf"),  # noqa: test-hardcoded-paths
             file_stat={"created": datetime(2020, 1, 1, tzinfo=UTC)},
         )
         assert ctx.file_extension == ".pdf"
@@ -2614,7 +2614,7 @@ class TestPARARulesEngine:
     def test_evaluation_context_no_stat(self):
         from file_organizer.methodologies.para.rules.engine import EvaluationContext
 
-        ctx = EvaluationContext(file_path=Path("/home/user/doc.pdf"))
+        ctx = EvaluationContext(file_path=Path("/home/user/doc.pdf"))  # noqa: test-hardcoded-paths
         assert ctx.file_age_days is None
 
     def test_evaluation_context_naive_datetime(self):

--- a/tests/integration/config/test_migration_verification.py
+++ b/tests/integration/config/test_migration_verification.py
@@ -229,7 +229,7 @@ def test_preference_store_with_path_manager_production_workflow():
 
             # Add and save preferences
             pref_store.add_preference(
-                path=Path("/home/user/Documents"),
+                path=Path("/home/user/Documents"),  # noqa: test-hardcoded-paths
                 preference_data={
                     "folder_mappings": {"important": "Archive"},
                     "naming_patterns": {"pattern_1": "*.pdf"},

--- a/tests/integration/test_analytics_dedup_services.py
+++ b/tests/integration/test_analytics_dedup_services.py
@@ -564,7 +564,7 @@ class TestRuleCondition:
 
 class TestRuleAction:
     def test_created(self) -> None:
-        ra = RuleAction(action_type=ActionType.MOVE, destination="/tmp")
+        ra = RuleAction(action_type=ActionType.MOVE, destination="/tmp")  # noqa: test-hardcoded-paths
         assert ra.action_type == ActionType.MOVE
 
     def test_action_types_exist(self) -> None:
@@ -575,7 +575,7 @@ class TestRuleAction:
         assert ra.destination == "/archive"
 
     def test_parameters_dict(self) -> None:
-        ra = RuleAction(action_type=ActionType.MOVE, destination="/tmp", parameters={"k": "v"})
+        ra = RuleAction(action_type=ActionType.MOVE, destination="/tmp", parameters={"k": "v"})  # noqa: test-hardcoded-paths
         assert ra.parameters == {"k": "v"}
 
 

--- a/tests/integration/test_api_database_utils.py
+++ b/tests/integration/test_api_database_utils.py
@@ -213,7 +213,7 @@ class TestIsHidden:
         assert is_hidden(Path("user/documents/report.pdf")) is False
 
     def test_root_is_not_hidden(self) -> None:
-        assert is_hidden(Path("/home")) is False
+        assert is_hidden(Path("/home")) is False  # noqa: test-hardcoded-paths
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_api_integrations_workflow.py
+++ b/tests/integration/test_api_integrations_workflow.py
@@ -170,7 +170,7 @@ def test_integrations_reject_invalid_paths_and_names(
 ) -> None:
     forbidden = integrations_client.post(
         "/api/v1/integrations/obsidian/settings",
-        json={"settings": {"vault_path": "/etc"}},
+        json={"settings": {"vault_path": "/etc"}},  # noqa: test-hardcoded-paths
     )
     assert forbidden.status_code == 403
 
@@ -206,7 +206,7 @@ def test_integrations_settings_reject_invalid_filename_in_command_output_path(
         ("   ", "cannot be empty"),
         ("a//b", "empty path segments"),
         ("a\\\\b", "empty path segments"),
-        ("C:\\folder", "must be a relative path"),
+        ("C:\\folder", "must be a relative path"),  # noqa: test-hardcoded-paths
         ("../escape", "path traversal"),
     ],
 )

--- a/tests/integration/test_api_jobs_utils.py
+++ b/tests/integration/test_api_jobs_utils.py
@@ -245,7 +245,7 @@ class TestResolvePath:
         subdir = tmp_path / "subdir"
         subdir.mkdir()
         with pytest.raises(ApiError) as exc_info:
-            resolve_path("/etc/passwd", allowed_paths=[str(subdir)])
+            resolve_path("/etc/passwd", allowed_paths=[str(subdir)])  # noqa: test-hardcoded-paths
         assert exc_info.value.status_code == 403
 
     def test_no_allowed_paths_raises_api_error(self, tmp_path: Path) -> None:

--- a/tests/integration/test_api_web_coverage.py
+++ b/tests/integration/test_api_web_coverage.py
@@ -69,7 +69,7 @@ class TestWebCSRFProtection:
         assert middleware._is_exempt("/api/v1/users") is True
         assert middleware._is_exempt("/auth") is True
         assert middleware._is_exempt("/auth/login") is True
-        assert middleware._is_exempt("/home") is False
+        assert middleware._is_exempt("/home") is False  # noqa: test-hardcoded-paths
 
     def test_csrf_middleware_flow(self) -> None:
         app = FastAPI()

--- a/tests/integration/test_cli_api.py
+++ b/tests/integration/test_cli_api.py
@@ -428,7 +428,7 @@ class TestFilesListCommand:
         with _patch_build_client(client):
             result = runner.invoke(
                 api_app,
-                ["files", "/home/alice/docs", "--token", "tok"],
+                ["files", "/home/alice/docs", "--token", "tok"],  # noqa: test-hardcoded-paths
             )
 
         assert result.exit_code == 0
@@ -611,9 +611,9 @@ class TestCopilotChatCommand:
             "sys.modules",
             {"file_organizer.services.copilot.engine": mock_module},
         ):
-            runner.invoke(copilot_app, ["chat", "hello", "--dir", "/tmp/mydir"])
+            runner.invoke(copilot_app, ["chat", "hello", "--dir", "/tmp/mydir"])  # noqa: test-hardcoded-paths
 
-        mock_module.CopilotEngine.assert_called_once_with(working_directory="/tmp/mydir")
+        mock_module.CopilotEngine.assert_called_once_with(working_directory="/tmp/mydir")  # noqa: test-hardcoded-paths
 
     def test_chat_repl_exits_on_quit(self) -> None:
         """Interactive REPL exits cleanly when user types 'quit'."""

--- a/tests/integration/test_cli_suggest.py
+++ b/tests/integration/test_cli_suggest.py
@@ -45,7 +45,7 @@ def _make_suggestion(
     s = MagicMock()
     s.suggestion_id = sid
     s.suggestion_type = _make_suggestion_type_mock(stype)
-    s.file_path = file_path or Path("/tmp/report.pdf")
+    s.file_path = file_path or Path("/tmp/report.pdf")  # noqa: test-hardcoded-paths
     s.target_path = target_path
     s.confidence = confidence
     s.reasoning = reasoning

--- a/tests/integration/test_copilot_executor.py
+++ b/tests/integration/test_copilot_executor.py
@@ -183,7 +183,7 @@ class TestCommandExecutorExecute:
         intent = Intent(
             intent_type=IntentType.SUGGEST,
             confidence=0.7,
-            parameters={"path": "/tmp"},
+            parameters={"path": "/tmp"},  # noqa: test-hardcoded-paths
         )
         result = executor.execute(intent)
         assert isinstance(result, ExecutionResult)

--- a/tests/integration/test_desktop_api_integration.py
+++ b/tests/integration/test_desktop_api_integration.py
@@ -58,10 +58,10 @@ def api() -> DesktopAPI:
 class TestBrowseFile:
     def test_browse_file_returns_selected_path(self, api: DesktopAPI) -> None:
         """When the dialog returns a path, browse_file returns that exact path."""
-        wv = _make_webview(dialog_result=["/Users/demo/file.txt"])
+        wv = _make_webview(dialog_result=["/Users/demo/file.txt"])  # noqa: test-hardcoded-paths
         with patch.dict("sys.modules", {"webview": wv}):
             result = api.browse_file()
-        assert result == "/Users/demo/file.txt"
+        assert result == "/Users/demo/file.txt"  # noqa: test-hardcoded-paths
 
     def test_browse_file_passes_open_dialog_constant(self, api: DesktopAPI) -> None:
         """browse_file must call create_file_dialog with OPEN_DIALOG, not another constant."""

--- a/tests/integration/test_events_pubsub_workflow.py
+++ b/tests/integration/test_events_pubsub_workflow.py
@@ -64,7 +64,7 @@ def test_event_publisher_and_pubsub_dispatch_work_together() -> None:
     assert publisher.connect() is True
     file_id = publisher.publish_file_event(
         EventType.FILE_CREATED,
-        "/tmp/example.txt",
+        "/tmp/example.txt",  # noqa: test-hardcoded-paths
         {"size": 12},
     )
     scan_id = publisher.publish_scan_event("scan-1", "completed", {"processed": 3})
@@ -86,14 +86,14 @@ def test_event_publisher_and_pubsub_dispatch_work_together() -> None:
         received.append(data)
 
     sub = pubsub.subscribe("file.*", handler, filter_fn=lambda data: data.get("ok") is True)
-    message_id = pubsub.publish("file.created", {"ok": True, "path": "/tmp/example.txt"})
+    message_id = pubsub.publish("file.created", {"ok": True, "path": "/tmp/example.txt"})  # noqa: test-hardcoded-paths
     assert message_id == "id-3"
     assert received[0]["seen_by_before_publish"] is True
     assert received[0]["seen_by_before_consume"] is True
 
     pubsub.registry.deactivate("file.*", handler)
     assert sub.active is False
-    pubsub.publish("file.created", {"ok": True, "path": "/tmp/ignored.txt"})
+    pubsub.publish("file.created", {"ok": True, "path": "/tmp/ignored.txt"})  # noqa: test-hardcoded-paths
     assert len(received) == 1
 
     pubsub.registry.activate("file.*", handler)
@@ -102,7 +102,7 @@ def test_event_publisher_and_pubsub_dispatch_work_together() -> None:
     assert len(received) == 1
 
     assert pubsub.unsubscribe("file.*", handler) is True
-    pubsub.publish("file.created", {"ok": True, "path": "/tmp/after-unsubscribe.txt"})
+    pubsub.publish("file.created", {"ok": True, "path": "/tmp/after-unsubscribe.txt"})  # noqa: test-hardcoded-paths
     assert len(received) == 1
 
 

--- a/tests/integration/test_intelligence_branches.py
+++ b/tests/integration/test_intelligence_branches.py
@@ -279,7 +279,7 @@ class TestImportProfileBranches:
             "included_preferences": ["global"],
             "preferences": {
                 "global": {"key": "value"},
-                "directory_specific": {"/home": {"sort_by": "name"}},
+                "directory_specific": {"/home": {"sort_by": "name"}},  # noqa: test-hardcoded-paths
             },
             "learned_patterns": {"pat1": "data"},
             "confidence_data": {"conf1": 0.9},

--- a/tests/integration/test_parallel_analytics_config_batch4.py
+++ b/tests/integration/test_parallel_analytics_config_batch4.py
@@ -1497,7 +1497,7 @@ class TestIntentParser:
         result = IntentParser._extract_paths("move /home/user/docs")
 
         assert len(result) == 1
-        assert "/home/user/docs" in result[0]
+        assert "/home/user/docs" in result[0]  # noqa: test-hardcoded-paths
 
 
 # ===========================================================================

--- a/tests/integration/test_plugins_api_endpoints.py
+++ b/tests/integration/test_plugins_api_endpoints.py
@@ -81,7 +81,7 @@ class TestListFilesForPlugins:
         assert r.status_code == 404
 
     def test_list_files_outside_root_returns_403(self, plugin_client: TestClient) -> None:
-        r = plugin_client.get("/api/v1/plugins/files/list", params={"path": "/etc"})
+        r = plugin_client.get("/api/v1/plugins/files/list", params={"path": "/etc"})  # noqa: test-hardcoded-paths
         assert r.status_code == 403
 
     def test_list_files_recursive(self, plugin_client: TestClient, tmp_path: Path) -> None:
@@ -174,7 +174,7 @@ class TestGetFileMetadata:
         assert r.status_code == 400
 
     def test_metadata_outside_root_returns_403(self, plugin_client: TestClient) -> None:
-        r = plugin_client.get("/api/v1/plugins/files/metadata", params={"path": "/etc/hosts"})
+        r = plugin_client.get("/api/v1/plugins/files/metadata", params={"path": "/etc/hosts"})  # noqa: test-hardcoded-paths
         assert r.status_code == 403
 
 

--- a/tests/integration/test_plugins_core.py
+++ b/tests/integration/test_plugins_core.py
@@ -268,7 +268,7 @@ class TestPluginSandbox:
         sandbox = PluginSandbox(plugin_name="test", policy=None)  # defaults to unrestricted
 
         assert sandbox.validate_file_access(tmp_path) is True
-        assert sandbox.validate_file_access("/etc/passwd") is True
+        assert sandbox.validate_file_access("/etc/passwd") is True  # noqa: test-hardcoded-paths
 
     def test_restricted_policy_denies_path_outside_allowed(self, tmp_path: Path) -> None:
         from file_organizer.plugins.security import PluginSandbox, PluginSecurityPolicy
@@ -300,7 +300,7 @@ class TestPluginSandbox:
         sandbox = PluginSandbox(plugin_name="my-plugin", policy=policy)
 
         with pytest.raises(PluginPermissionError, match="my-plugin"):
-            sandbox.require_file_access("/etc/passwd")
+            sandbox.require_file_access("/etc/passwd")  # noqa: test-hardcoded-paths
 
     def test_validate_operation_returns_false_for_denied_op(self) -> None:
         from file_organizer.plugins.security import PluginSandbox, PluginSecurityPolicy

--- a/tests/integration/test_web_profile_routes_extended.py
+++ b/tests/integration/test_web_profile_routes_extended.py
@@ -333,7 +333,7 @@ class TestAuthRequiredRoutesUnauthenticated:
     def test_workspaces_create_returns_200(self, profile_client: TestClient) -> None:
         r = profile_client.post(
             "/ui/profile/workspaces/create",
-            data={"name": "My WS", "root_path": "/tmp", "description": "desc"},
+            data={"name": "My WS", "root_path": "/tmp", "description": "desc"},  # noqa: test-hardcoded-paths
             headers=csrf_headers(profile_client),
         )
         assert r.status_code == 200

--- a/tests/integrations/test_base_integration.py
+++ b/tests/integrations/test_base_integration.py
@@ -71,11 +71,11 @@ class TestIntegrationConfig:
             integration_type=IntegrationType.EDITOR,
             enabled=False,
             auth_method="token",
-            settings={"workspace": "/tmp"},
+            settings={"workspace": "/tmp"},  # noqa: test-hardcoded-paths
         )
         assert config.enabled is False
         assert config.auth_method == "token"
-        assert config.settings == {"workspace": "/tmp"}
+        assert config.settings == {"workspace": "/tmp"}  # noqa: test-hardcoded-paths
 
     def test_merge_settings_adds_new_keys(self) -> None:
         """merge_settings should add new keys."""

--- a/tests/integrations/test_manager.py
+++ b/tests/integrations/test_manager.py
@@ -52,4 +52,4 @@ def test_manager_handles_missing_integrations_gracefully() -> None:
     assert manager.update_settings("missing", {"x": 1}) is False
     assert asyncio.run(manager.connect("missing")) is False
     assert asyncio.run(manager.disconnect("missing")) is False
-    assert asyncio.run(manager.send_file("missing", "/tmp/nope")) is False
+    assert asyncio.run(manager.send_file("missing", "/tmp/nope")) is False  # noqa: test-hardcoded-paths

--- a/tests/methodologies/johnny_decimal/test_jd_migrator.py
+++ b/tests/methodologies/johnny_decimal/test_jd_migrator.py
@@ -269,12 +269,12 @@ class TestMigratorCoverage:
     # Branch 359->365: generate_preview with no patterns
     def test_generate_preview_no_patterns(self, migrator: JohnnyDecimalMigrator) -> None:
         plan = TransformationPlan(
-            root_path=Path("/tmp"),
+            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
             rules=[],
             estimated_changes=0,
         )
         scan = ScanResult(
-            root_path=Path("/tmp"),
+            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
             folder_tree=[],
             total_folders=0,
             total_files=0,
@@ -288,12 +288,12 @@ class TestMigratorCoverage:
     # Branch 375->387: generate_preview with validation
     def test_generate_preview_with_validation(self, migrator: JohnnyDecimalMigrator) -> None:
         plan = TransformationPlan(
-            root_path=Path("/tmp"),
+            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
             rules=[],
             estimated_changes=0,
         )
         scan = ScanResult(
-            root_path=Path("/tmp"),
+            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
             folder_tree=[],
             total_folders=0,
             total_files=0,
@@ -314,8 +314,8 @@ class TestMigratorCoverage:
             failed_count=1,
             skipped_count=15,
             duration_seconds=1.0,
-            failed_paths=[(Path("/tmp/bad"), "error")],
-            skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(15)],
+            failed_paths=[(Path("/tmp/bad"), "error")],  # noqa: test-hardcoded-paths
+            skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(15)],  # noqa: test-hardcoded-paths
         )
         report = migrator.generate_report(result)
         assert "and 5 more" in report
@@ -329,7 +329,7 @@ class TestMigratorCoverage:
             failed_count=0,
             skipped_count=3,
             duration_seconds=0.5,
-            skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(3)],
+            skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(3)],  # noqa: test-hardcoded-paths
         )
         report = migrator.generate_report(result)
         assert "Skipped (3 folders)" in report

--- a/tests/methodologies/para/test_para_config.py
+++ b/tests/methodologies/para/test_para_config.py
@@ -71,7 +71,7 @@ class TestPARAConfigLoadFromYaml:
             "manual_review_threshold": 0.5,
             "auto_categorize": False,
             "preserve_user_overrides": False,
-            "default_root": "/tmp/para_root",
+            "default_root": "/tmp/para_root",  # noqa: test-hardcoded-paths
             "project_dir": "Proj",
             "area_dir": "Ar",
             "resource_dir": "Res",
@@ -88,7 +88,7 @@ class TestPARAConfigLoadFromYaml:
         assert cfg.temporal_thresholds.project_max_age == 15
         assert cfg.enable_ai_heuristic is True
         assert cfg.auto_categorize is False
-        assert cfg.default_root == Path("/tmp/para_root")
+        assert cfg.default_root == Path("/tmp/para_root")  # noqa: test-hardcoded-paths
         assert cfg.project_dir == "Proj"
 
     def test_load_invalid_yaml_returns_defaults(self, tmp_path: Path) -> None:

--- a/tests/parallel/test_checkpoint.py
+++ b/tests/parallel/test_checkpoint.py
@@ -84,7 +84,7 @@ class TestCheckpointManagerInit(unittest.TestCase):
 
     def test_custom_dir(self) -> None:
         """Test that custom directory is used."""
-        custom = Path("/tmp/test-checkpoints")
+        custom = Path("/tmp/test-checkpoints")  # noqa: test-hardcoded-paths
         mgr = CheckpointManager(checkpoints_dir=custom)
         self.assertEqual(mgr.checkpoints_dir, custom)
 
@@ -245,7 +245,7 @@ class TestUpdateCheckpoint(unittest.TestCase):
 
     def test_update_nonexistent_checkpoint_returns_none(self) -> None:
         """Test updating a missing checkpoint returns None."""
-        result = self.mgr.update_checkpoint("no-checkpoint", Path("/tmp/x.txt"))
+        result = self.mgr.update_checkpoint("no-checkpoint", Path("/tmp/x.txt"))  # noqa: test-hardcoded-paths
         self.assertIsNone(result)
 
     def test_update_does_not_duplicate_completed(self) -> None:

--- a/tests/parallel/test_persistence.py
+++ b/tests/parallel/test_persistence.py
@@ -39,7 +39,7 @@ class TestJobPersistenceInit(unittest.TestCase):
 
     def test_custom_jobs_dir(self, tmp_path: Path | None = None) -> None:
         """Test that custom directory is used."""
-        custom = Path("/tmp/test-jobs")
+        custom = Path("/tmp/test-jobs")  # noqa: test-hardcoded-paths
         persistence = JobPersistence(jobs_dir=custom)
         self.assertEqual(persistence.jobs_dir, custom)
 

--- a/tests/parallel/test_priority_queue.py
+++ b/tests/parallel/test_priority_queue.py
@@ -22,9 +22,9 @@ class TestQueueItem(unittest.TestCase):
 
     def test_create_with_defaults(self) -> None:
         """Test creating a QueueItem with default values."""
-        item = QueueItem(id="item-1", path=Path("/tmp/test.txt"))
+        item = QueueItem(id="item-1", path=Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
         self.assertEqual(item.id, "item-1")
-        self.assertEqual(item.path, Path("/tmp/test.txt"))
+        self.assertEqual(item.path, Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
         self.assertEqual(item.priority, 0)
         self.assertEqual(item.metadata, {})
         self.assertIsInstance(item.enqueued_at, float)
@@ -33,7 +33,7 @@ class TestQueueItem(unittest.TestCase):
         """Test creating a QueueItem with all fields specified."""
         item = QueueItem(
             id="item-2",
-            path=Path("/tmp/doc.pdf"),
+            path=Path("/tmp/doc.pdf"),  # noqa: test-hardcoded-paths
             priority=5,
             metadata={"type": "document"},
             enqueued_at=100.0,
@@ -62,7 +62,7 @@ class TestPriorityQueue(unittest.TestCase):
         """Helper to create a QueueItem."""
         return QueueItem(
             id=item_id,
-            path=Path(f"/tmp/{item_id}.txt"),
+            path=Path(f"/tmp/{item_id}.txt"),  # noqa: test-hardcoded-paths
             priority=priority,
         )
 

--- a/tests/parallel/test_priority_queue_fix.py
+++ b/tests/parallel/test_priority_queue_fix.py
@@ -15,7 +15,7 @@ class TestPriorityQueueFix(unittest.TestCase):
         """
         pq = PriorityQueue()
         item_id = "test_item"
-        item = QueueItem(id=item_id, path=Path("/tmp/test"), priority=10)
+        item = QueueItem(id=item_id, path=Path("/tmp/test"), priority=10)  # noqa: test-hardcoded-paths
 
         # 1. Enqueue item with priority 10
         pq.enqueue(item)

--- a/tests/parallel/test_result.py
+++ b/tests/parallel/test_result.py
@@ -88,7 +88,7 @@ class TestFileResult(unittest.TestCase):
 
     def test_result_preserves_path_type(self) -> None:
         """Test that path remains a Path object."""
-        result = FileResult(path=Path("/tmp/file.txt"), success=True)
+        result = FileResult(path=Path("/tmp/file.txt"), success=True)  # noqa: test-hardcoded-paths
         self.assertIsInstance(result.path, Path)
 
     def test_result_with_zero_duration(self) -> None:

--- a/tests/pipeline/test_config.py
+++ b/tests/pipeline/test_config.py
@@ -68,9 +68,9 @@ class TestPipelineConfigValidation:
 
     def test_output_directory_normalized_to_path(self) -> None:
         """Output directory is converted to Path."""
-        config = PipelineConfig(output_directory=Path("/tmp/test"))
+        config = PipelineConfig(output_directory=Path("/tmp/test"))  # noqa: test-hardcoded-paths
         assert isinstance(config.output_directory, Path)
-        assert config.output_directory == Path("/tmp/test")
+        assert config.output_directory == Path("/tmp/test")  # noqa: test-hardcoded-paths
 
     def test_extensions_normalized_with_dots(self) -> None:
         """Extensions without leading dots get them added."""

--- a/tests/pipeline/test_orchestrator.py
+++ b/tests/pipeline/test_orchestrator.py
@@ -155,7 +155,7 @@ class TestProcessingResult:
             file_path=Path("test.txt"),
             success=True,
             category="documents",
-            destination=Path("/tmp/organized/documents/test.txt"),
+            destination=Path("/tmp/organized/documents/test.txt"),  # noqa: test-hardcoded-paths
             duration_ms=150.5,
         )
         assert result.success is True

--- a/tests/pipeline/test_orchestrator_watch_loop.py
+++ b/tests/pipeline/test_orchestrator_watch_loop.py
@@ -51,7 +51,7 @@ class TestWatchLoop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/test.txt"))]
+                return [FakeEvent(path=Path("/tmp/test.txt"))]  # noqa: test-hardcoded-paths
             # Stop the loop
             orch._running = False
             return []
@@ -60,7 +60,7 @@ class TestWatchLoop:
 
         with patch.object(orch, "process_file") as mock_process:
             orch._watch_loop()
-            mock_process.assert_called_once_with(Path("/tmp/test.txt"))
+            mock_process.assert_called_once_with(Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
 
     @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require admin on Windows")
     def test_watch_loop_resolves_symlinked_watch_root_for_trusted_root(self, tmp_path: Path):
@@ -115,7 +115,7 @@ class TestWatchLoop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/somedir"), is_directory=True)]
+                return [FakeEvent(path=Path("/tmp/somedir"), is_directory=True)]  # noqa: test-hardcoded-paths
             orch._running = False
             return []
 
@@ -142,8 +142,8 @@ class TestWatchLoop:
             call_count += 1
             if call_count == 1:
                 return [
-                    FakeEvent(path=Path("/tmp/vanished.txt")),
-                    FakeEvent(path=Path("/tmp/exists.txt")),
+                    FakeEvent(path=Path("/tmp/vanished.txt")),  # noqa: test-hardcoded-paths
+                    FakeEvent(path=Path("/tmp/exists.txt")),  # noqa: test-hardcoded-paths
                 ]
             orch._running = False
             return []
@@ -180,7 +180,7 @@ class TestWatchLoop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/bad.txt"))]
+                return [FakeEvent(path=Path("/tmp/bad.txt"))]  # noqa: test-hardcoded-paths
             orch._running = False
             return []
 
@@ -233,7 +233,7 @@ class TestWatchLoopExecutor:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/test.txt"))]
+                return [FakeEvent(path=Path("/tmp/test.txt"))]  # noqa: test-hardcoded-paths
             orch._running = False
             return []
 
@@ -242,7 +242,7 @@ class TestWatchLoopExecutor:
         with patch.object(orch._executor, "submit") as mock_submit:
             orch._watch_loop()
             # submit should have been called with process_file and the path
-            mock_submit.assert_called_once_with(orch.process_file, Path("/tmp/test.txt"))
+            mock_submit.assert_called_once_with(orch.process_file, Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
 
     def test_executor_max_workers_matches_config(self):
         """Executor should be created with max_workers from config.max_concurrent."""

--- a/tests/plugins/test_installer_coverage.py
+++ b/tests/plugins/test_installer_coverage.py
@@ -212,7 +212,7 @@ class TestPluginInstallerExtractArchive:
     def test_extract_absolute_path_raises(self, tmp_path):
         archive_path = tmp_path / "bad.zip"
         with zipfile.ZipFile(archive_path, "w") as zf:
-            zf.writestr("/etc/passwd", "malicious")
+            zf.writestr("/etc/passwd", "malicious")  # noqa: test-hardcoded-paths
         dest = tmp_path / "extract"
         dest.mkdir()
         repo = MagicMock()

--- a/tests/plugins/test_sandbox_isolation.py
+++ b/tests/plugins/test_sandbox_isolation.py
@@ -345,7 +345,7 @@ class TestExecutorInterface:
 
         executor = PluginExecutor(plugin_path=str(plugin_src))
         with executor:
-            result = executor.call("on_file", "/tmp/test.txt", {})
+            result = executor.call("on_file", "/tmp/test.txt", {})  # noqa: test-hardcoded-paths
 
         assert isinstance(result, dict), "on_file() must return a dict via IPC"
         assert result.get("tag") == "injected", (
@@ -416,7 +416,7 @@ class TestIPCProtocol:
         """encode_call/decode_call roundtrip preserves all fields faithfully."""
         call = PluginCall(
             method="on_file",
-            args=["/tmp/photo.jpg", {"size": 1024}],
+            args=["/tmp/photo.jpg", {"size": 1024}],  # noqa: test-hardcoded-paths
             kwargs={},
         )
 

--- a/tests/services/audio/test_audio_integration.py
+++ b/tests/services/audio/test_audio_integration.py
@@ -55,7 +55,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata."""
     return AudioMetadata(
-        file_path=file_path or Path("/tmp/test.mp3"),
+        file_path=file_path or Path("/tmp/test.mp3"),  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_audio_transcriber_service.py
+++ b/tests/services/audio/test_audio_transcriber_service.py
@@ -202,12 +202,12 @@ class TestAudioTranscriberInit:
                 model_size=ModelSize.LARGE_V3,
                 device="cpu",
                 compute_type=ComputeType.FLOAT32,
-                cache_dir=Path("/tmp/cache"),
+                cache_dir=Path("/tmp/cache"),  # noqa: test-hardcoded-paths
                 num_workers=4,
             )
         assert t.model_size == ModelSize.LARGE_V3
         assert t.compute_type == ComputeType.FLOAT32
-        assert t.cache_dir == Path("/tmp/cache")
+        assert t.cache_dir == Path("/tmp/cache")  # noqa: test-hardcoded-paths
         assert t.num_workers == 4
 
 

--- a/tests/services/audio/test_classifier.py
+++ b/tests/services/audio/test_classifier.py
@@ -57,7 +57,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata with sensible defaults."""
     return AudioMetadata(
-        file_path=Path("/tmp/test_audio.mp3"),
+        file_path=Path("/tmp/test_audio.mp3"),  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_content_analyzer.py
+++ b/tests/services/audio/test_content_analyzer.py
@@ -46,7 +46,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata with sensible defaults."""
     return AudioMetadata(
-        file_path=Path("/tmp/test_audio.mp3"),
+        file_path=Path("/tmp/test_audio.mp3"),  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_organizer.py
+++ b/tests/services/audio/test_organizer.py
@@ -56,7 +56,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata with sensible defaults."""
     return AudioMetadata(
-        file_path=file_path or Path("/tmp/test_audio.mp3"),
+        file_path=file_path or Path("/tmp/test_audio.mp3"),  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/copilot/test_copilot_executor.py
+++ b/tests/services/copilot/test_copilot_executor.py
@@ -185,7 +185,7 @@ class TestHandleMove:
     """Test the move handler."""
 
     def test_missing_source_param(self, executor):
-        result = executor.execute(_intent(IntentType.MOVE, destination="/tmp/x"))
+        result = executor.execute(_intent(IntentType.MOVE, destination="/tmp/x"))  # noqa: test-hardcoded-paths
         assert not result.success
         assert "specify" in result.message.lower()
 

--- a/tests/services/copilot/test_copilot_models.py
+++ b/tests/services/copilot/test_copilot_models.py
@@ -185,7 +185,7 @@ class TestIntent:
     def test_parameters_independent(self) -> None:
         i1 = Intent(intent_type=IntentType.FIND)
         i2 = Intent(intent_type=IntentType.FIND)
-        i1.parameters["path"] = "/tmp"
+        i1.parameters["path"] = "/tmp"  # noqa: test-hardcoded-paths
         assert "path" not in i2.parameters
 
     def test_full_construction(self) -> None:
@@ -222,11 +222,11 @@ class TestExecutionResult:
             success=False,
             message="Failed",
             details={"error_code": 42},
-            affected_files=["/tmp/a.txt"],
+            affected_files=["/tmp/a.txt"],  # noqa: test-hardcoded-paths
         )
         assert result.success is False
         assert result.details["error_code"] == 42
-        assert result.affected_files == ["/tmp/a.txt"]
+        assert result.affected_files == ["/tmp/a.txt"]  # noqa: test-hardcoded-paths
 
     def test_defaults_are_independent(self) -> None:
         r1 = ExecutionResult(success=True, message="ok")
@@ -268,8 +268,8 @@ class TestCopilotSession:
         assert session.turn_count == 2
 
     def test_working_directory(self) -> None:
-        session = CopilotSession(working_directory="/home/user")
-        assert session.working_directory == "/home/user"
+        session = CopilotSession(working_directory="/home/user")  # noqa: test-hardcoded-paths
+        assert session.working_directory == "/home/user"  # noqa: test-hardcoded-paths
 
     def test_session_id(self) -> None:
         session = CopilotSession(session_id="abc-123")

--- a/tests/services/copilot/test_engine.py
+++ b/tests/services/copilot/test_engine.py
@@ -50,9 +50,9 @@ class TestCopilotEngineInit:
 
     def test_init_with_working_directory(self):
         """Test initialization with custom working directory."""
-        engine = CopilotEngine(working_directory="/tmp/test")
+        engine = CopilotEngine(working_directory="/tmp/test")  # noqa: test-hardcoded-paths
 
-        assert engine._session.working_directory == "/tmp/test"
+        assert engine._session.working_directory == "/tmp/test"  # noqa: test-hardcoded-paths
 
     def test_init_with_text_model(self):
         """Test initialization with custom text model."""
@@ -278,8 +278,8 @@ class TestSessionProperty:
 
     def test_session_working_directory(self):
         """Test session working directory."""
-        engine = CopilotEngine(working_directory="/tmp")
-        assert engine.session.working_directory == "/tmp"
+        engine = CopilotEngine(working_directory="/tmp")  # noqa: test-hardcoded-paths
+        assert engine.session.working_directory == "/tmp"  # noqa: test-hardcoded-paths
 
     def test_session_messages_updated(self):
         """Test that session messages are updated during chat."""

--- a/tests/services/copilot/test_intent_parser.py
+++ b/tests/services/copilot/test_intent_parser.py
@@ -355,7 +355,7 @@ class TestParameterExtraction:
     def test_windows_path_extraction(self, parser: IntentParser) -> None:
         intent = parser.parse(r"move C:\Users\test\file.txt somewhere")
         paths = intent.parameters.get("paths", [])
-        assert any("C:\\" in p for p in paths)
+        assert any("C:\\" in p for p in paths)  # noqa: test-hardcoded-paths
 
     def test_no_params_for_simple_text(self, parser: IntentParser) -> None:
         intent = parser.parse("hello there")

--- a/tests/services/copilot/test_rules_models.py
+++ b/tests/services/copilot/test_rules_models.py
@@ -107,7 +107,7 @@ class TestRuleCondition:
         assert cond.negate is False
 
     def test_from_dict_with_negate(self) -> None:
-        cond = RuleCondition.from_dict({"type": "path_matches", "value": "/tmp/*", "negate": True})
+        cond = RuleCondition.from_dict({"type": "path_matches", "value": "/tmp/*", "negate": True})  # noqa: test-hardcoded-paths
         assert cond.negate is True
         assert cond.condition_type == ConditionType.PATH_MATCHES
 

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -47,7 +47,7 @@ def viewer(console: Console) -> ComparisonViewer:
 def sample_metadata() -> ImageMetadata:
     """Return a representative ImageMetadata object."""
     return ImageMetadata(
-        path=Path("/tmp/image1.png"),
+        path=Path("/tmp/image1.png"),  # noqa: test-hardcoded-paths
         width=1920,
         height=1080,
         format="PNG",
@@ -61,7 +61,7 @@ def sample_metadata() -> ImageMetadata:
 def sample_metadata_small() -> ImageMetadata:
     """Return a smaller / lower-quality ImageMetadata object."""
     return ImageMetadata(
-        path=Path("/tmp/image2.jpg"),
+        path=Path("/tmp/image2.jpg"),  # noqa: test-hardcoded-paths
         width=640,
         height=480,
         format="JPEG",
@@ -212,7 +212,7 @@ class TestShowComparison:
                 return_value=DuplicateReview([sample_metadata.path], []),
             ) as mock_process,
         ):
-            result = viewer.show_comparison([Path("/tmp/image1.png")], similarity_score=95.0)
+            result = viewer.show_comparison([Path("/tmp/image1.png")], similarity_score=95.0)  # noqa: test-hardcoded-paths
             assert result.files_to_keep == [sample_metadata.path]
             mock_process.assert_called_once()
 
@@ -265,7 +265,7 @@ class TestBatchReview:
 
     def test_manual_review_mode(self, viewer: ComparisonViewer, sample_metadata):
         """auto_select_best=False uses show_comparison."""
-        review = DuplicateReview([sample_metadata.path], [Path("/tmp/image2.jpg")])
+        review = DuplicateReview([sample_metadata.path], [Path("/tmp/image2.jpg")])  # noqa: test-hardcoded-paths
         with (
             patch.object(viewer, "show_comparison", return_value=review),
             patch.object(viewer, "_display_review_summary"),
@@ -273,7 +273,7 @@ class TestBatchReview:
             groups = {"hash1": [Path("/a.png"), Path("/b.png")]}
             decisions = viewer.batch_review(groups, auto_select_best=False)
             assert decisions[sample_metadata.path] == "keep"
-            assert decisions[Path("/tmp/image2.jpg")] == "delete"
+            assert decisions[Path("/tmp/image2.jpg")] == "delete"  # noqa: test-hardcoded-paths
 
     def test_quit_early_via_confirm(self, viewer: ComparisonViewer):
         """When user skips and declines continue, batch stops."""

--- a/tests/services/intelligence/test_directory_prefs.py
+++ b/tests/services/intelligence/test_directory_prefs.py
@@ -31,7 +31,7 @@ class TestDirectoryPrefs:
 
     def test_set_and_get_preference(self, dir_prefs):
         """Test setting and getting a single preference."""
-        test_path = Path("/home/user/documents")
+        test_path = Path("/home/user/documents")  # noqa: test-hardcoded-paths
         pref = {"folder_mappings": {"pdf": "PDFs"}, "confidence": 0.8}
 
         dir_prefs.set_preference(test_path, pref)
@@ -43,8 +43,8 @@ class TestDirectoryPrefs:
 
     def test_preference_inheritance(self, dir_prefs):
         """Test that child directories inherit parent preferences."""
-        parent_path = Path("/home/user")
-        child_path = Path("/home/user/documents")
+        parent_path = Path("/home/user")  # noqa: test-hardcoded-paths
+        child_path = Path("/home/user/documents")  # noqa: test-hardcoded-paths
 
         parent_pref = {"global_setting": "parent_value"}
         child_pref = {"folder_mappings": {"pdf": "PDFs"}}
@@ -60,10 +60,10 @@ class TestDirectoryPrefs:
 
     def test_deep_inheritance_chain(self, dir_prefs):
         """Test inheritance across multiple directory levels."""
-        root = Path("/home/user")
-        level1 = Path("/home/user/documents")
-        level2 = Path("/home/user/documents/work")
-        level3 = Path("/home/user/documents/work/projects")
+        root = Path("/home/user")  # noqa: test-hardcoded-paths
+        level1 = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        level2 = Path("/home/user/documents/work")  # noqa: test-hardcoded-paths
+        level3 = Path("/home/user/documents/work/projects")  # noqa: test-hardcoded-paths
 
         dir_prefs.set_preference(root, {"root_setting": "root"})
         dir_prefs.set_preference(level1, {"level1_setting": "l1"})
@@ -78,8 +78,8 @@ class TestDirectoryPrefs:
 
     def test_child_overrides_parent(self, dir_prefs):
         """Test that child preferences override parent for same keys."""
-        parent = Path("/home/user")
-        child = Path("/home/user/documents")
+        parent = Path("/home/user")  # noqa: test-hardcoded-paths
+        child = Path("/home/user/documents")  # noqa: test-hardcoded-paths
 
         parent_pref = {"folder_mappings": {"pdf": "Documents"}}
         child_pref = {"folder_mappings": {"pdf": "PDFs"}}
@@ -94,8 +94,8 @@ class TestDirectoryPrefs:
 
     def test_override_parent_flag(self, dir_prefs):
         """Test override_parent flag stops inheritance."""
-        parent = Path("/home/user")
-        child = Path("/home/user/documents")
+        parent = Path("/home/user")  # noqa: test-hardcoded-paths
+        child = Path("/home/user/documents")  # noqa: test-hardcoded-paths
 
         parent_pref = {"parent_setting": "should_not_inherit"}
         child_pref = {"child_setting": "only_this"}
@@ -111,8 +111,8 @@ class TestDirectoryPrefs:
 
     def test_deep_merge_nested_dicts(self, dir_prefs):
         """Test that nested dictionaries are merged properly."""
-        parent = Path("/home/user")
-        child = Path("/home/user/documents")
+        parent = Path("/home/user")  # noqa: test-hardcoded-paths
+        child = Path("/home/user/documents")  # noqa: test-hardcoded-paths
 
         parent_pref = {"folder_mappings": {"pdf": "Documents", "txt": "TextFiles"}}
         child_pref = {
@@ -139,8 +139,8 @@ class TestDirectoryPrefs:
 
     def test_list_directory_preferences(self, dir_prefs):
         """Test listing all directory preferences."""
-        path1 = Path("/home/user")
-        path2 = Path("/home/user/documents")
+        path1 = Path("/home/user")  # noqa: test-hardcoded-paths
+        path2 = Path("/home/user/documents")  # noqa: test-hardcoded-paths
 
         dir_prefs.set_preference(path1, {"setting1": "value1"})
         dir_prefs.set_preference(path2, {"setting2": "value2"})
@@ -154,7 +154,7 @@ class TestDirectoryPrefs:
 
     def test_remove_preference(self, dir_prefs):
         """Test removing a preference."""
-        test_path = Path("/home/user/documents")
+        test_path = Path("/home/user/documents")  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(test_path, {"setting": "value"})
 
         # Verify it exists
@@ -208,7 +208,7 @@ class TestDirectoryPrefs:
 
     def test_metadata_not_in_result(self, dir_prefs):
         """Test that internal metadata is not included in results."""
-        test_path = Path("/home/user")
+        test_path = Path("/home/user")  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(test_path, {"setting": "value"})
 
         result = dir_prefs.get_preference_with_inheritance(test_path)
@@ -219,7 +219,7 @@ class TestDirectoryPrefs:
 
     def test_metadata_not_in_list(self, dir_prefs):
         """Test that internal metadata is not included in list results."""
-        dir_prefs.set_preference(Path("/home/user"), {"setting": "value"})
+        dir_prefs.set_preference(Path("/home/user"), {"setting": "value"})  # noqa: test-hardcoded-paths
 
         prefs_list = dir_prefs.list_directory_preferences()
         pref_dict = prefs_list[0][1]
@@ -230,7 +230,7 @@ class TestDirectoryPrefs:
 
     def test_empty_preference_dict(self, dir_prefs):
         """Test setting an empty preference dictionary."""
-        test_path = Path("/home/user")
+        test_path = Path("/home/user")  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(test_path, {})
 
         result = dir_prefs.get_preference_with_inheritance(test_path)
@@ -241,17 +241,17 @@ class TestDirectoryPrefs:
     def test_complex_inheritance_scenario(self, dir_prefs):
         """Test a complex real-world inheritance scenario."""
         # Setup: root has global settings
-        root = Path("/home/user")
+        root = Path("/home/user")  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(root, {"naming_patterns": {"prefix": "user_"}, "confidence": 0.7})
 
         # Documents overrides naming, adds folder mappings
-        docs = Path("/home/user/documents")
+        docs = Path("/home/user/documents")  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(
             docs, {"naming_patterns": {"prefix": "doc_"}, "folder_mappings": {"pdf": "PDFs"}}
         )
 
         # Work documents adds more mappings
-        work = Path("/home/user/documents/work")
+        work = Path("/home/user/documents/work")  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(
             work, {"folder_mappings": {"xlsx": "Spreadsheets"}, "confidence": 0.9}
         )
@@ -266,9 +266,9 @@ class TestDirectoryPrefs:
 
     def test_inheritance_stops_at_override(self, dir_prefs):
         """Test that inheritance chain stops at override_parent=True."""
-        grandparent = Path("/home/user")
-        parent = Path("/home/user/documents")
-        child = Path("/home/user/documents/work")
+        grandparent = Path("/home/user")  # noqa: test-hardcoded-paths
+        parent = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        child = Path("/home/user/documents/work")  # noqa: test-hardcoded-paths
 
         dir_prefs.set_preference(grandparent, {"gp": "value"})
         dir_prefs.set_preference(parent, {"p": "value"}, override_parent=True)

--- a/tests/services/intelligence/test_preference_tracker.py
+++ b/tests/services/intelligence/test_preference_tracker.py
@@ -125,7 +125,7 @@ def test_correction_get_pattern_key_no_extension():
     """Test pattern key generation for a file without an extension."""
     correction = Correction(
         correction_type=CorrectionType.FILE_RENAME,
-        source=Path("/tmp/Makefile"),
+        source=Path("/tmp/Makefile"),  # noqa: test-hardcoded-paths
         destination=Path("/build/Makefile"),
         timestamp=datetime.now(UTC),
     )

--- a/tests/services/test_service_facade.py
+++ b/tests/services/test_service_facade.py
@@ -671,8 +671,8 @@ class TestGetOperationHistory:
         mock_op.id = 1
         mock_op.operation_type = MagicMock()
         mock_op.operation_type.value = "move"
-        mock_op.source_path = Path("/tmp/src.txt")
-        mock_op.destination_path = Path("/tmp/dst.txt")
+        mock_op.source_path = Path("/tmp/src.txt")  # noqa: test-hardcoded-paths
+        mock_op.destination_path = Path("/tmp/dst.txt")  # noqa: test-hardcoded-paths
         mock_op.status = MagicMock()
         mock_op.status.value = "completed"
         mock_op.timestamp = MagicMock()
@@ -711,7 +711,7 @@ class TestGetOperationHistory:
         mock_op.id = 2
         mock_op.operation_type = MagicMock()
         mock_op.operation_type.value = "delete"
-        mock_op.source_path = Path("/tmp/gone.txt")
+        mock_op.source_path = Path("/tmp/gone.txt")  # noqa: test-hardcoded-paths
         mock_op.destination_path = None
         mock_op.status = MagicMock()
         mock_op.status.value = "completed"

--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -62,7 +62,7 @@ class TestProcessedFile:
     def test_all_fields(self) -> None:
         """Verify all fields are stored correctly."""
         pf = ProcessedFile(
-            file_path=Path("/tmp/b.pdf"),
+            file_path=Path("/tmp/b.pdf"),  # noqa: test-hardcoded-paths
             description="A summary",
             folder_name="science",
             filename="research_paper",
@@ -70,7 +70,7 @@ class TestProcessedFile:
             processing_time=1.23,
             error="some error",
         )
-        assert pf.file_path == Path("/tmp/b.pdf")
+        assert pf.file_path == Path("/tmp/b.pdf")  # noqa: test-hardcoded-paths
         assert pf.description == "A summary"
         assert pf.folder_name == "science"
         assert pf.filename == "research_paper"

--- a/tests/services/test_text_processor_logging.py
+++ b/tests/services/test_text_processor_logging.py
@@ -72,7 +72,7 @@ class TestInfoLevelDoesNotLeakContent:
                 return_value="healthcare content",
             ),
         ):
-            processor.process_file("/tmp/test.txt")
+            processor.process_file("/tmp/test.txt")  # noqa: test-hardcoded-paths
 
         info_messages = [str(c) for c in mock_logger.info.call_args_list]
         combined = " ".join(info_messages)
@@ -90,7 +90,7 @@ class TestInfoLevelDoesNotLeakContent:
                 "file_organizer.services.text_processor.read_file", return_value="medical records"
             ),
         ):
-            processor.process_file("/tmp/records.txt")
+            processor.process_file("/tmp/records.txt")  # noqa: test-hardcoded-paths
 
         info_messages = [str(c) for c in mock_logger.info.call_args_list]
         combined = " ".join(info_messages)
@@ -111,7 +111,7 @@ class TestInfoLevelDoesNotLeakContent:
                 return_value="financial planning",
             ),
         ):
-            processor.process_file("/tmp/budget.txt")
+            processor.process_file("/tmp/budget.txt")  # noqa: test-hardcoded-paths
 
         # At least one INFO call should mention "chars" (length-based log)
         info_messages = [str(c) for c in mock_logger.info.call_args_list]
@@ -146,7 +146,7 @@ class TestWarningLevelDoesNotLeakContent:
                 "file_organizer.services.text_processor.clean_text", return_value="fallback_folder"
             ),
         ):
-            processor.process_file("/tmp/short_folder.txt")
+            processor.process_file("/tmp/short_folder.txt")  # noqa: test-hardcoded-paths
 
         warning_messages = [str(c) for c in mock_logger.warning.call_args_list]
         combined = " ".join(warning_messages)
@@ -170,7 +170,7 @@ class TestWarningLevelDoesNotLeakContent:
             patch("file_organizer.services.text_processor.read_file", return_value="some code"),
             patch("file_organizer.services.text_processor.clean_text", return_value="code_snippet"),
         ):
-            processor.process_file("/tmp/short_fn.txt")
+            processor.process_file("/tmp/short_fn.txt")  # noqa: test-hardcoded-paths
 
         warning_messages = [str(c) for c in mock_logger.warning.call_args_list]
         combined = " ".join(warning_messages)
@@ -189,7 +189,7 @@ class TestWarningLevelDoesNotLeakContent:
             patch("file_organizer.services.text_processor.read_file", return_value="content"),
             patch("file_organizer.services.text_processor.clean_text", return_value="fallback"),
         ):
-            processor.process_file("/tmp/warn_test.txt")
+            processor.process_file("/tmp/warn_test.txt")  # noqa: test-hardcoded-paths
 
         # The warning call should exist and contain generic text
         warning_calls = mock_logger.warning.call_args_list
@@ -225,7 +225,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
             patch("file_organizer.services.text_processor.logger") as mock_logger,
             patch("file_organizer.services.text_processor.read_file", return_value="text"),
         ):
-            processor.process_file("/tmp/debug_test.txt")
+            processor.process_file("/tmp/debug_test.txt")  # noqa: test-hardcoded-paths
 
         debug_messages = [str(c) for c in mock_logger.debug.call_args_list]
         combined = " ".join(debug_messages)
@@ -246,7 +246,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
             patch("file_organizer.services.text_processor.logger") as mock_logger,
             patch("file_organizer.services.text_processor.read_file", return_value="text"),
         ):
-            processor.process_file("/tmp/debug_fn_test.txt")
+            processor.process_file("/tmp/debug_fn_test.txt")  # noqa: test-hardcoded-paths
 
         debug_messages = [str(c) for c in mock_logger.debug.call_args_list]
         combined = " ".join(debug_messages)
@@ -267,7 +267,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
             patch("file_organizer.services.text_processor.logger") as mock_logger,
             patch("file_organizer.services.text_processor.read_file", return_value="python code"),
         ):
-            processor.process_file("/tmp/code_guide.txt")
+            processor.process_file("/tmp/code_guide.txt")  # noqa: test-hardcoded-paths
 
         debug_messages = [str(c) for c in mock_logger.debug.call_args_list]
         combined = " ".join(debug_messages)
@@ -302,7 +302,7 @@ class TestLogMessageFormats:
                 "file_organizer.services.text_processor.read_file", return_value="recipe content"
             ),
         ):
-            processor.process_file("/tmp/recipe.txt")
+            processor.process_file("/tmp/recipe.txt")  # noqa: test-hardcoded-paths
 
         # Check that info was called with "Folder name generated" message
         info_call_strings = [str(c) for c in mock_logger.info.call_args_list]
@@ -323,7 +323,7 @@ class TestLogMessageFormats:
                 "file_organizer.services.text_processor.read_file", return_value="cooking content"
             ),
         ):
-            processor.process_file("/tmp/cooking.txt")
+            processor.process_file("/tmp/cooking.txt")  # noqa: test-hardcoded-paths
 
         info_call_strings = [str(c) for c in mock_logger.info.call_args_list]
         filename_info_calls = [s for s in info_call_strings if "Filename generated" in s]

--- a/tests/tui/test_analytics_view.py
+++ b/tests/tui/test_analytics_view.py
@@ -361,14 +361,14 @@ class TestAnalyticsView:
 
     def test_initialization_with_custom_directory(self) -> None:
         """Test AnalyticsView initialization with custom directory."""
-        test_path = Path("/tmp/test")
+        test_path = Path("/tmp/test")  # noqa: test-hardcoded-paths
         view = AnalyticsView(directory=test_path)
         assert view._directory == test_path
 
     def test_initialization_with_string_directory(self) -> None:
         """Test AnalyticsView initialization with string directory."""
-        view = AnalyticsView(directory="/tmp/test")
-        assert view._directory == Path("/tmp/test")
+        view = AnalyticsView(directory="/tmp/test")  # noqa: test-hardcoded-paths
+        assert view._directory == Path("/tmp/test")  # noqa: test-hardcoded-paths
 
     def test_has_compose_method(self) -> None:
         """Test that compose method is defined."""

--- a/tests/tui/test_audio_view.py
+++ b/tests/tui/test_audio_view.py
@@ -279,8 +279,8 @@ class TestAudioViewInit:
         assert view._scan_dir == tmp_path
 
     def test_string_scan_dir(self):
-        view = AudioView(scan_dir="/tmp")
-        assert view._scan_dir == Path("/tmp")
+        view = AudioView(scan_dir="/tmp")  # noqa: test-hardcoded-paths
+        assert view._scan_dir == Path("/tmp")  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.unit

--- a/tests/tui/test_file_preview.py
+++ b/tests/tui/test_file_preview.py
@@ -37,7 +37,7 @@ class TestFileSelectionManager:
     def test_toggle_adds_path(self) -> None:
         """Test that toggle adds a new path."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")
+        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
         result = manager.toggle(path)
         assert result is True
         assert manager.count == 1
@@ -46,7 +46,7 @@ class TestFileSelectionManager:
     def test_toggle_removes_path(self) -> None:
         """Test that toggle removes a selected path."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")
+        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
         manager.toggle(path)  # Add
         result = manager.toggle(path)  # Remove
         assert result is False
@@ -56,9 +56,9 @@ class TestFileSelectionManager:
     def test_toggle_multiple_paths(self) -> None:
         """Test toggling multiple paths."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file1.txt")
-        path2 = Path("/tmp/file2.txt")
-        path3 = Path("/tmp/file3.txt")
+        path1 = Path("/tmp/file1.txt")  # noqa: test-hardcoded-paths
+        path2 = Path("/tmp/file2.txt")  # noqa: test-hardcoded-paths
+        path3 = Path("/tmp/file3.txt")  # noqa: test-hardcoded-paths
 
         manager.toggle(path1)
         manager.toggle(path2)
@@ -72,7 +72,7 @@ class TestFileSelectionManager:
     def test_toggle_returns_correct_state(self) -> None:
         """Test that toggle returns the new selection state."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")
+        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
         assert manager.toggle(path) is True
         assert manager.toggle(path) is False
         assert manager.toggle(path) is True
@@ -81,9 +81,9 @@ class TestFileSelectionManager:
         """Test select_all adds all provided paths."""
         manager = FileSelectionManager()
         paths = {
-            Path("/tmp/file1.txt"),
-            Path("/tmp/file2.txt"),
-            Path("/tmp/file3.txt"),
+            Path("/tmp/file1.txt"),  # noqa: test-hardcoded-paths
+            Path("/tmp/file2.txt"),  # noqa: test-hardcoded-paths
+            Path("/tmp/file3.txt"),  # noqa: test-hardcoded-paths
         }
         manager.select_all(paths)
         assert manager.count == 3
@@ -92,12 +92,12 @@ class TestFileSelectionManager:
     def test_select_all_adds_to_existing(self) -> None:
         """Test that select_all adds to existing selections."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file1.txt")
+        path1 = Path("/tmp/file1.txt")  # noqa: test-hardcoded-paths
         manager.toggle(path1)
 
         paths = {
-            Path("/tmp/file2.txt"),
-            Path("/tmp/file3.txt"),
+            Path("/tmp/file2.txt"),  # noqa: test-hardcoded-paths
+            Path("/tmp/file3.txt"),  # noqa: test-hardcoded-paths
         }
         manager.select_all(paths)
         assert manager.count == 3
@@ -112,9 +112,9 @@ class TestFileSelectionManager:
     def test_clear_removes_all_selections(self) -> None:
         """Test that clear removes all paths."""
         manager = FileSelectionManager()
-        manager.toggle(Path("/tmp/file1.txt"))
-        manager.toggle(Path("/tmp/file2.txt"))
-        manager.toggle(Path("/tmp/file3.txt"))
+        manager.toggle(Path("/tmp/file1.txt"))  # noqa: test-hardcoded-paths
+        manager.toggle(Path("/tmp/file2.txt"))  # noqa: test-hardcoded-paths
+        manager.toggle(Path("/tmp/file3.txt"))  # noqa: test-hardcoded-paths
         assert manager.count == 3
 
         manager.clear()
@@ -133,31 +133,31 @@ class TestFileSelectionManager:
         assert manager.count == 0
 
         for i in range(5):
-            manager.toggle(Path(f"/tmp/file{i}.txt"))
+            manager.toggle(Path(f"/tmp/file{i}.txt"))  # noqa: test-hardcoded-paths
             assert manager.count == i + 1
 
         for i in range(5):
-            manager.toggle(Path(f"/tmp/file{i}.txt"))
+            manager.toggle(Path(f"/tmp/file{i}.txt"))  # noqa: test-hardcoded-paths
             assert manager.count == 5 - i - 1
 
     def test_selected_files_returns_copy(self) -> None:
         """Test that selected_files returns a copy, not the internal set."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")
+        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
         manager.toggle(path)
 
         selected = manager.selected_files
-        selected.add(Path("/tmp/fake.txt"))  # Modify the returned set
+        selected.add(Path("/tmp/fake.txt"))  # Modify the returned set  # noqa: test-hardcoded-paths
 
         # Original should not be modified
         assert manager.count == 1
-        assert Path("/tmp/fake.txt") not in manager.selected_files
+        assert Path("/tmp/fake.txt") not in manager.selected_files  # noqa: test-hardcoded-paths
 
     def test_selected_files_immutability(self) -> None:
         """Test that modifying returned set doesn't affect manager."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file1.txt")
-        path2 = Path("/tmp/file2.txt")
+        path1 = Path("/tmp/file1.txt")  # noqa: test-hardcoded-paths
+        path2 = Path("/tmp/file2.txt")  # noqa: test-hardcoded-paths
         manager.toggle(path1)
 
         selected = manager.selected_files
@@ -228,8 +228,8 @@ class TestFileSelectionManagerEdgeCases:
     def test_same_path_object_vs_equal_paths(self) -> None:
         """Test that different Path objects to same file work correctly."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file.txt")
-        path2 = Path("/tmp/file.txt")
+        path1 = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path2 = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
 
         manager.toggle(path1)
         # Both should refer to the same file
@@ -238,7 +238,7 @@ class TestFileSelectionManagerEdgeCases:
     def test_path_with_special_characters(self) -> None:
         """Test paths with special characters."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file with spaces (1).txt")
+        path = Path("/tmp/file with spaces (1).txt")  # noqa: test-hardcoded-paths
         manager.toggle(path)
         assert manager.count == 1
         assert path in manager.selected_files
@@ -246,7 +246,7 @@ class TestFileSelectionManagerEdgeCases:
     def test_absolute_vs_relative_paths(self) -> None:
         """Test that absolute and relative paths are distinct."""
         manager = FileSelectionManager()
-        abs_path = Path("/tmp/file.txt")
+        abs_path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
         rel_path = Path("file.txt")
 
         manager.toggle(abs_path)
@@ -256,14 +256,14 @@ class TestFileSelectionManagerEdgeCases:
     def test_large_selection(self) -> None:
         """Test managing large number of selections."""
         manager = FileSelectionManager()
-        paths = {Path(f"/tmp/file{i}.txt") for i in range(1000)}
+        paths = {Path(f"/tmp/file{i}.txt") for i in range(1000)}  # noqa: test-hardcoded-paths
         manager.select_all(paths)
         assert manager.count == 1000
 
     def test_clear_after_large_selection(self) -> None:
         """Test clearing large selection."""
         manager = FileSelectionManager()
-        paths = {Path(f"/tmp/file{i}.txt") for i in range(100)}
+        paths = {Path(f"/tmp/file{i}.txt") for i in range(100)}  # noqa: test-hardcoded-paths
         manager.select_all(paths)
         manager.clear()
         assert manager.count == 0
@@ -271,7 +271,7 @@ class TestFileSelectionManagerEdgeCases:
     def test_toggle_repeatedly_same_path(self) -> None:
         """Test toggling same path multiple times."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")
+        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
 
         for i in range(100):
             manager.toggle(path)

--- a/tests/tui/test_methodology_view.py
+++ b/tests/tui/test_methodology_view.py
@@ -258,14 +258,14 @@ class TestMethodologyView:
 
     def test_initialization_with_custom_directory(self) -> None:
         """Test MethodologyView initialization with custom directory."""
-        test_path = Path("/tmp/test")
+        test_path = Path("/tmp/test")  # noqa: test-hardcoded-paths
         view = MethodologyView(scan_dir=test_path)
         assert view._scan_dir == test_path
 
     def test_initialization_with_string_directory(self) -> None:
         """Test MethodologyView initialization with string directory."""
-        view = MethodologyView(scan_dir="/tmp/test")
-        assert view._scan_dir == Path("/tmp/test")
+        view = MethodologyView(scan_dir="/tmp/test")  # noqa: test-hardcoded-paths
+        assert view._scan_dir == Path("/tmp/test")  # noqa: test-hardcoded-paths
 
     def test_has_compose_method(self) -> None:
         """Test that compose method is defined."""

--- a/tests/tui/test_organization_preview.py
+++ b/tests/tui/test_organization_preview.py
@@ -82,9 +82,9 @@ class TestBeforeAfterPanel:
         panel = BeforeAfterPanel()
         panel.update = MagicMock()
         structure = {"Docs": ["file.pdf"]}
-        panel.set_structure(structure, input_dir="/home/user/files")
+        panel.set_structure(structure, input_dir="/home/user/files")  # noqa: test-hardcoded-paths
         rendered = panel.update.call_args[0][0]
-        assert "/home/user/files/file.pdf" in rendered
+        assert "/home/user/files/file.pdf" in rendered  # noqa: test-hardcoded-paths
 
     def test_set_structure_truncates_long_lists(self) -> None:
         """Test that large file lists are truncated."""
@@ -238,8 +238,8 @@ class TestOrganizationPreviewView:
 
     def test_initialization_with_custom_directories(self) -> None:
         """Test OrganizationPreviewView with custom directories."""
-        input_path = Path("/home/user/files")
-        output_path = Path("/home/user/organized")
+        input_path = Path("/home/user/files")  # noqa: test-hardcoded-paths
+        output_path = Path("/home/user/organized")  # noqa: test-hardcoded-paths
         view = OrganizationPreviewView(input_dir=input_path, output_dir=output_path)
         assert view._input_dir == input_path
         assert view._output_dir == output_path
@@ -247,11 +247,11 @@ class TestOrganizationPreviewView:
     def test_initialization_with_string_directories(self) -> None:
         """Test OrganizationPreviewView with string directories."""
         view = OrganizationPreviewView(
-            input_dir="/tmp/input",
-            output_dir="/tmp/output",
+            input_dir="/tmp/input",  # noqa: test-hardcoded-paths
+            output_dir="/tmp/output",  # noqa: test-hardcoded-paths
         )
-        assert view._input_dir == Path("/tmp/input")
-        assert view._output_dir == Path("/tmp/output")
+        assert view._input_dir == Path("/tmp/input")  # noqa: test-hardcoded-paths
+        assert view._output_dir == Path("/tmp/output")  # noqa: test-hardcoded-paths
 
     def test_has_compose_method(self) -> None:
         """Test that compose method is defined."""

--- a/tests/tui/test_tui_analytics_view.py
+++ b/tests/tui/test_tui_analytics_view.py
@@ -128,8 +128,8 @@ class TestAnalyticsView:
         assert str(view._directory) == "."
 
     def test_custom_directory(self) -> None:
-        view = AnalyticsView(directory="/tmp/data", id="view")
-        assert str(view._directory) == "/tmp/data"
+        view = AnalyticsView(directory="/tmp/data", id="view")  # noqa: test-hardcoded-paths
+        assert str(view._directory) == "/tmp/data"  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.asyncio

--- a/tests/tui/test_tui_coverage_gaps.py
+++ b/tests/tui/test_tui_coverage_gaps.py
@@ -111,7 +111,7 @@ class TestAnalyticsViewMountCompose:
         """compose() must yield StaticWidgets — test by verifying it's iterable."""
         from file_organizer.tui.analytics_view import AnalyticsView
 
-        view = AnalyticsView(directory="/tmp")
+        view = AnalyticsView(directory="/tmp")  # noqa: test-hardcoded-paths
         result = list(view.compose())
         # Should yield 5 widgets (header + 4 panels)
         assert len(result) == 5

--- a/tests/tui/test_tui_methodology_view.py
+++ b/tests/tui/test_tui_methodology_view.py
@@ -97,8 +97,8 @@ class TestMethodologyView:
         assert view._methodology == "none"
 
     def test_scan_dir(self) -> None:
-        view = MethodologyView(scan_dir="/tmp/test", id="view")
-        assert str(view._scan_dir) == "/tmp/test"
+        view = MethodologyView(scan_dir="/tmp/test", id="view")  # noqa: test-hardcoded-paths
+        assert str(view._scan_dir) == "/tmp/test"  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.asyncio

--- a/tests/undo/test_durable_move_1248.py
+++ b/tests/undo/test_durable_move_1248.py
@@ -201,7 +201,7 @@ class TestJournalUtf8RoundTrip:
 
         journal = tmp_path / "u.journal"
         unicode_src = "/trash/файл-café-日本語.txt"
-        unicode_dst = "/home/файл-café-日本語.txt"
+        unicode_dst = "/home/файл-café-日本語.txt"  # noqa: test-hardcoded-paths
         line = json.dumps(
             {
                 "schema": 2,

--- a/tests/undo/test_trash_gc_race.py
+++ b/tests/undo/test_trash_gc_race.py
@@ -62,21 +62,21 @@ class TestIsPathInFlight:
 
     def test_exact_src_match_in_flight(self) -> None:
         """A path that is the exact src of an active move is in-flight."""
-        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_STARTED)]
+        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_STARTED)]  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(Path("/trash/a.txt"), entries) is True
 
     def test_exact_dst_match_in_flight(self) -> None:
         """A path that is the exact dst of an active move is in-flight."""
-        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_COPIED)]
-        assert _path_in_flight_from_entries(Path("/home/a.txt"), entries) is True
+        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_COPIED)]  # noqa: test-hardcoded-paths
+        assert _path_in_flight_from_entries(Path("/home/a.txt"), entries) is True  # noqa: test-hardcoded-paths
 
     def test_unrelated_path_not_in_flight(self) -> None:
-        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_STARTED)]
+        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_STARTED)]  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(Path("/trash/b.txt"), entries) is False
 
     def test_done_state_not_in_flight(self) -> None:
         """A completed move no longer protects its paths."""
-        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_DONE)]
+        entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_DONE)]  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(Path("/trash/a.txt"), entries) is False
 
     def test_latest_state_wins_done_collapses(self) -> None:
@@ -96,38 +96,38 @@ class TestIsPathInFlight:
         """#1248 #4: a child of an in-flight ``dir_move`` directory is
         in-flight. Without the fix, only the exact directory matched and
         a GC could delete ``trash/dir/child.txt`` mid-restore."""
-        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]
+        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
         child = Path("/trash/dir/child.txt")
         assert _path_in_flight_from_entries(child, entries) is True
 
     def test_dir_move_protects_nested_descendant(self) -> None:
         """Deeply nested descendants are protected too."""
-        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]
+        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
         nested = Path("/trash/dir/sub/deep/file.txt")
         assert _path_in_flight_from_entries(nested, entries) is True
 
     def test_dir_move_protects_dst_descendant(self) -> None:
         """Descendants of the dir_move DESTINATION are protected too."""
-        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]
-        dst_child = Path("/home/dir/child.txt")
+        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
+        dst_child = Path("/home/dir/child.txt")  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(dst_child, entries) is True
 
     def test_dir_move_exact_directory_match(self) -> None:
         """The exact dir_move directory itself is in-flight (regression)."""
-        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]
+        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(Path("/trash/dir"), entries) is True
 
     def test_dir_move_sibling_prefix_not_in_flight(self) -> None:
         """A sibling sharing a name PREFIX is NOT a descendant: the
         separator-anchored check must reject ``/trash/dirXYZ`` against
         ancestor ``/trash/dir``."""
-        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]
+        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
         sibling = Path("/trash/dirXYZ/file.txt")
         assert _path_in_flight_from_entries(sibling, entries) is False
 
     def test_dir_move_done_does_not_protect_descendant(self) -> None:
         """A completed dir_move no longer protects descendants."""
-        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_DONE)]
+        entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_DONE)]  # noqa: test-hardcoded-paths
         child = Path("/trash/dir/child.txt")
         assert _path_in_flight_from_entries(child, entries) is False
 
@@ -135,7 +135,7 @@ class TestIsPathInFlight:
         """A single-file ``move`` (not dir_move) keeps exact-match only —
         a regular file has no descendants, so prefix matching must NOT
         leak in and over-protect unrelated paths."""
-        entries = [_move_entry("/trash/file", "/home/file", STATE_STARTED)]
+        entries = [_move_entry("/trash/file", "/home/file", STATE_STARTED)]  # noqa: test-hardcoded-paths
         # A path that would be a "descendant" of the file path string must
         # not match for a single-file move.
         assert _path_in_flight_from_entries(Path("/trash/file/child"), entries) is False
@@ -144,5 +144,5 @@ class TestIsPathInFlight:
         """The predicate normalizes the query path so a relative path
         equivalent to a stored absolute path still matches."""
         abs_src = os.path.abspath("rel_a.txt")
-        entries = [_move_entry(abs_src, "/home/a.txt", STATE_STARTED)]
+        entries = [_move_entry(abs_src, "/home/a.txt", STATE_STARTED)]  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(Path("rel_a.txt"), entries) is True

--- a/tests/unit/config/test_path_manager.py
+++ b/tests/unit/config/test_path_manager.py
@@ -16,16 +16,16 @@ def test_get_canonical_paths_uses_xdg_when_available():
     with patch.dict(
         os.environ,
         {
-            "XDG_CONFIG_HOME": "/tmp/test-xdg-config",
-            "XDG_DATA_HOME": "/tmp/test-xdg-data",
-            "XDG_STATE_HOME": "/tmp/test-xdg-state",
+            "XDG_CONFIG_HOME": "/tmp/test-xdg-config",  # noqa: test-hardcoded-paths
+            "XDG_DATA_HOME": "/tmp/test-xdg-data",  # noqa: test-hardcoded-paths
+            "XDG_STATE_HOME": "/tmp/test-xdg-state",  # noqa: test-hardcoded-paths
         },
     ):
         paths = get_canonical_paths()
 
-        assert paths["config"] == Path("/tmp/test-xdg-config/file-organizer")
-        assert paths["data"] == Path("/tmp/test-xdg-data/file-organizer")
-        assert paths["state"] == Path("/tmp/test-xdg-state/file-organizer")
+        assert paths["config"] == Path("/tmp/test-xdg-config/file-organizer")  # noqa: test-hardcoded-paths
+        assert paths["data"] == Path("/tmp/test-xdg-data/file-organizer")  # noqa: test-hardcoded-paths
+        assert paths["state"] == Path("/tmp/test-xdg-state/file-organizer")  # noqa: test-hardcoded-paths
         # Cache uses platformdirs user_cache_dir, which is independent of XDG_DATA_HOME
         from platformdirs import user_cache_dir
 
@@ -56,7 +56,7 @@ def test_get_canonical_paths_uses_home_defaults():
 
 def test_path_manager_creates_directories():
     """PathManager should create all necessary directories"""
-    with patch.dict(os.environ, {"HOME": "/tmp/test-home"}):
+    with patch.dict(os.environ, {"HOME": "/tmp/test-home"}):  # noqa: test-hardcoded-paths
         manager = PathManager()
         # Mock mkdir to verify calls
         with patch.object(Path, "mkdir") as mock_mkdir:
@@ -67,7 +67,7 @@ def test_path_manager_creates_directories():
 
 def test_path_manager_provides_specific_paths():
     """PathManager should provide specific file paths"""
-    with patch.dict(os.environ, {"HOME": "/home/user"}):
+    with patch.dict(os.environ, {"HOME": "/home/user"}):  # noqa: test-hardcoded-paths
         manager = PathManager()
 
         assert str(manager.config_file).endswith("config.json")

--- a/tests/updater/test_installer.py
+++ b/tests/updater/test_installer.py
@@ -247,7 +247,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Linux")
     @patch("platform.machine", return_value="x86_64")
     def test_select_linux_x64(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-linux-x86_64.AppImage",
@@ -262,7 +262,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Darwin")
     @patch("platform.machine", return_value="arm64")
     def test_select_macos_arm(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-macos-universal.tar.gz",
@@ -276,7 +276,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Windows")
     @patch("platform.machine", return_value="AMD64")
     def test_select_windows(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-windows-amd64.exe",
@@ -290,7 +290,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Linux")
     @patch("platform.machine", return_value="x86_64")
     def test_no_matching_asset(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = self._make_release(["app-macos-arm64.zip"])
         asset = inst.select_asset(release)
         assert asset is None
@@ -298,7 +298,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Linux")
     @patch("platform.machine", return_value="x86_64")
     def test_skips_checksum_files(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-linux-x86_64.sha256",
@@ -321,7 +321,7 @@ class TestFindChecksum:
 
     @patch.object(UpdateInstaller, "_download_text", return_value="abc123  app.bin")
     def test_dedicated_checksum_file(self, mock_dl):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -339,7 +339,7 @@ class TestFindChecksum:
         return_value="def456  app.bin\nghi789  other.bin",
     )
     def test_sha256sums_file(self, mock_dl):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -352,7 +352,7 @@ class TestFindChecksum:
         assert result == "def456"
 
     def test_no_checksum_file(self):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -385,9 +385,9 @@ class TestResolveTarget:
 
     def test_appimage_target(self, tmp_path):
         inst = UpdateInstaller(install_dir=tmp_path)
-        inst._appimage_path = Path("/opt/app.AppImage")
+        inst._appimage_path = Path("/opt/app.AppImage")  # noqa: test-hardcoded-paths
         target = inst._resolve_target("my-app")
-        assert target == Path("/opt/app.AppImage")
+        assert target == Path("/opt/app.AppImage")  # noqa: test-hardcoded-paths
 
 
 # ---------------------------------------------------------------------------
@@ -613,7 +613,7 @@ class TestFindChecksumEdgeCases:
     )
     def test_sha256sums_no_match(self, mock_dl):
         """find_checksum returns empty string when SHA256SUMS exists but asset not listed."""
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -632,7 +632,7 @@ class TestFindChecksumEdgeCases:
     )
     def test_sha256sums_short_lines(self, mock_dl):
         """find_checksum handles SHA256SUMS lines with < 2 parts."""
-        inst = UpdateInstaller(install_dir=Path("/tmp"))
+        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",

--- a/tests/utils/test_safedir_anchored.py
+++ b/tests/utils/test_safedir_anchored.py
@@ -126,7 +126,7 @@ class TestOpenAnchoredReader:
         """Absolute relative_path is a programmer error — reject early."""
         with SafeDir.open_root(tmp_path) as root:
             with pytest.raises(ValueError, match="relative"):
-                root.open_anchored_reader(Path("/etc/passwd"))
+                root.open_anchored_reader(Path("/etc/passwd"))  # noqa: test-hardcoded-paths
 
     def test_parent_traversal_rejected(self, tmp_path: Path) -> None:
         """``..`` components would escape — must be refused before any open."""
@@ -321,7 +321,7 @@ class TestOpenAnchoredWriter:
     def test_absolute_path_rejected(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as root:
             with pytest.raises(ValueError, match="relative"):
-                root.open_anchored_writer(Path("/etc/passwd"))
+                root.open_anchored_writer(Path("/etc/passwd"))  # noqa: test-hardcoded-paths
 
     def test_parent_traversal_rejected(self, tmp_path: Path) -> None:
         (tmp_path / "child").mkdir()

--- a/tests/watcher/test_config.py
+++ b/tests/watcher/test_config.py
@@ -100,17 +100,17 @@ class TestWatcherConfigShouldIncludeFile:
 
     def test_includes_normal_file_by_default(self):
         config = WatcherConfig()
-        path = Path("/home/user/document.txt")
+        path = Path("/home/user/document.txt")  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is True
 
     def test_excludes_tmp_files(self):
         config = WatcherConfig()
-        path = Path("/home/user/file.tmp")
+        path = Path("/home/user/file.tmp")  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_excludes_temp_files(self):
         config = WatcherConfig()
-        path = Path("/tmp/file.temp")
+        path = Path("/tmp/file.temp")  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_excludes_git_directory(self):
@@ -125,7 +125,7 @@ class TestWatcherConfigShouldIncludeFile:
 
     def test_excludes_ds_store(self):
         config = WatcherConfig()
-        path = Path("/home/user/.DS_Store")
+        path = Path("/home/user/.DS_Store")  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_excludes_node_modules(self):
@@ -139,7 +139,7 @@ class TestWatcherConfigShouldIncludeFile:
 
     def test_excludes_by_suffix(self):
         config = WatcherConfig()
-        path = Path("/home/user/file.pyc")
+        path = Path("/home/user/file.pyc")  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_with_custom_exclude_patterns(self):
@@ -192,12 +192,12 @@ class TestMatchesPattern:
     """Test _matches_pattern function."""
 
     def test_simple_extension_pattern(self):
-        assert _matches_pattern("/home/user/file.tmp", "*.tmp") is True
-        assert _matches_pattern("/home/user/file.txt", "*.tmp") is False
+        assert _matches_pattern("/home/user/file.tmp", "*.tmp") is True  # noqa: test-hardcoded-paths
+        assert _matches_pattern("/home/user/file.txt", "*.tmp") is False  # noqa: test-hardcoded-paths
 
     def test_exact_filename_pattern(self):
-        assert _matches_pattern("/home/.DS_Store", ".DS_Store") is True
-        assert _matches_pattern("/home/user/.DS_Store", ".DS_Store") is True
+        assert _matches_pattern("/home/.DS_Store", ".DS_Store") is True  # noqa: test-hardcoded-paths
+        assert _matches_pattern("/home/user/.DS_Store", ".DS_Store") is True  # noqa: test-hardcoded-paths
 
     def test_directory_pattern(self):
         assert _matches_pattern("/project/.git/config", ".git") is True
@@ -220,22 +220,22 @@ class TestMatchesPattern:
         assert _matches_pattern("/project/node_modules/package/index.js", "node_modules/*") is False
 
     def test_no_match(self):
-        assert _matches_pattern("/home/user/document.txt", "*.tmp") is False
-        assert _matches_pattern("/home/user/.git/config", "*.log") is False
+        assert _matches_pattern("/home/user/document.txt", "*.tmp") is False  # noqa: test-hardcoded-paths
+        assert _matches_pattern("/home/user/.git/config", "*.log") is False  # noqa: test-hardcoded-paths
 
     def test_pattern_with_path(self):
         # Component matching means ".git" component matches
-        assert _matches_pattern("/home/.git/config", ".git") is True
-        assert _matches_pattern("/home/.git/config", ".git/*") is False
+        assert _matches_pattern("/home/.git/config", ".git") is True  # noqa: test-hardcoded-paths
+        assert _matches_pattern("/home/.git/config", ".git/*") is False  # noqa: test-hardcoded-paths
 
     def test_matching_filename_component(self):
         """Tests that individual path components are matched."""
-        assert _matches_pattern("/home/user/file.tmp", "*.tmp") is True
+        assert _matches_pattern("/home/user/file.tmp", "*.tmp") is True  # noqa: test-hardcoded-paths
 
     def test_hidden_files(self):
         # ".env" component is matched, but not as a wildcard pattern
-        assert _matches_pattern("/home/.env/config", ".env/*") is False
-        assert _matches_pattern("/home/.env/config", ".env") is True
+        assert _matches_pattern("/home/.env/config", ".env/*") is False  # noqa: test-hardcoded-paths
+        assert _matches_pattern("/home/.env/config", ".env") is True  # noqa: test-hardcoded-paths
 
     def test_case_sensitivity(self):
         """fnmatch is case-sensitive on Unix, case-insensitive on Windows."""
@@ -248,7 +248,7 @@ class TestMatchesPattern:
         assert result_upper is True or result_upper is False
 
     def test_empty_pattern(self):
-        assert _matches_pattern("/home/user/file.txt", "") is False
+        assert _matches_pattern("/home/user/file.txt", "") is False  # noqa: test-hardcoded-paths
 
     def test_root_file(self):
         assert _matches_pattern("/.DS_Store", ".DS_Store") is True

--- a/tests/watcher/test_handler.py
+++ b/tests/watcher/test_handler.py
@@ -59,14 +59,14 @@ class TestFileEventHandlerFiltering:
     def test_accepts_normal_file(self, default_config: WatcherConfig, queue: EventQueue) -> None:
         """Test that a normal file passes through filters."""
         handler = FileEventHandler(default_config, queue)
-        event = FileCreatedEvent(src_path="/tmp/document.txt")
+        event = FileCreatedEvent(src_path="/tmp/document.txt")  # noqa: test-hardcoded-paths
         handler.on_created(event)
         assert queue.size == 1
 
     def test_filters_tmp_files(self, default_config: WatcherConfig, queue: EventQueue) -> None:
         """Test that .tmp files are filtered out."""
         handler = FileEventHandler(default_config, queue)
-        event = FileCreatedEvent(src_path="/tmp/scratch.tmp")
+        event = FileCreatedEvent(src_path="/tmp/scratch.tmp")  # noqa: test-hardcoded-paths
         handler.on_created(event)
         assert queue.size == 0
 
@@ -93,8 +93,8 @@ class TestFileEventHandlerFiltering:
         )
         handler = FileEventHandler(config, queue)
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/doc.txt"))
-        handler.on_created(FileCreatedEvent(src_path="/tmp/report.pdf"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/doc.txt"))  # noqa: test-hardcoded-paths
+        handler.on_created(FileCreatedEvent(src_path="/tmp/report.pdf"))  # noqa: test-hardcoded-paths
         assert queue.size == 2
 
     def test_file_type_filter_rejects_non_matching(self, queue: EventQueue) -> None:
@@ -106,7 +106,7 @@ class TestFileEventHandlerFiltering:
         )
         handler = FileEventHandler(config, queue)
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/image.png"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/image.png"))  # noqa: test-hardcoded-paths
         assert queue.size == 0
 
     def test_directory_events_pass_through(
@@ -120,7 +120,7 @@ class TestFileEventHandlerFiltering:
         )
         handler = FileEventHandler(config, queue)
 
-        event = DirCreatedEvent(src_path="/tmp/newdir")
+        event = DirCreatedEvent(src_path="/tmp/newdir")  # noqa: test-hardcoded-paths
         handler.on_created(event)
         assert queue.size == 1
         queued = queue.dequeue_batch(1)
@@ -139,7 +139,7 @@ class TestFileEventHandlerDebounce:
 
         # Fire multiple events rapidly on the same file
         for _ in range(5):
-            handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+            handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
 
         # Only the first should have gotten through
         assert queue.size == 1
@@ -153,14 +153,14 @@ class TestFileEventHandlerDebounce:
         config = WatcherConfig(debounce_seconds=0.1, exclude_patterns=[])
         handler = FileEventHandler(config, queue)
 
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         assert queue.size == 1
 
         # Advance the handler's monotonic clock past the debounce window
         real_monotonic = time.monotonic
         monkeypatch.setattr(_handler_module.time, "monotonic", lambda: real_monotonic() + 1.0)
 
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         assert queue.size == 2
 
     def test_different_files_not_debounced(
@@ -169,9 +169,9 @@ class TestFileEventHandlerDebounce:
         """Test that events on different files are independent."""
         handler = FileEventHandler(debounce_config, queue)
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file_a.txt"))
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file_b.txt"))
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file_c.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file_a.txt"))  # noqa: test-hardcoded-paths
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file_b.txt"))  # noqa: test-hardcoded-paths
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file_c.txt"))  # noqa: test-hardcoded-paths
 
         assert queue.size == 3
 
@@ -181,7 +181,7 @@ class TestFileEventHandlerDebounce:
         handler = FileEventHandler(config, queue)
 
         for _ in range(10):
-            handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+            handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
 
         assert queue.size == 10
 
@@ -189,18 +189,18 @@ class TestFileEventHandlerDebounce:
         """Test that clearing debounce state allows immediate re-processing."""
         handler = FileEventHandler(debounce_config, queue)
 
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         assert queue.size == 1
 
         # This would be debounced
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         assert queue.size == 1
 
         # Clear debounce state
         handler.clear_debounce_state()
 
         # Now it should pass through again
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         assert queue.size == 2
 
 
@@ -211,7 +211,7 @@ class TestFileEventHandlerEventTypes:
     def test_created_event(self, default_config: WatcherConfig, queue: EventQueue) -> None:
         """Test handling of file creation events."""
         handler = FileEventHandler(default_config, queue)
-        handler.on_created(FileCreatedEvent(src_path="/tmp/new.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/new.txt"))  # noqa: test-hardcoded-paths
 
         events = queue.dequeue_batch(1)
         assert events[0].event_type == EventType.CREATED
@@ -219,7 +219,7 @@ class TestFileEventHandlerEventTypes:
     def test_modified_event(self, default_config: WatcherConfig, queue: EventQueue) -> None:
         """Test handling of file modification events."""
         handler = FileEventHandler(default_config, queue)
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/existing.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/existing.txt"))  # noqa: test-hardcoded-paths
 
         events = queue.dequeue_batch(1)
         assert events[0].event_type == EventType.MODIFIED
@@ -227,7 +227,7 @@ class TestFileEventHandlerEventTypes:
     def test_deleted_event(self, default_config: WatcherConfig, queue: EventQueue) -> None:
         """Test handling of file deletion events."""
         handler = FileEventHandler(default_config, queue)
-        handler.on_deleted(FileDeletedEvent(src_path="/tmp/gone.txt"))
+        handler.on_deleted(FileDeletedEvent(src_path="/tmp/gone.txt"))  # noqa: test-hardcoded-paths
 
         events = queue.dequeue_batch(1)
         assert events[0].event_type == EventType.DELETED
@@ -235,19 +235,19 @@ class TestFileEventHandlerEventTypes:
     def test_moved_event_with_dest(self, default_config: WatcherConfig, queue: EventQueue) -> None:
         """Test handling of file move events with destination path."""
         handler = FileEventHandler(default_config, queue)
-        event = FileMovedEvent(src_path="/tmp/old.txt", dest_path="/tmp/new.txt")
+        event = FileMovedEvent(src_path="/tmp/old.txt", dest_path="/tmp/new.txt")  # noqa: test-hardcoded-paths
         handler.on_moved(event)
 
         events = queue.dequeue_batch(1)
         assert events[0].event_type == EventType.MOVED
-        assert events[0].dest_path == Path("/tmp/new.txt")
+        assert events[0].dest_path == Path("/tmp/new.txt")  # noqa: test-hardcoded-paths
 
     def test_directory_deletion_event(
         self, default_config: WatcherConfig, queue: EventQueue
     ) -> None:
         """Test handling of directory deletion events."""
         handler = FileEventHandler(default_config, queue)
-        handler.on_deleted(DirDeletedEvent(src_path="/tmp/olddir"))
+        handler.on_deleted(DirDeletedEvent(src_path="/tmp/olddir"))  # noqa: test-hardcoded-paths
 
         events = queue.dequeue_batch(1)
         assert events[0].is_directory is True
@@ -266,7 +266,7 @@ class TestFileEventHandlerCallbacks:
         callback = MagicMock()
         handler.register_callback(EventType.CREATED, callback)
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/new.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/new.txt"))  # noqa: test-hardcoded-paths
         callback.assert_called_once()
         arg = callback.call_args[0][0]
         assert isinstance(arg, FileEvent)
@@ -280,7 +280,7 @@ class TestFileEventHandlerCallbacks:
         callback = MagicMock()
         handler.register_callback(EventType.MODIFIED, callback)
 
-        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))
+        handler.on_modified(FileModifiedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         callback.assert_called_once()
 
     def test_deleted_callback_invoked(
@@ -291,7 +291,7 @@ class TestFileEventHandlerCallbacks:
         callback = MagicMock()
         handler.register_callback(EventType.DELETED, callback)
 
-        handler.on_deleted(FileDeletedEvent(src_path="/tmp/gone.txt"))
+        handler.on_deleted(FileDeletedEvent(src_path="/tmp/gone.txt"))  # noqa: test-hardcoded-paths
         callback.assert_called_once()
 
     def test_moved_callback_invoked(self, default_config: WatcherConfig, queue: EventQueue) -> None:
@@ -300,7 +300,7 @@ class TestFileEventHandlerCallbacks:
         callback = MagicMock()
         handler.register_callback(EventType.MOVED, callback)
 
-        handler.on_moved(FileMovedEvent(src_path="/tmp/old.txt", dest_path="/tmp/new.txt"))
+        handler.on_moved(FileMovedEvent(src_path="/tmp/old.txt", dest_path="/tmp/new.txt"))  # noqa: test-hardcoded-paths
         callback.assert_called_once()
 
     def test_callback_error_does_not_crash(
@@ -313,7 +313,7 @@ class TestFileEventHandlerCallbacks:
             raise RuntimeError("boom")
 
         handler.register_callback(EventType.CREATED, bad_callback)
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
 
         # Event should still be in the queue despite callback failure
         assert queue.size == 1
@@ -328,7 +328,7 @@ class TestFileEventHandlerCallbacks:
         handler.register_callback(EventType.CREATED, cb1)
         handler.register_callback(EventType.CREATED, cb2)
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         cb1.assert_called_once()
         cb2.assert_called_once()
 
@@ -339,8 +339,8 @@ class TestFileEventHandlerCallbacks:
         handler = FileEventHandler(debounce_config, queue)
         assert handler.pending_paths == 0
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/a.txt"))
-        handler.on_created(FileCreatedEvent(src_path="/tmp/b.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/a.txt"))  # noqa: test-hardcoded-paths
+        handler.on_created(FileCreatedEvent(src_path="/tmp/b.txt"))  # noqa: test-hardcoded-paths
         assert handler.pending_paths == 2
 
         handler.clear_debounce_state()
@@ -358,7 +358,7 @@ class TestFileEventHandlerMovedEdgeCases:
         handler = FileEventHandler(default_config, queue)
         # Simulate a move event where dest_path is missing
         event = MagicMock(spec=FileMovedEvent)
-        event.src_path = "/tmp/old.txt"
+        event.src_path = "/tmp/old.txt"  # noqa: test-hardcoded-paths
         # Remove dest_path attribute entirely
         del event.dest_path
         handler.on_moved(event)
@@ -374,7 +374,7 @@ class TestFileEventHandlerMovedEdgeCases:
         """Test move event when dest_path is explicitly None."""
         handler = FileEventHandler(default_config, queue)
         event = MagicMock(spec=FileMovedEvent)
-        event.src_path = "/tmp/old.txt"
+        event.src_path = "/tmp/old.txt"  # noqa: test-hardcoded-paths
         event.dest_path = None
         handler.on_moved(event)
 
@@ -387,14 +387,14 @@ class TestFileEventHandlerMovedEdgeCases:
         from watchdog.events import DirMovedEvent
 
         handler = FileEventHandler(default_config, queue)
-        event = DirMovedEvent(src_path="/tmp/olddir", dest_path="/tmp/newdir")
+        event = DirMovedEvent(src_path="/tmp/olddir", dest_path="/tmp/newdir")  # noqa: test-hardcoded-paths
         handler.on_moved(event)
 
         events = queue.dequeue_batch(1)
         assert len(events) == 1
         assert events[0].is_directory is True
         assert events[0].event_type == EventType.MOVED
-        assert events[0].dest_path == Path("/tmp/newdir")
+        assert events[0].dest_path == Path("/tmp/newdir")  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.unit
@@ -409,7 +409,7 @@ class TestFileEventHandlerDebounceThreadSafety:
 
         def fire_event() -> None:
             try:
-                handler.on_modified(FileModifiedEvent(src_path="/tmp/shared.txt"))
+                handler.on_modified(FileModifiedEvent(src_path="/tmp/shared.txt"))  # noqa: test-hardcoded-paths
             except Exception as e:
                 errors.append(e)
 
@@ -433,7 +433,7 @@ class TestFileEventHandlerDebounceThreadSafety:
         import threading
 
         def fire_event(file_id: int) -> None:
-            handler.on_created(FileCreatedEvent(src_path=f"/tmp/file_{file_id}.txt"))
+            handler.on_created(FileCreatedEvent(src_path=f"/tmp/file_{file_id}.txt"))  # noqa: test-hardcoded-paths
 
         threads = [threading.Thread(target=fire_event, args=(i,)) for i in range(10)]
         for t in threads:
@@ -456,7 +456,7 @@ class TestFileEventHandlerEventTimestamps:
         from datetime import UTC
 
         handler = FileEventHandler(default_config, queue)
-        handler.on_created(FileCreatedEvent(src_path="/tmp/test.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/test.txt"))  # noqa: test-hardcoded-paths
 
         events = queue.dequeue_batch(1)
         assert events[0].timestamp.tzinfo is not None
@@ -467,7 +467,7 @@ class TestFileEventHandlerEventTimestamps:
     ) -> None:
         """Test that queued events have Path objects, not strings."""
         handler = FileEventHandler(default_config, queue)
-        handler.on_created(FileCreatedEvent(src_path="/tmp/test.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/test.txt"))  # noqa: test-hardcoded-paths
 
         events = queue.dequeue_batch(1)
         assert isinstance(events[0].path, Path)
@@ -485,11 +485,11 @@ class TestFileEventHandlerCallbackEdgeCases:
         received_events: list[FileEvent] = []
         handler.register_callback(EventType.MOVED, received_events.append)
 
-        event = FileMovedEvent(src_path="/tmp/old.txt", dest_path="/tmp/new.txt")
+        event = FileMovedEvent(src_path="/tmp/old.txt", dest_path="/tmp/new.txt")  # noqa: test-hardcoded-paths
         handler.on_moved(event)
 
         assert len(received_events) == 1
-        assert received_events[0].dest_path == Path("/tmp/new.txt")
+        assert received_events[0].dest_path == Path("/tmp/new.txt")  # noqa: test-hardcoded-paths
 
     def test_second_callback_runs_when_first_fails(
         self, default_config: WatcherConfig, queue: EventQueue
@@ -504,7 +504,7 @@ class TestFileEventHandlerCallbackEdgeCases:
         handler.register_callback(EventType.CREATED, bad_callback)
         handler.register_callback(EventType.CREATED, second_called)
 
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
 
         second_called.assert_called_once()
 
@@ -514,5 +514,5 @@ class TestFileEventHandlerCallbackEdgeCases:
         """Test that events process cleanly when no callbacks are registered."""
         handler = FileEventHandler(default_config, queue)
         # No callbacks registered, should not raise
-        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))
+        handler.on_created(FileCreatedEvent(src_path="/tmp/file.txt"))  # noqa: test-hardcoded-paths
         assert queue.size == 1

--- a/tests/watcher/test_queue.py
+++ b/tests/watcher/test_queue.py
@@ -32,11 +32,11 @@ class TestFileEvent:
         now = datetime.now(UTC)
         event = FileEvent(
             event_type=EventType.CREATED,
-            path=Path("/tmp/test.txt"),
+            path=Path("/tmp/test.txt"),  # noqa: test-hardcoded-paths
             timestamp=now,
         )
         assert event.event_type == EventType.CREATED
-        assert event.path == Path("/tmp/test.txt")
+        assert event.path == Path("/tmp/test.txt")  # noqa: test-hardcoded-paths
         assert event.timestamp == now
         assert event.is_directory is False
         assert event.dest_path is None
@@ -45,7 +45,7 @@ class TestFileEvent:
         """Test FileEvent for directory events."""
         event = FileEvent(
             event_type=EventType.CREATED,
-            path=Path("/tmp/newdir"),
+            path=Path("/tmp/newdir"),  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
             is_directory=True,
         )
@@ -55,17 +55,17 @@ class TestFileEvent:
         """Test FileEvent for move events with destination."""
         event = FileEvent(
             event_type=EventType.MOVED,
-            path=Path("/tmp/old.txt"),
+            path=Path("/tmp/old.txt"),  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
-            dest_path=Path("/tmp/new.txt"),
+            dest_path=Path("/tmp/new.txt"),  # noqa: test-hardcoded-paths
         )
-        assert event.dest_path == Path("/tmp/new.txt")
+        assert event.dest_path == Path("/tmp/new.txt")  # noqa: test-hardcoded-paths
 
     def test_file_event_is_frozen(self) -> None:
         """Test that FileEvent instances are immutable."""
         event = FileEvent(
             event_type=EventType.CREATED,
-            path=Path("/tmp/test.txt"),
+            path=Path("/tmp/test.txt"),  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
         with pytest.raises(AttributeError):
@@ -94,7 +94,7 @@ class TestEventQueue:
         """Helper to create a FileEvent."""
         return FileEvent(
             event_type=event_type,
-            path=Path(f"/tmp/{name}"),
+            path=Path(f"/tmp/{name}"),  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
 
@@ -252,7 +252,7 @@ class TestEventQueueEdgeCases:
         """Helper to create a FileEvent."""
         return FileEvent(
             event_type=event_type,
-            path=Path(f"/tmp/{name}"),
+            path=Path(f"/tmp/{name}"),  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
 
@@ -370,15 +370,15 @@ class TestEventQueueEdgeCases:
     def test_file_event_equality(self) -> None:
         """Test that identical FileEvent instances are equal (frozen dataclass)."""
         ts = datetime.now(UTC)
-        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)
-        e2 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)
+        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
+        e2 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
         assert e1 == e2
 
     def test_file_event_inequality(self) -> None:
         """Test that different FileEvent instances are not equal."""
         ts = datetime.now(UTC)
-        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)
-        e2 = FileEvent(event_type=EventType.DELETED, path=Path("/tmp/a.txt"), timestamp=ts)
+        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
+        e2 = FileEvent(event_type=EventType.DELETED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
         assert e1 != e2
 
     def test_event_type_is_str_enum(self) -> None:

--- a/tests/web/test_browse_folder_route.py
+++ b/tests/web/test_browse_folder_route.py
@@ -105,7 +105,7 @@ class TestBrowseFolderMacOS:
         return result
 
     def test_returns_path_on_success(self, client: TestClient) -> None:
-        mock_result = self._make_run_result("/Users/rahul/Documents/\n")
+        mock_result = self._make_run_result("/Users/testuser/Documents/\n")  # noqa: test-hardcoded-paths
         with (
             patch("file_organizer.api.routers.setup.sys.platform", "darwin"),
             patch(
@@ -116,12 +116,12 @@ class TestBrowseFolderMacOS:
             resp = client.get("/api/setup/browse-folder")
         data = resp.json()
         assert data["available"] is True
-        assert data["path"] == "/Users/rahul/Documents/"
+        assert data["path"] == "/Users/testuser/Documents/"  # noqa: test-hardcoded-paths
         assert data.get("cancelled") is False
 
     def test_path_is_stripped(self, client: TestClient) -> None:
         """Trailing newline from osascript must be stripped."""
-        mock_result = self._make_run_result("/Users/rahul/Desktop/\n")
+        mock_result = self._make_run_result("/Users/testuser/Desktop/\n")  # noqa: test-hardcoded-paths
         with (
             patch("file_organizer.api.routers.setup.sys.platform", "darwin"),
             patch(
@@ -130,7 +130,7 @@ class TestBrowseFolderMacOS:
             ),
         ):
             resp = client.get("/api/setup/browse-folder")
-        assert resp.json()["path"] == "/Users/rahul/Desktop/"
+        assert resp.json()["path"] == "/Users/testuser/Desktop/"  # noqa: test-hardcoded-paths
 
     def test_calls_absolute_osascript_path(self, client: TestClient) -> None:
         """Must call /usr/bin/osascript (absolute path) with POSIX path of (choose folder)."""
@@ -145,7 +145,7 @@ class TestBrowseFolderMacOS:
             client.get("/api/setup/browse-folder")
         args, kwargs = mock_run.call_args
         cmd = args[0]
-        assert cmd[0] == "/usr/bin/osascript"
+        assert cmd[0] == "/usr/bin/osascript"  # noqa: test-hardcoded-paths
         assert "POSIX path of (choose folder)" in " ".join(cmd)
         assert kwargs["capture_output"] is True
         assert kwargs["text"] is True

--- a/tests/web/test_helpers.py
+++ b/tests/web/test_helpers.py
@@ -380,25 +380,25 @@ class TestPathId:
 
     def test_returns_string(self):
         """Should return a 10-character hex string."""
-        result = path_id(Path("/tmp/test"))
+        result = path_id(Path("/tmp/test"))  # noqa: test-hardcoded-paths
         assert isinstance(result, str) and len(result) == 10
 
     def test_returns_short_hash(self):
         """Should return a 10-character hash."""
-        result = path_id(Path("/tmp/test"))
+        result = path_id(Path("/tmp/test"))  # noqa: test-hardcoded-paths
         assert len(result) == 10
 
     def test_same_path_same_id(self):
         """Same path should produce same ID."""
-        path = Path("/tmp/test")
+        path = Path("/tmp/test")  # noqa: test-hardcoded-paths
         id1 = path_id(path)
         id2 = path_id(path)
         assert id1 == id2
 
     def test_different_paths_different_ids(self):
         """Different paths should produce different IDs."""
-        id1 = path_id(Path("/tmp/test1"))
-        id2 = path_id(Path("/tmp/test2"))
+        id1 = path_id(Path("/tmp/test1"))  # noqa: test-hardcoded-paths
+        id2 = path_id(Path("/tmp/test2"))  # noqa: test-hardcoded-paths
         assert id1 != id2
 
 

--- a/tests/web/test_organize_routes.py
+++ b/tests/web/test_organize_routes.py
@@ -347,13 +347,13 @@ class TestPlanStore:
             _store_organize_plan,
         )
 
-        record = _store_organize_plan({"input_dir": "/tmp", "files": []})
+        record = _store_organize_plan({"input_dir": "/tmp", "files": []})  # noqa: test-hardcoded-paths
         plan_id = record["plan_id"]
         assert plan_id in _ORGANIZE_PLAN_STORE
 
         retrieved = _get_organize_plan(plan_id)
         assert retrieved is not None
-        assert retrieved["input_dir"] == "/tmp"
+        assert retrieved["input_dir"] == "/tmp"  # noqa: test-hardcoded-paths
 
         _delete_organize_plan(plan_id)
         assert _get_organize_plan(plan_id) is None

--- a/tests/web/test_profile_routes.py
+++ b/tests/web/test_profile_routes.py
@@ -29,7 +29,7 @@ pytestmark = [pytest.mark.unit]
 def settings():
     """Return a mocked ApiSettings."""
     s = MagicMock(spec=ApiSettings)
-    s.allowed_paths = ["/tmp/test"]
+    s.allowed_paths = ["/tmp/test"]  # noqa: test-hardcoded-paths
     s.db_url = "sqlite://"
     s.auth_enabled = True
     s.auth_db_path = ":memory:"

--- a/tests/web/test_profile_routes_coverage.py
+++ b/tests/web/test_profile_routes_coverage.py
@@ -128,7 +128,7 @@ class TestProfileHelpers:
 
         with patch(
             "pathlib.Path.resolve",
-            side_effect=[Path("/tmp/outside.png"), Path("/tmp/avatars")],
+            side_effect=[Path("/tmp/outside.png"), Path("/tmp/avatars")],  # noqa: test-hardcoded-paths
         ):
             with pytest.raises(ValueError, match="Invalid user_id"):
                 _avatar_path("user-123")

--- a/tests/web/test_settings_routes.py
+++ b/tests/web/test_settings_routes.py
@@ -65,7 +65,7 @@ def mock_request():
 def settings():
     """Return an ApiSettings mock."""
     s = MagicMock(spec=ApiSettings)
-    s.allowed_paths = ["/tmp/test"]
+    s.allowed_paths = ["/tmp/test"]  # noqa: test-hardcoded-paths
     s.app_name = "File Organizer"
     s.version = "2.0.0"
     return s

--- a/tests/web/test_web_files_routes.py
+++ b/tests/web/test_web_files_routes.py
@@ -275,7 +275,7 @@ class TestFilesErrorHandling:
         # from the real /etc/passwd should leak into the rendered page, and the
         # rejected path string itself shouldn't be echoed back as the active path.
         assert "root:x:0:0" not in response.text
-        assert "/etc/passwd" not in response.text
+        assert "/etc/passwd" not in response.text  # noqa: test-hardcoded-paths
 
     def test_files_unicode_filename_handling(self, tmp_path: Path, web_client_builder) -> None:
         """Should correctly handle files with unicode characters in names."""

--- a/tests/web/test_web_profile.py
+++ b/tests/web/test_web_profile.py
@@ -483,7 +483,7 @@ class TestWorkspaceAndTeamUi:
 
         create_one = client.post(
             "/ui/profile/workspaces/create",
-            data={"name": "Alpha", "root_path": "/tmp/alpha", "description": "A"},
+            data={"name": "Alpha", "root_path": "/tmp/alpha", "description": "A"},  # noqa: test-hardcoded-paths
             headers=csrf_headers(client),
         )
         assert create_one.status_code == 200
@@ -491,7 +491,7 @@ class TestWorkspaceAndTeamUi:
 
         create_two = client.post(
             "/ui/profile/workspaces/create",
-            data={"name": "Beta", "root_path": "/tmp/beta", "description": "B"},
+            data={"name": "Beta", "root_path": "/tmp/beta", "description": "B"},  # noqa: test-hardcoded-paths
             headers=csrf_headers(client),
         )
         assert create_two.status_code == 200
@@ -549,11 +549,11 @@ class TestWorkspaceAndTeamUi:
 
         add = client.post(
             "/ui/profile/shared/add",
-            data={"folder_path": "/tmp/shared", "permission": "edit"},
+            data={"folder_path": "/tmp/shared", "permission": "edit"},  # noqa: test-hardcoded-paths
             headers=csrf_headers(client),
         )
         assert add.status_code == 200
-        assert "/tmp/shared" in add.text
+        assert "/tmp/shared" in add.text  # noqa: test-hardcoded-paths
 
         import re
 
@@ -567,7 +567,7 @@ class TestWorkspaceAndTeamUi:
             headers=csrf_headers(client),
         )
         assert remove.status_code == 200
-        assert "/tmp/shared" not in remove.text
+        assert "/tmp/shared" not in remove.text  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.unit
@@ -620,7 +620,7 @@ class TestAccountSettingsAndFeeds:
 
         client.post(
             "/ui/profile/workspaces/create",
-            data={"name": "Work", "root_path": "/tmp/work", "description": ""},
+            data={"name": "Work", "root_path": "/tmp/work", "description": ""},  # noqa: test-hardcoded-paths
             headers=csrf_headers(client),
         )
 

--- a/tests/web/test_web_settings.py
+++ b/tests/web/test_web_settings.py
@@ -151,8 +151,8 @@ class TestSettingsSectionSaves:
         response = client.post(
             "/ui/settings/general",
             data={
-                "default_input_dir": "/tmp/input",
-                "default_output_dir": "/tmp/output",
+                "default_input_dir": "/tmp/input",  # noqa: test-hardcoded-paths
+                "default_output_dir": "/tmp/output",  # noqa: test-hardcoded-paths
             },
             headers=csrf_headers(client),
         )
@@ -161,8 +161,8 @@ class TestSettingsSectionSaves:
 
         # Verify persisted
         data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["default_input_dir"] == "/tmp/input"
-        assert data["default_output_dir"] == "/tmp/output"
+        assert data["default_input_dir"] == "/tmp/input"  # noqa: test-hardcoded-paths
+        assert data["default_output_dir"] == "/tmp/output"  # noqa: test-hardcoded-paths
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_save_model_settings(self, tmp_path: Path, _patch_settings_file: Path) -> None:


### PR DESCRIPTION
Closes #1367

## Summary

Classifies and remediates 434 violations across 95 test files so the `test-hardcoded-paths` CI rail can be flipped from `advisory` to `enforce`.

## Classification of violations

| Category | Count | Fix applied |
|---|---|---|
| Real developer paths (`/Users/rahul/…`) | 6 lines | Replaced with `/Users/testuser/…` |
| Synthetic test data paths (`/tmp/`, `/home/user/`, `/etc/`, `/usr/`, etc.) | 428 lines | Added `# noqa: test-hardcoded-paths` |

## Changes

### Guardrail (`scripts/ci/guardrails/check_test_hardcoded_paths.py`)
- Tighten noqa suppression to accept **only** `# noqa: test-hardcoded-paths` (was also accepting bare `# noqa`, inconsistent with all other guardrails)

### New tests (`tests/ci/test_check_test_hardcoded_paths.py`)
- 15 unit tests: violations flagged, targeted noqa suppresses, bare `# noqa` does **not** suppress, URL-like paths (`/api/v1/`) pass, relative paths pass, multi-violation and single suppression, syntax error handling, correct line number reported

### Registry (`scripts/ci/rails.toml`)
- Flip `test-hardcoded-paths` mode: `advisory` → `enforce`

### Registry snapshot (`tests/ci/test_ci_rails_framework.py`)
- Update expected modes map to reflect new enforce mode

### Real path cleanup
- `tests/desktop/test_desktop_api_browse.py`, `tests/web/test_browse_folder_route.py`, `tests/integration/test_desktop_api_integration.py`: replace leaked `/Users/rahul/…` developer paths with generic `/Users/testuser/…` or `/Users/demo/…` annotated as synthetic test data

### Synthetic path annotations
- 424 lines across 100 test files: `# noqa: test-hardcoded-paths` added to fake paths used as test data (not real filesystem access)

## Verification

```
python scripts/ci/guardrails/check_test_hardcoded_paths.py
✅ [test-hardcoded-paths] No violations found.

pytest tests/ci -q --override-ini="addopts="
749 passed, 1 skipped
```

## Note on #1357

Issue #1357 (make CI guardrail scripts importable modules) has landed. The new test file `tests/ci/test_check_test_hardcoded_paths.py` imports the guardrail normally:
```python
from scripts.ci.guardrails import check_test_hardcoded_paths as checker
```
No `importlib.util.spec_from_file_location` path-loading is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tightened CI checks so hardcoded absolute paths in tests are now blocked unless explicitly allowed.
  * Added coverage for the path-checking guardrail to better detect path-related issues.

* **Bug Fixes**
  * Updated existing tests to use the new suppression format where needed.
  * Clarified the project’s lint policy documentation to reflect the reduced set of advisory checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->