### PR TITLE
Enforce test-separator-paths CI rail

### DIFF
--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -287,6 +287,41 @@ Run the rail directly to verify it exits 0:
 python scripts/ci/guardrails/check_atomic_write.py
 ```
 
+## Test-Separator-Paths Rule (WP-6.2)
+
+Issue `#1368` promotes `test-separator-paths` to an enforced CI rail. The rail
+is declared in `scripts/ci/rails.toml`, runs via
+`scripts/ci/guardrails/check_test_separator_paths.py`, and is executed by both
+the `ci-rails` pre-commit hook and `scripts/ci/ci_rails.py` in CI.
+
+The rail is now **enforced** — commits and CI runs fail when violations are
+found.
+
+### What is flagged
+
+- `Path("foo/bar")`
+- `Path("foo\\bar")`
+
+Prefer segment composition with the division operator:
+
+```python
+Path("foo") / "bar"
+```
+
+### Inline exemptions
+
+Use only targeted, line-local exemptions for true edge cases:
+
+```python
+value = Path("payload/that/must/stay/literal")  # noqa: test-separator-paths
+```
+
+Run the rail directly to verify it exits 0:
+
+```bash
+python scripts/ci/guardrails/check_test_separator_paths.py
+```
+
 ## GitHub-Environment Branching Helpers
 
 Guardrail code that branches on `GITHUB_*` variables is CI-first code. Treat it

--- a/scripts/ci/guardrails/check_test_separator_paths.py
+++ b/scripts/ci/guardrails/check_test_separator_paths.py
@@ -26,18 +26,19 @@ class TestSeparatorPathVisitor(ast.NodeVisitor):
         # Check for Path("foo/bar") or Path("foo\\bar")
         if isinstance(node.func, ast.Name) and node.func.id == "Path":
             for arg in node.args:
-                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-                    val = arg.value
-                    # Flag if it contains path separators (excluding root "/" and URL schemes)
-                    if (
-                        ("/" in val or "\\" in val)
-                        and val != "/"
-                        and not val.startswith(("http://", "https://"))
-                    ):
-                        self.add_violation(
-                            node,
-                            f"hardcoded path separator in Path('{val}'). Use division operator (/) instead.",
-                        )
+                val = _extract_path_literal(arg)
+                if val is None:
+                    continue
+                # Flag if it contains path separators (excluding root "/" and URL schemes)
+                if (
+                    ("/" in val or "\\" in val)
+                    and val != "/"
+                    and not val.startswith(("http://", "https://"))
+                ):
+                    self.add_violation(
+                        node,
+                        f"hardcoded path separator in Path('{val}'). Use division operator (/) instead.",
+                    )
         self.generic_visit(node)
 
     def add_violation(self, node: ast.AST, message: str) -> None:
@@ -68,6 +69,19 @@ def _has_targeted_noqa(line_content: str) -> bool:
         if "test-separator-paths" in codes:
             return True
     return False
+
+
+def _extract_path_literal(arg: ast.AST) -> str | None:
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg.value
+    if isinstance(arg, ast.JoinedStr):
+        literal_parts = []
+        for value in arg.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                literal_parts.append(value.value)
+        if literal_parts:
+            return "".join(literal_parts)
+    return None
 
 
 def check_file(filepath: Path) -> list[tuple[int, str, str]]:

--- a/scripts/ci/guardrails/check_test_separator_paths.py
+++ b/scripts/ci/guardrails/check_test_separator_paths.py
@@ -8,7 +8,9 @@ Ensures cross-platform compatibility by discouraging hardcoded path separators
 from __future__ import annotations
 
 import ast
+import io
 import sys
+import tokenize
 from pathlib import Path
 
 
@@ -43,10 +45,29 @@ class TestSeparatorPathVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support noqa override
-            if "noqa: test-separator-paths" in line_content or "noqa" in line_content:
+            # Support targeted override only by parsing actual comment tokens.
+            # This avoids treating '#' inside string literals as comments.
+            if _has_targeted_noqa(line_content):
                 return
             self.violations.append((lineno, message, line_content.strip()))
+
+
+def _has_targeted_noqa(line_content: str) -> bool:
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(line_content).readline)
+    except (tokenize.TokenError, IndentationError):
+        return False
+    for token in tokens:
+        if token.type != tokenize.COMMENT:
+            continue
+        comment_body = token.string.lstrip("#").strip()
+        if not comment_body.lower().startswith("noqa:"):
+            continue
+        _, _, code_list = comment_body.partition(":")
+        codes = [code.strip() for code in code_list.split(",")]
+        if "test-separator-paths" in codes:
+            return True
+    return False
 
 
 def check_file(filepath: Path) -> list[tuple[int, str, str]]:

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -45,7 +45,7 @@ description = "Flags hardcoded absolute system paths in tests, promoting tmp_pat
 [[rail]]
 name = "test-separator-paths"
 command = ["python", "scripts/ci/guardrails/check_test_separator_paths.py"]
-mode = "advisory"
+mode = "enforce"
 description = "Flags hardcoded path separators in Path() calls in tests, promoting the / operator (WP-6.2)."
 
 [[rail]]

--- a/tests/api/test_api_utils_coverage.py
+++ b/tests/api/test_api_utils_coverage.py
@@ -52,13 +52,13 @@ class TestIsHidden:
     """Covers is_hidden."""
 
     def test_hidden_file(self) -> None:
-        assert is_hidden(Path("/home/user/.config"))  # noqa: test-hardcoded-paths
+        assert is_hidden(Path("/") / "home" / "user" / ".config")  # noqa: test-hardcoded-paths
 
     def test_non_hidden_file(self) -> None:
-        assert not is_hidden(Path("/home/user/documents/file.txt"))  # noqa: test-hardcoded-paths
+        assert not is_hidden(Path("/") / "home" / "user" / "documents" / "file.txt")  # noqa: test-hardcoded-paths
 
     def test_hidden_parent(self) -> None:
-        assert is_hidden(Path("/home/user/.hidden/file.txt"))  # noqa: test-hardcoded-paths
+        assert is_hidden(Path("/") / "home" / "user" / ".hidden" / "file.txt")  # noqa: test-hardcoded-paths
 
 
 class TestFileInfoFromPath:

--- a/tests/api/test_dedupe_router.py
+++ b/tests/api/test_dedupe_router.py
@@ -58,14 +58,14 @@ def _make_mock_index(groups: dict | None = None, stats: dict | None = None):
         # Default: one group with 2 duplicate files
         now = datetime(2025, 1, 1, tzinfo=UTC)
         fm1 = FileMetadata(
-            path=Path("/tmp/a.txt"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "a.txt",  # noqa: test-hardcoded-paths
             size=100,
             modified_time=now,
             accessed_time=now,
             hash_value="abc123",
         )
         fm2 = FileMetadata(
-            path=Path("/tmp/b.txt"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "b.txt",  # noqa: test-hardcoded-paths
             size=100,
             modified_time=now,
             accessed_time=now,

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -139,10 +139,10 @@ class TestIsHidden:
         assert is_hidden(Path(".bashrc")) is True
 
     def test_dotdir_is_hidden(self) -> None:
-        assert is_hidden(Path(".config/settings.json")) is True
+        assert is_hidden(Path(".config") / "settings.json") is True
 
     def test_normal_path_not_hidden(self) -> None:
-        assert is_hidden(Path("documents/report.pdf")) is False
+        assert is_hidden(Path("documents") / "report.pdf") is False
 
     def test_root_path_not_hidden(self) -> None:
         assert is_hidden(Path("toplevel")) is False
@@ -151,7 +151,7 @@ class TestIsHidden:
         assert is_hidden(Path(".env")) is True
 
     def test_nested_normal_path(self) -> None:
-        assert is_hidden(Path("src/file_organizer/api/utils.py")) is False
+        assert is_hidden(Path("src") / "file_organizer" / "api" / "utils.py") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_api_compat_guardrails.py
+++ b/tests/ci/test_api_compat_guardrails.py
@@ -21,22 +21,22 @@ def _fixture_detector() -> PublicApiCompatibilityDetector:
     return PublicApiCompatibilityDetector(
         contracts=(
             PublicCallableContract(
-                path=Path("src/file_organizer/public/constructor_prefix_positive.py"),
+                path=Path("src") / "file_organizer" / "public" / "constructor_prefix_positive.py",
                 qualname="PipelineOrchestrator.__init__",
                 legacy_positional_params=("config", "stages", "prefetch_depth"),
             ),
             PublicCallableContract(
-                path=Path("src/file_organizer/public/optional_positional_positive.py"),
+                path=Path("src") / "file_organizer" / "public" / "optional_positional_positive.py",
                 qualname="FileOrganizer.__init__",
                 legacy_positional_params=("dry_run", "prefetch_depth"),
             ),
             PublicCallableContract(
-                path=Path("src/file_organizer/public/keyword_only_safe.py"),
+                path=Path("src") / "file_organizer" / "public" / "keyword_only_safe.py",
                 qualname="FileOrganizer.__init__",
                 legacy_positional_params=("dry_run", "prefetch_depth"),
             ),
             PublicCallableContract(
-                path=Path("src/file_organizer/public/process_batch_safe.py"),
+                path=Path("src") / "file_organizer" / "public" / "process_batch_safe.py",
                 qualname="PipelineOrchestrator.process_batch",
                 legacy_positional_params=("files",),
             ),

--- a/tests/ci/test_check_test_separator_paths.py
+++ b/tests/ci/test_check_test_separator_paths.py
@@ -1,0 +1,118 @@
+"""Tests for the WP-6.2 test-separator-paths CI rail."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.guardrails import check_test_separator_paths as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def test_flags_posix_separator_in_path_constructor(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text('value = Path("docs/report.pdf")\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "docs/report.pdf" in violations[0][1]  # noqa: test-separator-paths
+
+
+def test_flags_windows_separator_in_path_constructor(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text(r'value = Path("docs\\report.pdf")' "\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "docs\\report.pdf" in violations[0][1]  # noqa: test-separator-paths
+
+
+def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "exempt.py"
+    src.write_text(
+        'value = Path("docs/report.pdf")  # noqa: test-separator-paths\n',
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_comma_separated_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "exempt_codes.py"
+    src.write_text(
+        'value = Path("docs/report.pdf")  # noqa: E501, test-separator-paths\n',
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text('value = Path("docs/report.pdf")  # noqa\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_unrelated_noqa_code_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "other.py"
+    src.write_text('value = Path("docs/report.pdf")  # noqa: E501\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_noqa_suffix_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "suffix.py"
+    src.write_text(
+        'value = Path("docs/report.pdf")  # noqa: test-separator-paths-extra\n',
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_string_literal_noqa_text_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        'message = "contains noqa: test-separator-paths"\nvalue = Path("docs/report.pdf")\n',
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_hash_in_string_literal_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "hash_string.py"
+    src.write_text(
+        'value = Path("docs/# noqa: test-separator-paths/report.pdf")\n',
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_root_path_is_not_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "root_only.py"
+    src.write_text('value = Path("/")\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_url_literal_in_path_call_is_not_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "url.py"
+    src.write_text('value = Path("https://example.com/a/b")\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_syntax_error_returns_empty(tmp_path: Path) -> None:
+    src = tmp_path / "broken.py"
+    src.write_text("def bad_syntax(:\n", encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_check_file_returns_line_number(tmp_path: Path) -> None:
+    src = tmp_path / "lineno.py"
+    src.write_text('x = 1\ny = Path("docs/report.pdf")\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    lineno, msg, line = violations[0]
+    assert lineno == 2
+    assert "docs/report.pdf" in msg  # noqa: test-separator-paths
+    assert line == 'y = Path("docs/report.pdf")'

--- a/tests/ci/test_check_test_separator_paths.py
+++ b/tests/ci/test_check_test_separator_paths.py
@@ -27,6 +27,14 @@ def test_flags_windows_separator_in_path_constructor(tmp_path: Path) -> None:
     assert "docs\\report.pdf" in violations[0][1]  # noqa: test-separator-paths
 
 
+def test_flags_separator_in_fstring_path_constructor(tmp_path: Path) -> None:
+    src = tmp_path / "bad_fstring.py"
+    src.write_text('value = Path(f"/test/path{1}")\n', encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "/test/path" in violations[0][1]  # noqa: test-separator-paths
+
+
 def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
     src = tmp_path / "exempt.py"
     src.write_text(
@@ -98,6 +106,12 @@ def test_root_path_is_not_flagged(tmp_path: Path) -> None:
 def test_url_literal_in_path_call_is_not_flagged(tmp_path: Path) -> None:
     src = tmp_path / "url.py"
     src.write_text('value = Path("https://example.com/a/b")\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_url_fstring_literal_in_path_call_is_not_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "url_fstring.py"
+    src.write_text('value = Path(f"https://example.com/a/{1}")\n', encoding="utf-8")
     assert checker.check_file(src) == []
 
 

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -39,7 +39,7 @@ def _write_registry(tmp_path: Path, rails: list[tuple[str, list[str], str]]) -> 
 
 
 def test_missing_registry_is_noop() -> None:
-    assert ci_rails.load_rails(Path("/nonexistent/ci-rails.toml")) == []
+    assert ci_rails.load_rails(Path("/") / "nonexistent" / "ci-rails.toml") == []
     assert ci_rails.main(["--registry", "/nonexistent/ci-rails.toml"]) == 0
 
 
@@ -136,7 +136,7 @@ def test_repo_registry_loads_registered_rails() -> None:
         "cli-path-validation": "enforce",
         "defusedxml-fallback": "enforce",
         "test-hardcoded-paths": "enforce",
-        "test-separator-paths": "advisory",
+        "test-separator-paths": "enforce",
         "pytest-raises-hygiene": "advisory",
         "safedir-valueerror": "enforce",
         "textiowrapper-detach": "enforce",

--- a/tests/ci/test_pr92_review_fixes.py
+++ b/tests/ci/test_pr92_review_fixes.py
@@ -104,7 +104,7 @@ class TestPARAKeywordMatching:
     def test_evaluate_with_word_boundaries(self):
         """Test full evaluate() uses word boundary matching."""
         # Path with "projection" should not match "project" keyword
-        test_path = Path("/home/user/projection_analysis/data.txt")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "home" / "user" / "projection_analysis" / "data.txt"  # noqa: test-hardcoded-paths
 
         result = self.heuristic.evaluate(test_path)
 

--- a/tests/ci/test_publish.py
+++ b/tests/ci/test_publish.py
@@ -143,7 +143,7 @@ class TestCheckPackage:
     def test_check_nonexistent_dir_raises(self) -> None:
         """Non-existent directory raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError, match="Distribution directory not found"):
-            check_package(Path("/nonexistent/dist"))
+            check_package(Path("/") / "nonexistent" / "dist")
 
     def test_check_empty_dir_raises(self, tmp_path: Path) -> None:
         """Empty dist directory raises FileNotFoundError."""
@@ -180,7 +180,7 @@ class TestPublishPypi:
     def test_publish_nonexistent_dir_raises(self) -> None:
         """Non-existent dist directory raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            publish_pypi(Path("/nonexistent/dist"))
+            publish_pypi(Path("/") / "nonexistent" / "dist")
 
     @patch("publish._run_command")
     def test_publish_test_pypi_uses_test_url(self, mock_run: MagicMock, tmp_path: Path) -> None:
@@ -255,7 +255,7 @@ class TestGetDistFiles:
 
     def test_nonexistent_dir_returns_empty(self) -> None:
         """Non-existent directory returns empty list."""
-        result = get_dist_files(Path("/nonexistent/dist"))
+        result = get_dist_files(Path("/") / "nonexistent" / "dist")
         assert result == []
 
     def test_lists_tar_and_whl_files(self, tmp_path: Path) -> None:

--- a/tests/ci/test_release.py
+++ b/tests/ci/test_release.py
@@ -179,7 +179,7 @@ class TestValidateRelease:
         assert any("Uncommitted changes" in e for e in errors)
 
     @patch("release._run_command")
-    @patch("release._CHANGELOG", new=Path("/nonexistent/CHANGELOG.md"))
+    @patch("release._CHANGELOG", new=Path("/") / "nonexistent" / "CHANGELOG.md")
     def test_missing_changelog_reported(self, mock_run: MagicMock) -> None:
         """Missing CHANGELOG.md produces a validation error."""
         mock_run.return_value = MagicMock(returncode=0, stdout="")

--- a/tests/ci/test_review_regressions.py
+++ b/tests/ci/test_review_regressions.py
@@ -109,7 +109,7 @@ def test_stage_context_assignment_enforces_path_traversal_guard() -> None:
 
     from file_organizer.interfaces.pipeline import StageContext
 
-    ctx = StageContext(file_path=Path("input/file.txt"))
+    ctx = StageContext(file_path=Path("input") / "file.txt")
 
     # Post-construction assignments must also validate
     with pytest.raises(ValueError, match="Invalid category"):

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -722,7 +722,7 @@ class TestShardCoverage:
 
     @pytest.fixture
     def shard_script(self) -> str:
-        path = Path("scripts/ci_shard_paths.sh")
+        path = Path("scripts") / "ci_shard_paths.sh"
         assert path.exists(), "scripts/ci_shard_paths.sh must exist"
         return path.read_text()
 

--- a/tests/cli/test_cli_analytics.py
+++ b/tests/cli/test_cli_analytics.py
@@ -127,7 +127,7 @@ class TestDisplayStorageStats:
         file_info = MagicMock()
         file_info.size = 1024 * 1024
         file_info.type = ".pdf"
-        file_info.path = Path("/docs/big.pdf")
+        file_info.path = Path("/") / "docs" / "big.pdf"
 
         stats = MagicMock()
         stats.formatted_total_size = "1.5 GB"

--- a/tests/cli/test_cli_dedupe.py
+++ b/tests/cli/test_cli_dedupe.py
@@ -181,9 +181,9 @@ class TestSelectFilesToKeep:
 
     def _make_files(self):
         return [
-            {"path": Path("/a/file1.txt"), "size": 100, "mtime": 1000},
-            {"path": Path("/a/file2.txt"), "size": 200, "mtime": 2000},
-            {"path": Path("/a/file3.txt"), "size": 50, "mtime": 1500},
+            {"path": Path("/") / "a" / "file1.txt", "size": 100, "mtime": 1000},
+            {"path": Path("/") / "a" / "file2.txt", "size": 200, "mtime": 2000},
+            {"path": Path("/") / "a" / "file3.txt", "size": 50, "mtime": 1500},
         ]
 
     def test_oldest_strategy(self):
@@ -230,25 +230,25 @@ class TestGetUserSelection:
 
     def test_batch_mode_automatic(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": False},
-            {"path": Path("/a/f3.txt"), "keep": False},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": False},
+            {"path": Path("/") / "a" / "f3.txt", "keep": False},
         ]
         result = get_user_selection(files, "oldest", batch=True)
         assert result == [1, 2]  # Indices of files not marked as keep
 
     def test_batch_mode_all_keep(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": True},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": True},
         ]
         result = get_user_selection(files, "oldest", batch=True)
         assert result == []
 
     def test_keyboard_interrupt_is_reraised_for_auto_confirmation(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": False},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": False},
         ]
         console = MagicMock(spec=Console)
         console.input.side_effect = KeyboardInterrupt
@@ -520,8 +520,8 @@ class TestDisplayDuplicateGroup:
     def test_displays_group(self, capsys):
         console = Console(record=True)
         files = [
-            {"path": Path("/a/file1.txt"), "size": 1024, "mtime": 1000.0, "keep": True},
-            {"path": Path("/a/file2.txt"), "size": 1024, "mtime": 2000.0, "keep": False},
+            {"path": Path("/") / "a" / "file1.txt", "size": 1024, "mtime": 1000.0, "keep": True},
+            {"path": Path("/") / "a" / "file2.txt", "size": 1024, "mtime": 2000.0, "keep": False},
         ]
         display_duplicate_group(
             console,
@@ -533,15 +533,15 @@ class TestDisplayDuplicateGroup:
         output = console.export_text()
         assert "Duplicate Group 1/3" in output
         assert "abc123def4567890..." in output
-        assert str(Path("/a/file1.txt")) in output
-        assert str(Path("/a/file2.txt")) in output
+        assert str(Path("/") / "a" / "file1.txt") in output
+        assert str(Path("/") / "a" / "file2.txt") in output
         assert "Potential space savings: 1.0 KB" in output
 
     def test_displays_group_no_keep(self, capsys):
         console = Console(record=True)
         files = [
-            {"path": Path("/x/y.txt"), "size": 500, "mtime": 100.0},
-            {"path": Path("/x/z.txt"), "size": 500, "mtime": 200.0},
+            {"path": Path("/") / "x" / "y.txt", "size": 500, "mtime": 100.0},
+            {"path": Path("/") / "x" / "z.txt", "size": 500, "mtime": 200.0},
         ]
         display_duplicate_group(
             console,
@@ -552,8 +552,8 @@ class TestDisplayDuplicateGroup:
         )
         output = console.export_text()
         assert "Duplicate Group 2/5" in output
-        assert str(Path("/x/y.txt")) in output
-        assert str(Path("/x/z.txt")) in output
+        assert str(Path("/") / "x" / "y.txt") in output
+        assert str(Path("/") / "x" / "z.txt") in output
         assert "Potential space savings: 500.0 B" in output
 
 
@@ -569,8 +569,8 @@ class TestGetUserSelectionInteractive:
     def test_manual_skip(self):
         """User types 's' to skip."""
         files = [
-            {"path": Path("/a/f1.txt")},
-            {"path": Path("/a/f2.txt")},
+            {"path": Path("/") / "a" / "f1.txt"},
+            {"path": Path("/") / "a" / "f2.txt"},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.return_value = "s"
@@ -580,8 +580,8 @@ class TestGetUserSelectionInteractive:
     def test_manual_keep_all(self):
         """User types 'a' to keep all."""
         files = [
-            {"path": Path("/a/f1.txt")},
-            {"path": Path("/a/f2.txt")},
+            {"path": Path("/") / "a" / "f1.txt"},
+            {"path": Path("/") / "a" / "f2.txt"},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.return_value = "a"
@@ -591,8 +591,8 @@ class TestGetUserSelectionInteractive:
     def test_manual_select_keep(self):
         """User types '1' to keep file 1, remove file 2."""
         files = [
-            {"path": Path("/a/f1.txt")},
-            {"path": Path("/a/f2.txt")},
+            {"path": Path("/") / "a" / "f1.txt"},
+            {"path": Path("/") / "a" / "f2.txt"},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.return_value = "1"
@@ -602,8 +602,8 @@ class TestGetUserSelectionInteractive:
     def test_manual_invalid_then_valid(self):
         """User enters invalid input, then valid."""
         files = [
-            {"path": Path("/a/f1.txt")},
-            {"path": Path("/a/f2.txt")},
+            {"path": Path("/") / "a" / "f1.txt"},
+            {"path": Path("/") / "a" / "f2.txt"},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.side_effect = ["xyz", "1"]
@@ -613,8 +613,8 @@ class TestGetUserSelectionInteractive:
     def test_manual_invalid_index_then_valid(self):
         """User enters out-of-range index, then valid."""
         files = [
-            {"path": Path("/a/f1.txt")},
-            {"path": Path("/a/f2.txt")},
+            {"path": Path("/") / "a" / "f1.txt"},
+            {"path": Path("/") / "a" / "f2.txt"},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.side_effect = ["99", "1"]
@@ -623,7 +623,7 @@ class TestGetUserSelectionInteractive:
 
     def test_manual_keyboard_interrupt(self):
         """KeyboardInterrupt during manual selection is re-raised."""
-        files = [{"path": Path("/a/f1.txt")}]
+        files = [{"path": Path("/") / "a" / "f1.txt"}]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.side_effect = KeyboardInterrupt
             with pytest.raises(KeyboardInterrupt):
@@ -636,8 +636,8 @@ class TestGetUserSelectionConfirm:
 
     def test_confirm_yes(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": False},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": False},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.return_value = "y"
@@ -646,8 +646,8 @@ class TestGetUserSelectionConfirm:
 
     def test_confirm_no(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": False},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": False},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.return_value = "n"
@@ -656,8 +656,8 @@ class TestGetUserSelectionConfirm:
 
     def test_confirm_skip(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": False},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": False},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.return_value = "skip"
@@ -666,8 +666,8 @@ class TestGetUserSelectionConfirm:
 
     def test_confirm_invalid_then_yes(self):
         files = [
-            {"path": Path("/a/f1.txt"), "keep": True},
-            {"path": Path("/a/f2.txt"), "keep": False},
+            {"path": Path("/") / "a" / "f1.txt", "keep": True},
+            {"path": Path("/") / "a" / "f2.txt", "keep": False},
         ]
         with patch("file_organizer.cli.dedupe.console") as mock_console:
             mock_console.input.side_effect = ["maybe", "y"]
@@ -800,7 +800,7 @@ class TestDedupeCommandDuplicates:
         mock_detector.get_duplicate_groups.return_value = {"hash1": grp}
 
         mock_bkp = MagicMock()
-        mock_bkp.create_backup.return_value = Path("/tmp/backup")  # noqa: test-hardcoded-paths
+        mock_bkp.create_backup.return_value = Path("/") / "tmp" / "backup"  # noqa: test-hardcoded-paths
 
         with (
             patch(_DETECTOR_PATH, return_value=mock_detector),

--- a/tests/cli/test_cli_search_security.py
+++ b/tests/cli/test_cli_search_security.py
@@ -102,7 +102,7 @@ class TestCorpusHiddenFileFiltering:
         normal.write_text("content")
 
         # tmp_path itself may have dot components, so test relative behavior
-        assert not is_hidden(Path("documents/report.txt"))
+        assert not is_hidden(Path("documents") / "report.txt")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_suggest.py
+++ b/tests/cli/test_cli_suggest.py
@@ -33,8 +33,8 @@ def mock_engine_with_suggestions():
     suggestion = MagicMock()
     suggestion.suggestion_id = "s1"
     suggestion.suggestion_type = _MockSuggestionType.MOVE
-    suggestion.file_path = Path("/tmp/doc.txt")  # noqa: test-hardcoded-paths
-    suggestion.target_path = Path("/tmp/Documents/doc.txt")  # noqa: test-hardcoded-paths
+    suggestion.file_path = Path("/") / "tmp" / "doc.txt"  # noqa: test-hardcoded-paths
+    suggestion.target_path = Path("/") / "tmp" / "Documents" / "doc.txt"  # noqa: test-hardcoded-paths
     suggestion.confidence = 75.0
     suggestion.reasoning = "Matches document pattern"
     suggestion.new_name = None

--- a/tests/cli/test_cli_undo_history.py
+++ b/tests/cli/test_cli_undo_history.py
@@ -17,7 +17,7 @@ def _make_operation(op_id: int = 1, op_type: str = "move", dst: str | None = "/d
     op.id = op_id
     op.operation_type = MagicMock()
     op.operation_type.value = op_type
-    op.source_path = Path("/src/file.txt")
+    op.source_path = Path("/") / "src" / "file.txt"
     op.destination_path = Path(dst) if dst else None
     return op
 

--- a/tests/cli/test_dedupe_coverage.py
+++ b/tests/cli/test_dedupe_coverage.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unit
 
 def test_dedupe_config_initialization() -> None:
     """Verify DedupeConfig properties and defaults."""
-    dir_path = Path("/mock/path")
+    dir_path = Path("/") / "mock" / "path"
 
     # Test default values
     config = DedupeConfig(directory=dir_path)

--- a/tests/config/test_config_manager_coverage.py
+++ b/tests/config/test_config_manager_coverage.py
@@ -209,7 +209,7 @@ class TestConfigManagerModuleDelegation:
             }
         )
         result = mgr.to_daemon_config(cfg)
-        assert Path("/tmp/a") in result.watch_directories  # noqa: test-hardcoded-paths
+        assert Path("/") / "tmp" / "a" in result.watch_directories  # noqa: test-hardcoded-paths
 
     def test_config_to_dict_includes_overrides(self):
         mgr = ConfigManager()

--- a/tests/core/test_compatibility.py
+++ b/tests/core/test_compatibility.py
@@ -444,7 +444,7 @@ class TestIsinstanceTupleForm:
 
     def test_isinstance_path_types(self) -> None:
         """isinstance with Path types should work."""
-        p = Path("/tmp/test")  # noqa: test-hardcoded-paths
+        p = Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
         assert isinstance(p, (str, Path))
         assert not isinstance(42, (str, Path))
 

--- a/tests/daemon/test_service_coverage.py
+++ b/tests/daemon/test_service_coverage.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.ci]
 def _make_config(**kwargs) -> DaemonConfig:
     defaults = {
         "watch_directories": [],
-        "output_directory": Path("tmp/organized"),
+        "output_directory": Path("tmp") / "organized",
         "pid_file": None,
         "poll_interval": 0.05,
     }

--- a/tests/daemon/test_service_signal_safety.py
+++ b/tests/daemon/test_service_signal_safety.py
@@ -33,7 +33,7 @@ def _make_config(**kwargs) -> DaemonConfig:
     """
     defaults = {
         "watch_directories": [],
-        "output_directory": Path("tmp/organized"),
+        "output_directory": Path("tmp") / "organized",
         "pid_file": None,
         "poll_interval": 0.05,
     }

--- a/tests/daemon/test_service_thread_safety.py
+++ b/tests/daemon/test_service_thread_safety.py
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.ci]
 def _make_config(**kwargs) -> DaemonConfig:
     defaults = {
         "watch_directories": [],
-        "output_directory": Path("tmp/organized"),
+        "output_directory": Path("tmp") / "organized",
         "pid_file": None,
         "poll_interval": 0.05,
     }

--- a/tests/deploy/test_deploy_config.py
+++ b/tests/deploy/test_deploy_config.py
@@ -36,7 +36,7 @@ class TestDeploymentConfigDefaults:
     def test_default_data_directory(self) -> None:
         """Verify default data directory is /data."""
         config = DeploymentConfig()
-        assert config.data_directory == Path("/data")
+        assert config.data_directory == Path("/") / "data"
 
     def test_default_log_level(self) -> None:
         """Verify default log level is DEBUG."""
@@ -102,7 +102,7 @@ class TestDeploymentConfigValidation:
         """Verify string data_directory is converted to Path."""
         config = DeploymentConfig(data_directory="/tmp/test")  # type: ignore[arg-type]  # noqa: test-hardcoded-paths
         assert isinstance(config.data_directory, Path)
-        assert config.data_directory == Path("/tmp/test")  # noqa: test-hardcoded-paths
+        assert config.data_directory == Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
 
     def test_all_valid_environments_accepted(self) -> None:
         """Verify all defined valid environments are accepted."""
@@ -160,7 +160,7 @@ class TestDeploymentConfigFromEnv:
         env = {"FO_DATA_DIR": "/mnt/storage"}
         with mock.patch.dict(os.environ, env, clear=True):
             config = DeploymentConfig.from_env()
-            assert config.data_directory == Path("/mnt/storage")
+            assert config.data_directory == Path("/") / "mnt" / "storage"
 
     def test_from_env_custom_log_level(self) -> None:
         """Verify from_env picks up custom log level."""

--- a/tests/deploy/test_health.py
+++ b/tests/deploy/test_health.py
@@ -22,7 +22,7 @@ def dev_config() -> DeploymentConfig:
     return DeploymentConfig(
         environment="dev",
         redis_url="redis://localhost:6379/0",
-        data_directory=Path("/tmp/fo-test-data"),  # noqa: test-hardcoded-paths
+        data_directory=Path("/") / "tmp" / "fo-test-data",  # noqa: test-hardcoded-paths
     )
 
 
@@ -339,7 +339,7 @@ class TestHealthEndpointDiskCheck:
 
     def test_check_disk_space_uses_fallback_path(self, dev_config: DeploymentConfig) -> None:
         """Verify disk check uses fallback path when data dir doesn't exist."""
-        dev_config.data_directory = Path("/nonexistent/path/fo-test")
+        dev_config.data_directory = Path("/") / "nonexistent" / "path" / "fo-test"
         endpoint = HealthEndpoint(config=dev_config, min_disk_space_mb=1)
         # Should not raise; falls back to /
         result = endpoint.check_disk_space()

--- a/tests/history/test_cleanup.py
+++ b/tests/history/test_cleanup.py
@@ -155,7 +155,7 @@ class TestHistoryCleanup:
         history.start_transaction()
 
         # Add operations without transaction
-        history.log_operation(OperationType.MOVE, Path("/test/path"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path")
 
         # Cleanup orphaned transactions
         deleted = cleanup._cleanup_orphaned_transactions()
@@ -207,18 +207,20 @@ class TestHistoryCleanup:
     def test_get_statistics(self, history, cleanup):
         """Test getting history statistics."""
         # Add various operations
-        history.log_operation(OperationType.MOVE, Path("/test/path1"))
-        history.log_operation(OperationType.RENAME, Path("/test/path2"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path1")
+        history.log_operation(OperationType.RENAME, Path("/") / "test" / "path2")
         history.log_operation(
             OperationType.DELETE,
-            Path("/test/path3"),
+            Path("/") / "test" / "path3",
             status=OperationStatus.FAILED,
             error_message="Error",
         )
 
         # Start a transaction
         txn_id = history.start_transaction()
-        history.log_operation(OperationType.COPY, Path("/test/path4"), transaction_id=txn_id)
+        history.log_operation(
+            OperationType.COPY, Path("/") / "test" / "path4", transaction_id=txn_id
+        )
         history.commit_transaction(txn_id)
 
         stats = cleanup.get_statistics()

--- a/tests/history/test_cleanup.py
+++ b/tests/history/test_cleanup.py
@@ -58,7 +58,7 @@ class TestHistoryCleanup:
         """Test cleanup trigger based on operation count."""
         # Add operations exceeding limit
         for i in range(150):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         assert cleanup.should_cleanup() is True
 
@@ -66,7 +66,7 @@ class TestHistoryCleanup:
         """Test that cleanup is not triggered when under limits."""
         # Add few operations
         for i in range(50):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         # Should not need cleanup (50 < 100)
         assert cleanup.should_cleanup() is False
@@ -82,7 +82,7 @@ class TestHistoryCleanup:
         """Test keeping only N most recent operations."""
         # Add 150 operations
         for i in range(150):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         # Keep only 100
         deleted = cleanup.cleanup_by_count(max_operations=100)
@@ -96,7 +96,7 @@ class TestHistoryCleanup:
         """Test cleanup by count when under limit."""
         # Add only 50 operations
         for i in range(50):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         # Try to keep 100 (should delete 0)
         deleted = cleanup.cleanup_by_count(max_operations=100)
@@ -108,7 +108,16 @@ class TestHistoryCleanup:
         # Add many operations to increase size
         for i in range(1000):
             history.log_operation(
-                OperationType.MOVE, Path(f"/test/very/long/path/with/many/segments/file{i}")
+                OperationType.MOVE,
+                Path("/")
+                / "test"
+                / "very"
+                / "long"
+                / "path"
+                / "with"
+                / "many"
+                / "segments"
+                / f"file{i}",
             )
 
         history.db.get_operation_count()
@@ -124,14 +133,14 @@ class TestHistoryCleanup:
         for i in range(5):
             history.log_operation(
                 OperationType.MOVE,
-                Path(f"/test/path{i}"),
+                Path("/") / "test" / f"path{i}",
                 status=OperationStatus.FAILED,
                 error_message="Test error",
             )
 
         # Add some successful operations
         for i in range(5):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i + 5}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i + 5}")
 
         # This won't delete anything since operations are not old enough
         deleted = cleanup.cleanup_failed_operations(older_than_days=7)
@@ -142,7 +151,9 @@ class TestHistoryCleanup:
         # Add some rolled back operations
         for i in range(5):
             history.log_operation(
-                OperationType.MOVE, Path(f"/test/path{i}"), status=OperationStatus.ROLLED_BACK
+                OperationType.MOVE,
+                Path("/") / "test" / f"path{i}",
+                status=OperationStatus.ROLLED_BACK,
             )
 
         # This won't delete anything since operations are not old enough
@@ -165,7 +176,7 @@ class TestHistoryCleanup:
         """Test automatic cleanup."""
         # Add many operations to trigger cleanup
         for i in range(150):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         # Run auto cleanup
         stats = cleanup.auto_cleanup()
@@ -180,7 +191,7 @@ class TestHistoryCleanup:
 
         # Add many operations
         for i in range(150):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         assert cleanup.should_cleanup() is False
 
@@ -188,7 +199,7 @@ class TestHistoryCleanup:
         """Test that clear_all requires confirmation."""
         # Add operations
         for i in range(10):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         result = cleanup.clear_all(confirm=False)
         assert result is False
@@ -198,7 +209,7 @@ class TestHistoryCleanup:
         """Test clearing all history data."""
         # Add operations
         for i in range(10):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         result = cleanup.clear_all(confirm=True)
         assert result is True

--- a/tests/history/test_export.py
+++ b/tests/history/test_export.py
@@ -86,8 +86,12 @@ class TestHistoryExporter:
         """Test exporting operations with transaction details."""
         # Create transaction with operations
         txn_id = history.start_transaction()
-        history.log_operation(OperationType.MOVE, Path("/test/path1"), transaction_id=txn_id)
-        history.log_operation(OperationType.MOVE, Path("/test/path2"), transaction_id=txn_id)
+        history.log_operation(
+            OperationType.MOVE, Path("/") / "test" / "path1", transaction_id=txn_id
+        )
+        history.log_operation(
+            OperationType.MOVE, Path("/") / "test" / "path2", transaction_id=txn_id
+        )
         history.commit_transaction(txn_id)
 
         output_path = temp_output_dir / "export.json"
@@ -104,9 +108,9 @@ class TestHistoryExporter:
     def test_export_to_json_filter_by_type(self, history, exporter, temp_output_dir):
         """Test exporting with operation type filter."""
         # Add different operation types
-        history.log_operation(OperationType.MOVE, Path("/test/path1"))
-        history.log_operation(OperationType.RENAME, Path("/test/path2"))
-        history.log_operation(OperationType.DELETE, Path("/test/path3"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path1")
+        history.log_operation(OperationType.RENAME, Path("/") / "test" / "path2")
+        history.log_operation(OperationType.DELETE, Path("/") / "test" / "path3")
 
         output_path = temp_output_dir / "export.json"
         stats = exporter.export_to_json(output_path, operation_type=OperationType.MOVE)
@@ -143,9 +147,9 @@ class TestHistoryExporter:
     def test_export_to_csv_filter_by_type(self, history, exporter, temp_output_dir):
         """Test CSV export with operation type filter."""
         # Add different operation types
-        history.log_operation(OperationType.MOVE, Path("/test/path1"))
-        history.log_operation(OperationType.RENAME, Path("/test/path2"))
-        history.log_operation(OperationType.DELETE, Path("/test/path3"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path1")
+        history.log_operation(OperationType.RENAME, Path("/") / "test" / "path2")
+        history.log_operation(OperationType.DELETE, Path("/") / "test" / "path3")
 
         output_path = temp_output_dir / "export.csv"
         count = exporter.export_to_csv(output_path, operation_type=OperationType.MOVE)
@@ -193,9 +197,9 @@ class TestHistoryExporter:
     def test_export_statistics(self, history, exporter, temp_output_dir):
         """Test exporting database statistics."""
         # Add various operations
-        history.log_operation(OperationType.MOVE, Path("/test/path1"))
-        history.log_operation(OperationType.RENAME, Path("/test/path2"))
-        history.log_operation(OperationType.DELETE, Path("/test/path3"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path1")
+        history.log_operation(OperationType.RENAME, Path("/") / "test" / "path2")
+        history.log_operation(OperationType.DELETE, Path("/") / "test" / "path3")
 
         output_path = temp_output_dir / "stats.json"
         result = exporter.export_statistics(output_path)
@@ -218,7 +222,7 @@ class TestHistoryExporter:
     def test_export_creates_parent_directory(self, history, exporter, temp_output_dir):
         """Test that export creates parent directories if needed."""
         # Add operation
-        history.log_operation(OperationType.MOVE, Path("/test/path"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path")
 
         # Use nested path that doesn't exist
         output_path = temp_output_dir / "nested" / "dir" / "export.json"

--- a/tests/history/test_export.py
+++ b/tests/history/test_export.py
@@ -65,7 +65,7 @@ class TestHistoryExporter:
         """Test exporting operations to JSON."""
         # Add some operations
         for i in range(5):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         output_path = temp_output_dir / "export.json"
         stats = exporter.export_to_json(output_path)
@@ -126,7 +126,7 @@ class TestHistoryExporter:
         """Test exporting operations to CSV."""
         # Add some operations
         for i in range(5):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         output_path = temp_output_dir / "export.csv"
         count = exporter.export_to_csv(output_path)
@@ -175,7 +175,9 @@ class TestHistoryExporter:
         # Create transactions
         for i in range(3):
             txn_id = history.start_transaction()
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"), transaction_id=txn_id)
+            history.log_operation(
+                OperationType.MOVE, Path("/") / "test" / f"path{i}", transaction_id=txn_id
+            )
             history.commit_transaction(txn_id)
 
         output_path = temp_output_dir / "transactions.csv"
@@ -235,7 +237,7 @@ class TestHistoryExporter:
         """Test exporting with date range filter."""
         # Add operations (will have current timestamp)
         for i in range(5):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         # Export with date range that includes current time
         from datetime import timedelta

--- a/tests/history/test_history_models.py
+++ b/tests/history/test_history_models.py
@@ -125,7 +125,7 @@ class TestOperation:
         return Operation(
             operation_type=OperationType.MOVE,
             timestamp=now,
-            source_path=Path("/src/file.txt"),
+            source_path=Path("/") / "src" / "file.txt",
         )
 
     @pytest.fixture()
@@ -135,8 +135,8 @@ class TestOperation:
             id=42,
             operation_type=OperationType.COPY,
             timestamp=now,
-            source_path=Path("/src/file.txt"),
-            destination_path=Path("/dst/file.txt"),
+            source_path=Path("/") / "src" / "file.txt",
+            destination_path=Path("/") / "dst" / "file.txt",
             file_hash="abc123",
             metadata={"size": 1024, "type": "text"},
             transaction_id="txn-001",
@@ -149,7 +149,7 @@ class TestOperation:
 
     def test_minimal_construction(self, minimal_op: Operation) -> None:
         assert minimal_op.operation_type is OperationType.MOVE
-        assert minimal_op.source_path == Path("/src/file.txt")
+        assert minimal_op.source_path == Path("/") / "src" / "file.txt"
         assert minimal_op.id is None
         assert minimal_op.destination_path is None
         assert minimal_op.file_hash is None
@@ -163,7 +163,7 @@ class TestOperation:
         assert full_op.id == 42
         assert full_op.operation_type is OperationType.COPY
         assert full_op.timestamp == now
-        assert full_op.destination_path == Path("/dst/file.txt")
+        assert full_op.destination_path == Path("/") / "dst" / "file.txt"
         assert full_op.file_hash == "abc123"
         assert full_op.metadata == {"size": 1024, "type": "text"}
         assert full_op.transaction_id == "txn-001"
@@ -176,12 +176,12 @@ class TestOperation:
         op1 = Operation(
             operation_type=OperationType.MOVE,
             timestamp=now,
-            source_path=Path("/a"),
+            source_path=Path("/") / "a",
         )
         op2 = Operation(
             operation_type=OperationType.MOVE,
             timestamp=now,
-            source_path=Path("/b"),
+            source_path=Path("/") / "b",
         )
         op1.metadata["key"] = "val"
         assert "key" not in op2.metadata
@@ -219,7 +219,7 @@ class TestOperation:
         op = Operation(
             operation_type=OperationType.DELETE,
             timestamp=now,
-            source_path=Path("/tmp/gone.txt"),  # noqa: test-hardcoded-paths
+            source_path=Path("/") / "tmp" / "gone.txt",  # noqa: test-hardcoded-paths
             status=OperationStatus.FAILED,
             error_message="Permission denied",
         )
@@ -232,7 +232,7 @@ class TestOperation:
         op = Operation(
             operation_type=OperationType.MOVE,
             timestamp=now,
-            source_path=Path("/a"),
+            source_path=Path("/") / "a",
         )
         # Force plain-string values to exercise the isinstance branches
         op.operation_type = "move"  # type: ignore[assignment]
@@ -256,7 +256,7 @@ class TestOperation:
         op = Operation.from_dict(data)
         assert op.operation_type is OperationType.RENAME
         assert isinstance(op.timestamp, datetime)
-        assert op.source_path == Path("/src/old.txt")
+        assert op.source_path == Path("/") / "src" / "old.txt"
         assert op.destination_path is None
         assert op.status is OperationStatus.COMPLETED
         assert op.metadata == {}
@@ -278,7 +278,7 @@ class TestOperation:
         op = Operation.from_dict(data)
         assert op.id == 7
         assert op.operation_type is OperationType.DELETE
-        assert op.destination_path == Path("/dst/file.txt")
+        assert op.destination_path == Path("/") / "dst" / "file.txt"
         assert op.file_hash == "deadbeef"
         assert op.metadata == {"permissions": "0644"}
         assert op.transaction_id == "txn-abc"
@@ -415,7 +415,7 @@ class TestOperation:
         op = Operation.from_row(mock_row)
         assert op.id == 1
         assert op.operation_type is OperationType.MOVE
-        assert op.source_path == Path("/src/file.txt")
+        assert op.source_path == Path("/") / "src" / "file.txt"
 
     # -- Edge cases ---------------------------------------------------------
 
@@ -425,7 +425,7 @@ class TestOperation:
             op = Operation(
                 operation_type=op_type,
                 timestamp=now,
-                source_path=Path("/test"),
+                source_path=Path("/") / "test",
             )
             restored = Operation.from_dict(op.to_dict())
             assert restored.operation_type is op_type
@@ -436,7 +436,7 @@ class TestOperation:
             op = Operation(
                 operation_type=OperationType.MOVE,
                 timestamp=now,
-                source_path=Path("/test"),
+                source_path=Path("/") / "test",
                 status=status,
             )
             restored = Operation.from_dict(op.to_dict())

--- a/tests/history/test_tracker.py
+++ b/tests/history/test_tracker.py
@@ -56,7 +56,7 @@ class TestOperationHistory:
         operation_id = history.log_operation(
             operation_type=OperationType.MOVE,
             source_path=temp_file,
-            destination_path=Path("/test/dest"),
+            destination_path=Path("/") / "test" / "dest",
             metadata={"test": "data"},
         )
 
@@ -148,9 +148,9 @@ class TestOperationHistory:
     def test_get_operations_by_type(self, history):
         """Test filtering operations by type."""
         # Log different operation types
-        history.log_operation(OperationType.MOVE, Path("/test/path1"))
-        history.log_operation(OperationType.RENAME, Path("/test/path2"))
-        history.log_operation(OperationType.DELETE, Path("/test/path3"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path1")
+        history.log_operation(OperationType.RENAME, Path("/") / "test" / "path2")
+        history.log_operation(OperationType.DELETE, Path("/") / "test" / "path3")
 
         # Filter by type
         move_ops = history.get_operations(operation_type=OperationType.MOVE)
@@ -163,14 +163,14 @@ class TestOperationHistory:
 
         # Log operations in transaction
         history.log_operation(
-            OperationType.MOVE, Path("/test/path1"), transaction_id=transaction_id
+            OperationType.MOVE, Path("/") / "test" / "path1", transaction_id=transaction_id
         )
         history.log_operation(
-            OperationType.MOVE, Path("/test/path2"), transaction_id=transaction_id
+            OperationType.MOVE, Path("/") / "test" / "path2", transaction_id=transaction_id
         )
 
         # Log operation outside transaction
-        history.log_operation(OperationType.MOVE, Path("/test/path3"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path3")
 
         # Filter by transaction
         txn_ops = history.get_operations(transaction_id=transaction_id)
@@ -180,11 +180,11 @@ class TestOperationHistory:
         """Test filtering operations by status."""
         # Log operations with different statuses
         history.log_operation(
-            OperationType.MOVE, Path("/test/path1"), status=OperationStatus.COMPLETED
+            OperationType.MOVE, Path("/") / "test" / "path1", status=OperationStatus.COMPLETED
         )
         history.log_operation(
             OperationType.MOVE,
-            Path("/test/path2"),
+            Path("/") / "test" / "path2",
             status=OperationStatus.FAILED,
             error_message="Test error",
         )
@@ -201,7 +201,7 @@ class TestOperationHistory:
         yesterday = now - timedelta(days=1)
         tomorrow = now + timedelta(days=1)
 
-        history.log_operation(OperationType.MOVE, Path("/test/path1"))
+        history.log_operation(OperationType.MOVE, Path("/") / "test" / "path1")
 
         # Filter by date range
         ops = history.get_operations(start_date=yesterday, end_date=tomorrow)
@@ -256,7 +256,7 @@ class TestOperationHistory:
     def test_context_manager(self, temp_db_path):
         """Test OperationHistory as context manager."""
         with OperationHistory(temp_db_path) as history:
-            history.log_operation(OperationType.MOVE, Path("/test/path"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / "path")
 
         # Should close cleanly
 
@@ -264,7 +264,7 @@ class TestOperationHistory:
         """Test logging a failed operation."""
         history.log_operation(
             operation_type=OperationType.MOVE,
-            source_path=Path("/test/source"),
+            source_path=Path("/") / "test" / "source",
             status=OperationStatus.FAILED,
             error_message="Permission denied",
         )

--- a/tests/history/test_tracker.py
+++ b/tests/history/test_tracker.py
@@ -139,7 +139,7 @@ class TestOperationHistory:
         # Log multiple operations
         for i in range(3):
             history.log_operation(
-                operation_type=OperationType.MOVE, source_path=Path(f"/test/path{i}")
+                operation_type=OperationType.MOVE, source_path=Path("/") / "test" / f"path{i}"
             )
 
         operations = history.get_operations()
@@ -211,7 +211,7 @@ class TestOperationHistory:
         """Test limiting number of operations returned."""
         # Log multiple operations
         for i in range(10):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         # Get with limit
         ops = history.get_operations(limit=5)
@@ -221,7 +221,7 @@ class TestOperationHistory:
         """Test getting recent operations."""
         # Log multiple operations
         for i in range(5):
-            history.log_operation(OperationType.MOVE, Path(f"/test/path{i}"))
+            history.log_operation(OperationType.MOVE, Path("/") / "test" / f"path{i}")
 
         recent = history.get_recent_operations(limit=3)
         assert len(recent) == 3
@@ -247,7 +247,7 @@ class TestOperationHistory:
         # Log operations
         for i in range(3):
             history.log_operation(
-                OperationType.MOVE, Path(f"/test/path{i}"), transaction_id=transaction_id
+                OperationType.MOVE, Path("/") / "test" / f"path{i}", transaction_id=transaction_id
             )
 
         transaction = history.get_transaction(transaction_id)

--- a/tests/history/test_transaction.py
+++ b/tests/history/test_transaction.py
@@ -43,7 +43,7 @@ class TestOperationTransaction:
     def test_context_manager_commit(self, history):
         """Test that transaction commits on successful exit."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
 
         # Verify transaction was committed
         transaction = history.get_transaction(txn.transaction_id)
@@ -54,7 +54,7 @@ class TestOperationTransaction:
         """Test that transaction rolls back on exception."""
         try:
             with OperationTransaction(history) as txn:
-                txn.log_move(Path("/test/source"), Path("/test/dest"))
+                txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
                 raise ValueError("Test error")
         except ValueError:
             pass
@@ -72,8 +72,8 @@ class TestOperationTransaction:
         with OperationTransaction(history) as txn:
             operation_id = txn.log_operation(
                 operation_type=OperationType.MOVE,
-                source_path=Path("/test/source"),
-                destination_path=Path("/test/dest"),
+                source_path=Path("/") / "test" / "source",
+                destination_path=Path("/") / "test" / "dest",
             )
 
             assert operation_id > 0
@@ -86,18 +86,18 @@ class TestOperationTransaction:
     def test_log_move(self, history):
         """Test log_move convenience method."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
 
         operations = history.get_operations()
         assert len(operations) == 1
         assert operations[0].operation_type == OperationType.MOVE
-        assert operations[0].source_path == Path("/test/source")
-        assert operations[0].destination_path == Path("/test/dest")
+        assert operations[0].source_path == Path("/") / "test" / "source"
+        assert operations[0].destination_path == Path("/") / "test" / "dest"
 
     def test_log_rename(self, history):
         """Test log_rename convenience method."""
         with OperationTransaction(history) as txn:
-            txn.log_rename(Path("/test/old"), Path("/test/new"))
+            txn.log_rename(Path("/") / "test" / "old", Path("/") / "test" / "new")
 
         operations = history.get_operations()
         assert len(operations) == 1
@@ -106,7 +106,7 @@ class TestOperationTransaction:
     def test_log_delete(self, history):
         """Test log_delete convenience method."""
         with OperationTransaction(history) as txn:
-            txn.log_delete(Path("/test/file"))
+            txn.log_delete(Path("/") / "test" / "file")
 
         operations = history.get_operations()
         assert len(operations) == 1
@@ -116,7 +116,7 @@ class TestOperationTransaction:
     def test_log_copy(self, history):
         """Test log_copy convenience method."""
         with OperationTransaction(history) as txn:
-            txn.log_copy(Path("/test/source"), Path("/test/dest"))
+            txn.log_copy(Path("/") / "test" / "source", Path("/") / "test" / "dest")
 
         operations = history.get_operations()
         assert len(operations) == 1
@@ -125,7 +125,7 @@ class TestOperationTransaction:
     def test_log_create(self, history):
         """Test log_create convenience method."""
         with OperationTransaction(history) as txn:
-            txn.log_create(Path("/test/new_file"))
+            txn.log_create(Path("/") / "test" / "new_file")
 
         operations = history.get_operations()
         assert len(operations) == 1
@@ -136,7 +136,7 @@ class TestOperationTransaction:
         with OperationTransaction(history) as txn:
             txn.log_failed_operation(
                 operation_type=OperationType.MOVE,
-                source_path=Path("/test/source"),
+                source_path=Path("/") / "test" / "source",
                 error_message="Permission denied",
             )
 
@@ -148,9 +148,9 @@ class TestOperationTransaction:
     def test_multiple_operations_in_transaction(self, history):
         """Test logging multiple operations in a single transaction."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/file1"), Path("/test/dest1"))
-            txn.log_rename(Path("/test/file2"), Path("/test/file2_new"))
-            txn.log_delete(Path("/test/file3"))
+            txn.log_move(Path("/") / "test" / "file1", Path("/") / "test" / "dest1")
+            txn.log_rename(Path("/") / "test" / "file2", Path("/") / "test" / "file2_new")
+            txn.log_delete(Path("/") / "test" / "file3")
 
         # Verify all operations share the same transaction ID
         operations = history.get_operations()
@@ -164,7 +164,7 @@ class TestOperationTransaction:
     def test_manual_commit(self, history):
         """Test manual commit of transaction."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
             result = txn.commit()
             assert result is True
 
@@ -175,7 +175,7 @@ class TestOperationTransaction:
     def test_manual_rollback(self, history):
         """Test manual rollback of transaction."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
             result = txn.rollback()
             assert result is True
 
@@ -186,21 +186,21 @@ class TestOperationTransaction:
     def test_cannot_commit_twice(self, history):
         """Test that committing twice returns False."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
             assert txn.commit() is True
             assert txn.commit() is False  # Second commit should fail
 
     def test_cannot_rollback_after_commit(self, history):
         """Test that rolling back after commit returns False."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
             assert txn.commit() is True
             assert txn.rollback() is False  # Rollback should fail
 
     def test_cannot_commit_after_rollback(self, history):
         """Test that committing after rollback returns False."""
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
             assert txn.rollback() is True
             assert txn.commit() is False  # Commit should fail
 
@@ -219,7 +219,7 @@ class TestOperationTransaction:
         metadata = {"batch_name": "test_batch", "user": "test_user"}
 
         with OperationTransaction(history, metadata=metadata) as txn:
-            txn.log_move(Path("/test/source"), Path("/test/dest"))
+            txn.log_move(Path("/") / "test" / "source", Path("/") / "test" / "dest")
 
         transaction = history.get_transaction(txn.transaction_id)
         assert transaction.metadata == metadata
@@ -229,15 +229,15 @@ class TestOperationTransaction:
         txn = OperationTransaction(history)
 
         with pytest.raises(RuntimeError):
-            txn.log_operation(OperationType.MOVE, Path("/test/source"))
+            txn.log_operation(OperationType.MOVE, Path("/") / "test" / "source")
 
     def test_nested_transactions_not_supported(self, history):
         """Test that nested transactions each get their own ID."""
         with OperationTransaction(history) as txn1:
-            txn1.log_move(Path("/test/file1"), Path("/test/dest1"))
+            txn1.log_move(Path("/") / "test" / "file1", Path("/") / "test" / "dest1")
 
             with OperationTransaction(history) as txn2:
-                txn2.log_move(Path("/test/file2"), Path("/test/dest2"))
+                txn2.log_move(Path("/") / "test" / "file2", Path("/") / "test" / "dest2")
 
                 # Should have different transaction IDs
                 assert txn1.transaction_id != txn2.transaction_id

--- a/tests/infrastructure/test_coverage_infrastructure.py
+++ b/tests/infrastructure/test_coverage_infrastructure.py
@@ -222,7 +222,7 @@ class TestHealthEndpoint:
         from file_organizer.deploy.config import DeploymentConfig
         from file_organizer.deploy.health import HealthEndpoint
 
-        cfg = DeploymentConfig(data_directory=Path("/nonexistent/path"))
+        cfg = DeploymentConfig(data_directory=Path("/") / "nonexistent" / "path")
         ep = HealthEndpoint(config=cfg, min_disk_space_mb=1)
         # Falls back to "/" - should still work
         result = ep._check_disk_space()
@@ -232,7 +232,7 @@ class TestHealthEndpoint:
         from file_organizer.deploy.config import DeploymentConfig
         from file_organizer.deploy.health import HealthEndpoint
 
-        cfg = DeploymentConfig(data_directory=Path("/nonexistent"))
+        cfg = DeploymentConfig(data_directory=Path("/") / "nonexistent")
         ep = HealthEndpoint(config=cfg)
         with patch("shutil.disk_usage", side_effect=OSError("disk error")):
             status = ep._check_disk_space()
@@ -2604,7 +2604,7 @@ class TestPARARulesEngine:
         from file_organizer.methodologies.para.rules.engine import EvaluationContext
 
         ctx = EvaluationContext(
-            file_path=Path("/home/user/doc.pdf"),  # noqa: test-hardcoded-paths
+            file_path=Path("/") / "home" / "user" / "doc.pdf",  # noqa: test-hardcoded-paths
             file_stat={"created": datetime(2020, 1, 1, tzinfo=UTC)},
         )
         assert ctx.file_extension == ".pdf"
@@ -2614,7 +2614,7 @@ class TestPARARulesEngine:
     def test_evaluation_context_no_stat(self):
         from file_organizer.methodologies.para.rules.engine import EvaluationContext
 
-        ctx = EvaluationContext(file_path=Path("/home/user/doc.pdf"))  # noqa: test-hardcoded-paths
+        ctx = EvaluationContext(file_path=Path("/") / "home" / "user" / "doc.pdf")  # noqa: test-hardcoded-paths
         assert ctx.file_age_days is None
 
     def test_evaluation_context_naive_datetime(self):

--- a/tests/integration/config/test_migration_verification.py
+++ b/tests/integration/config/test_migration_verification.py
@@ -229,7 +229,7 @@ def test_preference_store_with_path_manager_production_workflow():
 
             # Add and save preferences
             pref_store.add_preference(
-                path=Path("/home/user/Documents"),  # noqa: test-hardcoded-paths
+                path=Path("/") / "home" / "user" / "Documents",  # noqa: test-hardcoded-paths
                 preference_data={
                     "folder_mappings": {"important": "Archive"},
                     "naming_patterns": {"pattern_1": "*.pdf"},

--- a/tests/integration/test_api_database_utils.py
+++ b/tests/integration/test_api_database_utils.py
@@ -204,16 +204,16 @@ class TestResolvePath:
 
 class TestIsHidden:
     def test_hidden_file(self) -> None:
-        assert is_hidden(Path("user/.dotfile")) is True
+        assert is_hidden(Path("user") / ".dotfile") is True
 
     def test_hidden_dir(self) -> None:
-        assert is_hidden(Path("user/.git/config")) is True
+        assert is_hidden(Path("user") / ".git" / "config") is True
 
     def test_normal_file(self) -> None:
-        assert is_hidden(Path("user/documents/report.pdf")) is False
+        assert is_hidden(Path("user") / "documents" / "report.pdf") is False
 
     def test_root_is_not_hidden(self) -> None:
-        assert is_hidden(Path("/home")) is False  # noqa: test-hardcoded-paths
+        assert is_hidden(Path("/") / "home") is False  # noqa: test-hardcoded-paths
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cli_suggest.py
+++ b/tests/integration/test_cli_suggest.py
@@ -45,7 +45,7 @@ def _make_suggestion(
     s = MagicMock()
     s.suggestion_id = sid
     s.suggestion_type = _make_suggestion_type_mock(stype)
-    s.file_path = file_path or Path("/tmp/report.pdf")  # noqa: test-hardcoded-paths
+    s.file_path = file_path or Path("/") / "tmp" / "report.pdf"  # noqa: test-hardcoded-paths
     s.target_path = target_path
     s.confidence = confidence
     s.reasoning = reasoning

--- a/tests/integration/test_context_menu_linux.py
+++ b/tests/integration/test_context_menu_linux.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 class TestNautilusScript(unittest.TestCase):
     def setUp(self):
-        self.script = Path("desktop/context-menus/nautilus/Organize with File Organizer")
+        self.script = (
+            Path("desktop") / "context-menus" / "nautilus" / "Organize with File Organizer"
+        )
 
     def test_nautilus_script_exists(self):
         self.assertTrue(self.script.exists())
@@ -35,7 +37,7 @@ class TestNautilusScript(unittest.TestCase):
 
 class TestDolphinServiceFile(unittest.TestCase):
     def setUp(self):
-        self.desktop_file = Path("desktop/context-menus/dolphin/file-organizer.desktop")
+        self.desktop_file = Path("desktop") / "context-menus" / "dolphin" / "file-organizer.desktop"
 
     def test_desktop_file_exists(self):
         self.assertTrue(self.desktop_file.exists())
@@ -59,7 +61,7 @@ class TestDolphinServiceFile(unittest.TestCase):
 
 class TestInstallScript(unittest.TestCase):
     def setUp(self):
-        self.install_script = Path("desktop/context-menus/install-linux.sh")
+        self.install_script = Path("desktop") / "context-menus" / "install-linux.sh"
 
     def test_install_script_exists(self):
         self.assertTrue(self.install_script.exists())

--- a/tests/integration/test_context_menu_macos.py
+++ b/tests/integration/test_context_menu_macos.py
@@ -11,7 +11,7 @@ import pytest
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only test")
 class TestMacOSQuickAction(unittest.TestCase):
     def setUp(self):
-        self.macos_dir = Path("desktop/context-menus/macos")
+        self.macos_dir = Path("desktop") / "context-menus" / "macos"
         self.quick_action_sh = self.macos_dir / "organize-quick-action.sh"
         self.workflow_dir = self.macos_dir / "OrganizeWithFileOrganizer.workflow"
         self.info_plist = self.workflow_dir / "Contents" / "Info.plist"
@@ -58,7 +58,7 @@ class TestMacOSQuickAction(unittest.TestCase):
         self.assertIn("servicesMenu", content)
 
     def test_install_script_exists(self):
-        install_sh = Path("desktop/context-menus/install-macos.sh")
+        install_sh = Path("desktop") / "context-menus" / "install-macos.sh"
         self.assertTrue(install_sh.exists())
 
 

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -747,7 +747,9 @@ class TestDispatcher:
         mock_classifier_cls.return_value.classify.return_value = mock_classification
 
         mock_organizer_cls = MagicMock()
-        mock_organizer_cls.return_value.generate_path.return_value = Path("Music/Artist/Track.mp3")
+        mock_organizer_cls.return_value.generate_path.return_value = (
+            Path("Music") / "Artist" / "Track.mp3"
+        )
 
         # AudioClassifier and AudioOrganizer are imported locally inside
         # process_audio_files; patch their module-level definitions so the

--- a/tests/integration/test_desktop_api_integration.py
+++ b/tests/integration/test_desktop_api_integration.py
@@ -216,7 +216,7 @@ class TestOpenPath:
         assert args_passed[0] == "open"
         assert args_passed[1] == "-R"
         assert len(args_passed) == 3
-        assert args_passed[2] == str(Path("/some/file.txt").resolve())
+        assert args_passed[2] == str(Path("/") / "some" / "file.txt".resolve())
 
     def test_open_path_win32_dispatches_explorer_select(self, api: DesktopAPI) -> None:
         """On Windows, open_path uses 'explorer /select,<path>' and returns True."""

--- a/tests/integration/test_desktop_api_integration.py
+++ b/tests/integration/test_desktop_api_integration.py
@@ -216,7 +216,7 @@ class TestOpenPath:
         assert args_passed[0] == "open"
         assert args_passed[1] == "-R"
         assert len(args_passed) == 3
-        assert args_passed[2] == str(Path("/") / "some" / "file.txt".resolve())
+        assert args_passed[2] == str((Path("/") / "some" / "file.txt").resolve())
 
     def test_open_path_win32_dispatches_explorer_select(self, api: DesktopAPI) -> None:
         """On Windows, open_path uses 'explorer /select,<path>' and returns True."""

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -81,7 +81,7 @@ class TestProcessTextFiles:
         from file_organizer.core.dispatcher import process_text_files
         from file_organizer.services import ProcessedFile
 
-        file_path = Path("/mock/docs/report.txt")
+        file_path = Path("/") / "mock" / "docs" / "report.txt"
         processed = ProcessedFile(
             file_path=file_path,
             description="A quarterly report",
@@ -113,7 +113,7 @@ class TestProcessTextFiles:
         from file_organizer.core.dispatcher import process_text_files
         from file_organizer.services import ProcessedFile
 
-        file_path = Path("/mock/docs/broken.txt")
+        file_path = Path("/") / "mock" / "docs" / "broken.txt"
         processed = ProcessedFile(
             file_path=file_path,
             description="",
@@ -142,7 +142,7 @@ class TestProcessTextFiles:
         from file_organizer.core.dispatcher import process_text_files
         from file_organizer.core.types import ERROR_FALLBACK_FOLDER
 
-        file_path = Path("/mock/docs/missing.txt")
+        file_path = Path("/") / "mock" / "docs" / "missing.txt"
         file_result = _make_file_result(success=False, path=file_path, error="process failed")
 
         mock_pp = MagicMock()
@@ -166,7 +166,7 @@ class TestProcessTextFiles:
         """When error is None on a failed result, fallback should use 'Unknown error'."""
         from file_organizer.core.dispatcher import process_text_files
 
-        file_path = Path("/mock/docs/mystery.txt")
+        file_path = Path("/") / "mock" / "docs" / "mystery.txt"
         file_result = _make_file_result(success=False, path=file_path, error=None)
 
         mock_pp = MagicMock()
@@ -206,8 +206,8 @@ class TestProcessTextFiles:
         from file_organizer.core.types import ERROR_FALLBACK_FOLDER
         from file_organizer.services import ProcessedFile
 
-        path_ok = Path("/mock/docs/good.txt")
-        path_fail = Path("/mock/docs/bad.txt")
+        path_ok = Path("/") / "mock" / "docs" / "good.txt"
+        path_fail = Path("/") / "mock" / "docs" / "bad.txt"
 
         processed_ok = ProcessedFile(
             file_path=path_ok,
@@ -248,7 +248,7 @@ class TestProcessImageFiles:
         from file_organizer.core.dispatcher import process_image_files
         from file_organizer.services import ProcessedImage
 
-        file_path = Path("/mock/photos/sunset.jpg")
+        file_path = Path("/") / "mock" / "photos" / "sunset.jpg"
         processed = ProcessedImage(
             file_path=file_path,
             description="A sunset over the ocean",
@@ -279,7 +279,7 @@ class TestProcessImageFiles:
         from file_organizer.core.dispatcher import process_image_files
         from file_organizer.services import ProcessedImage
 
-        file_path = Path("/mock/photos/corrupt.jpg")
+        file_path = Path("/") / "mock" / "photos" / "corrupt.jpg"
         processed = ProcessedImage(
             file_path=file_path,
             description="",
@@ -308,7 +308,7 @@ class TestProcessImageFiles:
         from file_organizer.core.dispatcher import process_image_files
         from file_organizer.core.types import ERROR_FALLBACK_FOLDER
 
-        file_path = Path("/mock/photos/missing.png")
+        file_path = Path("/") / "mock" / "photos" / "missing.png"
         file_result = _make_file_result(success=False, path=file_path, error="vision timeout")
 
         mock_pp = MagicMock()
@@ -337,9 +337,9 @@ class TestProcessImageFiles:
         from file_organizer.core.dispatcher import process_image_files
         from file_organizer.services import ProcessedImage
 
-        hung_path = Path("/mock/photos/hung.jpg")
-        retry1 = Path("/mock/photos/never_started_1.jpg")
-        retry2 = Path("/mock/photos/never_started_2.jpg")
+        hung_path = Path("/") / "mock" / "photos" / "hung.jpg"
+        retry1 = Path("/") / "mock" / "photos" / "never_started_1.jpg"
+        retry2 = Path("/") / "mock" / "photos" / "never_started_2.jpg"
 
         # Parallel processor yields one truly-hung abort (non_retryable)
         # + two never-started aborts (retryable).
@@ -441,7 +441,7 @@ class TestProcessImageFiles:
         # than letting the timeout escape as a generic error.
         from file_organizer.core.dispatcher import process_image_files
 
-        path = Path("/mock/photos/retry_timeout.jpg")
+        path = Path("/") / "mock" / "photos" / "retry_timeout.jpg"
         initial_abort = _make_file_result(
             success=False,
             path=path,
@@ -489,7 +489,7 @@ class TestProcessImageFiles:
         from file_organizer.core.dispatcher import process_image_files
         from file_organizer.core.types import ERROR_FALLBACK_FOLDER
 
-        path = Path("/mock/photos/retry_bad.jpg")
+        path = Path("/") / "mock" / "photos" / "retry_bad.jpg"
         initial_abort = _make_file_result(
             success=False,
             path=path,
@@ -532,7 +532,7 @@ class TestProcessImageFiles:
         # failures, reintroducing the cascade this path exists to prevent.
         from file_organizer.core.dispatcher import process_image_files
 
-        path = Path("/mock/photos/retry_never_ran.jpg")
+        path = Path("/") / "mock" / "photos" / "retry_never_ran.jpg"
         initial_abort = _make_file_result(
             success=False,
             path=path,
@@ -577,7 +577,7 @@ class TestProcessImageFiles:
     def test_failure_result_unknown_error(self) -> None:
         from file_organizer.core.dispatcher import process_image_files
 
-        file_path = Path("/mock/photos/unknown.jpg")
+        file_path = Path("/") / "mock" / "photos" / "unknown.jpg"
         file_result = _make_file_result(success=False, path=file_path, error=None)
 
         mock_pp = MagicMock()
@@ -654,7 +654,7 @@ class TestProcessAudioFiles:
     def test_success_path_appended(self) -> None:
         from file_organizer.core.dispatcher import process_audio_files
 
-        audio_path = Path("/mock/music/song.mp3")
+        audio_path = Path("/") / "mock" / "music" / "song.mp3"
         meta = self._make_audio_metadata(artist="The Band", title="My Song")
         classification = self._make_audio_classification()
         dest = self._make_dest_path("Music/The Band", "My_Song")
@@ -683,7 +683,7 @@ class TestProcessAudioFiles:
     def test_success_description_contains_type_and_artist(self) -> None:
         from file_organizer.core.dispatcher import process_audio_files
 
-        audio_path = Path("/mock/music/track.mp3")
+        audio_path = Path("/") / "mock" / "music" / "track.mp3"
         meta = self._make_audio_metadata(artist="DJ Echo", title="Night Drive")
         classification = self._make_audio_classification("music")
         dest = self._make_dest_path("Music/DJ Echo", "Night_Drive")
@@ -711,7 +711,7 @@ class TestProcessAudioFiles:
         from file_organizer.core.dispatcher import process_audio_files
         from file_organizer.core.types import AUDIO_FALLBACK_FOLDER
 
-        audio_path = Path("/mock/music/corrupt.mp3")
+        audio_path = Path("/") / "mock" / "music" / "corrupt.mp3"
 
         mock_extractor_instance = MagicMock()
         mock_extractor_instance.extract.side_effect = OSError("cannot read file")
@@ -734,7 +734,7 @@ class TestProcessAudioFiles:
         from file_organizer.core.dispatcher import process_audio_files
         from file_organizer.core.types import AUDIO_FALLBACK_FOLDER
 
-        audio_path = Path("/mock/music/bad.flac")
+        audio_path = Path("/") / "mock" / "music" / "bad.flac"
         mock_extractor_instance = MagicMock()
         mock_extractor_instance.extract.side_effect = ValueError("bad tag data")
         mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
@@ -804,7 +804,7 @@ class TestAudioTranscription:
         from file_organizer.core.dispatcher import _maybe_transcribe
 
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=None,
             max_transcribe_seconds=None,
@@ -817,7 +817,7 @@ class TestAudioTranscription:
 
         bad = object()  # no .transcribe / .generate
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=bad,
             max_transcribe_seconds=None,
@@ -829,7 +829,7 @@ class TestAudioTranscription:
 
         transcriber = MagicMock(spec=["transcribe"])
         result = _maybe_transcribe(
-            Path("/mock/long.mp3"),
+            Path("/") / "mock" / "long.mp3",
             metadata=MagicMock(duration=900.0),
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
@@ -858,7 +858,7 @@ class TestAudioTranscription:
         )
         transcriber.transcribe.return_value = whisper_result
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
@@ -867,7 +867,7 @@ class TestAudioTranscription:
         assert result is whisper_result
         assert result.text == "hello from whisper"
         assert result.segments == whisper_result.segments
-        transcriber.transcribe.assert_called_once_with(str(Path("/mock/a.mp3")))
+        transcriber.transcribe.assert_called_once_with(str(Path("/") / "mock" / "a.mp3"))
 
     def test_maybe_transcribe_incomplete_object_synthesizes_result(self) -> None:
         """A text-bearing object lacking .segments/.duration is wrapped, not passed through.
@@ -885,7 +885,7 @@ class TestAudioTranscription:
         # Has .text but NOT .segments/.duration — not classify-ready.
         transcriber.transcribe.return_value = SimpleNamespace(text="partial adapter")
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=12.0),
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
@@ -908,7 +908,7 @@ class TestAudioTranscription:
         transcriber = MagicMock(spec=["transcribe"])
         transcriber.transcribe.return_value = "plain text only"
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
@@ -929,7 +929,7 @@ class TestAudioTranscription:
         transcriber = MagicMock(spec=["generate"])
         transcriber.generate.return_value = "hello world"
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=600.0,
@@ -937,7 +937,7 @@ class TestAudioTranscription:
         assert isinstance(result, TranscriptionResult)
         assert result.text == "hello world"
         assert result.segments == []
-        transcriber.generate.assert_called_once_with(str(Path("/mock/a.mp3")))
+        transcriber.generate.assert_called_once_with(str(Path("/") / "mock" / "a.mp3"))
 
     def test_maybe_transcribe_recoverable_error_degrades(self) -> None:
         """A RuntimeError during transcription degrades, not aborts."""
@@ -946,7 +946,7 @@ class TestAudioTranscription:
         transcriber = MagicMock(spec=["transcribe"])
         transcriber.transcribe.side_effect = RuntimeError("decode failed")
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=None,
@@ -964,7 +964,7 @@ class TestAudioTranscription:
         transcriber = MagicMock(spec=["transcribe"])
         transcriber.transcribe.side_effect = TypeError("transcribe() takes no arguments")
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=None,
@@ -978,7 +978,7 @@ class TestAudioTranscription:
         transcriber = MagicMock(spec=["generate"])
         transcriber.generate.side_effect = AttributeError("no such attribute")
         result = _maybe_transcribe(
-            Path("/mock/a.mp3"),
+            Path("/") / "mock" / "a.mp3",
             metadata=MagicMock(duration=10.0),
             transcriber=transcriber,
             max_transcribe_seconds=None,
@@ -1005,7 +1005,7 @@ class TestAudioTranscription:
         """End-to-end: transcript attaches to ProcessedFile and reaches classify()."""
         from file_organizer.core.dispatcher import process_audio_files
 
-        audio_path = Path("/mock/podcasts/ep1.mp3")
+        audio_path = Path("/") / "mock" / "podcasts" / "ep1.mp3"
         meta = MagicMock()
         meta.artist = None
         meta.title = None
@@ -1067,7 +1067,7 @@ class TestAudioTranscription:
         """A transcription failure degrades to metadata-only — file still classified."""
         from file_organizer.core.dispatcher import process_audio_files
 
-        audio_path = Path("/mock/music/song.mp3")
+        audio_path = Path("/") / "mock" / "music" / "song.mp3"
         meta = MagicMock()
         meta.artist = "Band"
         meta.title = "Song"
@@ -1127,7 +1127,7 @@ class TestProcessVideoFiles:
     def test_success_path_appended(self) -> None:
         from file_organizer.core.dispatcher import process_video_files
 
-        video_path = Path("/mock/videos/movie.mp4")
+        video_path = Path("/") / "mock" / "videos" / "movie.mp4"
         meta = MagicMock()
 
         mock_extractor_instance = MagicMock()
@@ -1152,7 +1152,7 @@ class TestProcessVideoFiles:
         from file_organizer.core.dispatcher import process_video_files
         from file_organizer.core.types import VIDEO_FALLBACK_FOLDER
 
-        video_path = Path("/mock/videos/missing.avi")
+        video_path = Path("/") / "mock" / "videos" / "missing.avi"
 
         mock_extractor_instance = MagicMock()
         mock_extractor_instance.extract.side_effect = FileNotFoundError("file gone")
@@ -1171,7 +1171,7 @@ class TestProcessVideoFiles:
         from file_organizer.core.dispatcher import process_video_files
         from file_organizer.core.types import VIDEO_FALLBACK_FOLDER
 
-        video_path = Path("/mock/videos/locked.mkv")
+        video_path = Path("/") / "mock" / "videos" / "locked.mkv"
         mock_extractor_instance = MagicMock()
         mock_extractor_instance.extract.side_effect = OSError("permission denied")
         mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
@@ -1187,7 +1187,7 @@ class TestProcessVideoFiles:
         from file_organizer.core.dispatcher import process_video_files
         from file_organizer.core.types import VIDEO_FALLBACK_FOLDER
 
-        video_path = Path("/mock/videos/crash.mp4")
+        video_path = Path("/") / "mock" / "videos" / "crash.mp4"
         mock_extractor_instance = MagicMock()
         mock_extractor_instance.extract.side_effect = RuntimeError("ffprobe crashed")
         mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
@@ -1227,7 +1227,7 @@ class TestProcessVideoFiles:
     def test_description_stored_from_organizer(self) -> None:
         from file_organizer.core.dispatcher import process_video_files
 
-        video_path = Path("/mock/videos/documentary.mp4")
+        video_path = Path("/") / "mock" / "videos" / "documentary.mp4"
         meta = MagicMock()
 
         mock_extractor_instance = MagicMock()

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -759,7 +759,7 @@ class TestProcessAudioFiles:
     def test_multiple_files_all_processed(self) -> None:
         from file_organizer.core.dispatcher import process_audio_files
 
-        paths = [Path(f"/mock/music/track{i}.mp3") for i in range(3)]
+        paths = [Path("/") / "mock" / "music" / f"track{i}.mp3" for i in range(3)]
 
         call_count = {"n": 0}
 
@@ -1209,7 +1209,7 @@ class TestProcessVideoFiles:
     def test_multiple_files_all_processed(self) -> None:
         from file_organizer.core.dispatcher import process_video_files
 
-        paths = [Path(f"/mock/videos/clip{i}.mp4") for i in range(4)]
+        paths = [Path("/") / "mock" / "videos" / f"clip{i}.mp4" for i in range(4)]
 
         mock_extractor_instance = MagicMock()
         mock_extractor_instance.extract.return_value = MagicMock()

--- a/tests/integration/test_feedback_processor_branches.py
+++ b/tests/integration/test_feedback_processor_branches.py
@@ -92,7 +92,9 @@ class TestProcessCorrection:
         fp = _fp()
         fp.learning_threshold = 3
         for i in range(3):
-            result = fp.process_correction(Path(f"/a/f{i}.txt"), Path(f"/b/g{i}.txt"))
+            result = fp.process_correction(
+                Path("/") / "a" / f"f{i}.txt", Path("/") / "b" / f"g{i}.txt"
+            )
         assert result.get("trigger_retraining") is True
 
     def test_below_threshold_no_trigger(self) -> None:

--- a/tests/integration/test_feedback_processor_branches.py
+++ b/tests/integration/test_feedback_processor_branches.py
@@ -44,27 +44,27 @@ class TestProcessCorrection:
     def test_same_path_no_signals(self) -> None:
         """No name or folder change → no learning signals."""
         fp = _fp()
-        result = fp.process_correction(Path("/a/x.txt"), Path("/a/x.txt"))
+        result = fp.process_correction(Path("/") / "a" / "x.txt", Path("/") / "a" / "x.txt")
         assert result["learning_signals"] == []
 
     def test_name_change_adds_naming_signal(self) -> None:
         """Different file names → naming signal appended."""
         fp = _fp()
-        result = fp.process_correction(Path("/a/old.txt"), Path("/a/new.txt"))
+        result = fp.process_correction(Path("/") / "a" / "old.txt", Path("/") / "a" / "new.txt")
         types = [s["type"] for s in result["learning_signals"]]
         assert "naming" in types
 
     def test_folder_change_adds_folder_signal(self) -> None:
         """Different parent folders → folder signal appended."""
         fp = _fp()
-        result = fp.process_correction(Path("/a/x.txt"), Path("/b/x.txt"))
+        result = fp.process_correction(Path("/") / "a" / "x.txt", Path("/") / "b" / "x.txt")
         types = [s["type"] for s in result["learning_signals"]]
         assert "folder" in types
 
     def test_both_changes_add_both_signals(self) -> None:
         """Name AND folder change → both signals."""
         fp = _fp()
-        result = fp.process_correction(Path("/a/old.txt"), Path("/b/new.txt"))
+        result = fp.process_correction(Path("/") / "a" / "old.txt", Path("/") / "b" / "new.txt")
         types = [s["type"] for s in result["learning_signals"]]
         assert "naming" in types
         assert "folder" in types
@@ -73,7 +73,7 @@ class TestProcessCorrection:
         """Context with 'operation' key → context signal appended."""
         fp = _fp()
         result = fp.process_correction(
-            Path("/a/x.txt"), Path("/a/x.txt"), context={"operation": "rename"}
+            Path("/") / "a" / "x.txt", Path("/") / "a" / "x.txt", context={"operation": "rename"}
         )
         types = [s["type"] for s in result["learning_signals"]]
         assert "context" in types
@@ -82,7 +82,7 @@ class TestProcessCorrection:
         """Context with no recognized keys → _extract_context_patterns returns None."""
         fp = _fp()
         result = fp.process_correction(
-            Path("/a/x.txt"), Path("/a/x.txt"), context={"unrelated": "value"}
+            Path("/") / "a" / "x.txt", Path("/") / "a" / "x.txt", context={"unrelated": "value"}
         )
         types = [s["type"] for s in result["learning_signals"]]
         assert "context" not in types
@@ -99,7 +99,7 @@ class TestProcessCorrection:
         """Below threshold → no trigger_retraining key."""
         fp = _fp()
         fp.learning_threshold = 10
-        result = fp.process_correction(Path("/a/x.txt"), Path("/b/y.txt"))
+        result = fp.process_correction(Path("/") / "a" / "x.txt", Path("/") / "b" / "y.txt")
         assert "trigger_retraining" not in result
 
 
@@ -325,8 +325,8 @@ class TestAnalyzeFolderCorrection:
         """Context with 'category' key → category_change pattern."""
         fp = _fp()
         result = fp._analyze_folder_correction(
-            Path("/a/x.pdf"),
-            Path("/docs/x.pdf"),
+            Path("/") / "a" / "x.pdf",
+            Path("/") / "docs" / "x.pdf",
             context={"category": "documents"},
         )
         pattern_types = [p["pattern_type"] for p in result["patterns"]]
@@ -336,8 +336,8 @@ class TestAnalyzeFolderCorrection:
         """Moving to deeper path → subfolder_structure pattern."""
         fp = _fp()
         result = fp._analyze_folder_correction(
-            Path("/a/x.pdf"),
-            Path("/docs/reports/2024/x.pdf"),
+            Path("/") / "a" / "x.pdf",
+            Path("/") / "docs" / "reports" / "2024" / "x.pdf",
             context=None,
         )
         pattern_types = [p["pattern_type"] for p in result["patterns"]]
@@ -347,8 +347,8 @@ class TestAnalyzeFolderCorrection:
         """No context → no category_change pattern."""
         fp = _fp()
         result = fp._analyze_folder_correction(
-            Path("/a/x.pdf"),
-            Path("/b/x.pdf"),
+            Path("/") / "a" / "x.pdf",
+            Path("/") / "b" / "x.pdf",
             context=None,
         )
         pattern_types = [p["pattern_type"] for p in result["patterns"]]
@@ -358,8 +358,8 @@ class TestAnalyzeFolderCorrection:
         """Context without 'category' key → no category_change pattern."""
         fp = _fp()
         result = fp._analyze_folder_correction(
-            Path("/a/x.pdf"),
-            Path("/b/x.pdf"),
+            Path("/") / "a" / "x.pdf",
+            Path("/") / "b" / "x.pdf",
             context={"other": "value"},
         )
         pattern_types = [p["pattern_type"] for p in result["patterns"]]

--- a/tests/integration/test_history_workflow.py
+++ b/tests/integration/test_history_workflow.py
@@ -65,14 +65,14 @@ def populated_history(history: OperationHistory, tmp_path: Path) -> OperationHis
     # Rename (file does not need to exist for non-hashing path)
     history.log_operation(
         OperationType.RENAME,
-        source_path=Path("/virtual/old_name.txt"),
-        destination_path=Path("/virtual/new_name.txt"),
+        source_path=Path("/") / "virtual" / "old_name.txt",
+        destination_path=Path("/") / "virtual" / "new_name.txt",
     )
 
     # Failed operation
     history.log_operation(
         OperationType.DELETE,
-        source_path=Path("/virtual/missing.txt"),
+        source_path=Path("/") / "virtual" / "missing.txt",
         status=OperationStatus.FAILED,
         error_message="File not found",
     )
@@ -122,7 +122,7 @@ class TestOperationHistoryTracker:
     def test_log_failed_operation(self, history: OperationHistory) -> None:
         history.log_operation(
             OperationType.DELETE,
-            source_path=Path("/no/such/file.txt"),
+            source_path=Path("/") / "no" / "such" / "file.txt",
             status=OperationStatus.FAILED,
             error_message="Permission denied",
         )
@@ -151,7 +151,7 @@ class TestOperationHistoryTracker:
         assert len(ops) == 2
 
     def test_date_range_filter(self, history: OperationHistory) -> None:
-        history.log_operation(OperationType.CREATE, source_path=Path("/virtual/x.txt"))
+        history.log_operation(OperationType.CREATE, source_path=Path("/") / "virtual" / "x.txt")
         before = datetime.now(UTC) + timedelta(seconds=1)
         ops = history.get_operations(end_date=before)
         assert len(ops) == 1
@@ -170,8 +170,8 @@ class TestOperationHistoryTracker:
 
         history.log_operation(
             OperationType.MOVE,
-            source_path=Path("/virtual/src.txt"),
-            destination_path=Path("/virtual/dst.txt"),
+            source_path=Path("/") / "virtual" / "src.txt",
+            destination_path=Path("/") / "virtual" / "dst.txt",
             transaction_id=txn_id,
         )
 
@@ -188,8 +188,8 @@ class TestOperationHistoryTracker:
         txn_id = history.start_transaction()
         history.log_operation(
             OperationType.MOVE,
-            source_path=Path("/virtual/src.txt"),
-            destination_path=Path("/virtual/dst.txt"),
+            source_path=Path("/") / "virtual" / "src.txt",
+            destination_path=Path("/") / "virtual" / "dst.txt",
             transaction_id=txn_id,
         )
 
@@ -217,8 +217,8 @@ class TestOperationTransaction:
 
     def test_auto_commit_on_success(self, history: OperationHistory) -> None:
         with OperationTransaction(history, metadata={"note": "batch"}) as txn:
-            txn.log_move(Path("/src/a.txt"), Path("/dst/a.txt"))
-            txn.log_rename(Path("/src/b.txt"), Path("/src/b_new.txt"))
+            txn.log_move(Path("/") / "src" / "a.txt", Path("/") / "dst" / "a.txt")
+            txn.log_rename(Path("/") / "src" / "b.txt", Path("/") / "src" / "b_new.txt")
             txn_id = txn.get_transaction_id()
 
         assert txn._committed is True
@@ -234,7 +234,7 @@ class TestOperationTransaction:
         def _log_and_fail() -> None:
             nonlocal txn_id, txn
             with OperationTransaction(history) as txn:
-                txn.log_move(Path("/src/a.txt"), Path("/dst/a.txt"))
+                txn.log_move(Path("/") / "src" / "a.txt", Path("/") / "dst" / "a.txt")
                 txn_id = txn.get_transaction_id()
                 raise ValueError("test error")
 
@@ -249,16 +249,16 @@ class TestOperationTransaction:
 
     def test_log_all_operation_types(self, history: OperationHistory) -> None:
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/src/move.txt"), Path("/dst/move.txt"))
-            txn.log_rename(Path("/src/old.txt"), Path("/src/new.txt"))
-            txn.log_delete(Path("/src/del.txt"))
-            txn.log_copy(Path("/src/orig.txt"), Path("/dst/copy.txt"))
-            txn.log_create(Path("/src/new.txt"))
+            txn.log_move(Path("/") / "src" / "move.txt", Path("/") / "dst" / "move.txt")
+            txn.log_rename(Path("/") / "src" / "old.txt", Path("/") / "src" / "new.txt")
+            txn.log_delete(Path("/") / "src" / "del.txt")
+            txn.log_copy(Path("/") / "src" / "orig.txt", Path("/") / "dst" / "copy.txt")
+            txn.log_create(Path("/") / "src" / "new.txt")
             txn.log_failed_operation(
                 OperationType.MOVE,
-                Path("/src/fail.txt"),
+                Path("/") / "src" / "fail.txt",
                 error_message="Disk full",
-                destination_path=Path("/dst/fail.txt"),
+                destination_path=Path("/") / "dst" / "fail.txt",
             )
 
         ops = history.get_operations()
@@ -275,7 +275,7 @@ class TestOperationTransaction:
 
     def test_explicit_commit_before_exit(self, history: OperationHistory) -> None:
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/s.txt"), Path("/d.txt"))
+            txn.log_move(Path("/") / "s.txt", Path("/") / "d.txt")
             txn.commit()
             assert txn._committed is True
         # __exit__ should not double-commit
@@ -283,7 +283,7 @@ class TestOperationTransaction:
 
     def test_explicit_rollback_before_exit(self, history: OperationHistory) -> None:
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/s.txt"), Path("/d.txt"))
+            txn.log_move(Path("/") / "s.txt", Path("/") / "d.txt")
             txn.rollback()
             assert txn._rolled_back is True
         assert txn._rolled_back is True
@@ -291,11 +291,11 @@ class TestOperationTransaction:
     def test_log_operation_outside_context_raises(self, history: OperationHistory) -> None:
         txn = OperationTransaction(history)
         with pytest.raises(RuntimeError, match="outside of transaction context"):
-            txn.log_move(Path("/s.txt"), Path("/d.txt"))
+            txn.log_move(Path("/") / "s.txt", Path("/") / "d.txt")
 
     def test_commit_idempotent(self, history: OperationHistory) -> None:
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/s.txt"), Path("/d.txt"))
+            txn.log_move(Path("/") / "s.txt", Path("/") / "d.txt")
             first = txn.commit()
             second = txn.commit()  # should return False, not raise
         assert first is True
@@ -303,14 +303,14 @@ class TestOperationTransaction:
 
     def test_cannot_rollback_committed(self, history: OperationHistory) -> None:
         with OperationTransaction(history) as txn:
-            txn.log_move(Path("/s.txt"), Path("/d.txt"))
+            txn.log_move(Path("/") / "s.txt", Path("/") / "d.txt")
             txn.commit()
             result = txn.rollback()
         assert result is False
 
     def test_nested_transactions_independent(self, history: OperationHistory) -> None:
         with OperationTransaction(history) as txn1:
-            txn1.log_move(Path("/s1.txt"), Path("/d1.txt"))
+            txn1.log_move(Path("/") / "s1.txt", Path("/") / "d1.txt")
 
         txn1_id = txn1.get_transaction_id()
 
@@ -319,7 +319,7 @@ class TestOperationTransaction:
         def _log_and_abort() -> None:
             nonlocal txn2
             with OperationTransaction(history) as txn2:
-                txn2.log_move(Path("/s2.txt"), Path("/d2.txt"))
+                txn2.log_move(Path("/") / "s2.txt", Path("/") / "d2.txt")
                 raise RuntimeError("abort txn2")
 
         with pytest.raises(RuntimeError):
@@ -380,7 +380,7 @@ class TestHistoryCleanup:
     ) -> None:
         self._add_old_ops(history, 5, days_old=100)
         # Add recent op that should survive
-        history.log_operation(OperationType.CREATE, Path("/recent.txt"))
+        history.log_operation(OperationType.CREATE, Path("/") / "recent.txt")
 
         deleted = cleanup.cleanup_old_operations(max_age_days=30)
         assert deleted == 5
@@ -454,7 +454,7 @@ class TestHistoryCleanup:
         history.db.get_connection().commit()
 
         # Add a recent completed op that must survive
-        history.log_operation(OperationType.CREATE, Path("/ok.txt"))
+        history.log_operation(OperationType.CREATE, Path("/") / "ok.txt")
 
         deleted = cleanup.cleanup_failed_operations(older_than_days=1)
         assert deleted == 1
@@ -468,8 +468,8 @@ class TestHistoryCleanup:
         txn_id = history.start_transaction()
         history.log_operation(
             OperationType.MOVE,
-            Path("/s.txt"),
-            Path("/d.txt"),
+            Path("/") / "s.txt",
+            Path("/") / "d.txt",
             transaction_id=txn_id,
         )
         history.rollback_transaction(txn_id)
@@ -504,7 +504,7 @@ class TestHistoryCleanup:
     def test_clear_all_without_confirm_is_noop(
         self, history: OperationHistory, cleanup: HistoryCleanup
     ) -> None:
-        history.log_operation(OperationType.CREATE, Path("/f.txt"))
+        history.log_operation(OperationType.CREATE, Path("/") / "f.txt")
         result = cleanup.clear_all(confirm=False)
         assert result is False
         assert len(history.get_operations()) == 1
@@ -514,7 +514,7 @@ class TestHistoryCleanup:
     ) -> None:
         txn_id = history.start_transaction()
         history.log_operation(
-            OperationType.MOVE, Path("/s.txt"), Path("/d.txt"), transaction_id=txn_id
+            OperationType.MOVE, Path("/") / "s.txt", Path("/") / "d.txt", transaction_id=txn_id
         )
         history.commit_transaction(txn_id)
 
@@ -523,10 +523,10 @@ class TestHistoryCleanup:
         assert len(history.get_operations()) == 0
 
     def test_get_statistics(self, history: OperationHistory, cleanup: HistoryCleanup) -> None:
-        history.log_operation(OperationType.MOVE, Path("/s.txt"), Path("/d.txt"))
+        history.log_operation(OperationType.MOVE, Path("/") / "s.txt", Path("/") / "d.txt")
         history.log_operation(
             OperationType.DELETE,
-            Path("/x.txt"),
+            Path("/") / "x.txt",
             status=OperationStatus.FAILED,
         )
 
@@ -615,20 +615,20 @@ class TestHistoryExporter:
         txn_id = history.start_transaction({"note": "export_test"})
         history.log_operation(
             OperationType.MOVE,
-            source_path=Path("/src/a.txt"),
-            destination_path=Path("/dst/a.txt"),
+            source_path=Path("/") / "src" / "a.txt",
+            destination_path=Path("/") / "dst" / "a.txt",
             transaction_id=txn_id,
         )
         history.log_operation(
             OperationType.RENAME,
-            source_path=Path("/src/b.txt"),
-            destination_path=Path("/src/b_new.txt"),
+            source_path=Path("/") / "src" / "b.txt",
+            destination_path=Path("/") / "src" / "b_new.txt",
             transaction_id=txn_id,
         )
         history.commit_transaction(txn_id)
         history.log_operation(
             OperationType.DELETE,
-            source_path=Path("/trash/c.txt"),
+            source_path=Path("/") / "trash" / "c.txt",
             status=OperationStatus.FAILED,
             error_message="No permission",
         )

--- a/tests/integration/test_history_workflow.py
+++ b/tests/integration/test_history_workflow.py
@@ -392,7 +392,7 @@ class TestHistoryCleanup:
         self, history: OperationHistory, cleanup: HistoryCleanup
     ) -> None:
         for i in range(10):
-            history.log_operation(OperationType.CREATE, Path(f"/file_{i}.txt"))
+            history.log_operation(OperationType.CREATE, Path("/") / f"file_{i}.txt")
 
         deleted = cleanup.cleanup_by_count(max_operations=3)
         remaining = history.get_operations()
@@ -406,7 +406,7 @@ class TestHistoryCleanup:
         self, history: OperationHistory, cleanup: HistoryCleanup
     ) -> None:
         for i in range(5):
-            history.log_operation(OperationType.CREATE, Path(f"/file_{i}.txt"))
+            history.log_operation(OperationType.CREATE, Path("/") / f"file_{i}.txt")
 
         deleted = cleanup.cleanup_by_count(max_operations=10)
         assert deleted == 0
@@ -416,7 +416,7 @@ class TestHistoryCleanup:
         self, history: OperationHistory, cleanup: HistoryCleanup
     ) -> None:
         for i in range(5):
-            history.log_operation(OperationType.CREATE, Path(f"/file_{i}.txt"))
+            history.log_operation(OperationType.CREATE, Path("/") / f"file_{i}.txt")
 
         deleted = cleanup.cleanup_by_count(max_operations=0)
         assert deleted == 5
@@ -490,7 +490,7 @@ class TestHistoryCleanup:
         cleanup = HistoryCleanup(history.db, config)
 
         for i in range(3):
-            history.log_operation(OperationType.CREATE, Path(f"/f{i}.txt"))
+            history.log_operation(OperationType.CREATE, Path("/") / f"f{i}.txt")
 
         assert cleanup.should_cleanup() is True
 
@@ -498,7 +498,7 @@ class TestHistoryCleanup:
         config = HistoryCleanupConfig(max_operations=1, auto_cleanup_enabled=False)
         cleanup = HistoryCleanup(history.db, config)
         for i in range(5):
-            history.log_operation(OperationType.CREATE, Path(f"/f{i}.txt"))
+            history.log_operation(OperationType.CREATE, Path("/") / f"f{i}.txt")
         assert cleanup.should_cleanup() is False
 
     def test_clear_all_without_confirm_is_noop(
@@ -547,7 +547,7 @@ class TestHistoryCleanup:
         cleanup = HistoryCleanup(history.db, config)
 
         for i in range(5):
-            history.log_operation(OperationType.CREATE, Path(f"/f{i}.txt"))
+            history.log_operation(OperationType.CREATE, Path("/") / f"f{i}.txt")
 
         stats = cleanup.auto_cleanup()
         assert stats["deleted_operations"] > 0

--- a/tests/integration/test_intelligence_branches.py
+++ b/tests/integration/test_intelligence_branches.py
@@ -336,13 +336,15 @@ class TestPatternLearnerBranches:
         """learning_enabled=False returns early (lines 83-84)."""
         learner = self._make_learner(tmp_path)
         learner.learning_enabled = False
-        result = learner.learn_from_correction(Path("/src/file.txt"), Path("/dst/file.txt"))
+        result = learner.learn_from_correction(
+            Path("/") / "src" / "file.txt", Path("/") / "dst" / "file.txt"
+        )
         assert result.get("learning_enabled") is False
 
     def test_learn_from_correction_same_name_same_parent(self, tmp_path: Path) -> None:
         """Correction with no change — no naming or folder learning."""
         learner = self._make_learner(tmp_path)
-        p = Path("/src/file.txt")
+        p = Path("/") / "src" / "file.txt"
         result = learner.learn_from_correction(p, p)
         assert "learned" in result
 
@@ -354,24 +356,24 @@ class TestPatternLearnerBranches:
         propagates; we assert it to cover the call-site and naming-pattern method body.
         """
         learner = self._make_learner(tmp_path)
-        original = Path("/src/MyFile.txt")
-        corrected = Path("/src/my_file.txt")
+        original = Path("/") / "src" / "MyFile.txt"
+        corrected = Path("/") / "src" / "my_file.txt"
         with pytest.raises(KeyError):
             learner.learn_from_correction(original, corrected)
 
     def test_learn_from_correction_different_parents(self, tmp_path: Path) -> None:
         """original.parent != corrected.parent → _learn_folder_preference."""
         learner = self._make_learner(tmp_path)
-        original = Path("/docs/file.txt")
-        corrected = Path("/reports/file.txt")
+        original = Path("/") / "docs" / "file.txt"
+        corrected = Path("/") / "reports" / "file.txt"
         result = learner.learn_from_correction(original, corrected)
         assert any(r.get("type") == "folder" for r in result.get("learned", []))
 
     def test_learn_from_correction_both_differ_hits_naming_path(self, tmp_path: Path) -> None:
         """Both name and parent differ → naming path called first, KeyError propagates."""
         learner = self._make_learner(tmp_path)
-        original = Path("/docs/OldName.txt")
-        corrected = Path("/reports/new_name.txt")
+        original = Path("/") / "docs" / "OldName.txt"
+        corrected = Path("/") / "reports" / "new_name.txt"
         # Same note: _learn_naming_pattern raises KeyError due to 'case_style' bug
         with pytest.raises(KeyError):
             learner.learn_from_correction(original, corrected)
@@ -410,7 +412,9 @@ class TestPatternLearnerBranches:
         learner = self._make_learner(tmp_path)
         with (
             patch.object(
-                learner.folder_learner, "suggest_folder_structure", return_value=Path("/reports")
+                learner.folder_learner,
+                "suggest_folder_structure",
+                return_value=Path("/") / "reports",
             ),
             patch.object(learner.folder_learner, "get_folder_confidence", return_value=0.8),
         ):
@@ -427,7 +431,7 @@ class TestPatternLearnerBranches:
         with (
             patch.object(learner, "_get_naming_suggestions", return_value=mock_naming),
             patch.object(
-                learner.folder_learner, "suggest_folder_structure", return_value=Path("/docs")
+                learner.folder_learner, "suggest_folder_structure", return_value=Path("/") / "docs"
             ),
             patch.object(learner.folder_learner, "get_folder_confidence", return_value=0.7),
         ):
@@ -448,8 +452,8 @@ class TestPatternLearnerBranches:
         learner = self._make_learner(tmp_path)
         corrections = [
             {
-                "original": str(Path("/src/OldName.txt")),
-                "corrected": str(Path("/src/new_name.txt")),
+                "original": str(Path("/") / "src" / "OldName.txt"),
+                "corrected": str(Path("/") / "src" / "new_name.txt"),
                 "timestamp": "2026-01-01T00:00:00Z",
             }
         ]
@@ -495,7 +499,7 @@ class TestPatternLearnerBranches:
     def test_identify_folder_preference_calls_learner(self, tmp_path: Path) -> None:
         """identify_folder_preference delegates to folder_learner (line 181)."""
         learner = self._make_learner(tmp_path)
-        learner.identify_folder_preference(".pdf", Path("/reports"))
+        learner.identify_folder_preference(".pdf", Path("/") / "reports")
         # Verify it tracked without error
 
     def test_update_confidence_calls_engine(self, tmp_path: Path) -> None:

--- a/tests/integration/test_methodologies_jd.py
+++ b/tests/integration/test_methodologies_jd.py
@@ -868,7 +868,7 @@ class TestAdapters:
         adapter = PARAAdapter(cfg)
         item = OrganizationItem(
             name="project-doc.pdf",
-            path=Path("docs/project-doc.pdf"),
+            path=Path("docs") / "project-doc.pdf",
             category="projects",
             metadata={},
         )
@@ -887,7 +887,7 @@ class TestAdapters:
         adapter = PARAAdapter(cfg)
         item = OrganizationItem(
             name="doc.pdf",
-            path=Path("Projects/doc.pdf"),
+            path=Path("Projects") / "doc.pdf",
             category="projects",
             metadata={},
         )

--- a/tests/integration/test_models_vision_text_config_registry.py
+++ b/tests/integration/test_models_vision_text_config_registry.py
@@ -365,7 +365,7 @@ class TestVisionModelGenerate:
     def test_generate_raises_file_not_found(self) -> None:
         model = _make_vision_model()
         with pytest.raises(FileNotFoundError):
-            model.generate("p", image_path=Path("/nonexistent/image.png"))
+            model.generate("p", image_path=Path("/") / "nonexistent" / "image.png")
 
     def test_generate_raises_on_empty_response(self, tmp_path: Path) -> None:
         model = _make_vision_model()
@@ -626,7 +626,7 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s1",
             suggestion_type=SuggestionType.MOVE,
-            file_path=Path("/a/b.txt"),
+            file_path=Path("/") / "a" / "b.txt",
             confidence=85.0,
         )
         assert s.confidence_level == ConfidenceLevel.VERY_HIGH
@@ -641,7 +641,7 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s2",
             suggestion_type=SuggestionType.RENAME,
-            file_path=Path("/a/b.txt"),
+            file_path=Path("/") / "a" / "b.txt",
             confidence=65.0,
         )
         assert s.confidence_level == ConfidenceLevel.HIGH
@@ -656,7 +656,7 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s3",
             suggestion_type=SuggestionType.TAG,
-            file_path=Path("/a/b.txt"),
+            file_path=Path("/") / "a" / "b.txt",
             confidence=45.0,
         )
         assert s.confidence_level == ConfidenceLevel.MEDIUM
@@ -671,7 +671,7 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s4",
             suggestion_type=SuggestionType.DELETE,
-            file_path=Path("/a/b.txt"),
+            file_path=Path("/") / "a" / "b.txt",
             confidence=25.0,
         )
         assert s.confidence_level == ConfidenceLevel.LOW
@@ -686,7 +686,7 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s5",
             suggestion_type=SuggestionType.MERGE,
-            file_path=Path("/a/b.txt"),
+            file_path=Path("/") / "a" / "b.txt",
             confidence=10.0,
         )
         assert s.confidence_level == ConfidenceLevel.VERY_LOW
@@ -697,13 +697,13 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s-123",
             suggestion_type=SuggestionType.MOVE,
-            file_path=Path("/docs/report.pdf"),
-            target_path=Path("/archive/report.pdf"),
+            file_path=Path("/") / "docs" / "report.pdf",
+            target_path=Path("/") / "archive" / "report.pdf",
             confidence=72.0,
             reasoning="Matches archive pattern",
             tags=["archive", "report"],
             new_name="report_2024.pdf",
-            related_files=[Path("/docs/appendix.pdf")],
+            related_files=[Path("/") / "docs" / "appendix.pdf"],
         )
         d = s.to_dict()
         assert d["suggestion_id"] == "s-123"
@@ -724,7 +724,7 @@ class TestSuggestionTypes:
         s = Suggestion(
             suggestion_id="s-no-target",
             suggestion_type=SuggestionType.TAG,
-            file_path=Path("/a.txt"),
+            file_path=Path("/") / "a.txt",
         )
         d = s.to_dict()
         assert d["target_path"] is None
@@ -737,8 +737,8 @@ class TestSuggestionTypes:
         )
 
         suggestions = [
-            Suggestion("s1", SuggestionType.MOVE, Path("/a.txt"), confidence=60.0),
-            Suggestion("s2", SuggestionType.MOVE, Path("/b.txt"), confidence=80.0),
+            Suggestion("s1", SuggestionType.MOVE, Path("/") / "a.txt", confidence=60.0),
+            Suggestion("s2", SuggestionType.MOVE, Path("/") / "b.txt", confidence=80.0),
         ]
         batch = SuggestionBatch(
             batch_id="b1",
@@ -767,9 +767,9 @@ class TestSuggestionTypes:
         )
 
         suggestions = [
-            Suggestion("s1", SuggestionType.MOVE, Path("/a.txt")),
-            Suggestion("s2", SuggestionType.RENAME, Path("/b.txt")),
-            Suggestion("s3", SuggestionType.TAG, Path("/c.txt")),
+            Suggestion("s1", SuggestionType.MOVE, Path("/") / "a.txt"),
+            Suggestion("s2", SuggestionType.RENAME, Path("/") / "b.txt"),
+            Suggestion("s3", SuggestionType.TAG, Path("/") / "c.txt"),
         ]
         batch = SuggestionBatch(
             batch_id="b3",
@@ -787,7 +787,7 @@ class TestSuggestionTypes:
         )
 
         suggestions = [
-            Suggestion("s1", SuggestionType.MOVE, Path("/a.txt"), confidence=50.0),
+            Suggestion("s1", SuggestionType.MOVE, Path("/") / "a.txt", confidence=50.0),
         ]
         batch = SuggestionBatch(
             batch_id="b4",
@@ -1650,8 +1650,8 @@ class TestFileInfo:
         from file_organizer.models.analytics import FileInfo
 
         now = datetime.now(tz=UTC)
-        fi = FileInfo(path=Path("/docs/report.pdf"), size=1024, type="pdf", modified=now)
-        assert fi.path == Path("/docs/report.pdf")
+        fi = FileInfo(path=Path("/") / "docs" / "report.pdf", size=1024, type="pdf", modified=now)
+        assert fi.path == Path("/") / "docs" / "report.pdf"
         assert fi.size == 1024
         assert fi.type == "pdf"
         assert fi.modified == now
@@ -1662,7 +1662,7 @@ class TestFileInfo:
 
         now = datetime.now(tz=UTC)
         fi = FileInfo(
-            path=Path("/docs/report.pdf"),
+            path=Path("/") / "docs" / "report.pdf",
             size=2048,
             type="pdf",
             modified=now,

--- a/tests/integration/test_para_feedback_collector.py
+++ b/tests/integration/test_para_feedback_collector.py
@@ -389,7 +389,7 @@ class TestPatternLearner:
 
         return [
             FeedbackEvent(
-                file_path=Path(f"/mock/{parent_dir}/file_{i}{extension}"),
+                file_path=Path("/") / "mock" / f"{parent_dir}" / f"file_{i}{extension}",
                 suggested=category,
                 actual=category,
                 confidence=0.75,
@@ -461,7 +461,7 @@ class TestPatternLearner:
         # 4 acceptances: .pdf → PROJECT (actual = PROJECT)
         acc_events = [
             FeedbackEvent(
-                file_path=Path(f"/mock/work/doc{i}.pdf"),
+                file_path=Path("/") / "mock" / "work" / f"doc{i}.pdf",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.PROJECT,
                 confidence=0.8,
@@ -474,7 +474,7 @@ class TestPatternLearner:
         # 4 rejections: suggested=PROJECT, actual=RESOURCE
         rej_events = [
             FeedbackEvent(
-                file_path=Path(f"/mock/work/ref{i}.pdf"),
+                file_path=Path("/") / "mock" / "work" / f"ref{i}.pdf",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.RESOURCE,
                 confidence=0.5,

--- a/tests/integration/test_para_feedback_collector.py
+++ b/tests/integration/test_para_feedback_collector.py
@@ -81,7 +81,7 @@ class TestFeedbackEvent:
 
         before = datetime.now(UTC)
         event = FeedbackEvent(
-            file_path=Path("/mock/file.txt"),
+            file_path=Path("/") / "mock" / "file.txt",
             suggested=PARACategory.AREA,
             actual=PARACategory.AREA,
             confidence=0.5,
@@ -97,7 +97,7 @@ class TestFeedbackEvent:
         from file_organizer.methodologies.para.categories import PARACategory
 
         event = FeedbackEvent(
-            file_path=Path("/mock/projects/budget.xlsx"),
+            file_path=Path("/") / "mock" / "projects" / "budget.xlsx",
             suggested=PARACategory.PROJECT,
             actual=PARACategory.PROJECT,
             confidence=0.9,
@@ -111,7 +111,7 @@ class TestFeedbackEvent:
         from file_organizer.methodologies.para.categories import PARACategory
 
         event = FeedbackEvent(
-            file_path=Path("/mock/invoices/q3.pdf"),
+            file_path=Path("/") / "mock" / "invoices" / "q3.pdf",
             suggested=PARACategory.RESOURCE,
             actual=PARACategory.RESOURCE,
             confidence=0.75,
@@ -125,7 +125,7 @@ class TestFeedbackEvent:
         from file_organizer.methodologies.para.categories import PARACategory
 
         event = FeedbackEvent(
-            file_path=Path("/mock/data/file.pdf"),
+            file_path=Path("/") / "mock" / "data" / "file.pdf",
             suggested=PARACategory.AREA,
             actual=PARACategory.AREA,
             confidence=0.6,
@@ -180,7 +180,7 @@ class TestFeedbackCollector:
         collector = FeedbackCollector(storage_dir=tmp_path)
         suggestion = _make_suggestion(PARACategory.PROJECT, confidence=0.85)
 
-        collector.record_acceptance(Path("/mock/sprint.md"), suggestion)
+        collector.record_acceptance(Path("/") / "mock" / "sprint.md", suggestion)
 
         events = collector.get_events()
         assert len(events) == 1
@@ -198,7 +198,7 @@ class TestFeedbackCollector:
         suggestion = _make_suggestion(PARACategory.PROJECT, confidence=0.65)
 
         collector.record_rejection(
-            Path("/mock/reference.pdf"),
+            Path("/") / "mock" / "reference.pdf",
             suggestion,
             correct_category=PARACategory.RESOURCE,
         )
@@ -219,9 +219,9 @@ class TestFeedbackCollector:
 
         # 3 acceptances, 1 rejection
         for _ in range(3):
-            collector.record_acceptance(Path("/mock/file.txt"), sugg)
+            collector.record_acceptance(Path("/") / "mock" / "file.txt", sugg)
         collector.record_rejection(
-            Path("/mock/other.txt"), sugg, correct_category=PARACategory.RESOURCE
+            Path("/") / "mock" / "other.txt", sugg, correct_category=PARACategory.RESOURCE
         )
 
         stats = collector.get_accuracy_stats()
@@ -248,7 +248,7 @@ class TestFeedbackCollector:
 
         collector = FeedbackCollector(storage_dir=tmp_path)
         sugg = _make_suggestion(PARACategory.PROJECT)
-        collector.record_acceptance(Path("/mock/file.txt"), sugg)
+        collector.record_acceptance(Path("/") / "mock" / "file.txt", sugg)
         assert len(collector.get_events()) == 1
 
         collector.clear()
@@ -264,7 +264,7 @@ class TestFeedbackCollector:
 
         collector1 = FeedbackCollector(storage_dir=tmp_path)
         sugg = _make_suggestion(PARACategory.ARCHIVE, confidence=0.9)
-        collector1.record_acceptance(Path("/mock/old.pdf"), sugg)
+        collector1.record_acceptance(Path("/") / "mock" / "old.pdf", sugg)
 
         # New instance pointing to same directory
         collector2 = FeedbackCollector(storage_dir=tmp_path)
@@ -282,7 +282,7 @@ class TestFeedbackCollector:
         # Seed storage with one event
         seed = FeedbackCollector(storage_dir=tmp_path)
         sugg = _make_suggestion(PARACategory.PROJECT)
-        seed.record_acceptance(Path("/mock/seed.txt"), sugg)
+        seed.record_acceptance(Path("/") / "mock" / "seed.txt", sugg)
 
         collector = FeedbackCollector(storage_dir=tmp_path)
         assert collector._loaded is False  # not yet loaded
@@ -305,11 +305,11 @@ class TestFeedbackCollector:
         sugg_proj = _make_suggestion(PARACategory.PROJECT, confidence=0.8)
         sugg_res = _make_suggestion(PARACategory.RESOURCE, confidence=0.6)
 
-        collector.record_acceptance(Path("/mock/plan.md"), sugg_proj)
+        collector.record_acceptance(Path("/") / "mock" / "plan.md", sugg_proj)
         collector.record_rejection(
-            Path("/mock/ref.pdf"), sugg_proj, correct_category=PARACategory.RESOURCE
+            Path("/") / "mock" / "ref.pdf", sugg_proj, correct_category=PARACategory.RESOURCE
         )
-        collector.record_acceptance(Path("/mock/guide.txt"), sugg_res)
+        collector.record_acceptance(Path("/") / "mock" / "guide.txt", sugg_res)
 
         loaded = FeedbackCollector(storage_dir=tmp_path)
         events = loaded.get_events()
@@ -328,7 +328,7 @@ class TestFeedbackCollector:
         storage = tmp_path / "subdir"
         collector = FeedbackCollector(storage_dir=storage)
         sugg = _make_suggestion(PARACategory.AREA)
-        collector.record_acceptance(Path("/mock/notes.txt"), sugg)
+        collector.record_acceptance(Path("/") / "mock" / "notes.txt", sugg)
 
         assert (storage / "feedback_events.json").exists()
 
@@ -341,9 +341,9 @@ class TestFeedbackCollector:
         sugg_high = _make_suggestion(PARACategory.PROJECT, confidence=0.9)
         sugg_low = _make_suggestion(PARACategory.PROJECT, confidence=0.3)
 
-        collector.record_acceptance(Path("/mock/a.txt"), sugg_high)
+        collector.record_acceptance(Path("/") / "mock" / "a.txt", sugg_high)
         collector.record_rejection(
-            Path("/mock/b.txt"), sugg_low, correct_category=PARACategory.AREA
+            Path("/") / "mock" / "b.txt", sugg_low, correct_category=PARACategory.AREA
         )
 
         stats = collector.get_accuracy_stats()
@@ -360,8 +360,8 @@ class TestFeedbackCollector:
         sugg = _make_suggestion(PARACategory.RESOURCE, confidence=0.8)
 
         # 2 acceptances for RESOURCE
-        collector.record_acceptance(Path("/mock/r1.pdf"), sugg)
-        collector.record_acceptance(Path("/mock/r2.pdf"), sugg)
+        collector.record_acceptance(Path("/") / "mock" / "r1.pdf", sugg)
+        collector.record_acceptance(Path("/") / "mock" / "r2.pdf", sugg)
 
         stats = collector.get_accuracy_stats()
         assert "resource" in stats.per_category_accuracy
@@ -527,7 +527,7 @@ class TestPatternLearner:
         learner = PatternLearner()
         events = [
             FeedbackEvent(
-                file_path=Path("/mock/docs/ref.pdf"),
+                file_path=Path("/") / "mock" / "docs" / "ref.pdf",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.RESOURCE,
                 confidence=0.5,

--- a/tests/integration/test_parallel_processor.py
+++ b/tests/integration/test_parallel_processor.py
@@ -187,8 +187,8 @@ class TestCheckpointModel:
         """Verify to_dict/from_dict preserves completed paths, pending paths, and hashes."""
         from file_organizer.parallel.models import Checkpoint
 
-        completed = [Path("/a/b.txt"), Path("/c/d.txt")]
-        pending = [Path("/e/f.txt")]
+        completed = [Path("/") / "a" / "b.txt", Path("/") / "c" / "d.txt"]
+        pending = [Path("/") / "e" / "f.txt"]
         cp = Checkpoint(
             job_id="cp-test",
             completed_paths=completed,

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -140,8 +140,8 @@ class TestCorrectionGetPatternKey:
 
         c = Correction(
             correction_type=CorrectionType.FILE_MOVE,
-            source=Path("/a/b.txt"),
-            destination=Path("/docs/b.txt"),
+            source=Path("/") / "a" / "b.txt",
+            destination=Path("/") / "docs" / "b.txt",
             timestamp=datetime.now(UTC),
         )
         key = c.get_pattern_key()
@@ -157,8 +157,8 @@ class TestCorrectionGetPatternKey:
 
         c = Correction(
             correction_type=CorrectionType.FILE_RENAME,
-            source=Path("/a/makefile"),
-            destination=Path("/b/makefile"),
+            source=Path("/") / "a" / "makefile",
+            destination=Path("/") / "b" / "makefile",
             timestamp=datetime.now(UTC),
         )
         key = c.get_pattern_key()
@@ -174,7 +174,7 @@ class TestCorrectionGetPatternKey:
         c = Correction(
             correction_type=CorrectionType.FILE_MOVE,
             source=Path("file.pdf"),
-            destination=Path("/docs/reports/file.pdf"),
+            destination=Path("/") / "docs" / "reports" / "file.pdf",
             timestamp=datetime.now(UTC),
         )
         key = c.get_pattern_key()
@@ -190,8 +190,8 @@ class TestCorrectionGetPatternKey:
         ts = datetime.now(UTC)
         c = Correction(
             correction_type=CorrectionType.CATEGORY_CHANGE,
-            source=Path("/a/x.txt"),
-            destination=Path("/b/x.txt"),
+            source=Path("/") / "a" / "x.txt",
+            destination=Path("/") / "b" / "x.txt",
             timestamp=ts,
             context={"key": "value"},
         )
@@ -215,8 +215,8 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/src/file.pdf"),
-            destination=Path("/docs/archive/file.pdf"),
+            source=Path("/") / "src" / "file.pdf",
+            destination=Path("/") / "docs" / "archive" / "file.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
@@ -232,8 +232,8 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/src/old_name.txt"),
-            destination=Path("/src/new_name.txt"),
+            source=Path("/") / "src" / "old_name.txt",
+            destination=Path("/") / "src" / "new_name.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         prefs = tracker.get_all_preferences(PreferenceType.NAMING_PATTERN)
@@ -249,8 +249,8 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/src/x.pdf"),
-            destination=Path("/src/x.pdf"),
+            source=Path("/") / "src" / "x.pdf",
+            destination=Path("/") / "src" / "x.pdf",
             correction_type=CorrectionType.CATEGORY_CHANGE,
             context={"new_category": "legal"},
         )
@@ -267,8 +267,8 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/src/x.pdf"),
-            destination=Path("/src/x.pdf"),
+            source=Path("/") / "src" / "x.pdf",
+            destination=Path("/") / "src" / "x.pdf",
             correction_type=CorrectionType.CATEGORY_CHANGE,
         )
         prefs = tracker.get_all_preferences(PreferenceType.CATEGORY_OVERRIDE)
@@ -283,8 +283,8 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/b.txt"),
-            destination=Path("/docs/b.txt"),
+            source=Path("/") / "a" / "b.txt",
+            destination=Path("/") / "docs" / "b.txt",
             correction_type=CorrectionType.FOLDER_CREATION,
         )
         prefs = tracker.get_all_preferences(PreferenceType.CUSTOM)
@@ -299,8 +299,8 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/x/y.txt"),
-            destination=Path("/z/y.txt"),
+            source=Path("/") / "x" / "y.txt",
+            destination=Path("/") / "z" / "y.txt",
             correction_type=CorrectionType.MANUAL_OVERRIDE,
         )
         prefs = tracker.get_all_preferences(PreferenceType.CUSTOM)
@@ -315,13 +315,13 @@ class TestExtractPreferencesFromCorrection:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/report.pdf"),
-            destination=Path("/docs/report.pdf"),
+            source=Path("/") / "a" / "report.pdf",
+            destination=Path("/") / "docs" / "report.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.track_correction(
-            source=Path("/a/report.pdf"),
-            destination=Path("/docs/report.pdf"),
+            source=Path("/") / "a" / "report.pdf",
+            destination=Path("/") / "docs" / "report.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
@@ -344,15 +344,15 @@ class TestExtractPreferencesFromCorrection:
         tracker = _tracker()
         # First correction — creates preference: key=file_move|.txt|docs, value=/storage/docs
         tracker.track_correction(
-            source=Path("/a/file.txt"),
-            destination=Path("/storage/docs/file.txt"),
+            source=Path("/") / "a" / "file.txt",
+            destination=Path("/") / "storage" / "docs" / "file.txt",
             correction_type=CorrectionType.FILE_MOVE,
         )
         # Second correction — same key (parent name still "docs") but different full path
         # → value changes from /storage/docs to /archive/docs
         tracker.track_correction(
-            source=Path("/a/file.txt"),
-            destination=Path("/archive/docs/file.txt"),
+            source=Path("/") / "a" / "file.txt",
+            destination=Path("/") / "archive" / "docs" / "file.txt",
             correction_type=CorrectionType.FILE_MOVE,
         )
         prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
@@ -369,8 +369,8 @@ class TestExtractPreferencesFromCorrection:
         tracker = _tracker()
         for _ in range(2):
             tracker.track_correction(
-                source=Path("/a/file.txt"),
-                destination=Path("/docs/file.txt"),
+                source=Path("/") / "a" / "file.txt",
+                destination=Path("/") / "docs" / "file.txt",
                 correction_type=CorrectionType.FILE_MOVE,
             )
         prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
@@ -388,7 +388,7 @@ class TestGetPreference:
         from file_organizer.services.intelligence.preference_tracker import PreferenceType
 
         tracker = _tracker()
-        result = tracker.get_preference(Path("/a/file.pdf"), PreferenceType.FOLDER_MAPPING)
+        result = tracker.get_preference(Path("/") / "a" / "file.pdf", PreferenceType.FOLDER_MAPPING)
         assert result is None
 
     def test_get_folder_mapping_returns_best_match(self) -> None:
@@ -400,11 +400,13 @@ class TestGetPreference:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/report.pdf"),
-            destination=Path("/docs/report.pdf"),
+            source=Path("/") / "a" / "report.pdf",
+            destination=Path("/") / "docs" / "report.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
-        result = tracker.get_preference(Path("/a/invoice.pdf"), PreferenceType.FOLDER_MAPPING)
+        result = tracker.get_preference(
+            Path("/") / "a" / "invoice.pdf", PreferenceType.FOLDER_MAPPING
+        )
         assert result is not None
         assert result.preference_type == PreferenceType.FOLDER_MAPPING
 
@@ -413,7 +415,7 @@ class TestGetPreference:
         from file_organizer.services.intelligence.preference_tracker import PreferenceType
 
         tracker = _tracker()
-        result = tracker.get_preference(Path("/a/file.txt"), PreferenceType.NAMING_PATTERN)
+        result = tracker.get_preference(Path("/") / "a" / "file.txt", PreferenceType.NAMING_PATTERN)
         assert result is None
 
     def test_get_naming_pattern_returns_match(self) -> None:
@@ -425,13 +427,15 @@ class TestGetPreference:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/old.txt"),
-            destination=Path("/a/new.txt"),
+            source=Path("/") / "a" / "old.txt",
+            destination=Path("/") / "a" / "new.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         # Same parent + same extension → same pattern key, so lookup must hit
         # and must return the naming pattern recorded from the prior correction.
-        result = tracker.get_preference(Path("/a/another.txt"), PreferenceType.NAMING_PATTERN)
+        result = tracker.get_preference(
+            Path("/") / "a" / "another.txt", PreferenceType.NAMING_PATTERN
+        )
         assert result is not None
         assert result.preference_type == PreferenceType.NAMING_PATTERN
         assert result.value == "new.txt"
@@ -441,7 +445,7 @@ class TestGetPreference:
         from file_organizer.services.intelligence.preference_tracker import PreferenceType
 
         tracker = _tracker()
-        result = tracker.get_preference(Path("/x/f.pdf"), PreferenceType.CATEGORY_OVERRIDE)
+        result = tracker.get_preference(Path("/") / "x" / "f.pdf", PreferenceType.CATEGORY_OVERRIDE)
         assert result is None
 
     def test_get_custom_no_match(self) -> None:
@@ -449,7 +453,7 @@ class TestGetPreference:
         from file_organizer.services.intelligence.preference_tracker import PreferenceType
 
         tracker = _tracker()
-        result = tracker.get_preference(Path("/x/f.txt"), PreferenceType.CUSTOM)
+        result = tracker.get_preference(Path("/") / "x" / "f.txt", PreferenceType.CUSTOM)
         assert result is None
 
     def test_get_folder_mapping_updates_last_used(self) -> None:
@@ -461,11 +465,11 @@ class TestGetPreference:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
-        result = tracker.get_preference(Path("/a/y.pdf"), PreferenceType.FOLDER_MAPPING)
+        result = tracker.get_preference(Path("/") / "a" / "y.pdf", PreferenceType.FOLDER_MAPPING)
         assert result is not None
         assert result.metadata.last_used is not None
 
@@ -482,13 +486,13 @@ class TestGetAllPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/f.pdf"),
-            destination=Path("/docs/f.pdf"),
+            source=Path("/") / "a" / "f.pdf",
+            destination=Path("/") / "docs" / "f.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.track_correction(
-            source=Path("/a/old.txt"),
-            destination=Path("/a/new.txt"),
+            source=Path("/") / "a" / "old.txt",
+            destination=Path("/") / "a" / "new.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         all_prefs = tracker.get_all_preferences()
@@ -503,13 +507,13 @@ class TestGetAllPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/f.pdf"),
-            destination=Path("/docs/f.pdf"),
+            source=Path("/") / "a" / "f.pdf",
+            destination=Path("/") / "docs" / "f.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.track_correction(
-            source=Path("/a/old.txt"),
-            destination=Path("/a/new.txt"),
+            source=Path("/") / "a" / "old.txt",
+            destination=Path("/") / "a" / "new.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         folder_prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
@@ -526,8 +530,8 @@ class TestGetAllPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/f.pdf"),
-            destination=Path("/docs/f.pdf"),
+            source=Path("/") / "a" / "f.pdf",
+            destination=Path("/") / "docs" / "f.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         naming_prefs = tracker.get_all_preferences(PreferenceType.NAMING_PATTERN)
@@ -549,8 +553,8 @@ class TestUpdatePreferenceConfidence:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         pref = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)[0]
@@ -570,8 +574,8 @@ class TestUpdatePreferenceConfidence:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         pref = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)[0]
@@ -591,8 +595,8 @@ class TestUpdatePreferenceConfidence:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         pref = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)[0]
@@ -609,8 +613,8 @@ class TestUpdatePreferenceConfidence:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         pref = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)[0]
@@ -627,8 +631,8 @@ class TestUpdatePreferenceConfidence:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         pref = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)[0]
@@ -645,8 +649,8 @@ class TestUpdatePreferenceConfidence:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         pref = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)[0]
@@ -675,8 +679,8 @@ class TestGetStatistics:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         stats = tracker.get_statistics()
@@ -712,13 +716,13 @@ class TestClearPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.track_correction(
-            source=Path("/a/old.txt"),
-            destination=Path("/a/new.txt"),
+            source=Path("/") / "a" / "old.txt",
+            destination=Path("/") / "a" / "new.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         cleared = tracker.clear_preferences()
@@ -734,13 +738,13 @@ class TestClearPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.track_correction(
-            source=Path("/a/old.txt"),
-            destination=Path("/a/new.txt"),
+            source=Path("/") / "a" / "old.txt",
+            destination=Path("/") / "a" / "new.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         cleared = tracker.clear_preferences(PreferenceType.FOLDER_MAPPING)
@@ -758,8 +762,8 @@ class TestClearPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         # Clear the only preference type → no preferences remain
@@ -779,8 +783,8 @@ class TestClearPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         cleared = tracker.clear_preferences(PreferenceType.NAMING_PATTERN)
@@ -795,8 +799,8 @@ class TestClearPreferences:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.clear_preferences(PreferenceType.FOLDER_MAPPING)
@@ -816,8 +820,8 @@ class TestExportImportData:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         data = tracker.export_data()
@@ -837,8 +841,8 @@ class TestExportImportData:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         data = tracker.export_data()
@@ -859,8 +863,8 @@ class TestExportImportData:
         tracker = _tracker()
         # Add a rename preference
         tracker.track_correction(
-            source=Path("/a/old.txt"),
-            destination=Path("/a/new.txt"),
+            source=Path("/") / "a" / "old.txt",
+            destination=Path("/") / "a" / "new.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         # Import data that only has folder_mapping
@@ -949,15 +953,15 @@ class TestCorrectionQueries:
         from file_organizer.services.intelligence.preference_tracker import CorrectionType
 
         tracker = _tracker()
-        target = Path("/a/x.pdf")
+        target = Path("/") / "a" / "x.pdf"
         tracker.track_correction(
             source=target,
-            destination=Path("/docs/x.pdf"),
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
         tracker.track_correction(
-            source=Path("/other/y.txt"),
-            destination=Path("/other/z.txt"),
+            source=Path("/") / "other" / "y.txt",
+            destination=Path("/") / "other" / "z.txt",
             correction_type=CorrectionType.FILE_RENAME,
         )
         results = tracker.get_corrections_for_file(target)
@@ -969,9 +973,9 @@ class TestCorrectionQueries:
         from file_organizer.services.intelligence.preference_tracker import CorrectionType
 
         tracker = _tracker()
-        dest = Path("/docs/x.pdf")
+        dest = Path("/") / "docs" / "x.pdf"
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
             destination=dest,
             correction_type=CorrectionType.FILE_MOVE,
         )
@@ -984,11 +988,11 @@ class TestCorrectionQueries:
 
         tracker = _tracker()
         tracker.track_correction(
-            source=Path("/a/x.pdf"),
-            destination=Path("/docs/x.pdf"),
+            source=Path("/") / "a" / "x.pdf",
+            destination=Path("/") / "docs" / "x.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
-        results = tracker.get_corrections_for_file(Path("/unrelated/file.txt"))
+        results = tracker.get_corrections_for_file(Path("/") / "unrelated" / "file.txt")
         assert results == []
 
     def test_get_recent_corrections_sorted(self) -> None:
@@ -1049,7 +1053,7 @@ class TestConvenienceFunctions:
         )
 
         t = create_tracker()
-        track_file_move(t, Path("/a/x.pdf"), Path("/docs/x.pdf"))
+        track_file_move(t, Path("/") / "a" / "x.pdf", Path("/") / "docs" / "x.pdf")
         assert len(t.get_all_preferences(PreferenceType.FOLDER_MAPPING)) == 1
 
     def test_track_file_rename(self) -> None:
@@ -1061,7 +1065,7 @@ class TestConvenienceFunctions:
         )
 
         t = create_tracker()
-        track_file_rename(t, Path("/a/old.txt"), Path("/a/new.txt"))
+        track_file_rename(t, Path("/") / "a" / "old.txt", Path("/") / "a" / "new.txt")
         assert len(t.get_all_preferences(PreferenceType.NAMING_PATTERN)) == 1
 
     def test_track_category_change(self) -> None:
@@ -1073,7 +1077,7 @@ class TestConvenienceFunctions:
         )
 
         t = create_tracker()
-        track_category_change(t, Path("/a/f.pdf"), "old_cat", "new_cat")
+        track_category_change(t, Path("/") / "a" / "f.pdf", "old_cat", "new_cat")
         prefs = t.get_all_preferences(PreferenceType.CATEGORY_OVERRIDE)
         assert len(prefs) == 1
         assert prefs[0].value == "new_cat"
@@ -1087,6 +1091,6 @@ class TestConvenienceFunctions:
         )
 
         t = create_tracker()
-        track_category_change(t, Path("/a/f.pdf"), "old", "new", context={"user": "alice"})
+        track_category_change(t, Path("/") / "a" / "f.pdf", "old", "new", context={"user": "alice"})
         prefs = t.get_all_preferences(PreferenceType.CATEGORY_OVERRIDE)
         assert len(prefs) == 1

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -696,8 +696,8 @@ class TestGetStatistics:
         tracker = _tracker()
         for i in range(3):
             tracker.track_correction(
-                source=Path(f"/a/f{i}.txt"),
-                destination=Path(f"/b/f{i}.txt"),
+                source=Path("/") / "a" / f"f{i}.txt",
+                destination=Path("/") / "b" / f"f{i}.txt",
                 correction_type=CorrectionType.FILE_RENAME,
             )
         stats = tracker.get_statistics()
@@ -1002,8 +1002,8 @@ class TestCorrectionQueries:
         tracker = _tracker()
         for i in range(5):
             tracker.track_correction(
-                source=Path(f"/a/f{i}.txt"),
-                destination=Path(f"/b/f{i}.txt"),
+                source=Path("/") / "a" / f"f{i}.txt",
+                destination=Path("/") / "b" / f"f{i}.txt",
                 correction_type=CorrectionType.FILE_RENAME,
             )
         recent = tracker.get_recent_corrections(limit=3)
@@ -1019,8 +1019,8 @@ class TestCorrectionQueries:
         tracker = _tracker()
         for i in range(15):
             tracker.track_correction(
-                source=Path(f"/a/f{i}.txt"),
-                destination=Path(f"/b/f{i}.txt"),
+                source=Path("/") / "a" / f"f{i}.txt",
+                destination=Path("/") / "b" / f"f{i}.txt",
                 correction_type=CorrectionType.FILE_RENAME,
             )
         recent = tracker.get_recent_corrections()

--- a/tests/integration/test_services_coverage.py
+++ b/tests/integration/test_services_coverage.py
@@ -1017,7 +1017,7 @@ class TestAudioOrganizer:
 
         rel_path = organizer.generate_path(AudioType.MUSIC, meta_music)
         # Expect: Rock/The Band/First Album/03 - Song One.mp3
-        assert rel_path == Path("Rock/The Band/First Album/03 - Song One.mp3")
+        assert rel_path == Path("Rock") / "The Band" / "First Album" / "03 - Song One.mp3"
 
         # Podcast type path generation
         meta_pod = AudioMetadata(
@@ -1035,7 +1035,7 @@ class TestAudioOrganizer:
         rel_path_pod = organizer.generate_path(AudioType.PODCAST, meta_pod)
         # Expect: Tech Show/2026/Episode 42 - Episode 42.mp3 (Show/Year/Episode - Title)
         # Episode fallback is title, Show fallback is album_artist
-        assert rel_path_pod == Path("Tech Show/2026/Episode 42 - Episode 42.mp3")
+        assert rel_path_pod == Path("Tech Show") / "2026" / "Episode 42 - Episode 42.mp3"
 
     def test_preview_and_organize_dry_run(self, tmp_path: Path) -> None:
         source_file = tmp_path / "song.mp3"

--- a/tests/methodologies/johnny_decimal/test_categories.py
+++ b/tests/methodologies/johnny_decimal/test_categories.py
@@ -300,13 +300,13 @@ class TestNumberingResult:
         """Test creating a valid numbering result."""
         number = JohnnyDecimalNumber(area=10, category=1)
         result = NumberingResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             number=number,
             confidence=0.85,
             reasons=["Matched keywords", "High confidence"],
         )
 
-        assert result.file_path == Path("/test/file.txt")
+        assert result.file_path == Path("/") / "test" / "file.txt"
         assert result.number == number
         assert result.confidence == 0.85
         assert result.is_confident
@@ -319,7 +319,7 @@ class TestNumberingResult:
 
         with pytest.raises(ValueError, match=r"confidence must be between 0.0 and 1.0"):
             NumberingResult(
-                file_path=Path("/test/file.txt"),
+                file_path=Path("/") / "test" / "file.txt",
                 number=number,
                 confidence=1.5,
                 reasons=["Test"],
@@ -327,7 +327,7 @@ class TestNumberingResult:
 
         with pytest.raises(ValueError, match="reasons list cannot be empty"):
             NumberingResult(
-                file_path=Path("/test/file.txt"),
+                file_path=Path("/") / "test" / "file.txt",
                 number=number,
                 confidence=0.8,
                 reasons=[],
@@ -338,7 +338,7 @@ class TestNumberingResult:
         number = JohnnyDecimalNumber(area=10)
 
         high_confidence = NumberingResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             number=number,
             confidence=0.85,
             reasons=["High"],
@@ -347,7 +347,7 @@ class TestNumberingResult:
         assert not high_confidence.requires_review
 
         low_confidence = NumberingResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             number=number,
             confidence=0.5,
             reasons=["Low"],
@@ -359,7 +359,7 @@ class TestNumberingResult:
         """Test conflict handling."""
         number = JohnnyDecimalNumber(area=10)
         result = NumberingResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             number=number,
             confidence=0.8,
             reasons=["Test"],
@@ -373,7 +373,7 @@ class TestNumberingResult:
         """Test dictionary conversion."""
         number = JohnnyDecimalNumber(area=10, category=1, name="Test")
         result = NumberingResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             number=number,
             confidence=0.8,
             reasons=["Reason 1"],

--- a/tests/methodologies/johnny_decimal/test_compatibility.py
+++ b/tests/methodologies/johnny_decimal/test_compatibility.py
@@ -309,7 +309,7 @@ class TestPARAAdapter:
         """Test adapting Projects item to JD."""
         item = OrganizationItem(
             name="Website Redesign",
-            path=Path("Projects/Website Redesign"),
+            path=Path("Projects") / "Website Redesign",
             category="projects",
             metadata={"subcategory": 1},
         )
@@ -323,7 +323,7 @@ class TestPARAAdapter:
         """Test adapting Areas item to JD."""
         item = OrganizationItem(
             name="Personal Finance",
-            path=Path("Areas/Personal Finance"),
+            path=Path("Areas") / "Personal Finance",
             category="areas",
             metadata={"subcategory": 2},
         )
@@ -337,7 +337,7 @@ class TestPARAAdapter:
         """Test adapting Resources item to JD."""
         item = OrganizationItem(
             name="Code Snippets",
-            path=Path("Resources/Code Snippets"),
+            path=Path("Resources") / "Code Snippets",
             category="resources",
             metadata={},
         )
@@ -350,7 +350,7 @@ class TestPARAAdapter:
         """Test adapting Archive item to JD."""
         item = OrganizationItem(
             name="2023 Projects",
-            path=Path("Archive/2023 Projects"),
+            path=Path("Archive") / "2023 Projects",
             category="archive",
             metadata={},
         )
@@ -391,7 +391,7 @@ class TestPARAAdapter:
         """Test adapter compatibility checking."""
         para_item = OrganizationItem(
             name="Project",
-            path=Path("Projects/Project"),
+            path=Path("Projects") / "Project",
             category="projects",
             metadata={},
         )
@@ -450,7 +450,7 @@ class TestPARAIntegration:
         # Original item
         original = OrganizationItem(
             name="Website Project",
-            path=Path("Projects/Website"),
+            path=Path("Projects") / "Website",
             category="projects",
             metadata={},
         )
@@ -487,7 +487,7 @@ class TestEdgeCases:
         """Test adapter with custom metadata."""
         item = OrganizationItem(
             name="Complex Project",
-            path=Path("Projects/Complex"),
+            path=Path("Projects") / "Complex",
             category="projects",
             metadata={"subcategory": 5, "priority": "high"},
         )

--- a/tests/methodologies/johnny_decimal/test_integration.py
+++ b/tests/methodologies/johnny_decimal/test_integration.py
@@ -213,13 +213,13 @@ class TestCompleteWorkflows:
         items = [
             OrganizationItem(
                 name="Project A",
-                path=Path("Projects/Project A"),
+                path=Path("Projects") / "Project A",
                 category="projects",
                 metadata={},
             ),
             OrganizationItem(
                 name="Finance Docs",
-                path=Path("Areas/Finance"),
+                path=Path("Areas") / "Finance",
                 category="areas",
                 metadata={},
             ),
@@ -322,7 +322,7 @@ class TestCrossComponentIntegration:
         # Test item
         item = OrganizationItem(
             name="Test",
-            path=Path("Projects/Test"),
+            path=Path("Projects") / "Test",
             category="projects",
             metadata={},
         )

--- a/tests/methodologies/johnny_decimal/test_jd_adapters.py
+++ b/tests/methodologies/johnny_decimal/test_jd_adapters.py
@@ -45,7 +45,9 @@ class TestPARAAdapter:
     def test_adapt_to_jd_invalid_category_raises(self, jd_config: MagicMock) -> None:
         """Unknown PARA category raises ValueError (line 128)."""
         adapter = PARAAdapter(jd_config)
-        item = OrganizationItem(name="test", path=Path("/x"), category="unknown_cat", metadata={})
+        item = OrganizationItem(
+            name="test", path=Path("/") / "x", category="unknown_cat", metadata={}
+        )
         with pytest.raises(ValueError, match="Cannot determine PARA category"):
             adapter.adapt_to_jd(item)
 
@@ -54,7 +56,10 @@ class TestPARAAdapter:
         adapter = PARAAdapter(jd_config)
         adapter.bridge.para_to_jd_area = MagicMock(return_value=10)
         item = OrganizationItem(
-            name="test", path=Path("/x"), category="projects", metadata={"subcategory": "not_int"}
+            name="test",
+            path=Path("/") / "x",
+            category="projects",
+            metadata={"subcategory": "not_int"},
         )
         result = adapter.adapt_to_jd(item)
         assert result.category == 1
@@ -70,7 +75,7 @@ class TestPARAAdapter:
     def test_can_adapt_false(self, jd_config: MagicMock) -> None:
         """Non-PARA item returns False."""
         adapter = PARAAdapter(jd_config)
-        item = OrganizationItem(name="x", path=Path("/x"), category="random", metadata={})
+        item = OrganizationItem(name="x", path=Path("/") / "x", category="random", metadata={})
         assert adapter.can_adapt(item) is False
 
 
@@ -96,7 +101,7 @@ class TestFileSystemAdapter:
         """Depth 2 => category level (line 221-225)."""
         adapter = FileSystemAdapter(jd_config)
         item = OrganizationItem(
-            name="Budgets", path=Path("Finance/Budgets"), category="fs", metadata={}
+            name="Budgets", path=Path("Finance") / "Budgets", category="fs", metadata={}
         )
         result = adapter.adapt_to_jd(item)
         assert result.level == NumberLevel.CATEGORY
@@ -105,7 +110,7 @@ class TestFileSystemAdapter:
         """Depth 3+ => ID level (line 226-231)."""
         adapter = FileSystemAdapter(jd_config)
         item = OrganizationItem(
-            name="Q1", path=Path("Finance/Budgets/Q1"), category="fs", metadata={}
+            name="Q1", path=Path("Finance") / "Budgets" / "Q1", category="fs", metadata={}
         )
         result = adapter.adapt_to_jd(item)
         assert result.level == NumberLevel.ID
@@ -133,7 +138,7 @@ class TestFileSystemAdapter:
 
     def test_can_adapt_always_true(self, jd_config: MagicMock) -> None:
         adapter = FileSystemAdapter(jd_config)
-        item = OrganizationItem(name="any", path=Path("/any"), category="any", metadata={})
+        item = OrganizationItem(name="any", path=Path("/") / "any", category="any", metadata={})
         assert adapter.can_adapt(item) is True
 
     def test_suggest_area_from_name_with_number(self, jd_config: MagicMock) -> None:
@@ -172,13 +177,13 @@ class TestAdapterRegistry:
 
     def test_get_adapter_returns_none_when_empty(self) -> None:
         registry = AdapterRegistry()
-        item = OrganizationItem(name="x", path=Path("/x"), category="x", metadata={})
+        item = OrganizationItem(name="x", path=Path("/") / "x", category="x", metadata={})
         assert registry.get_adapter(item) is None
 
     def test_adapt_to_jd_no_adapter(self) -> None:
         """adapt_to_jd returns None when no adapter matches (line 347)."""
         registry = AdapterRegistry()
-        item = OrganizationItem(name="x", path=Path("/x"), category="x", metadata={})
+        item = OrganizationItem(name="x", path=Path("/") / "x", category="x", metadata={})
         assert registry.adapt_to_jd(item) is None
 
     def test_adapt_from_jd_para(self, jd_config: MagicMock) -> None:
@@ -187,7 +192,7 @@ class TestAdapterRegistry:
         adapter = PARAAdapter(jd_config)
         adapter.adapt_from_jd = MagicMock(
             return_value=OrganizationItem(
-                name="x", path=Path("/x"), category="project", metadata={}
+                name="x", path=Path("/") / "x", category="project", metadata={}
             )
         )
         registry.register(adapter)

--- a/tests/methodologies/johnny_decimal/test_jd_migrator.py
+++ b/tests/methodologies/johnny_decimal/test_jd_migrator.py
@@ -209,7 +209,7 @@ class TestGenerateReport:
             failed_count=0,
             skipped_count=15,
             duration_seconds=0.5,
-            skipped_paths=[Path(f"/skip/{i}") for i in range(15)],
+            skipped_paths=[Path("/") / "skip" / f"{i}" for i in range(15)],
         )
         report = migrator.generate_report(result)
         assert "Skipped" in report
@@ -315,7 +315,7 @@ class TestMigratorCoverage:
             skipped_count=15,
             duration_seconds=1.0,
             failed_paths=[(Path("/") / "tmp" / "bad", "error")],  # noqa: test-hardcoded-paths
-            skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(15)],  # noqa: test-hardcoded-paths
+            skipped_paths=[Path("/") / "tmp" / f"skip_{i}" for i in range(15)],  # noqa: test-hardcoded-paths
         )
         report = migrator.generate_report(result)
         assert "and 5 more" in report
@@ -329,7 +329,7 @@ class TestMigratorCoverage:
             failed_count=0,
             skipped_count=3,
             duration_seconds=0.5,
-            skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(3)],  # noqa: test-hardcoded-paths
+            skipped_paths=[Path("/") / "tmp" / f"skip_{i}" for i in range(3)],  # noqa: test-hardcoded-paths
         )
         report = migrator.generate_report(result)
         assert "Skipped (3 folders)" in report

--- a/tests/methodologies/johnny_decimal/test_jd_migrator.py
+++ b/tests/methodologies/johnny_decimal/test_jd_migrator.py
@@ -182,7 +182,7 @@ class TestGenerateReport:
             failed_count=0,
             skipped_count=0,
             duration_seconds=1.5,
-            backup_path=Path("/backup/loc"),
+            backup_path=Path("/") / "backup" / "loc",
         )
         report = migrator.generate_report(result)
         assert "Backup" in report
@@ -195,7 +195,7 @@ class TestGenerateReport:
             failed_count=2,
             skipped_count=0,
             duration_seconds=2.0,
-            failed_paths=[(Path("/a"), "err1"), (Path("/b"), "err2")],
+            failed_paths=[(Path("/") / "a", "err1"), (Path("/") / "b", "err2")],
         )
         report = migrator.generate_report(result)
         assert "Failures" in report
@@ -269,12 +269,12 @@ class TestMigratorCoverage:
     # Branch 359->365: generate_preview with no patterns
     def test_generate_preview_no_patterns(self, migrator: JohnnyDecimalMigrator) -> None:
         plan = TransformationPlan(
-            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
+            root_path=Path("/") / "tmp",  # noqa: test-hardcoded-paths
             rules=[],
             estimated_changes=0,
         )
         scan = ScanResult(
-            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
+            root_path=Path("/") / "tmp",  # noqa: test-hardcoded-paths
             folder_tree=[],
             total_folders=0,
             total_files=0,
@@ -288,12 +288,12 @@ class TestMigratorCoverage:
     # Branch 375->387: generate_preview with validation
     def test_generate_preview_with_validation(self, migrator: JohnnyDecimalMigrator) -> None:
         plan = TransformationPlan(
-            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
+            root_path=Path("/") / "tmp",  # noqa: test-hardcoded-paths
             rules=[],
             estimated_changes=0,
         )
         scan = ScanResult(
-            root_path=Path("/tmp"),  # noqa: test-hardcoded-paths
+            root_path=Path("/") / "tmp",  # noqa: test-hardcoded-paths
             folder_tree=[],
             total_folders=0,
             total_files=0,
@@ -314,7 +314,7 @@ class TestMigratorCoverage:
             failed_count=1,
             skipped_count=15,
             duration_seconds=1.0,
-            failed_paths=[(Path("/tmp/bad"), "error")],  # noqa: test-hardcoded-paths
+            failed_paths=[(Path("/") / "tmp" / "bad", "error")],  # noqa: test-hardcoded-paths
             skipped_paths=[Path(f"/tmp/skip_{i}") for i in range(15)],  # noqa: test-hardcoded-paths
         )
         report = migrator.generate_report(result)

--- a/tests/methodologies/johnny_decimal/test_jd_numbering.py
+++ b/tests/methodologies/johnny_decimal/test_jd_numbering.py
@@ -38,9 +38,9 @@ class TestRegisterExisting:
 
     def test_register_conflict_raises(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1)
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         with pytest.raises(NumberConflictError, match="already registered"):
-            generator.register_existing_number(num, Path("/b"))
+            generator.register_existing_number(num, Path("/") / "b")
 
 
 class TestIsNumberAvailable:
@@ -48,7 +48,7 @@ class TestIsNumberAvailable:
 
     def test_used_number_not_available(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1)
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         assert generator.is_number_available(num) is False
 
 
@@ -80,7 +80,7 @@ class TestGenerateNumbers:
     def test_generate_area_preferred_unavailable(self, generator: JohnnyDecimalGenerator) -> None:
         """Preferred area occupied falls back to next available."""
         taken = JohnnyDecimalNumber(area=20)
-        generator.register_existing_number(taken, Path("/a"))
+        generator.register_existing_number(taken, Path("/") / "a")
         num = generator.generate_area_number("Finance", preferred_area=20)
         assert num.area != 20 or num.name == "Finance"
 
@@ -92,7 +92,7 @@ class TestGenerateNumbers:
         self, generator: JohnnyDecimalGenerator
     ) -> None:
         taken = JohnnyDecimalNumber(area=10, category=5)
-        generator.register_existing_number(taken, Path("/a"))
+        generator.register_existing_number(taken, Path("/") / "a")
         num = generator.generate_category_number(10, "Budgets", preferred_category=5)
         assert num.category != 5
 
@@ -102,7 +102,7 @@ class TestGenerateNumbers:
 
     def test_generate_id_preferred_unavailable(self, generator: JohnnyDecimalGenerator) -> None:
         taken = JohnnyDecimalNumber(area=10, category=1, item_id=42)
-        generator.register_existing_number(taken, Path("/a"))
+        generator.register_existing_number(taken, Path("/") / "a")
         num = generator.generate_id_number(10, 1, "Doc", preferred_id=42)
         assert num.item_id != 42
 
@@ -141,7 +141,7 @@ class TestValidateNumber:
 
     def test_validate_used_number(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1)
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         is_valid, errors = generator.validate_number(num)
         assert is_valid is False
         assert any("already used" in e for e in errors)
@@ -152,14 +152,14 @@ class TestFindConflicts:
 
     def test_find_exact_conflict(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1)
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         conflicts = generator.find_conflicts(num)
         assert len(conflicts) >= 1
 
     def test_find_parent_conflict(self, generator: JohnnyDecimalGenerator) -> None:
         """Category number conflicts with existing area (line 461)."""
         area_num = JohnnyDecimalNumber(area=10)
-        generator.register_existing_number(area_num, Path("/a"))
+        generator.register_existing_number(area_num, Path("/") / "a")
         cat_num = JohnnyDecimalNumber(area=10, category=1)
         conflicts = generator.find_conflicts(cat_num)
         parent_conflicts = [c for c in conflicts if c[0] == "10"]
@@ -168,7 +168,7 @@ class TestFindConflicts:
     def test_find_child_conflict(self, generator: JohnnyDecimalGenerator) -> None:
         """Area number conflicts with existing category (lines 469-471)."""
         cat_num = JohnnyDecimalNumber(area=10, category=1)
-        generator.register_existing_number(cat_num, Path("/a"))
+        generator.register_existing_number(cat_num, Path("/") / "a")
         area_num = JohnnyDecimalNumber(area=10)
         conflicts = generator.find_conflicts(area_num)
         child_conflicts = [c for c in conflicts if "10." in c[0]]
@@ -180,37 +180,37 @@ class TestResolveConflict:
 
     def test_resolve_increment_id(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1, item_id=1, name="Doc")
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         resolved = generator.resolve_conflict(num, strategy="increment")
         assert resolved.item_id != 1
 
     def test_resolve_increment_category(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1, name="Cat")
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         resolved = generator.resolve_conflict(num, strategy="increment")
         assert resolved.category != 1
 
     def test_resolve_increment_area(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, name="Area")
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         resolved = generator.resolve_conflict(num, strategy="increment")
         assert resolved is not None
 
     def test_resolve_skip_id(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1, item_id=1, name="Doc")
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         resolved = generator.resolve_conflict(num, strategy="skip")
         assert resolved.item_id != 1
 
     def test_resolve_skip_category(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, category=1, name="Cat")
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         resolved = generator.resolve_conflict(num, strategy="skip")
         assert resolved is not None
 
     def test_resolve_skip_area(self, generator: JohnnyDecimalGenerator) -> None:
         num = JohnnyDecimalNumber(area=10, name="Area")
-        generator.register_existing_number(num, Path("/a"))
+        generator.register_existing_number(num, Path("/") / "a")
         resolved = generator.resolve_conflict(num, strategy="skip")
         assert resolved is not None
 
@@ -228,10 +228,12 @@ class TestGetUsageStatistics:
         assert stats["total_numbers"] == 0
 
     def test_stats_with_numbers(self, generator: JohnnyDecimalGenerator) -> None:
-        generator.register_existing_number(JohnnyDecimalNumber(area=10), Path("/a"))
-        generator.register_existing_number(JohnnyDecimalNumber(area=10, category=1), Path("/b"))
+        generator.register_existing_number(JohnnyDecimalNumber(area=10), Path("/") / "a")
         generator.register_existing_number(
-            JohnnyDecimalNumber(area=10, category=1, item_id=1), Path("/c")
+            JohnnyDecimalNumber(area=10, category=1), Path("/") / "b"
+        )
+        generator.register_existing_number(
+            JohnnyDecimalNumber(area=10, category=1, item_id=1), Path("/") / "c"
         )
         stats = generator.get_usage_statistics()
         assert stats["total_numbers"] == 3
@@ -242,7 +244,7 @@ class TestGetUsageStatistics:
 
 class TestClearRegistrations:
     def test_clear(self, generator: JohnnyDecimalGenerator) -> None:
-        generator.register_existing_number(JohnnyDecimalNumber(area=10), Path("/a"))
+        generator.register_existing_number(JohnnyDecimalNumber(area=10), Path("/") / "a")
         generator.clear_registrations()
         assert generator.get_usage_statistics()["total_numbers"] == 0
 

--- a/tests/methodologies/johnny_decimal/test_jd_scanner.py
+++ b/tests/methodologies/johnny_decimal/test_jd_scanner.py
@@ -37,7 +37,7 @@ class TestScanDirectory:
 
     def test_nonexistent_path_raises(self, scanner: FolderScanner) -> None:
         with pytest.raises(ValueError, match="does not exist"):
-            scanner.scan_directory(Path("/nonexistent"))
+            scanner.scan_directory(Path("/") / "nonexistent")
 
     def test_not_a_dir_raises(self, scanner: FolderScanner, tmp_path: Path) -> None:
         f = tmp_path / "file.txt"

--- a/tests/methodologies/johnny_decimal/test_jd_system.py
+++ b/tests/methodologies/johnny_decimal/test_jd_system.py
@@ -69,28 +69,28 @@ class TestExtractNumberFromPath:
     """Cover _extract_number_from_path — lines 107."""
 
     def test_extract_area_number(self, system: JohnnyDecimalSystem) -> None:
-        num = system._extract_number_from_path(Path("root/10 Finance"))
+        num = system._extract_number_from_path(Path("root") / "10 Finance")
         assert num is not None
         assert num.area == 10
 
     def test_extract_category_number(self, system: JohnnyDecimalSystem) -> None:
-        num = system._extract_number_from_path(Path("root/11.01 Budgets"))
+        num = system._extract_number_from_path(Path("root") / "11.01 Budgets")
         assert num is not None
         assert num.area == 11
         assert num.category == 1
 
     def test_extract_id_number(self, system: JohnnyDecimalSystem) -> None:
-        num = system._extract_number_from_path(Path("root/11.01.001 Q1 Budget"))
+        num = system._extract_number_from_path(Path("root") / "11.01.001 Q1 Budget")
         assert num is not None
         assert num.item_id == 1
 
     def test_extract_no_number(self, system: JohnnyDecimalSystem) -> None:
-        num = system._extract_number_from_path(Path("root/Random Folder"))
+        num = system._extract_number_from_path(Path("root") / "Random Folder")
         assert num is None
 
     def test_extract_empty_name(self, system: JohnnyDecimalSystem) -> None:
         """Edge case with empty name returns None — no crash expected."""
-        num = system._extract_number_from_path(Path("root/"))
+        num = system._extract_number_from_path(Path("root"))
         assert num is None
 
 
@@ -245,7 +245,7 @@ class TestSystemCoverage:
     # Single part (just a number, no name)
     def test_extract_number_no_name_part(self, system: JohnnyDecimalSystem) -> None:
         """When path name is just '10' with no additional parts, name stays empty."""
-        num = system._extract_number_from_path(Path("root/10"))
+        num = system._extract_number_from_path(Path("root") / "10")
         assert num is not None
         assert num.area == 10
         assert num.name == ""
@@ -253,7 +253,7 @@ class TestSystemCoverage:
     # Line 116->122: when len(parts) > 1 with extension in name part
     def test_extract_number_with_extension_in_name(self, system: JohnnyDecimalSystem) -> None:
         """Name part containing a dot triggers Path().stem extraction."""
-        num = system._extract_number_from_path(Path("root/10 report.pdf"))
+        num = system._extract_number_from_path(Path("root") / "10 report.pdf")
         assert num is not None
         assert num.name == "report"
 

--- a/tests/methodologies/johnny_decimal/test_jd_validator.py
+++ b/tests/methodologies/johnny_decimal/test_jd_validator.py
@@ -68,7 +68,7 @@ class TestCheckSourcePaths:
     def test_nonexistent_source(self, validator: MigrationValidator) -> None:
         """Source path doesn't exist => error (line 97)."""
         rule = TransformationRule(
-            source_path=Path("/nonexistent/folder"),
+            source_path=Path("/") / "nonexistent" / "folder",
             target_name="10 Folder",
             jd_number=JohnnyDecimalNumber(area=10),
             action="rename",

--- a/tests/methodologies/johnny_decimal/test_johnny_decimal_integration.py
+++ b/tests/methodologies/johnny_decimal/test_johnny_decimal_integration.py
@@ -251,12 +251,12 @@ class TestJohnnyDecimalConfiguration:
         # Set up system
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file1.txt"),
+            Path("/") / "test" / "file1.txt",
         )
 
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=2),
-            Path("/test/file2.txt"),
+            Path("/") / "test" / "file2.txt",
         )
 
         # Save configuration
@@ -279,7 +279,7 @@ class TestJohnnyDecimalConfiguration:
         # Register some numbers
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file1.txt"),
+            Path("/") / "test" / "file1.txt",
         )
 
         # Reserve a number

--- a/tests/methodologies/johnny_decimal/test_migrator.py
+++ b/tests/methodologies/johnny_decimal/test_migrator.py
@@ -97,7 +97,7 @@ class TestFolderScanner:
     def test_scan_invalid_path(self, scanner):
         """Test scanning invalid path."""
         with pytest.raises(ValueError, match="does not exist"):
-            scanner.scan_directory(Path("/nonexistent"))
+            scanner.scan_directory(Path("/") / "nonexistent")
 
     def test_scan_file_not_directory(self, scanner, tmp_path):
         """Test scanning file instead of directory."""

--- a/tests/methodologies/johnny_decimal/test_numbering.py
+++ b/tests/methodologies/johnny_decimal/test_numbering.py
@@ -90,7 +90,7 @@ class TestJohnnyDecimalGenerator:
     def test_register_existing_number(self, generator):
         """Test registering an existing number."""
         number = JohnnyDecimalNumber(area=10, category=1)
-        file_path = Path("/test/file.txt")
+        file_path = Path("/") / "test" / "file.txt"
 
         generator.register_existing_number(number, file_path)
 
@@ -100,8 +100,8 @@ class TestJohnnyDecimalGenerator:
     def test_register_duplicate_number(self, generator):
         """Test that registering duplicate number raises error."""
         number = JohnnyDecimalNumber(area=10, category=1)
-        file1 = Path("/test/file1.txt")
-        file2 = Path("/test/file2.txt")
+        file1 = Path("/") / "test" / "file1.txt"
+        file2 = Path("/") / "test" / "file2.txt"
 
         generator.register_existing_number(number, file1)
 
@@ -113,7 +113,7 @@ class TestJohnnyDecimalGenerator:
         number = JohnnyDecimalNumber(area=10, category=1)
         assert generator.is_number_available(number)
 
-        generator.register_existing_number(number, Path("/test/file.txt"))
+        generator.register_existing_number(number, Path("/") / "test" / "file.txt")
         assert not generator.is_number_available(number)
 
     def test_get_next_available_area(self, generator):
@@ -233,7 +233,7 @@ class TestJohnnyDecimalGenerator:
     def test_validate_number_already_used(self, generator):
         """Test validating an already used number."""
         number = JohnnyDecimalNumber(area=10, category=1)
-        generator.register_existing_number(number, Path("/test/file.txt"))
+        generator.register_existing_number(number, Path("/") / "test" / "file.txt")
 
         is_valid, errors = generator.validate_number(number)
 
@@ -254,7 +254,7 @@ class TestJohnnyDecimalGenerator:
     def test_find_conflicts_exact(self, generator):
         """Test finding exact number conflicts."""
         number = JohnnyDecimalNumber(area=10, category=1)
-        file_path = Path("/test/file.txt")
+        file_path = Path("/") / "test" / "file.txt"
 
         generator.register_existing_number(number, file_path)
 
@@ -267,7 +267,7 @@ class TestJohnnyDecimalGenerator:
         """Test finding parent conflicts."""
         # Register parent (area only)
         parent = JohnnyDecimalNumber(area=10)
-        generator.register_existing_number(parent, Path("/test/parent.txt"))
+        generator.register_existing_number(parent, Path("/") / "test" / "parent.txt")
 
         # Try to use child (category)
         child = JohnnyDecimalNumber(area=10, category=1)
@@ -281,8 +281,8 @@ class TestJohnnyDecimalGenerator:
         # Register children (categories)
         child1 = JohnnyDecimalNumber(area=10, category=1)
         child2 = JohnnyDecimalNumber(area=10, category=2)
-        generator.register_existing_number(child1, Path("/test/child1.txt"))
-        generator.register_existing_number(child2, Path("/test/child2.txt"))
+        generator.register_existing_number(child1, Path("/") / "test" / "child1.txt")
+        generator.register_existing_number(child2, Path("/") / "test" / "child2.txt")
 
         # Try to use parent (area)
         parent = JohnnyDecimalNumber(area=10)
@@ -323,15 +323,15 @@ class TestJohnnyDecimalGenerator:
         # Register some numbers
         generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file1.txt"),
+            Path("/") / "test" / "file1.txt",
         )
         generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=2),
-            Path("/test/file2.txt"),
+            Path("/") / "test" / "file2.txt",
         )
         generator.register_existing_number(
             JohnnyDecimalNumber(area=20, category=1),
-            Path("/test/file3.txt"),
+            Path("/") / "test" / "file3.txt",
         )
 
         stats = generator.get_usage_statistics()
@@ -345,7 +345,7 @@ class TestJohnnyDecimalGenerator:
         # Register some numbers
         generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file.txt"),
+            Path("/") / "test" / "file.txt",
         )
 
         assert len(generator._used_numbers) == 1
@@ -389,9 +389,9 @@ class TestAdvancedScenarios:
         category = JohnnyDecimalNumber(area=16, category=1)
         item = JohnnyDecimalNumber(area=17, category=1, item_id=5)
 
-        generator.register_existing_number(area, Path("/test/area.txt"))
-        generator.register_existing_number(category, Path("/test/category.txt"))
-        generator.register_existing_number(item, Path("/test/item.txt"))
+        generator.register_existing_number(area, Path("/") / "test" / "area.txt")
+        generator.register_existing_number(category, Path("/") / "test" / "category.txt")
+        generator.register_existing_number(item, Path("/") / "test" / "item.txt")
 
         # All should be registered
         assert "15" in generator._used_numbers
@@ -402,7 +402,7 @@ class TestAdvancedScenarios:
         """Test fallback when preferred number is taken."""
         # Register preferred number
         preferred = JohnnyDecimalNumber(area=10, category=5)
-        generator.register_existing_number(preferred, Path("/test/existing.txt"))
+        generator.register_existing_number(preferred, Path("/") / "test" / "existing.txt")
 
         # Try to generate with same preference
         new_number = generator.generate_category_number(

--- a/tests/methodologies/johnny_decimal/test_numbering.py
+++ b/tests/methodologies/johnny_decimal/test_numbering.py
@@ -136,7 +136,7 @@ class TestJohnnyDecimalGenerator:
         # Register some categories
         for i in range(5):
             num = JohnnyDecimalNumber(area=10, category=i)
-            generator.register_existing_number(num, Path(f"/test/file{i}.txt"))
+            generator.register_existing_number(num, Path("/") / "test" / f"file{i}.txt")
 
         # Next available should be 5
         category = generator.get_next_available_category(area=10)
@@ -295,7 +295,7 @@ class TestJohnnyDecimalGenerator:
         # Register some numbers
         for i in range(3):
             num = JohnnyDecimalNumber(area=10, category=i)
-            generator.register_existing_number(num, Path(f"/test/file{i}.txt"))
+            generator.register_existing_number(num, Path("/") / "test" / f"file{i}.txt")
 
         # Resolve conflict for category 2
         conflicting = JohnnyDecimalNumber(area=10, category=2, name="Test")
@@ -310,7 +310,7 @@ class TestJohnnyDecimalGenerator:
         # Register 0, 1, 2, skip 3, register 4
         for i in [0, 1, 2, 4]:
             num = JohnnyDecimalNumber(area=10, category=i)
-            generator.register_existing_number(num, Path(f"/test/file{i}.txt"))
+            generator.register_existing_number(num, Path("/") / "test" / f"file{i}.txt")
 
         # Resolve should find 3
         conflicting = JohnnyDecimalNumber(area=10, category=2)
@@ -365,7 +365,7 @@ class TestAdvancedScenarios:
         # Fill up all IDs in a category
         for i in range(1000):
             num = JohnnyDecimalNumber(area=10, category=1, item_id=i)
-            generator.register_existing_number(num, Path(f"/test/file{i}.txt"))
+            generator.register_existing_number(num, Path("/") / "test" / f"file{i}.txt")
 
         # Try to get next ID - should raise error
         with pytest.raises(InvalidNumberError, match="No available ID numbers"):
@@ -376,7 +376,7 @@ class TestAdvancedScenarios:
         # Fill up all categories in area 10
         for i in range(100):
             num = JohnnyDecimalNumber(area=10, category=i)
-            generator.register_existing_number(num, Path(f"/test/file{i}.txt"))
+            generator.register_existing_number(num, Path("/") / "test" / f"file{i}.txt")
 
         # Try to get next category - should raise error
         with pytest.raises(InvalidNumberError, match="No available category numbers"):

--- a/tests/methodologies/johnny_decimal/test_system.py
+++ b/tests/methodologies/johnny_decimal/test_system.py
@@ -82,7 +82,7 @@ class TestJohnnyDecimalSystem:
 
     def test_extract_number_from_path_area(self, system):
         """Test extracting area number from path."""
-        path = Path("/test/10 Finance")
+        path = Path("/") / "test" / "10 Finance"
         number = system._extract_number_from_path(path)
 
         assert number is not None
@@ -91,7 +91,7 @@ class TestJohnnyDecimalSystem:
 
     def test_extract_number_from_path_category(self, system):
         """Test extracting category number from path."""
-        path = Path("/test/10.01 Budgets")
+        path = Path("/") / "test" / "10.01 Budgets"
         number = system._extract_number_from_path(path)
 
         assert number is not None
@@ -101,7 +101,7 @@ class TestJohnnyDecimalSystem:
 
     def test_extract_number_from_path_id(self, system):
         """Test extracting ID number from path."""
-        path = Path("/test/10.01.005 Q1 Budget.xlsx")
+        path = Path("/") / "test" / "10.01.005 Q1 Budget.xlsx"
         number = system._extract_number_from_path(path)
 
         assert number is not None
@@ -112,7 +112,7 @@ class TestJohnnyDecimalSystem:
 
     def test_extract_number_from_path_no_number(self, system):
         """Test extracting from path with no number."""
-        path = Path("/test/random_file.txt")
+        path = Path("/") / "test" / "random_file.txt"
         number = system._extract_number_from_path(path)
 
         assert number is None
@@ -134,7 +134,7 @@ class TestJohnnyDecimalSystem:
     def test_initialize_from_nonexistent_directory(self, system):
         """Test initializing from non-existent directory."""
         with pytest.raises(ValueError, match="Directory does not exist"):
-            system.initialize_from_directory(Path("/nonexistent"))
+            system.initialize_from_directory(Path("/") / "nonexistent")
 
     def test_assign_number_to_file(self, system, temp_dir):
         """Test assigning number to a file."""
@@ -252,11 +252,11 @@ class TestJohnnyDecimalSystem:
         # Register some numbers in area 10
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file1.txt"),
+            Path("/") / "test" / "file1.txt",
         )
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=2),
-            Path("/test/file2.txt"),
+            Path("/") / "test" / "file2.txt",
         )
 
         summary = system.get_area_summary(10)
@@ -280,7 +280,7 @@ class TestJohnnyDecimalSystem:
         # Register some numbers
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file.txt"),
+            Path("/") / "test" / "file.txt",
         )
 
         report = system.get_usage_report()
@@ -341,7 +341,7 @@ class TestJohnnyDecimalSystem:
         """Test clearing all registrations."""
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file.txt"),
+            Path("/") / "test" / "file.txt",
         )
 
         assert len(system.generator._used_numbers) > 0
@@ -363,7 +363,7 @@ class TestConfiguration:
         # Register some numbers
         system.generator.register_existing_number(
             JohnnyDecimalNumber(area=10, category=1),
-            Path("/test/file.txt"),
+            Path("/") / "test" / "file.txt",
         )
 
         system.save_configuration(config_path)
@@ -417,8 +417,8 @@ class TestConfiguration:
         num1 = JohnnyDecimalNumber(area=10, category=1, name="Test1")
         num2 = JohnnyDecimalNumber(area=10, category=2, name="Test2")
 
-        system.generator.register_existing_number(num1, Path("/test/file1.txt"))
-        system.generator.register_existing_number(num2, Path("/test/file2.txt"))
+        system.generator.register_existing_number(num1, Path("/") / "test" / "file1.txt")
+        system.generator.register_existing_number(num2, Path("/") / "test" / "file2.txt")
 
         # Reserve a number
         reserved = JohnnyDecimalNumber(area=15, category=1)
@@ -439,7 +439,7 @@ class TestConfiguration:
     def test_load_nonexistent_file(self, system):
         """Test loading from non-existent file."""
         with pytest.raises(FileNotFoundError):
-            system.load_configuration(Path("/nonexistent/config.json"))
+            system.load_configuration(Path("/") / "nonexistent" / "config.json")
 
 
 @pytest.mark.unit

--- a/tests/methodologies/para/test_ai_file_mover_branches.py
+++ b/tests/methodologies/para/test_ai_file_mover_branches.py
@@ -54,7 +54,7 @@ class TestComputeTargetPath:
         config = PARAConfig()
         mover = PARAFileMover(config, root_dir=tmp_path)
 
-        file_path = Path("/some/path/document.txt")
+        file_path = Path("/") / "some" / "path" / "document.txt"
         suggestion = PARASuggestion(
             category=PARACategory.PROJECT,
             confidence=0.8,
@@ -81,18 +81,18 @@ class TestMoveSuggestionValidation:
     def test_confidence_too_high(self) -> None:
         with pytest.raises(ValueError, match=r"between 0.0 and 1.0"):
             MoveSuggestion(
-                file_path=Path("/x.txt"),
+                file_path=Path("/") / "x.txt",
                 target_category=PARACategory.PROJECT,
-                target_path=Path("/dst/x.txt"),
+                target_path=Path("/") / "dst" / "x.txt",
                 confidence=1.5,
             )
 
     def test_confidence_too_low(self) -> None:
         with pytest.raises(ValueError, match=r"between 0.0 and 1.0"):
             MoveSuggestion(
-                file_path=Path("/x.txt"),
+                file_path=Path("/") / "x.txt",
                 target_category=PARACategory.PROJECT,
-                target_path=Path("/dst/x.txt"),
+                target_path=Path("/") / "dst" / "x.txt",
                 confidence=-0.1,
             )
 
@@ -153,7 +153,7 @@ class TestMoveFile:
         suggestion = MoveSuggestion(
             file_path=src,
             target_category=PARACategory.PROJECT,
-            target_path=Path("/proc/impossible/dst.txt"),
+            target_path=Path("/") / "proc" / "impossible" / "dst.txt",
             confidence=0.8,
         )
         result = mover.move_file(suggestion, dry_run=False)

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1079,7 +1079,7 @@ class TestHeuristicEngineEdgeCases:
         )
 
         with pytest.raises(ValueError, match="No heuristics enabled"):
-            engine.evaluate(Path("/fake/file.txt"))
+            engine.evaluate(Path("/") / "fake" / "file.txt")
 
     def test_engine_all_heuristics_fail_returns_zero_result(self, tmp_path: Path) -> None:
         """When all heuristics raise exceptions, engine returns zero result."""

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -178,7 +178,7 @@ class TestExtractMetadataFeatures:
 
     def test_nonexistent_file_returns_defaults(self, extractor: FeatureExtractor) -> None:
         """Should return defaults with file_type for non-existent file."""
-        features = extractor.extract_metadata_features(Path("/nonexistent/file.pdf"))
+        features = extractor.extract_metadata_features(Path("/") / "nonexistent" / "file.pdf")
         assert features.file_type == ".pdf"
         assert features.file_size == 0
         assert features.creation_date is None
@@ -485,7 +485,7 @@ class TestEdgeCasesAndErrorHandling:
         extractor: FeatureExtractor,
     ) -> None:
         """Should return False for non-existent directory."""
-        result = extractor._has_project_structure(Path("/nonexistent/path"))
+        result = extractor._has_project_structure(Path("/") / "nonexistent" / "path")
         assert result is False
 
     def test_has_project_structure_with_file_not_directory(
@@ -523,7 +523,7 @@ class TestEdgeCasesAndErrorHandling:
     ) -> None:
         """Should handle file with non-existent parent directory."""
         # Use a path that doesn't exist
-        fake_file = Path("/nonexistent/directory/file.txt")
+        fake_file = Path("/") / "nonexistent" / "directory" / "file.txt"
         features = extractor.extract_structural_features(fake_file)
         # Should handle gracefully - parent doesn't exist
         assert features.sibling_count == 0

--- a/tests/methodologies/para/test_feedback.py
+++ b/tests/methodologies/para/test_feedback.py
@@ -45,7 +45,7 @@ class TestFeedbackEvent:
     def test_creation_with_defaults(self) -> None:
         """Should create event with derived fields."""
         event = FeedbackEvent(
-            file_path=Path("/docs/report.pdf"),
+            file_path=Path("/") / "docs" / "report.pdf",
             suggested=PARACategory.PROJECT,
             actual=PARACategory.PROJECT,
             confidence=0.85,
@@ -57,7 +57,7 @@ class TestFeedbackEvent:
     def test_to_dict_roundtrip(self) -> None:
         """Should serialize and deserialize losslessly."""
         event = FeedbackEvent(
-            file_path=Path("/docs/report.pdf"),
+            file_path=Path("/") / "docs" / "report.pdf",
             suggested=PARACategory.PROJECT,
             actual=PARACategory.AREA,
             confidence=0.65,
@@ -88,7 +88,7 @@ class TestFeedbackEvent:
     def test_rejection_event_fields(self) -> None:
         """Rejected event should have different suggested vs actual."""
         event = FeedbackEvent(
-            file_path=Path("/docs/notes.md"),
+            file_path=Path("/") / "docs" / "notes.md",
             suggested=PARACategory.PROJECT,
             actual=PARACategory.AREA,
             confidence=0.55,
@@ -115,7 +115,7 @@ class TestFeedbackCollector:
     def test_record_acceptance(self, collector: FeedbackCollector) -> None:
         """Should record an acceptance event."""
         suggestion = _make_suggestion()
-        collector.record_acceptance(Path("/test/file.pdf"), suggestion)
+        collector.record_acceptance(Path("/") / "test" / "file.pdf", suggestion)
         events = collector.get_events()
         assert len(events) == 1
         assert events[0].accepted is True
@@ -126,7 +126,7 @@ class TestFeedbackCollector:
         """Should record a rejection with correct category."""
         suggestion = _make_suggestion(PARACategory.PROJECT)
         collector.record_rejection(
-            Path("/test/file.pdf"),
+            Path("/") / "test" / "file.pdf",
             suggestion,
             correct_category=PARACategory.RESOURCE,
         )
@@ -149,8 +149,8 @@ class TestFeedbackCollector:
 
         # Write events
         c1 = FeedbackCollector(storage_dir=storage)
-        c1.record_acceptance(Path("/test/a.txt"), _make_suggestion())
-        c1.record_acceptance(Path("/test/b.txt"), _make_suggestion())
+        c1.record_acceptance(Path("/") / "test" / "a.txt", _make_suggestion())
+        c1.record_acceptance(Path("/") / "test" / "b.txt", _make_suggestion())
 
         # Read from new instance
         c2 = FeedbackCollector(storage_dir=storage)
@@ -159,7 +159,7 @@ class TestFeedbackCollector:
 
     def test_clear_removes_all_events(self, collector: FeedbackCollector) -> None:
         """clear() should remove all events."""
-        collector.record_acceptance(Path("/test/file.txt"), _make_suggestion())
+        collector.record_acceptance(Path("/") / "test" / "file.txt", _make_suggestion())
         assert len(collector.get_events()) == 1
         collector.clear()
         assert len(collector.get_events()) == 0
@@ -220,13 +220,13 @@ class TestFeedbackCollector:
             )
         # 1 rejected project
         collector.record_rejection(
-            Path("/test/pr.txt"),
+            Path("/") / "test" / "pr.txt",
             _make_suggestion(PARACategory.PROJECT),
             correct_category=PARACategory.AREA,
         )
         # 1 accepted resource
         collector.record_acceptance(
-            Path("/test/res.txt"),
+            Path("/") / "test" / "res.txt",
             _make_suggestion(PARACategory.RESOURCE),
         )
 
@@ -240,11 +240,11 @@ class TestFeedbackCollector:
     ) -> None:
         """Should compute average confidence correctly."""
         collector.record_acceptance(
-            Path("/test/a.txt"),
+            Path("/") / "test" / "a.txt",
             _make_suggestion(confidence=0.90),
         )
         collector.record_rejection(
-            Path("/test/b.txt"),
+            Path("/") / "test" / "b.txt",
             _make_suggestion(confidence=0.50),
             correct_category=PARACategory.ARCHIVE,
         )
@@ -302,7 +302,7 @@ class TestFeedbackCollector:
             raise OSError("Disk full")
 
         monkeypatch.setattr(json, "dump", mock_dump)
-        collector.record_acceptance(Path("/test/file.txt"), _make_suggestion())
+        collector.record_acceptance(Path("/") / "test" / "file.txt", _make_suggestion())
 
         assert dump_called is True
         assert len(collector.get_events()) == 1
@@ -406,7 +406,7 @@ class TestPatternLearner:
         """Should capture override patterns from rejections."""
         events = [
             FeedbackEvent(
-                file_path=Path("/test/file.txt"),
+                file_path=Path("/") / "test" / "file.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.AREA,
                 confidence=0.6,

--- a/tests/methodologies/para/test_feedback.py
+++ b/tests/methodologies/para/test_feedback.py
@@ -140,7 +140,7 @@ class TestFeedbackCollector:
         """Multiple events should accumulate."""
         for i in range(5):
             suggestion = _make_suggestion()
-            collector.record_acceptance(Path(f"/test/file_{i}.txt"), suggestion)
+            collector.record_acceptance(Path("/") / "test" / f"file_{i}.txt", suggestion)
         assert len(collector.get_events()) == 5
 
     def test_persistence_across_instances(self, tmp_path: Path) -> None:
@@ -179,7 +179,7 @@ class TestFeedbackCollector:
     ) -> None:
         """100% acceptance should show accuracy_rate of 1.0."""
         for i in range(10):
-            collector.record_acceptance(Path(f"/test/f{i}.txt"), _make_suggestion())
+            collector.record_acceptance(Path("/") / "test" / f"f{i}.txt", _make_suggestion())
         stats = collector.get_accuracy_stats()
         assert stats.total_events == 10
         assert stats.accepted_count == 10
@@ -193,11 +193,11 @@ class TestFeedbackCollector:
         """Mixed feedback should compute correct accuracy."""
         # 7 accepted
         for i in range(7):
-            collector.record_acceptance(Path(f"/test/a{i}.txt"), _make_suggestion())
+            collector.record_acceptance(Path("/") / "test" / f"a{i}.txt", _make_suggestion())
         # 3 rejected
         for i in range(3):
             collector.record_rejection(
-                Path(f"/test/r{i}.txt"),
+                Path("/") / "test" / f"r{i}.txt",
                 _make_suggestion(),
                 correct_category=PARACategory.ARCHIVE,
             )
@@ -215,7 +215,7 @@ class TestFeedbackCollector:
         # 2 accepted projects
         for i in range(2):
             collector.record_acceptance(
-                Path(f"/test/p{i}.txt"),
+                Path("/") / "test" / f"p{i}.txt",
                 _make_suggestion(PARACategory.PROJECT),
             )
         # 1 rejected project
@@ -333,7 +333,7 @@ class TestPatternLearner:
         """Create a batch of feedback events."""
         return [
             FeedbackEvent(
-                file_path=Path(f"/{directory}/file_{i}{extension}"),
+                file_path=Path("/") / f"{directory}" / f"file_{i}{extension}",
                 suggested=category,
                 actual=category,
                 confidence=0.8,
@@ -446,7 +446,7 @@ class TestPatternLearner:
         # Mix of accepted and rejected
         accepted = [
             FeedbackEvent(
-                file_path=Path(f"/test/a{i}.txt"),
+                file_path=Path("/") / "test" / f"a{i}.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.PROJECT,
                 confidence=0.8,
@@ -456,7 +456,7 @@ class TestPatternLearner:
         ]
         rejected = [
             FeedbackEvent(
-                file_path=Path(f"/test/r{i}.txt"),
+                file_path=Path("/") / "test" / f"r{i}.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.AREA,
                 confidence=0.5,
@@ -475,7 +475,7 @@ class TestPatternLearner:
         # Create events where >60% of rejections have parent_directory
         accepted = [
             FeedbackEvent(
-                file_path=Path(f"/test/a{i}.txt"),
+                file_path=Path("/") / "test" / f"a{i}.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.PROJECT,
                 confidence=0.8,
@@ -486,7 +486,7 @@ class TestPatternLearner:
         # 10 rejections with parent_directory (>60% of rejections)
         rejected_with_dir = [
             FeedbackEvent(
-                file_path=Path(f"/documents/r{i}.txt"),
+                file_path=Path("/") / "documents" / f"r{i}.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.AREA,
                 confidence=0.5,
@@ -498,7 +498,7 @@ class TestPatternLearner:
         # 2 rejections without parent_directory
         rejected_no_dir = [
             FeedbackEvent(
-                file_path=Path(f"/r{i}.txt"),
+                file_path=Path("/") / f"r{i}.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.RESOURCE,
                 confidence=0.5,

--- a/tests/methodologies/para/test_file_mover.py
+++ b/tests/methodologies/para/test_file_mover.py
@@ -87,9 +87,9 @@ class TestMoveSuggestion:
     def test_valid_creation(self) -> None:
         """Should create a valid suggestion."""
         s = MoveSuggestion(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             target_category=PARACategory.PROJECT,
-            target_path=Path("/para/Projects/file.txt"),
+            target_path=Path("/") / "para" / "Projects" / "file.txt",
             confidence=0.85,
         )
         assert s.confidence == 0.85
@@ -98,9 +98,9 @@ class TestMoveSuggestion:
         """Should reject out-of-range confidence."""
         with pytest.raises(ValueError, match="confidence"):
             MoveSuggestion(
-                file_path=Path("/test/file.txt"),
+                file_path=Path("/") / "test" / "file.txt",
                 target_category=PARACategory.PROJECT,
-                target_path=Path("/para/Projects/file.txt"),
+                target_path=Path("/") / "para" / "Projects" / "file.txt",
                 confidence=1.5,
             )
 
@@ -229,7 +229,7 @@ class TestMoveFile:
     ) -> None:
         """Moving a non-existent file should fail."""
         suggestion = MoveSuggestion(
-            file_path=Path("/nonexistent/file.txt"),
+            file_path=Path("/") / "nonexistent" / "file.txt",
             target_category=PARACategory.PROJECT,
             target_path=mover.root_dir / "Projects" / "file.txt",
             confidence=0.8,
@@ -329,7 +329,7 @@ class TestBulkOrganize:
         mover: PARAFileMover,
     ) -> None:
         """Non-existent directory should return empty report."""
-        report = mover.bulk_organize(Path("/nonexistent/dir"))
+        report = mover.bulk_organize(Path("/") / "nonexistent" / "dir")
         assert report.total_files == 0
 
     def test_dry_run_counts_files(
@@ -469,7 +469,7 @@ class TestSuggestArchive:
         mover: PARAFileMover,
     ) -> None:
         """Non-existent directory should return empty list."""
-        result = mover.suggest_archive(Path("/nonexistent"))
+        result = mover.suggest_archive(Path("/") / "nonexistent")
         assert result == []
 
     def test_archive_reasoning_includes_days(

--- a/tests/methodologies/para/test_folder_generator.py
+++ b/tests/methodologies/para/test_folder_generator.py
@@ -356,7 +356,7 @@ class TestFolderCreationResult:
     def test_success_result(self):
         """Test successful creation result."""
         result = FolderCreationResult(
-            created_folders=[Path("/test/Projects")],
+            created_folders=[Path("/") / "test" / "Projects"],
             skipped_folders=[],
             errors=[],
             success=True,
@@ -370,8 +370,8 @@ class TestFolderCreationResult:
     def test_partial_success_result(self):
         """Test result with both created and skipped folders."""
         result = FolderCreationResult(
-            created_folders=[Path("/test/Projects")],
-            skipped_folders=[Path("/test/Areas")],
+            created_folders=[Path("/") / "test" / "Projects"],
+            skipped_folders=[Path("/") / "test" / "Areas"],
             errors=[],
             success=True,
         )
@@ -385,7 +385,7 @@ class TestFolderCreationResult:
         result = FolderCreationResult(
             created_folders=[],
             skipped_folders=[],
-            errors=[(Path("/test/Projects"), "Permission denied")],
+            errors=[(Path("/") / "test" / "Projects", "Permission denied")],
             success=False,
         )
 

--- a/tests/methodologies/para/test_folder_mapper.py
+++ b/tests/methodologies/para/test_folder_mapper.py
@@ -133,8 +133,8 @@ class TestCategoryFolderMapper:
         """Test batch mapping handles errors gracefully."""
         # Include a non-existent file
         files = [
-            Path("/nonexistent/file1.txt"),
-            Path("/nonexistent/file2.txt"),
+            Path("/") / "nonexistent" / "file1.txt",
+            Path("/") / "nonexistent" / "file2.txt",
         ]
 
         results = mapper.map_batch(files, temp_target)
@@ -333,15 +333,15 @@ class TestMappingResult:
     def test_valid_mapping_result(self):
         """Test creating valid mapping result."""
         result = MappingResult(
-            source_path=Path("/source/file.txt"),
+            source_path=Path("/") / "source" / "file.txt",
             target_category=PARACategory.PROJECT,
-            target_folder=Path("/target/Projects"),
+            target_folder=Path("/") / "target" / "Projects",
             confidence=0.85,
             reasoning=["Reason 1"],
             subfolder_path="2024/01",
         )
 
-        assert result.source_path == Path("/source/file.txt")
+        assert result.source_path == Path("/") / "source" / "file.txt"
         assert result.target_category == PARACategory.PROJECT
         assert result.confidence == 0.85
         assert result.subfolder_path == "2024/01"
@@ -349,16 +349,16 @@ class TestMappingResult:
     def test_mapping_result_without_subfolder(self):
         """Test mapping result without subfolder."""
         result = MappingResult(
-            source_path=Path("/source/file.txt"),
+            source_path=Path("/") / "source" / "file.txt",
             target_category=PARACategory.AREA,
-            target_folder=Path("/target/Areas"),
+            target_folder=Path("/") / "target" / "Areas",
             confidence=0.75,
             reasoning=[],
             subfolder_path=None,
         )
 
         assert result.subfolder_path is None
-        assert result.target_folder == Path("/target/Areas")
+        assert result.target_folder == Path("/") / "target" / "Areas"
 
 
 @pytest.mark.unit
@@ -406,7 +406,7 @@ class TestMappingStrategy:
         strategy = MappingStrategy(custom_subfolder_fn=custom_fn)
 
         assert strategy.custom_subfolder_fn is not None
-        assert strategy.custom_subfolder_fn(Path("/test"), PARACategory.PROJECT) == "custom"
+        assert strategy.custom_subfolder_fn(Path("/") / "test", PARACategory.PROJECT) == "custom"
 
 
 @pytest.mark.unit
@@ -536,7 +536,7 @@ class TestCategoryFolderMapperEdgeCases:
         mapper = CategoryFolderMapper(config, strategy=strategy)
 
         # Use a non-existent file
-        nonexistent_file = Path("/nonexistent/file.txt")
+        nonexistent_file = Path("/") / "nonexistent" / "file.txt"
         result = mapper.map_file(nonexistent_file, temp_target)
 
         # Should handle gracefully, subfolder might be None or have no date part
@@ -677,7 +677,7 @@ class TestCategoryFolderMapperEdgeCases:
 
         mapper.map_file = failing_map_file
 
-        files = [Path("/test/failing_file.txt"), Path("/test/normal_file.txt")]
+        files = [Path("/") / "test" / "failing_file.txt", Path("/") / "test" / "normal_file.txt"]
         results = mapper.map_batch(files, temp_target)
 
         # Should have results for both files

--- a/tests/methodologies/para/test_heuristics_read_content_safedir.py
+++ b/tests/methodologies/para/test_heuristics_read_content_safedir.py
@@ -169,7 +169,7 @@ class TestReadContentBytesTrustedRoot:
 
         assert result == b"anchored content"
         mock_open_root.assert_called_once_with(root)
-        fake_safe_dir.open_anchored_reader.assert_called_once_with(Path("nested/doc.txt"))
+        fake_safe_dir.open_anchored_reader.assert_called_once_with(Path("nested") / "doc.txt")
 
     def test_relative_to_falls_back_to_resolve_across_symlinked_root(self, tmp_path: Path) -> None:
         """Mirrors the macOS ``/tmp`` vs ``/private/tmp``-style mismatch: the

--- a/tests/methodologies/para/test_migration_manager.py
+++ b/tests/methodologies/para/test_migration_manager.py
@@ -266,14 +266,14 @@ class TestMigrationFile:
     def test_valid_migration_file(self):
         """Test creating valid migration file."""
         migration_file = MigrationFile(
-            source_path=Path("/source/file.txt"),
+            source_path=Path("/") / "source" / "file.txt",
             target_category=PARACategory.PROJECT,
-            target_path=Path("/target/Projects/file.txt"),
+            target_path=Path("/") / "target" / "Projects" / "file.txt",
             confidence=0.85,
             reasoning=["Reason 1", "Reason 2"],
         )
 
-        assert migration_file.source_path == Path("/source/file.txt")
+        assert migration_file.source_path == Path("/") / "source" / "file.txt"
         assert migration_file.target_category == PARACategory.PROJECT
         assert migration_file.confidence == 0.85
         assert len(migration_file.reasoning) == 2
@@ -287,16 +287,16 @@ class TestMigrationPlan:
         """Test creating valid migration plan."""
         files = [
             MigrationFile(
-                source_path=Path("/source/file1.txt"),
+                source_path=Path("/") / "source" / "file1.txt",
                 target_category=PARACategory.PROJECT,
-                target_path=Path("/target/Projects/file1.txt"),
+                target_path=Path("/") / "target" / "Projects" / "file1.txt",
                 confidence=0.8,
                 reasoning=[],
             ),
             MigrationFile(
-                source_path=Path("/source/file2.txt"),
+                source_path=Path("/") / "source" / "file2.txt",
                 target_category=PARACategory.RESOURCE,
-                target_path=Path("/target/Resources/file2.txt"),
+                target_path=Path("/") / "target" / "Resources" / "file2.txt",
                 confidence=0.7,
                 reasoning=[],
             ),
@@ -339,7 +339,7 @@ class TestMigrationReport:
 
         report = MigrationReport(
             plan=plan,
-            migrated=[Path("/target/file1.txt")],
+            migrated=[Path("/") / "target" / "file1.txt"],
             failed=[],
             skipped=[],
             duration_seconds=1.5,
@@ -364,7 +364,7 @@ class TestMigrationReport:
         report = MigrationReport(
             plan=plan,
             migrated=[],
-            failed=[(Path("/source/file.txt"), "Permission denied")],
+            failed=[(Path("/") / "source" / "file.txt", "Permission denied")],
             skipped=[],
             duration_seconds=0.5,
             success=False,

--- a/tests/methodologies/para/test_para_config.py
+++ b/tests/methodologies/para/test_para_config.py
@@ -88,7 +88,7 @@ class TestPARAConfigLoadFromYaml:
         assert cfg.temporal_thresholds.project_max_age == 15
         assert cfg.enable_ai_heuristic is True
         assert cfg.auto_categorize is False
-        assert cfg.default_root == Path("/tmp/para_root")  # noqa: test-hardcoded-paths
+        assert cfg.default_root == Path("/") / "tmp" / "para_root"  # noqa: test-hardcoded-paths
         assert cfg.project_dir == "Proj"
 
     def test_load_invalid_yaml_returns_defaults(self, tmp_path: Path) -> None:
@@ -129,7 +129,7 @@ class TestPARAConfigSaveToYaml:
             temporal_thresholds=TemporalThresholds(project_max_age=10),
             enable_ai_heuristic=True,
             auto_categorize=False,
-            default_root=Path("/some/path"),
+            default_root=Path("/") / "some" / "path",
             project_dir="P",
             area_dir="A",
             resource_dir="R",
@@ -142,7 +142,7 @@ class TestPARAConfigSaveToYaml:
         reloaded = PARAConfig.load_from_yaml(out_file)
         assert reloaded.enable_ai_heuristic is True
         assert reloaded.auto_categorize is False
-        assert reloaded.default_root == Path("/some/path")
+        assert reloaded.default_root == Path("/") / "some" / "path"
 
     def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
         """save_to_yaml creates parent directories."""
@@ -211,7 +211,7 @@ class TestCategorizationResultValidation:
         )
         # Verify conversion happened (line 115)
         assert isinstance(result.file_path, Path)
-        assert result.file_path == Path("/test/file.txt")
+        assert result.file_path == Path("/") / "test" / "file.txt"
         assert result.category == PARACategory.PROJECT
         assert result.confidence == 0.85
 
@@ -280,7 +280,7 @@ class TestLoadConfig:
         """When config_path is None and no default files exist, returns defaults."""
         with patch(
             "file_organizer.methodologies.para.config._get_para_config_dir",
-            return_value=Path("/nonexistent/dir"),
+            return_value=Path("/") / "nonexistent" / "dir",
         ):
             cfg = load_config(None)
             assert cfg.auto_categorize is True
@@ -309,7 +309,7 @@ class TestLoadConfig:
         with (
             patch(
                 "file_organizer.methodologies.para.config._get_para_config_dir",
-                return_value=Path("/nonexistent/dir"),
+                return_value=Path("/") / "nonexistent" / "dir",
             ),
             patch("file_organizer.methodologies.para.config.Path.cwd", return_value=tmp_path),
         ):
@@ -329,10 +329,11 @@ class TestLoadConfig:
         with (
             patch(
                 "file_organizer.methodologies.para.config._get_para_config_dir",
-                return_value=Path("/nonexistent/dir"),
+                return_value=Path("/") / "nonexistent" / "dir",
             ),
             patch(
-                "file_organizer.methodologies.para.config.Path.cwd", return_value=Path("/nowhere")
+                "file_organizer.methodologies.para.config.Path.cwd",
+                return_value=Path("/") / "nowhere",
             ),
             patch.object(config_module, "__file__", str(tmp_path / "config.py")),
         ):
@@ -346,11 +347,11 @@ class TestLoadConfig:
         with (
             patch(
                 "file_organizer.methodologies.para.config._get_para_config_dir",
-                return_value=Path("/nonexistent1"),
+                return_value=Path("/") / "nonexistent1",
             ),
             patch(
                 "file_organizer.methodologies.para.config.Path.cwd",
-                return_value=Path("/nonexistent2"),
+                return_value=Path("/") / "nonexistent2",
             ),
             patch.object(config_module, "__file__", "/nonexistent3/config.py"),
         ):

--- a/tests/methodologies/para/test_para_coverage_100.py
+++ b/tests/methodologies/para/test_para_coverage_100.py
@@ -287,7 +287,7 @@ class TestFeedbackPatternLearningEdges:
 
         events = [
             FeedbackEvent(
-                file_path=Path("/noext"),
+                file_path=Path("/") / "noext",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.RESOURCE,
                 confidence=0.8,
@@ -307,7 +307,7 @@ class TestFeedbackPatternLearningEdges:
 
         events = [
             FeedbackEvent(
-                file_path=Path("/file.txt"),
+                file_path=Path("/") / "file.txt",
                 suggested=PARACategory.PROJECT,
                 actual=PARACategory.RESOURCE,
                 confidence=0.8,

--- a/tests/methodologies/para/test_para_coverage_100.py
+++ b/tests/methodologies/para/test_para_coverage_100.py
@@ -222,9 +222,9 @@ class TestFeedbackWeightAdjustment:
 
             events.append(
                 FeedbackEvent(
-                    file_path=Path(f"/{parent_dir}/file{i}.txt")
+                    file_path=Path("/") / f"{parent_dir}" / f"file{i}.txt"
                     if parent_dir
-                    else Path(f"/file{i}.txt"),
+                    else Path("/") / f"file{i}.txt",
                     suggested=PARACategory.PROJECT,
                     actual=cat,
                     confidence=0.8,

--- a/tests/methodologies/para/test_para_folder_mapper_branches.py
+++ b/tests/methodologies/para/test_para_folder_mapper_branches.py
@@ -110,7 +110,7 @@ class TestFolderMapperBranches:
         mapper = CategoryFolderMapper(config)
         results = [
             MappingResult(
-                source_path=Path(f"/src/file{i}.txt"),
+                source_path=Path("/") / "src" / f"file{i}.txt",
                 target_category=PARACategory.RESOURCE,
                 target_folder=Path("/") / "dst" / "Resources",
                 confidence=0.7,

--- a/tests/methodologies/para/test_para_folder_mapper_branches.py
+++ b/tests/methodologies/para/test_para_folder_mapper_branches.py
@@ -35,13 +35,13 @@ class TestFolderMapperBranches:
         rule_engine = MagicMock()
         rule_engine.evaluate_file.side_effect = RuntimeError("rule error")
         mapper = CategoryFolderMapper(config, rule_engine=rule_engine)
-        result = mapper._evaluate_rules(Path("/fake/file.txt"))
+        result = mapper._evaluate_rules(Path("/") / "fake" / "file.txt")
         assert result is None
 
     def test_evaluate_rules_no_engine_returns_none(self, config: PARAConfig) -> None:
         """_evaluate_rules returns None when no rule engine (line 189)."""
         mapper = CategoryFolderMapper(config, rule_engine=None)
-        result = mapper._evaluate_rules(Path("/fake/file.txt"))
+        result = mapper._evaluate_rules(Path("/") / "fake" / "file.txt")
         assert result is None
 
     def test_extract_reasoning_none_category(self, config: PARAConfig) -> None:
@@ -77,20 +77,20 @@ class TestFolderMapperBranches:
         """_match_keyword_folder returns None when keyword_mapping is None (line 299)."""
         strategy = MappingStrategy(use_keyword_folders=True, keyword_mapping=None)
         mapper = CategoryFolderMapper(config, strategy=strategy)
-        result = mapper._match_keyword_folder(Path("/some/file.txt"))
+        result = mapper._match_keyword_folder(Path("/") / "some" / "file.txt")
         assert result is None
 
     def test_match_keyword_folder_no_match(self, config: PARAConfig) -> None:
         """_match_keyword_folder returns None when no keyword matches (line 308)."""
         strategy = MappingStrategy(use_keyword_folders=True, keyword_mapping={"budget": "Finance"})
         mapper = CategoryFolderMapper(config, strategy=strategy)
-        result = mapper._match_keyword_folder(Path("/some/report.txt"))
+        result = mapper._match_keyword_folder(Path("/") / "some" / "report.txt")
         assert result is None
 
     def test_create_target_folders_error(self, config: PARAConfig, tmp_path: Path) -> None:
         """create_target_folders handles mkdir failure (lines 334-336)."""
         mapper = CategoryFolderMapper(config)
-        bad_folder = Path("/proc/fake/folder")
+        bad_folder = Path("/") / "proc" / "fake" / "folder"
         results = [
             MappingResult(
                 source_path=tmp_path / "a.txt",
@@ -112,7 +112,7 @@ class TestFolderMapperBranches:
             MappingResult(
                 source_path=Path(f"/src/file{i}.txt"),
                 target_category=PARACategory.RESOURCE,
-                target_folder=Path("/dst/Resources"),
+                target_folder=Path("/") / "dst" / "Resources",
                 confidence=0.7,
                 reasoning=["reason"],
             )
@@ -319,14 +319,14 @@ class TestFolderMapperBranches:
     def test_get_date_folder_nonexistent_file(self, config: PARAConfig) -> None:
         """_get_date_folder handles stat error (lines 286-288)."""
         mapper = CategoryFolderMapper(config)
-        result = mapper._get_date_folder(Path("/nonexistent/file.txt"))
+        result = mapper._get_date_folder(Path("/") / "nonexistent" / "file.txt")
         assert result is None
 
     def test_match_keyword_folder_success(self, config: PARAConfig) -> None:
         """_match_keyword_folder returns folder when keyword matches (line 307)."""
         strategy = MappingStrategy(use_keyword_folders=True, keyword_mapping={"invoice": "Billing"})
         mapper = CategoryFolderMapper(config, strategy=strategy)
-        result = mapper._match_keyword_folder(Path("/path/to/invoice_2024.pdf"))
+        result = mapper._match_keyword_folder(Path("/") / "path" / "to" / "invoice_2024.pdf")
 
         assert result == "Billing"
 
@@ -373,9 +373,9 @@ class TestFolderMapperBranches:
         mapper = CategoryFolderMapper(config)
         results = [
             MappingResult(
-                source_path=Path("/src/test.txt"),
+                source_path=Path("/") / "src" / "test.txt",
                 target_category=PARACategory.PROJECT,
-                target_folder=Path("/dst/Projects"),
+                target_folder=Path("/") / "dst" / "Projects",
                 confidence=0.85,
                 reasoning=["Contains project keywords", "High priority"],
             )
@@ -490,9 +490,9 @@ class TestFolderMapperBranches:
         mapper = CategoryFolderMapper(config)
         results = [
             MappingResult(
-                source_path=Path("/src/test.txt"),
+                source_path=Path("/") / "src" / "test.txt",
                 target_category=PARACategory.PROJECT,
-                target_folder=Path("/dst/Projects"),
+                target_folder=Path("/") / "dst" / "Projects",
                 confidence=0.85,
                 reasoning=[],  # Empty reasoning
             )
@@ -510,7 +510,9 @@ class TestFolderMapperBranches:
         mapper = CategoryFolderMapper(config, strategy=strategy)
 
         # Use nonexistent file so _get_date_folder returns None
-        result = mapper._determine_subfolder(Path("/nonexistent/file.txt"), PARACategory.PROJECT)
+        result = mapper._determine_subfolder(
+            Path("/") / "nonexistent" / "file.txt", PARACategory.PROJECT
+        )
 
         assert result is None
 

--- a/tests/methodologies/para/test_para_migration_manager_branches.py
+++ b/tests/methodologies/para/test_para_migration_manager_branches.py
@@ -276,9 +276,9 @@ class TestGeneratePreview:
     ) -> None:
         files = [
             MigrationFile(
-                source_path=Path(f"/src/file{i}.txt"),
+                source_path=Path("/") / "src" / f"file{i}.txt",
                 target_category=PARACategory.RESOURCE,
-                target_path=Path(f"/dst/file{i}.txt"),
+                target_path=Path("/") / "dst" / f"file{i}.txt",
                 confidence=0.7,
             )
             for i in range(25)

--- a/tests/methodologies/para/test_para_rules_engine.py
+++ b/tests/methodologies/para/test_para_rules_engine.py
@@ -143,37 +143,43 @@ class TestEvaluationContext:
     """Test EvaluationContext properties — lines 187, 192, 197-204."""
 
     def test_file_extension(self) -> None:
-        ctx = EvaluationContext(file_path=Path("/doc/report.PDF"))
+        ctx = EvaluationContext(file_path=Path("/") / "doc" / "report.PDF")
         assert ctx.file_extension == ".pdf"
 
     def test_file_name(self) -> None:
-        ctx = EvaluationContext(file_path=Path("/doc/report.pdf"))
+        ctx = EvaluationContext(file_path=Path("/") / "doc" / "report.pdf")
         assert ctx.file_name == "report.pdf"
 
     def test_file_age_days_no_stat(self) -> None:
-        ctx = EvaluationContext(file_path=Path("/doc/x.txt"), file_stat=None)
+        ctx = EvaluationContext(file_path=Path("/") / "doc" / "x.txt", file_stat=None)
         assert ctx.file_age_days is None
 
     def test_file_age_days_no_created(self) -> None:
-        ctx = EvaluationContext(file_path=Path("/doc/x.txt"), file_stat={"size": 100})
+        ctx = EvaluationContext(file_path=Path("/") / "doc" / "x.txt", file_stat={"size": 100})
         assert ctx.file_age_days is None
 
     def test_file_age_days_with_datetime(self) -> None:
         created = datetime(2020, 1, 1, tzinfo=UTC)
-        ctx = EvaluationContext(file_path=Path("/doc/x.txt"), file_stat={"created": created})
+        ctx = EvaluationContext(
+            file_path=Path("/") / "doc" / "x.txt", file_stat={"created": created}
+        )
         age = ctx.file_age_days
         assert age is not None
         assert age > 0
 
     def test_file_age_days_naive_datetime(self) -> None:
         created = datetime(2020, 1, 1)  # noqa: DTZ001
-        ctx = EvaluationContext(file_path=Path("/doc/x.txt"), file_stat={"created": created})
+        ctx = EvaluationContext(
+            file_path=Path("/") / "doc" / "x.txt", file_stat={"created": created}
+        )
         age = ctx.file_age_days
         assert age is not None
         assert age > 0
 
     def test_file_age_days_non_datetime(self) -> None:
-        ctx = EvaluationContext(file_path=Path("/doc/x.txt"), file_stat={"created": "2020-01-01"})
+        ctx = EvaluationContext(
+            file_path=Path("/") / "doc" / "x.txt", file_stat={"created": "2020-01-01"}
+        )
         assert ctx.file_age_days is None
 
 
@@ -204,7 +210,7 @@ class TestRuleEngine:
     def test_load_rules(self) -> None:
         engine, parser, *_ = self._make_engine()
         parser.parse_file.return_value = [self._make_rule()]
-        count = engine.load_rules(Path("/rules.yaml"))
+        count = engine.load_rules(Path("/") / "rules.yaml")
         assert count == 1
         assert len(engine.rules) == 1
 
@@ -224,14 +230,14 @@ class TestRuleEngine:
 
     def test_evaluate_file_no_rules(self) -> None:
         engine, *_ = self._make_engine()
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is None
 
     def test_evaluate_file_disabled_rule_skipped(self) -> None:
         engine, _, evaluator, *_ = self._make_engine()
         engine.rules = [self._make_rule(enabled=False)]
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is None
         evaluator.evaluate_condition.assert_not_called()
@@ -240,7 +246,7 @@ class TestRuleEngine:
         engine, _, evaluator, _, resolver, _ = self._make_engine()
         evaluator.evaluate_condition.return_value = True
         engine.rules = [self._make_rule()]
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is not None
         assert result.matched is True
@@ -251,7 +257,7 @@ class TestRuleEngine:
         engine, _, evaluator, *_ = self._make_engine()
         evaluator.evaluate_condition.return_value = False
         engine.rules = [self._make_rule()]
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is None
 
@@ -263,7 +269,7 @@ class TestRuleEngine:
         engine.rules = [r1, r2]
         resolved = RuleMatchResult(rule=r1, matched=True, confidence=0.9, category="project")
         resolver.resolve.return_value = resolved
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is resolved
         resolver.resolve.assert_called_once()
@@ -273,7 +279,7 @@ class TestRuleEngine:
         evaluator.evaluate_condition.return_value = True
         engine.rules = [self._make_rule()]
         scorer.calculate_category_scores.return_value = {"project": 0.9}
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         scores = engine.get_category_scores(ctx)
         assert scores == {"project": 0.9}
 
@@ -281,7 +287,7 @@ class TestRuleEngine:
         engine, _, evaluator, _, _, scorer = self._make_engine()
         engine.rules = [self._make_rule(enabled=False)]
         scorer.calculate_category_scores.return_value = {}
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         engine.get_category_scores(ctx)
         evaluator.evaluate_condition.assert_not_called()
 
@@ -297,7 +303,7 @@ class TestRuleEngine:
             actions=[RuleAction(type=ActionType.FLAG_REVIEW)],
         )
         engine.rules = [rule]
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is not None
         assert result.matched is True
@@ -319,7 +325,7 @@ class TestRuleEngine:
             ],
         )
         engine.rules = [rule]
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         result = engine.evaluate_file(ctx)
         assert result is not None
         assert result.matched is True
@@ -361,7 +367,7 @@ class TestRuleEngine:
 
         evaluator.evaluate_condition.side_effect = eval_side_effect
         scorer.calculate_category_scores.return_value = {"project": 0.8}
-        ctx = EvaluationContext(file_path=Path("/test.txt"))
+        ctx = EvaluationContext(file_path=Path("/") / "test.txt")
         scores = engine.get_category_scores(ctx)
         assert scores == {"project": 0.8}
         # Both rules' conditions are evaluated (r1 passes, r2 fails and continues loop)

--- a/tests/methodologies/para/test_para_system.py
+++ b/tests/methodologies/para/test_para_system.py
@@ -135,7 +135,7 @@ class TestCategorizationResult:
     def test_valid_result(self):
         """Test creating valid categorization result."""
         result = CategorizationResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             category=PARACategory.PROJECT,
             confidence=0.85,
             reasons=["Has deadline", "Time-bound"],
@@ -150,7 +150,7 @@ class TestCategorizationResult:
         """Test that invalid confidence raises error."""
         with pytest.raises(ValueError, match="confidence"):
             CategorizationResult(
-                file_path=Path("/test/file.txt"),
+                file_path=Path("/") / "test" / "file.txt",
                 category=PARACategory.PROJECT,
                 confidence=1.5,  # Invalid
                 reasons=["Reason"],
@@ -160,7 +160,7 @@ class TestCategorizationResult:
         """Test that empty reasons list raises error."""
         with pytest.raises(ValueError, match="reasons"):
             CategorizationResult(
-                file_path=Path("/test/file.txt"),
+                file_path=Path("/") / "test" / "file.txt",
                 category=PARACategory.PROJECT,
                 confidence=0.8,
                 reasons=[],  # Empty
@@ -169,13 +169,13 @@ class TestCategorizationResult:
     def test_is_confident_property(self):
         """Test confidence threshold check."""
         high_confidence = CategorizationResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             category=PARACategory.PROJECT,
             confidence=0.80,
             reasons=["Reason"],
         )
         low_confidence = CategorizationResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             category=PARACategory.PROJECT,
             confidence=0.70,
             reasons=["Reason"],
@@ -187,13 +187,13 @@ class TestCategorizationResult:
     def test_requires_review_property(self):
         """Test manual review requirement check."""
         needs_review = CategorizationResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             category=PARACategory.PROJECT,
             confidence=0.50,
             reasons=["Reason"],
         )
         no_review = CategorizationResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             category=PARACategory.PROJECT,
             confidence=0.70,
             reasons=["Reason"],
@@ -205,7 +205,7 @@ class TestCategorizationResult:
     def test_to_dict_conversion(self):
         """Test converting result to dictionary."""
         result = CategorizationResult(
-            file_path=Path("/test/file.txt"),
+            file_path=Path("/") / "test" / "file.txt",
             category=PARACategory.PROJECT,
             confidence=0.85,
             reasons=["Reason 1"],
@@ -447,7 +447,7 @@ class TestHeuristicEngine:
         )
 
         with pytest.raises(ValueError, match="No heuristics enabled"):
-            engine.evaluate(Path("/test/file.txt"))
+            engine.evaluate(Path("/") / "test" / "file.txt")
 
     def test_combined_evaluation(self, tmp_path):
         """Test combining multiple heuristics."""

--- a/tests/methodologies/para/test_smart_suggestions_integration.py
+++ b/tests/methodologies/para/test_smart_suggestions_integration.py
@@ -222,7 +222,7 @@ class TestFullPipeline:
                 confidence=0.8,
                 reasoning=["reference document"],
             )
-            collector.record_acceptance(Path(f"/docs/ref_{i}.pdf"), suggestion)
+            collector.record_acceptance(Path("/") / "docs" / f"ref_{i}.pdf", suggestion)
 
         learner = PatternLearner(min_occurrences=3)
         events = collector.get_events()

--- a/tests/methodologies/para/test_suggestion_engine.py
+++ b/tests/methodologies/para/test_suggestion_engine.py
@@ -281,7 +281,7 @@ class TestSuggest:
         suggestion_engine: PARASuggestionEngine,
     ) -> None:
         """Should handle non-existent file paths gracefully."""
-        result = suggestion_engine.suggest(Path("/nonexistent/path/file.txt"))
+        result = suggestion_engine.suggest(Path("/") / "nonexistent" / "path" / "file.txt")
         assert isinstance(result, PARASuggestion)
 
     def test_structural_hint_influences_category(

--- a/tests/models/test_claude_vision_model.py
+++ b/tests/models/test_claude_vision_model.py
@@ -369,7 +369,7 @@ class TestClaudeVisionModelGenerateGuards:
             model = ClaudeVisionModel(claude_vision_config)
 
         with pytest.raises(RuntimeError, match="not initialized"):
-            model.generate("prompt", image_path=Path("/any"))
+            model.generate("prompt", image_path=Path("/") / "any")
 
     def test_raises_value_error_when_neither_image_nor_data(
         self,

--- a/tests/models/test_openai_vision_model.py
+++ b/tests/models/test_openai_vision_model.py
@@ -365,7 +365,7 @@ class TestOpenAIVisionModelGenerateGuards:
             model = OpenAIVisionModel(openai_vision_config)
 
         with pytest.raises(RuntimeError, match="not initialized"):
-            model.generate("prompt", image_path=Path("/any"))
+            model.generate("prompt", image_path=Path("/") / "any")
 
     def test_raises_value_error_when_neither_image_nor_data(
         self,

--- a/tests/models/test_vision_model.py
+++ b/tests/models/test_vision_model.py
@@ -70,7 +70,7 @@ class TestVisionModel:
                     assert kwargs["model"] == vision_model_config.name
                     assert kwargs["prompt"] == "Describe this image"
                     # Note: We check if images list contains the path string
-                    assert kwargs["images"][0] == str(Path("/path/to/image.jpg"))
+                    assert kwargs["images"][0] == str(Path("/") / "path" / "to" / "image.jpg")
 
     def test_generate_from_image_error(self, vision_model_config: ModelConfig) -> None:
         """Test image generation error handling."""

--- a/tests/parallel/test_checkpoint.py
+++ b/tests/parallel/test_checkpoint.py
@@ -84,7 +84,7 @@ class TestCheckpointManagerInit(unittest.TestCase):
 
     def test_custom_dir(self) -> None:
         """Test that custom directory is used."""
-        custom = Path("/tmp/test-checkpoints")  # noqa: test-hardcoded-paths
+        custom = Path("/") / "tmp" / "test-checkpoints"  # noqa: test-hardcoded-paths
         mgr = CheckpointManager(checkpoints_dir=custom)
         self.assertEqual(mgr.checkpoints_dir, custom)
 
@@ -245,7 +245,7 @@ class TestUpdateCheckpoint(unittest.TestCase):
 
     def test_update_nonexistent_checkpoint_returns_none(self) -> None:
         """Test updating a missing checkpoint returns None."""
-        result = self.mgr.update_checkpoint("no-checkpoint", Path("/tmp/x.txt"))  # noqa: test-hardcoded-paths
+        result = self.mgr.update_checkpoint("no-checkpoint", Path("/") / "tmp" / "x.txt")  # noqa: test-hardcoded-paths
         self.assertIsNone(result)
 
     def test_update_does_not_duplicate_completed(self) -> None:

--- a/tests/parallel/test_parallel_models.py
+++ b/tests/parallel/test_parallel_models.py
@@ -287,8 +287,8 @@ class TestCheckpoint(unittest.TestCase):
 
     def test_with_paths(self) -> None:
         """Test creating checkpoint with file paths."""
-        completed = [Path("/a/b.txt"), Path("/c/d.txt")]
-        pending = [Path("/e/f.txt")]
+        completed = [Path("/") / "a" / "b.txt", Path("/") / "c" / "d.txt"]
+        pending = [Path("/") / "e" / "f.txt"]
         ckpt = Checkpoint(
             job_id="paths-test",
             completed_paths=completed,
@@ -304,8 +304,8 @@ class TestCheckpoint(unittest.TestCase):
         now = datetime(2026, 6, 15, 14, 0, 0, tzinfo=UTC)
         ckpt = Checkpoint(
             job_id="ser-ckpt",
-            completed_paths=[Path("/done/a.txt")],
-            pending_paths=[Path("/todo/b.txt"), Path("/todo/c.txt")],
+            completed_paths=[Path("/") / "done" / "a.txt"],
+            pending_paths=[Path("/") / "todo" / "b.txt", Path("/") / "todo" / "c.txt"],
             file_hashes={"/done/a.txt": "hash-a"},
             last_updated=now,
         )
@@ -336,7 +336,7 @@ class TestCheckpoint(unittest.TestCase):
         }
         ckpt = Checkpoint.from_dict(data)
         self.assertEqual(ckpt.job_id, "deser-ckpt")
-        self.assertEqual(ckpt.completed_paths, [Path("/x/a.txt")])
+        self.assertEqual(ckpt.completed_paths, [Path("/") / "x" / "a.txt"])
         self.assertEqual(len(ckpt.pending_paths), 2)
         self.assertEqual(ckpt.file_hashes, {"/x/a.txt": "hash-a"})
 
@@ -357,8 +357,8 @@ class TestCheckpoint(unittest.TestCase):
         now = datetime(2026, 8, 1, 10, 0, 0, tzinfo=UTC)
         original = Checkpoint(
             job_id="roundtrip-ckpt",
-            completed_paths=[Path("/a.txt"), Path("/b.txt")],
-            pending_paths=[Path("/c.txt")],
+            completed_paths=[Path("/") / "a.txt", Path("/") / "b.txt"],
+            pending_paths=[Path("/") / "c.txt"],
             file_hashes={"/a.txt": "h1", "/b.txt": "h2"},
             last_updated=now,
         )
@@ -381,7 +381,7 @@ class TestCheckpoint(unittest.TestCase):
         """Test that default mutable fields are independent."""
         ckpt1 = Checkpoint(job_id="a")
         ckpt2 = Checkpoint(job_id="b")
-        ckpt1.completed_paths.append(Path("/x.txt"))
+        ckpt1.completed_paths.append(Path("/") / "x.txt")
         self.assertEqual(len(ckpt2.completed_paths), 0)
 
     def test_file_hashes_independent_across_instances(self) -> None:

--- a/tests/parallel/test_persistence.py
+++ b/tests/parallel/test_persistence.py
@@ -39,7 +39,7 @@ class TestJobPersistenceInit(unittest.TestCase):
 
     def test_custom_jobs_dir(self, tmp_path: Path | None = None) -> None:
         """Test that custom directory is used."""
-        custom = Path("/tmp/test-jobs")  # noqa: test-hardcoded-paths
+        custom = Path("/") / "tmp" / "test-jobs"  # noqa: test-hardcoded-paths
         persistence = JobPersistence(jobs_dir=custom)
         self.assertEqual(persistence.jobs_dir, custom)
 

--- a/tests/parallel/test_priority_queue.py
+++ b/tests/parallel/test_priority_queue.py
@@ -62,7 +62,7 @@ class TestPriorityQueue(unittest.TestCase):
         """Helper to create a QueueItem."""
         return QueueItem(
             id=item_id,
-            path=Path(f"/tmp/{item_id}.txt"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / f"{item_id}.txt",  # noqa: test-hardcoded-paths
             priority=priority,
         )
 

--- a/tests/parallel/test_priority_queue.py
+++ b/tests/parallel/test_priority_queue.py
@@ -22,9 +22,9 @@ class TestQueueItem(unittest.TestCase):
 
     def test_create_with_defaults(self) -> None:
         """Test creating a QueueItem with default values."""
-        item = QueueItem(id="item-1", path=Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
+        item = QueueItem(id="item-1", path=Path("/") / "tmp" / "test.txt")  # noqa: test-hardcoded-paths
         self.assertEqual(item.id, "item-1")
-        self.assertEqual(item.path, Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
+        self.assertEqual(item.path, Path("/") / "tmp" / "test.txt")  # noqa: test-hardcoded-paths
         self.assertEqual(item.priority, 0)
         self.assertEqual(item.metadata, {})
         self.assertIsInstance(item.enqueued_at, float)
@@ -33,7 +33,7 @@ class TestQueueItem(unittest.TestCase):
         """Test creating a QueueItem with all fields specified."""
         item = QueueItem(
             id="item-2",
-            path=Path("/tmp/doc.pdf"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "doc.pdf",  # noqa: test-hardcoded-paths
             priority=5,
             metadata={"type": "document"},
             enqueued_at=100.0,
@@ -44,8 +44,8 @@ class TestQueueItem(unittest.TestCase):
 
     def test_metadata_isolation(self) -> None:
         """Test that default metadata dicts are independent."""
-        item1 = QueueItem(id="a", path=Path("/a"))
-        item2 = QueueItem(id="b", path=Path("/b"))
+        item1 = QueueItem(id="a", path=Path("/") / "a")
+        item2 = QueueItem(id="b", path=Path("/") / "b")
         item1.metadata["key"] = "value"
         self.assertNotIn("key", item2.metadata)
 

--- a/tests/parallel/test_priority_queue_fix.py
+++ b/tests/parallel/test_priority_queue_fix.py
@@ -15,7 +15,7 @@ class TestPriorityQueueFix(unittest.TestCase):
         """
         pq = PriorityQueue()
         item_id = "test_item"
-        item = QueueItem(id=item_id, path=Path("/tmp/test"), priority=10)  # noqa: test-hardcoded-paths
+        item = QueueItem(id=item_id, path=Path("/") / "tmp" / "test", priority=10)  # noqa: test-hardcoded-paths
 
         # 1. Enqueue item with priority 10
         pq.enqueue(item)

--- a/tests/parallel/test_result.py
+++ b/tests/parallel/test_result.py
@@ -88,7 +88,7 @@ class TestFileResult(unittest.TestCase):
 
     def test_result_preserves_path_type(self) -> None:
         """Test that path remains a Path object."""
-        result = FileResult(path=Path("/tmp/file.txt"), success=True)  # noqa: test-hardcoded-paths
+        result = FileResult(path=Path("/") / "tmp" / "file.txt", success=True)  # noqa: test-hardcoded-paths
         self.assertIsInstance(result.path, Path)
 
     def test_result_with_zero_duration(self) -> None:

--- a/tests/parallel/test_resume_coverage.py
+++ b/tests/parallel/test_resume_coverage.py
@@ -107,7 +107,7 @@ class TestResumeJob:
 
         cp = MagicMock(spec=Checkpoint)
         cp.pending_paths = []
-        cp.completed_paths = [Path("/a"), Path("/b")]
+        cp.completed_paths = [Path("/") / "a", Path("/") / "b"]
         mock_checkpoint_mgr.load_checkpoint.return_value = cp
         mock_checkpoint_mgr.has_file_changed.return_value = False
         mock_checkpoint_mgr.create_checkpoint.return_value = cp

--- a/tests/pipeline/test_config.py
+++ b/tests/pipeline/test_config.py
@@ -68,9 +68,9 @@ class TestPipelineConfigValidation:
 
     def test_output_directory_normalized_to_path(self) -> None:
         """Output directory is converted to Path."""
-        config = PipelineConfig(output_directory=Path("/tmp/test"))  # noqa: test-hardcoded-paths
+        config = PipelineConfig(output_directory=Path("/") / "tmp" / "test")  # noqa: test-hardcoded-paths
         assert isinstance(config.output_directory, Path)
-        assert config.output_directory == Path("/tmp/test")  # noqa: test-hardcoded-paths
+        assert config.output_directory == Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
 
     def test_extensions_normalized_with_dots(self) -> None:
         """Extensions without leading dots get them added."""
@@ -165,7 +165,7 @@ class TestPipelineConfigEdgeCases:
         """String output_directory is coerced to Path."""
         config = PipelineConfig(output_directory="/some/path")
         assert isinstance(config.output_directory, Path)
-        assert config.output_directory == Path("/some/path")
+        assert config.output_directory == Path("/") / "some" / "path"
 
     def test_empty_supported_extensions(self) -> None:
         """Empty set of supported extensions means nothing is supported."""

--- a/tests/pipeline/test_orchestrator.py
+++ b/tests/pipeline/test_orchestrator.py
@@ -155,7 +155,7 @@ class TestProcessingResult:
             file_path=Path("test.txt"),
             success=True,
             category="documents",
-            destination=Path("/tmp/organized/documents/test.txt"),  # noqa: test-hardcoded-paths
+            destination=Path("/") / "tmp" / "organized" / "documents" / "test.txt",  # noqa: test-hardcoded-paths
             duration_ms=150.5,
         )
         assert result.success is True
@@ -306,7 +306,7 @@ class TestPipelineProcessFile:
         pipeline_with_mock: PipelineOrchestrator,
     ) -> None:
         """Processing a non-existent file returns failure."""
-        result = pipeline_with_mock.process_file(Path("/nonexistent/file.txt"))
+        result = pipeline_with_mock.process_file(Path("/") / "nonexistent" / "file.txt")
         assert result.success is False
         assert "not found" in result.error.lower()
 

--- a/tests/pipeline/test_orchestrator_branches.py
+++ b/tests/pipeline/test_orchestrator_branches.py
@@ -398,7 +398,7 @@ class TestSafeFileSizeFallback:
     def test_safe_file_size_returns_zero_on_oserror(self) -> None:
         """_safe_file_size returns 0 when stat() raises OSError for a nonexistent path."""
         orch = PipelineOrchestrator()
-        ghost = Path("/nonexistent/totally/made/up.bin")
+        ghost = Path("/") / "nonexistent" / "totally" / "made" / "up.bin"
         size = orch._safe_file_size(ghost)
         assert size == 0
 

--- a/tests/pipeline/test_orchestrator_watch_loop.py
+++ b/tests/pipeline/test_orchestrator_watch_loop.py
@@ -51,7 +51,7 @@ class TestWatchLoop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/test.txt"))]  # noqa: test-hardcoded-paths
+                return [FakeEvent(path=Path("/") / "tmp" / "test.txt")]  # noqa: test-hardcoded-paths
             # Stop the loop
             orch._running = False
             return []
@@ -60,7 +60,7 @@ class TestWatchLoop:
 
         with patch.object(orch, "process_file") as mock_process:
             orch._watch_loop()
-            mock_process.assert_called_once_with(Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
+            mock_process.assert_called_once_with(Path("/") / "tmp" / "test.txt")  # noqa: test-hardcoded-paths
 
     @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require admin on Windows")
     def test_watch_loop_resolves_symlinked_watch_root_for_trusted_root(self, tmp_path: Path):
@@ -115,7 +115,7 @@ class TestWatchLoop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/somedir"), is_directory=True)]  # noqa: test-hardcoded-paths
+                return [FakeEvent(path=Path("/") / "tmp" / "somedir", is_directory=True)]  # noqa: test-hardcoded-paths
             orch._running = False
             return []
 
@@ -142,8 +142,8 @@ class TestWatchLoop:
             call_count += 1
             if call_count == 1:
                 return [
-                    FakeEvent(path=Path("/tmp/vanished.txt")),  # noqa: test-hardcoded-paths
-                    FakeEvent(path=Path("/tmp/exists.txt")),  # noqa: test-hardcoded-paths
+                    FakeEvent(path=Path("/") / "tmp" / "vanished.txt"),  # noqa: test-hardcoded-paths
+                    FakeEvent(path=Path("/") / "tmp" / "exists.txt"),  # noqa: test-hardcoded-paths
                 ]
             orch._running = False
             return []
@@ -180,7 +180,7 @@ class TestWatchLoop:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/bad.txt"))]  # noqa: test-hardcoded-paths
+                return [FakeEvent(path=Path("/") / "tmp" / "bad.txt")]  # noqa: test-hardcoded-paths
             orch._running = False
             return []
 
@@ -233,7 +233,7 @@ class TestWatchLoopExecutor:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [FakeEvent(path=Path("/tmp/test.txt"))]  # noqa: test-hardcoded-paths
+                return [FakeEvent(path=Path("/") / "tmp" / "test.txt")]  # noqa: test-hardcoded-paths
             orch._running = False
             return []
 
@@ -242,7 +242,7 @@ class TestWatchLoopExecutor:
         with patch.object(orch._executor, "submit") as mock_submit:
             orch._watch_loop()
             # submit should have been called with process_file and the path
-            mock_submit.assert_called_once_with(orch.process_file, Path("/tmp/test.txt"))  # noqa: test-hardcoded-paths
+            mock_submit.assert_called_once_with(orch.process_file, Path("/") / "tmp" / "test.txt")  # noqa: test-hardcoded-paths
 
     def test_executor_max_workers_matches_config(self):
         """Executor should be created with max_workers from config.max_concurrent."""

--- a/tests/pipeline/test_router.py
+++ b/tests/pipeline/test_router.py
@@ -223,8 +223,8 @@ class TestFileRouterCustomRules:
             lambda p: "screenshots" in p.parts,
             ProcessorType.IMAGE,
         )
-        assert router.route(Path("screenshots/data.csv")) == ProcessorType.IMAGE
-        assert router.route(Path("documents/data.csv")) == ProcessorType.TEXT
+        assert router.route(Path("screenshots") / "data.csv") == ProcessorType.IMAGE
+        assert router.route(Path("documents") / "data.csv") == ProcessorType.TEXT
 
 
 class TestFileRouterEdgeCases:

--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -51,38 +51,38 @@ class TestStageContext:
 
     def test_rejects_path_traversal_in_category(self) -> None:
         with pytest.raises(ValueError, match="Invalid category"):
-            StageContext(file_path=Path("input/file.txt"), category="../etc")
+            StageContext(file_path=Path("input") / "file.txt", category="../etc")
 
     def test_rejects_path_traversal_in_filename(self) -> None:
         with pytest.raises(ValueError, match="Invalid filename"):
-            StageContext(file_path=Path("input/file.txt"), filename="../../etc/passwd")
+            StageContext(file_path=Path("input") / "file.txt", filename="../../etc/passwd")
 
     def test_rejects_windows_drive_in_category(self) -> None:
         # Regression for #760: "C:" has no slash but still escapes output_dir / category
         # on Windows via PureWindowsPath.drive being non-empty.
         with pytest.raises(ValueError, match="Invalid category"):
-            StageContext(file_path=Path("input/file.txt"), category="C:")
+            StageContext(file_path=Path("input") / "file.txt", category="C:")
 
     def test_rejects_windows_drive_with_path_in_category(self) -> None:
         # Drive-qualified path without a separator also escapes containment.
         with pytest.raises(ValueError, match="Invalid category"):
-            StageContext(file_path=Path("input/file.txt"), category="C:docs")
+            StageContext(file_path=Path("input") / "file.txt", category="C:docs")
 
     def test_rejects_windows_drive_in_filename(self) -> None:
         with pytest.raises(ValueError, match="Invalid filename"):
-            StageContext(file_path=Path("input/file.txt"), filename="C:")
+            StageContext(file_path=Path("input") / "file.txt", filename="C:")
 
     def test_rejects_windows_drive_in_filename_via_setattr(self) -> None:
-        ctx = StageContext(file_path=Path("input/file.txt"))
+        ctx = StageContext(file_path=Path("input") / "file.txt")
         with pytest.raises(ValueError, match="Invalid filename"):
             ctx.filename = "C:evil"
 
     def test_accepts_normal_category(self) -> None:
-        ctx = StageContext(file_path=Path("input/file.txt"), category="Documents")
+        ctx = StageContext(file_path=Path("input") / "file.txt", category="Documents")
         assert ctx.category == "Documents"
 
     def test_accepts_normal_filename(self) -> None:
-        ctx = StageContext(file_path=Path("input/file.txt"), filename="report_2026")
+        ctx = StageContext(file_path=Path("input") / "file.txt", filename="report_2026")
         assert ctx.filename == "report_2026"
 
 
@@ -116,7 +116,7 @@ class TestPreprocessorStage:
         assert result.filename == "hello"
 
     def test_file_not_found(self) -> None:
-        ctx = StageContext(file_path=Path("nonexistent/file.txt"))
+        ctx = StageContext(file_path=Path("nonexistent") / "file.txt")
         result = PreprocessorStage().process(ctx)
         assert result.failed
         assert result.error is not None
@@ -234,7 +234,7 @@ class TestPostprocessorStage:
     def test_builds_destination(self, tmp_path: Path) -> None:
         stage = PostprocessorStage(output_directory=tmp_path / "out")
         ctx = StageContext(
-            file_path=Path("input/report.pdf"),
+            file_path=Path("input") / "report.pdf",
             category="Documents",
             filename="quarterly_report",
         )
@@ -244,7 +244,7 @@ class TestPostprocessorStage:
 
     def test_defaults_to_uncategorized(self, tmp_path: Path) -> None:
         stage = PostprocessorStage(output_directory=tmp_path / "out")
-        ctx = StageContext(file_path=Path("input/file.txt"))
+        ctx = StageContext(file_path=Path("input") / "file.txt")
         result = stage.process(ctx)
 
         assert "uncategorized" in str(result.destination)
@@ -256,7 +256,7 @@ class TestPostprocessorStage:
 
         stage = PostprocessorStage(output_directory=tmp_path / "out")
         ctx = StageContext(
-            file_path=Path("input/file.txt"),
+            file_path=Path("input") / "file.txt",
             category="Docs",
             filename="file",
         )
@@ -277,7 +277,7 @@ class TestPostprocessorStage:
         out = tmp_path / "out"
         stage = PostprocessorStage(output_directory=out)
         ctx = StageContext(
-            file_path=Path("input/report.pdf"),
+            file_path=Path("input") / "report.pdf",
             category="Documents",
             filename="q3",
         )
@@ -286,7 +286,7 @@ class TestPostprocessorStage:
         assert result.output_root == out
         assert result.destination is not None
         # destination is reachable as a relative path under output_root
-        assert result.destination.relative_to(result.output_root) == Path("Documents/q3.pdf")
+        assert result.destination.relative_to(result.output_root) == Path("Documents") / "q3.pdf"
 
 
 # ---------------------------------------------------------------------------
@@ -417,7 +417,7 @@ class TestWriterStage:
     def test_skips_when_already_failed(self) -> None:
         ctx = StageContext(
             file_path=Path("x.txt"),
-            destination=Path("out/x.txt"),
+            destination=Path("out") / "x.txt",
             error="prior",
             dry_run=False,
         )

--- a/tests/plugins/test_executor_coverage.py
+++ b/tests/plugins/test_executor_coverage.py
@@ -18,24 +18,24 @@ pytestmark = pytest.mark.unit
 
 class TestPluginExecutorInit:
     def test_default_name_from_path(self):
-        executor = PluginExecutor(plugin_path=Path("/plugins/my_plugin.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "plugins" / "my_plugin.py")
         assert executor._plugin_name == "my_plugin"
 
     def test_custom_name(self):
         executor = PluginExecutor(
-            plugin_path=Path("/plugins/foo.py"),
+            plugin_path=Path("/") / "plugins" / "foo.py",
             plugin_name="custom",
         )
         assert executor._plugin_name == "custom"
 
     def test_default_policy_is_unrestricted(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         assert executor._policy.allow_all_paths is True
 
 
 class TestPluginExecutorStart:
     def test_start_noop_when_already_started(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor._proc = MagicMock()
         executor.start()
         # Should not spawn another process
@@ -45,7 +45,7 @@ class TestPluginExecutorStart:
         mock_proc = MagicMock()
         mock_popen.return_value = mock_proc
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         executor.start()
 
         mock_popen.assert_called_once()
@@ -55,14 +55,14 @@ class TestPluginExecutorStart:
     def test_start_raises_plugin_load_error_on_os_error(self, mock_popen):
         mock_popen.side_effect = OSError("no such file")
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         with pytest.raises(PluginLoadError, match="Failed to spawn worker"):
             executor.start()
 
 
 class TestPluginExecutorStop:
     def test_stop_noop_when_not_started(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor.stop()
         assert executor._proc is None
 
@@ -73,7 +73,7 @@ class TestPluginExecutorStop:
         mock_proc.stdout = MagicMock()
         mock_proc.stderr = MagicMock()
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor._proc = mock_proc
 
         executor.stop()
@@ -88,7 +88,7 @@ class TestPluginExecutorStop:
         mock_proc.stdout = MagicMock()
         mock_proc.stderr = MagicMock()
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor._proc = mock_proc
 
         executor.stop()
@@ -105,7 +105,7 @@ class TestPluginExecutorStop:
         mock_proc.stdout = MagicMock()
         mock_proc.stderr = MagicMock()
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor._proc = mock_proc
 
         # Should not raise
@@ -123,7 +123,7 @@ class TestPluginExecutorContextManager:
         mock_proc.stderr = MagicMock()
         mock_popen.return_value = mock_proc
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         with executor as ex:
             assert ex is executor
             assert executor._proc is not None
@@ -133,12 +133,12 @@ class TestPluginExecutorContextManager:
 
 class TestPluginExecutorCall:
     def test_call_raises_when_not_started(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         with pytest.raises(RuntimeError, match="not started"):
             executor.call("on_load")
 
     def test_call_raises_when_pipes_closed(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         executor._proc = MagicMock()
         executor._proc.stdin = None
         executor._proc.stdout = None
@@ -147,7 +147,7 @@ class TestPluginExecutorCall:
             executor.call("on_load")
 
     def test_call_raises_on_broken_pipe(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         mock_proc = MagicMock()
         mock_proc.stdin.write.side_effect = BrokenPipeError("broken")
         executor._proc = mock_proc
@@ -158,7 +158,7 @@ class TestPluginExecutorCall:
     @patch.object(PluginExecutor, "_readline_with_timeout")
     def test_call_raises_on_empty_response(self, mock_readline):
         mock_readline.return_value = b""
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         mock_proc = MagicMock()
         mock_proc.stderr.read.return_value = b"error output"
         executor._proc = mock_proc
@@ -172,7 +172,7 @@ class TestPluginExecutorCall:
         mock_readline.return_value = b"bad json\n"
         mock_decode.side_effect = ValueError("invalid")
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         executor._proc = MagicMock()
 
         with pytest.raises(PluginError, match="Corrupt IPC response"):
@@ -184,7 +184,7 @@ class TestPluginExecutorCall:
         mock_readline.return_value = b'{"ok":true}\n'
         mock_decode.return_value = PluginResult(success=True, return_value=42)
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         executor._proc = MagicMock()
 
         result = executor.call("method")
@@ -196,7 +196,7 @@ class TestPluginExecutorCall:
         mock_readline.return_value = b'{"ok":false}\n'
         mock_decode.return_value = PluginResult(success=False, error="something went wrong")
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         executor._proc = MagicMock()
 
         with pytest.raises(PluginError, match="raised an error"):
@@ -208,7 +208,7 @@ class TestPluginExecutorCall:
         mock_readline.return_value = b'{"ok":false}\n'
         mock_decode.return_value = PluginResult(success=False, error="init failed")
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"), plugin_name="test")
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py", plugin_name="test")
         executor._proc = MagicMock()
 
         with pytest.raises(PluginLoadError, match="raised an error"):
@@ -217,14 +217,14 @@ class TestPluginExecutorCall:
 
 class TestReadlineWithTimeout:
     def test_raises_when_proc_none(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor._proc = None
 
         with pytest.raises(PluginError, match="not running"):
             executor._readline_with_timeout()
 
     def test_raises_when_stdout_none(self):
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         executor._proc = MagicMock()
         executor._proc.stdout = None
 
@@ -234,7 +234,7 @@ class TestReadlineWithTimeout:
     @patch("file_organizer.plugins.executor.sys")
     def test_windows_timeout_raises(self, mock_sys):
         mock_sys.platform = "win32"
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         mock_proc = MagicMock()
         mock_stdout = MagicMock()
 
@@ -260,7 +260,7 @@ class TestReadlineWithTimeout:
         mock_sys.platform = "linux"
         mock_select.return_value = ([], [], [])
 
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         mock_proc = MagicMock()
         executor._proc = mock_proc
 
@@ -271,7 +271,7 @@ class TestReadlineWithTimeout:
     @patch("file_organizer.plugins.executor.select.select")
     def test_unix_success(self, mock_select, mock_sys):
         mock_sys.platform = "linux"
-        executor = PluginExecutor(plugin_path=Path("/x.py"))
+        executor = PluginExecutor(plugin_path=Path("/") / "x.py")
         mock_proc = MagicMock()
         mock_proc.stdout.readline.return_value = b"data\n"
         executor._proc = mock_proc

--- a/tests/plugins/test_lifecycle_coverage.py
+++ b/tests/plugins/test_lifecycle_coverage.py
@@ -23,7 +23,7 @@ def _make_record(name: str = "demo") -> PluginRecord:
     return PluginRecord(
         name=name,
         version="1.0.0",
-        plugin_dir=Path("/fake"),
+        plugin_dir=Path("/") / "fake",
         policy=MagicMock(),
         manifest={"name": name, "version": "1.0.0"},
         executor=executor,
@@ -46,10 +46,10 @@ class TestLifecycleLoad:
         registry.load_plugin.return_value = record
 
         mgr = PluginLifecycleManager(registry)
-        result = mgr.load(Path("/fake"), policy=None)
+        result = mgr.load(Path("/") / "fake", policy=None)
 
         assert result is record
-        registry.load_plugin.assert_called_once_with(Path("/fake"), policy=None)
+        registry.load_plugin.assert_called_once_with(Path("/") / "fake", policy=None)
         assert mgr.get_state(record.name) == PluginState.LOADED
 
     def test_load_with_explicit_policy(self):
@@ -59,8 +59,8 @@ class TestLifecycleLoad:
         policy = MagicMock()
 
         mgr = PluginLifecycleManager(registry)
-        mgr.load(Path("/p"), policy=policy)
-        registry.load_plugin.assert_called_once_with(Path("/p"), policy=policy)
+        mgr.load(Path("/") / "p", policy=policy)
+        registry.load_plugin.assert_called_once_with(Path("/") / "p", policy=policy)
 
 
 class TestLifecycleEnable:

--- a/tests/plugins/test_plugin_executor_comprehensive.py
+++ b/tests/plugins/test_plugin_executor_comprehensive.py
@@ -43,15 +43,15 @@ class TestExecutorInit:
     """Tests for PluginExecutor.__init__."""
 
     def test_default_name_from_path(self) -> None:
-        ex = PluginExecutor(plugin_path=Path("foo/bar/my_plugin.py"))
+        ex = PluginExecutor(plugin_path=Path("foo") / "bar" / "my_plugin.py")
         assert ex._plugin_name == "my_plugin"
 
     def test_explicit_name(self) -> None:
-        ex = PluginExecutor(plugin_path=Path("foo/plugin.py"), plugin_name="custom")
+        ex = PluginExecutor(plugin_path=Path("foo") / "plugin.py", plugin_name="custom")
         assert ex._plugin_name == "custom"
 
     def test_default_policy_is_unrestricted(self) -> None:
-        ex = PluginExecutor(plugin_path=Path("foo/plugin.py"))
+        ex = PluginExecutor(plugin_path=Path("foo") / "plugin.py")
         assert ex._policy.allow_all_paths is True
         assert ex._policy.allow_all_operations is True
 

--- a/tests/plugins/test_plugin_lifecycle_state_machine.py
+++ b/tests/plugins/test_plugin_lifecycle_state_machine.py
@@ -69,7 +69,7 @@ class TestHappyPathTransitions:
         registry.load_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        result = mgr.load(Path("fake/plugin"))
+        result = mgr.load(Path("fake") / "plugin")
         assert result is record
         assert mgr.get_state(record.name) == PluginState.LOADED
 
@@ -80,7 +80,7 @@ class TestHappyPathTransitions:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         mgr.enable(record.name)
         assert mgr.get_state(record.name) == PluginState.ENABLED
         record.executor.call.assert_called_with("on_enable")
@@ -92,7 +92,7 @@ class TestHappyPathTransitions:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         mgr.enable(record.name)
         mgr.disable(record.name)
         assert mgr.get_state(record.name) == PluginState.DISABLED
@@ -105,7 +105,7 @@ class TestHappyPathTransitions:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         mgr.unload(record.name)
         assert mgr.get_state(record.name) == PluginState.UNLOADED
         registry.unload_plugin.assert_called_once_with(record.name)
@@ -126,7 +126,7 @@ class TestEnableIdempotency:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         mgr.enable(record.name)
         record.executor.call.reset_mock()
 
@@ -149,7 +149,7 @@ class TestDisableGuards:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         mgr.disable(record.name)  # Not enabled, should be no-op
         record.executor.call.assert_not_called()
 
@@ -170,7 +170,7 @@ class TestErrorState:
         record.executor.call.side_effect = RuntimeError("enable boom")
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         with pytest.raises(PluginLifecycleError, match="Failed to enable"):
             mgr.enable(record.name)
         assert mgr.get_state(record.name) == PluginState.ERROR
@@ -182,7 +182,7 @@ class TestErrorState:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         # First enable succeeds
         mgr.enable(record.name)
         # Now make disable fail
@@ -207,7 +207,7 @@ class TestUnloadAutoDisable:
         registry.get_plugin.return_value = record
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         mgr.enable(record.name)
 
         # Track calls to executor
@@ -226,7 +226,7 @@ class TestUnloadAutoDisable:
         registry.unload_plugin.side_effect = RuntimeError("unload boom")
         mgr = PluginLifecycleManager(registry)
 
-        mgr.load(Path("fake/plugin"))
+        mgr.load(Path("fake") / "plugin")
         with pytest.raises(PluginLifecycleError, match="Failed to unload"):
             mgr.unload(record.name)
         # State should be cleaned up (popped)

--- a/tests/plugins/test_registry_coverage.py
+++ b/tests/plugins/test_registry_coverage.py
@@ -127,7 +127,7 @@ class TestRegistryUnloadPlugin:
         record = PluginRecord(
             name="demo",
             version="1.0",
-            plugin_dir=Path("/fake"),
+            plugin_dir=Path("/") / "fake",
             policy=MagicMock(),
             manifest={},
             executor=executor,
@@ -147,7 +147,7 @@ class TestRegistryUnloadPlugin:
         record = PluginRecord(
             name="demo",
             version="1.0",
-            plugin_dir=Path("/fake"),
+            plugin_dir=Path("/") / "fake",
             policy=MagicMock(),
             manifest={},
             executor=executor,
@@ -167,7 +167,7 @@ class TestRegistryEnableDisable:
         record = PluginRecord(
             name="demo",
             version="1.0",
-            plugin_dir=Path("/fake"),
+            plugin_dir=Path("/") / "fake",
             policy=MagicMock(),
             manifest={},
             executor=executor,
@@ -183,7 +183,7 @@ class TestRegistryEnableDisable:
         record = PluginRecord(
             name="demo",
             version="1.0",
-            plugin_dir=Path("/fake"),
+            plugin_dir=Path("/") / "fake",
             policy=MagicMock(),
             manifest={},
             executor=executor,

--- a/tests/services/analytics/test_analytics_service.py
+++ b/tests/services/analytics/test_analytics_service.py
@@ -121,7 +121,7 @@ class TestGetStorageStats:
 
     def test_delegates_to_storage_analyzer(self, mock_service, mock_storage_analyzer):
         """Test that get_storage_stats delegates to storage analyzer."""
-        directory = Path("/fake/dir")
+        directory = Path("/") / "fake" / "dir"
         result = mock_service.get_storage_stats(directory)
 
         mock_storage_analyzer.analyze_directory.assert_called_once_with(directory, None)
@@ -130,7 +130,7 @@ class TestGetStorageStats:
 
     def test_passes_max_depth(self, mock_service, mock_storage_analyzer):
         """Test that max_depth parameter is forwarded."""
-        directory = Path("/fake/dir")
+        directory = Path("/") / "fake" / "dir"
         mock_service.get_storage_stats(directory, max_depth=2)
 
         mock_storage_analyzer.analyze_directory.assert_called_once_with(directory, 2)
@@ -475,7 +475,7 @@ class TestGenerateDashboard:
 
     def test_dashboard_with_mocked_deps(self, mock_service, mock_storage_analyzer):
         """Test dashboard generation with mocked dependencies."""
-        directory = Path("/fake/dir")
+        directory = Path("/") / "fake" / "dir"
 
         # Need to mock rglob for quality metrics
         with patch.object(Path, "rglob", return_value=iter([])):

--- a/tests/services/analytics/test_storage_analyzer.py
+++ b/tests/services/analytics/test_storage_analyzer.py
@@ -53,7 +53,7 @@ class TestStorageAnalyzer:
         analyzer = StorageAnalyzer()
 
         with pytest.raises(ValueError, match="Invalid directory"):
-            analyzer.analyze_directory(Path("/nonexistent/path"))
+            analyzer.analyze_directory(Path("/") / "nonexistent" / "path")
 
     def test_analyze_file_instead_of_directory(self, temp_directory):
         """Test error handling when given a file instead of directory."""

--- a/tests/services/audio/test_audio_integration.py
+++ b/tests/services/audio/test_audio_integration.py
@@ -55,7 +55,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata."""
     return AudioMetadata(
-        file_path=file_path or Path("/tmp/test.mp3"),  # noqa: test-hardcoded-paths
+        file_path=file_path or Path("/") / "tmp" / "test.mp3",  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_audio_organizer_coverage.py
+++ b/tests/services/audio/test_audio_organizer_coverage.py
@@ -210,8 +210,8 @@ class TestOrganize:
         result = OrganizationResult()
         result.failed_files.append(
             FileMove(
-                source=Path("/a.mp3"),
-                destination=Path("/b.mp3"),
+                source=Path("/") / "a.mp3",
+                destination=Path("/") / "b.mp3",
                 audio_type=AudioType.MUSIC,
                 success=False,
                 error="Permission denied",

--- a/tests/services/audio/test_audio_transcriber_service.py
+++ b/tests/services/audio/test_audio_transcriber_service.py
@@ -202,12 +202,12 @@ class TestAudioTranscriberInit:
                 model_size=ModelSize.LARGE_V3,
                 device="cpu",
                 compute_type=ComputeType.FLOAT32,
-                cache_dir=Path("/tmp/cache"),  # noqa: test-hardcoded-paths
+                cache_dir=Path("/") / "tmp" / "cache",  # noqa: test-hardcoded-paths
                 num_workers=4,
             )
         assert t.model_size == ModelSize.LARGE_V3
         assert t.compute_type == ComputeType.FLOAT32
-        assert t.cache_dir == Path("/tmp/cache")  # noqa: test-hardcoded-paths
+        assert t.cache_dir == Path("/") / "tmp" / "cache"  # noqa: test-hardcoded-paths
         assert t.num_workers == 4
 
 

--- a/tests/services/audio/test_classifier.py
+++ b/tests/services/audio/test_classifier.py
@@ -57,7 +57,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata with sensible defaults."""
     return AudioMetadata(
-        file_path=Path("/tmp/test_audio.mp3"),  # noqa: test-hardcoded-paths
+        file_path=Path("/") / "tmp" / "test_audio.mp3",  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_content_analyzer.py
+++ b/tests/services/audio/test_content_analyzer.py
@@ -46,7 +46,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata with sensible defaults."""
     return AudioMetadata(
-        file_path=Path("/tmp/test_audio.mp3"),  # noqa: test-hardcoded-paths
+        file_path=Path("/") / "tmp" / "test_audio.mp3",  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_organizer.py
+++ b/tests/services/audio/test_organizer.py
@@ -56,7 +56,7 @@ def _make_metadata(
 ) -> AudioMetadata:
     """Helper to create AudioMetadata with sensible defaults."""
     return AudioMetadata(
-        file_path=file_path or Path("/tmp/test_audio.mp3"),  # noqa: test-hardcoded-paths
+        file_path=file_path or Path("/") / "tmp" / "test_audio.mp3",  # noqa: test-hardcoded-paths
         file_size=5_000_000,
         format="MP3",
         duration=duration,

--- a/tests/services/audio/test_utils_branches.py
+++ b/tests/services/audio/test_utils_branches.py
@@ -548,7 +548,7 @@ class TestIsAudioFileBranches:
         """Only the filename suffix matters; an audio extension in the dir name is ignored."""
         # The directory has .mp3 in name but the file has .txt extension
         # is_audio_file uses suffix of the full path, so it checks the last component
-        p = Path("/audio.mp3/actual_file.txt")
+        p = Path("/") / "audio.mp3" / "actual_file.txt"
         assert is_audio_file(p) is False
 
 

--- a/tests/services/auto_tagging/test_content_analyzer_coverage.py
+++ b/tests/services/auto_tagging/test_content_analyzer_coverage.py
@@ -23,7 +23,7 @@ def analyzer():
 
 class TestAnalyzeFile:
     def test_nonexistent_file(self, analyzer):
-        result = analyzer.analyze_file(Path("nonexistent/file.txt"))
+        result = analyzer.analyze_file(Path("nonexistent") / "file.txt")
         assert result == []
 
     def test_text_file(self, analyzer, tmp_path):
@@ -56,7 +56,7 @@ class TestAnalyzeFile:
 
 class TestExtractKeywords:
     def test_nonexistent_file(self, analyzer):
-        assert analyzer.extract_keywords(Path("no/such.txt")) == []
+        assert analyzer.extract_keywords(Path("no") / "such.txt") == []
 
     def test_non_text_file(self, analyzer, tmp_path):
         f = tmp_path / "binary.bin"
@@ -100,7 +100,7 @@ class TestExtractKeywords:
 
 class TestExtractEntities:
     def test_nonexistent_file(self, analyzer):
-        assert analyzer.extract_entities(Path("no/such.txt")) == []
+        assert analyzer.extract_entities(Path("no") / "such.txt") == []
 
     def test_non_text_file(self, analyzer, tmp_path):
         f = tmp_path / "img.jpg"
@@ -147,7 +147,7 @@ class TestBatchAnalyze:
     def test_batch_with_error(self, analyzer, tmp_path):
         f1 = tmp_path / "good.txt"
         f1.write_text("content")
-        f2 = Path("nonexistent/bad.txt")
+        f2 = Path("nonexistent") / "bad.txt"
         results = analyzer.batch_analyze([f1, f2])
         assert f1 in results
         assert f2 in results
@@ -219,7 +219,7 @@ class TestExtractFromMetadata:
         assert "small" in tags
 
     def test_nonexistent_file(self, analyzer):
-        tags = analyzer._extract_from_metadata(Path("no/such/file"))
+        tags = analyzer._extract_from_metadata(Path("no") / "such" / "file")
         assert tags == []
 
 

--- a/tests/services/auto_tagging/test_tag_recommender_coverage.py
+++ b/tests/services/auto_tagging/test_tag_recommender_coverage.py
@@ -57,7 +57,7 @@ class TestTagRecommendation:
             TagSuggestion("b", 50, "content", "x"),
             TagSuggestion("c", 75, "content", "x"),
         ]
-        rec = TagRecommendation(file_path=Path("tmp/f.txt"), suggestions=suggestions)
+        rec = TagRecommendation(file_path=Path("tmp") / "f.txt", suggestions=suggestions)
         high = rec.get_high_confidence_tags()
         assert "a" in high
         assert "c" in high
@@ -69,7 +69,7 @@ class TestTagRecommendation:
             TagSuggestion("b", 50, "content", "x"),
             TagSuggestion("c", 30, "content", "x"),
         ]
-        rec = TagRecommendation(file_path=Path("tmp/f.txt"), suggestions=suggestions)
+        rec = TagRecommendation(file_path=Path("tmp") / "f.txt", suggestions=suggestions)
         medium = rec.get_medium_confidence_tags()
         assert "b" in medium
         assert "a" not in medium
@@ -78,7 +78,7 @@ class TestTagRecommendation:
     def test_to_dict(self):
         suggestions = [TagSuggestion("a", 90, "content", "x")]
         rec = TagRecommendation(
-            file_path=Path("tmp/f.txt"),
+            file_path=Path("tmp") / "f.txt",
             suggestions=suggestions,
             existing_tags=["old"],
         )
@@ -110,7 +110,7 @@ class TestRecommendTags:
 
     def test_nonexistent_file(self):
         rec = self._make_recommender()
-        result = rec.recommend_tags(Path("nonexistent/file.txt"))
+        result = rec.recommend_tags(Path("nonexistent") / "file.txt")
         assert len(result.suggestions) == 0
 
     def test_recommend_content_only(self, tmp_path):

--- a/tests/services/deduplication/test_dedup_backup.py
+++ b/tests/services/deduplication/test_dedup_backup.py
@@ -123,7 +123,7 @@ class TestCreateBackup:
 
     def test_file_not_found(self, manager):
         with pytest.raises(FileNotFoundError, match="Source file not found"):
-            manager.create_backup(Path("/nonexistent/file.txt"))
+            manager.create_backup(Path("/") / "nonexistent" / "file.txt")
 
     def test_not_a_file(self, manager, tmp_path):
         with pytest.raises(ValueError, match="not a file"):
@@ -168,7 +168,7 @@ class TestRestoreBackup:
 
     def test_backup_not_found(self, manager):
         with pytest.raises(FileNotFoundError, match="Backup file not found"):
-            manager.restore_backup(Path("/nonexistent/backup.txt"))
+            manager.restore_backup(Path("/") / "nonexistent" / "backup.txt")
 
     def test_backup_not_in_manifest(self, manager, tmp_path):
         fake_backup = tmp_path / "fake_backup.txt"
@@ -239,7 +239,7 @@ class TestGetBackupInfo:
         assert "original_path" in info
 
     def test_nonexistent_backup(self, manager):
-        info = manager.get_backup_info(Path("/nonexistent/backup.txt"))
+        info = manager.get_backup_info(Path("/") / "nonexistent" / "backup.txt")
         assert info is None
 
 

--- a/tests/services/deduplication/test_dedup_backup_coverage.py
+++ b/tests/services/deduplication/test_dedup_backup_coverage.py
@@ -37,7 +37,7 @@ class TestCreateBackup:
 
     def test_backup_nonexistent_raises(self, bm):
         with pytest.raises(FileNotFoundError):
-            bm.create_backup(Path("no/such/file.txt"))
+            bm.create_backup(Path("no") / "such" / "file.txt")
 
     def test_backup_directory_raises(self, bm, tmp_path):
         d = tmp_path / "adir"
@@ -74,7 +74,7 @@ class TestRestoreBackup:
 
     def test_restore_nonexistent_backup(self, bm):
         with pytest.raises(FileNotFoundError):
-            bm.restore_backup(Path("no/such/backup.txt"))
+            bm.restore_backup(Path("no") / "such" / "backup.txt")
 
     def test_restore_not_in_manifest(self, bm, tmp_path):
         f = tmp_path / "rogue.txt"

--- a/tests/services/deduplication/test_dedup_detector.py
+++ b/tests/services/deduplication/test_dedup_detector.py
@@ -88,7 +88,7 @@ class TestDuplicateDetector(unittest.TestCase):
         """Test scanning non-existent directory."""
         detector = DuplicateDetector()
         with self.assertRaises(ValueError):
-            detector.scan_directory(Path("/nonexistent_path_xyz"))
+            detector.scan_directory(Path("/") / "nonexistent_path_xyz")
 
     def test_scan_directory_not_a_dir(self):
         """Test scanning a file instead of directory."""
@@ -271,7 +271,7 @@ class TestDuplicateDetector(unittest.TestCase):
         """Test find_duplicates_of_file raises for missing file."""
         detector = DuplicateDetector()
         with self.assertRaises(FileNotFoundError):
-            detector.find_duplicates_of_file(Path("/nonexistent.txt"), self.test_dir)
+            detector.find_duplicates_of_file(Path("/") / "nonexistent.txt", self.test_dir)
 
     def test_find_duplicates_of_file_success(self):
         """Test find_duplicates_of_file with real files."""

--- a/tests/services/deduplication/test_dedup_embedder.py
+++ b/tests/services/deduplication/test_dedup_embedder.py
@@ -360,7 +360,7 @@ class TestModelPersistence:
     def test_load_nonexistent_raises(self, embedder):
         """load_model raises an error when the model file does not exist."""
         with pytest.raises((FileNotFoundError, OSError, ValueError)):
-            embedder.load_model(Path("/nonexistent/model.pkl"))
+            embedder.load_model(Path("/") / "nonexistent" / "model.pkl")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/deduplication/test_dedup_extractor.py
+++ b/tests/services/deduplication/test_dedup_extractor.py
@@ -154,7 +154,7 @@ class TestExtractText:
 
     def test_file_not_found(self, extractor):
         with pytest.raises(OSError, match="File not found"):
-            extractor.extract_text(Path("/nonexistent/file.txt"))
+            extractor.extract_text(Path("/") / "nonexistent" / "file.txt")
 
     def test_unsupported_format_raises(self, extractor, tmp_path):
         p = tmp_path / "photo.jpg"
@@ -367,7 +367,7 @@ class TestExtractBatch:
     def test_extract_batch_with_errors(self, extractor, tmp_path):
         good = tmp_path / "good.txt"
         good.write_text("Good text", encoding="utf-8")
-        bad = Path("/nonexistent/bad.txt")
+        bad = Path("/") / "nonexistent" / "bad.txt"
 
         results = extractor.extract_batch([good, bad])
         assert len(results) == 2

--- a/tests/services/deduplication/test_dedup_extractor_coverage.py
+++ b/tests/services/deduplication/test_dedup_extractor_coverage.py
@@ -25,7 +25,7 @@ def extractor():
 class TestExtractText:
     def test_nonexistent_file_raises(self, extractor):
         with pytest.raises(OSError, match="File not found"):
-            extractor.extract_text(Path("/no/such/file.pdf"))
+            extractor.extract_text(Path("/") / "no" / "such" / "file.pdf")
 
     def test_unsupported_format_raises(self, extractor, tmp_path):
         f = tmp_path / "file.xyz"

--- a/tests/services/deduplication/test_dedup_image_utils.py
+++ b/tests/services/deduplication/test_dedup_image_utils.py
@@ -197,7 +197,7 @@ class TestGetImageMetadata:
     """Tests for get_image_metadata."""
 
     def test_nonexistent_file(self):
-        result = get_image_metadata(Path("/nonexistent/img.png"))
+        result = get_image_metadata(Path("/") / "nonexistent" / "img.png")
         assert result is None
 
     def test_successful_extraction(self, tmp_path):
@@ -332,7 +332,7 @@ class TestValidateImageFile:
     """Tests for validate_image_file."""
 
     def test_file_not_found(self):
-        is_valid, msg = validate_image_file(Path("/nonexistent/img.png"))
+        is_valid, msg = validate_image_file(Path("/") / "nonexistent" / "img.png")
         assert not is_valid
         assert "not found" in msg
 
@@ -420,7 +420,7 @@ class TestFindImagesInDirectory:
 
     def test_nonexistent_dir(self):
         with pytest.raises(FileNotFoundError):
-            find_images_in_directory(Path("/nonexistent"))
+            find_images_in_directory(Path("/") / "nonexistent")
 
     def test_not_a_directory(self, tmp_path):
         p = tmp_path / "file.txt"

--- a/tests/services/deduplication/test_dedup_reporter.py
+++ b/tests/services/deduplication/test_dedup_reporter.py
@@ -137,7 +137,7 @@ class TestStorageReporter(unittest.TestCase):
 
     def test_export_to_csv_error(self):
         """Test CSV export with invalid path raises."""
-        bad_path = Path("/nonexistent_dir/subdir/report.csv")
+        bad_path = Path("/") / "nonexistent_dir" / "subdir" / "report.csv"
         with self.assertRaises(OSError):
             self.reporter.export_to_csv(self.sample_groups, bad_path)
 
@@ -153,7 +153,7 @@ class TestStorageReporter(unittest.TestCase):
 
     def test_export_to_json_error(self):
         """Test JSON export with invalid path raises."""
-        bad_path = Path("/nonexistent_dir/subdir/report.json")
+        bad_path = Path("/") / "nonexistent_dir" / "subdir" / "report.json"
         with self.assertRaises(OSError):
             self.reporter.export_to_json(self.sample_results, bad_path)
 

--- a/tests/services/deduplication/test_dedup_semantic.py
+++ b/tests/services/deduplication/test_dedup_semantic.py
@@ -51,10 +51,10 @@ def sample_embeddings():
 def sample_paths():
     """Create sample file paths."""
     return [
-        Path("/docs/a.txt"),
-        Path("/docs/b.txt"),
-        Path("/docs/c.txt"),
-        Path("/docs/d.txt"),
+        Path("/") / "docs" / "a.txt",
+        Path("/") / "docs" / "b.txt",
+        Path("/") / "docs" / "c.txt",
+        Path("/") / "docs" / "d.txt",
     ]
 
 

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -47,7 +47,7 @@ def viewer(console: Console) -> ComparisonViewer:
 def sample_metadata() -> ImageMetadata:
     """Return a representative ImageMetadata object."""
     return ImageMetadata(
-        path=Path("/tmp/image1.png"),  # noqa: test-hardcoded-paths
+        path=Path("/") / "tmp" / "image1.png",  # noqa: test-hardcoded-paths
         width=1920,
         height=1080,
         format="PNG",
@@ -61,7 +61,7 @@ def sample_metadata() -> ImageMetadata:
 def sample_metadata_small() -> ImageMetadata:
     """Return a smaller / lower-quality ImageMetadata object."""
     return ImageMetadata(
-        path=Path("/tmp/image2.jpg"),  # noqa: test-hardcoded-paths
+        path=Path("/") / "tmp" / "image2.jpg",  # noqa: test-hardcoded-paths
         width=640,
         height=480,
         format="JPEG",
@@ -148,8 +148,8 @@ class TestDuplicateReview:
         assert review.skipped is True
 
     def test_keep_and_delete_lists(self):
-        k = [Path("/a")]
-        d = [Path("/b"), Path("/c")]
+        k = [Path("/") / "a"]
+        d = [Path("/") / "b", Path("/") / "c"]
         review = DuplicateReview(files_to_keep=k, files_to_delete=d)
         assert review.files_to_keep == k
         assert review.files_to_delete == d
@@ -196,7 +196,9 @@ class TestShowComparison:
     def test_all_images_fail_to_load(self, viewer: ComparisonViewer):
         """When every image fails to load, result is skipped."""
         with patch.object(viewer, "_get_image_metadata", side_effect=ValueError("bad")):
-            result = viewer.show_comparison([Path("/fake/a.png"), Path("/fake/b.png")])
+            result = viewer.show_comparison(
+                [Path("/") / "fake" / "a.png", Path("/") / "fake" / "b.png"]
+            )
         assert result.skipped is True
 
     def test_delegates_to_prompt_and_process(self, viewer: ComparisonViewer, sample_metadata):
@@ -212,7 +214,9 @@ class TestShowComparison:
                 return_value=DuplicateReview([sample_metadata.path], []),
             ) as mock_process,
         ):
-            result = viewer.show_comparison([Path("/tmp/image1.png")], similarity_score=95.0)  # noqa: test-hardcoded-paths
+            result = viewer.show_comparison(
+                [Path("/") / "tmp" / "image1.png"], similarity_score=95.0
+            )  # noqa: test-hardcoded-paths
             assert result.files_to_keep == [sample_metadata.path]
             mock_process.assert_called_once()
 
@@ -238,7 +242,7 @@ class TestShowComparison:
                 return_value=DuplicateReview([], [], skipped=True),
             ),
         ):
-            result = viewer.show_comparison([Path("/a.png"), Path("/b.png")])
+            result = viewer.show_comparison([Path("/") / "a.png", Path("/") / "b.png"])
             assert result.skipped is True
 
 
@@ -258,22 +262,22 @@ class TestBatchReview:
             patch.object(viewer, "_auto_select_best", return_value=review) as mock_auto,
             patch.object(viewer, "_display_review_summary"),
         ):
-            groups = {"hash1": [Path("/a.png"), Path("/b.png")]}
+            groups = {"hash1": [Path("/") / "a.png", Path("/") / "b.png"]}
             decisions = viewer.batch_review(groups, auto_select_best=True)
             mock_auto.assert_called_once()
             assert decisions[sample_metadata.path] == "keep"
 
     def test_manual_review_mode(self, viewer: ComparisonViewer, sample_metadata):
         """auto_select_best=False uses show_comparison."""
-        review = DuplicateReview([sample_metadata.path], [Path("/tmp/image2.jpg")])  # noqa: test-hardcoded-paths
+        review = DuplicateReview([sample_metadata.path], [Path("/") / "tmp" / "image2.jpg"])  # noqa: test-hardcoded-paths
         with (
             patch.object(viewer, "show_comparison", return_value=review),
             patch.object(viewer, "_display_review_summary"),
         ):
-            groups = {"hash1": [Path("/a.png"), Path("/b.png")]}
+            groups = {"hash1": [Path("/") / "a.png", Path("/") / "b.png"]}
             decisions = viewer.batch_review(groups, auto_select_best=False)
             assert decisions[sample_metadata.path] == "keep"
-            assert decisions[Path("/tmp/image2.jpg")] == "delete"  # noqa: test-hardcoded-paths
+            assert decisions[Path("/") / "tmp" / "image2.jpg"] == "delete"  # noqa: test-hardcoded-paths
 
     def test_quit_early_via_confirm(self, viewer: ComparisonViewer):
         """When user skips and declines continue, batch stops."""
@@ -283,7 +287,7 @@ class TestBatchReview:
             patch("file_organizer.services.deduplication.viewer.Confirm.ask", return_value=False),
             patch.object(viewer, "_display_review_summary"),
         ):
-            groups = {"h1": [Path("/a.png")], "h2": [Path("/b.png")]}
+            groups = {"h1": [Path("/") / "a.png"], "h2": [Path("/") / "b.png"]}
             decisions = viewer.batch_review(groups, auto_select_best=False)
             # Only the first group is processed; second is skipped entirely.
             assert len(decisions) == 0
@@ -299,7 +303,7 @@ class TestBatchReview:
             patch("file_organizer.services.deduplication.viewer.Confirm.ask", return_value=True),
             patch.object(viewer, "_display_review_summary"),
         ):
-            groups = {"h1": [Path("/a.png")], "h2": [Path("/b.png")]}
+            groups = {"h1": [Path("/") / "a.png"], "h2": [Path("/") / "b.png"]}
             decisions = viewer.batch_review(groups, auto_select_best=False)
             assert decisions.get(sample_metadata.path) == "keep"
 
@@ -311,7 +315,7 @@ class TestBatchReview:
             patch("file_organizer.services.deduplication.viewer.Confirm.ask") as mock_confirm,
             patch.object(viewer, "_display_review_summary"),
         ):
-            groups = {"h1": [Path("/a.png")]}
+            groups = {"h1": [Path("/") / "a.png"]}
             viewer.batch_review(groups, auto_select_best=False)
             mock_confirm.assert_not_called()
 
@@ -339,7 +343,7 @@ class TestGetImageMetadata:
 
     def test_raises_on_invalid_path(self, viewer: ComparisonViewer):
         with pytest.raises(OSError):
-            viewer._get_image_metadata(Path("/nonexistent/img.png"))
+            viewer._get_image_metadata(Path("/") / "nonexistent" / "img.png")
 
 
 # ===========================================================================
@@ -436,7 +440,7 @@ class TestGenerateAsciiPreview:
     """
 
     def test_returns_none_on_nonexistent_file(self, viewer: ComparisonViewer):
-        result = viewer._generate_ascii_preview(Path("/nonexistent/img.png"))
+        result = viewer._generate_ascii_preview(Path("/") / "nonexistent" / "img.png")
         assert result is None
 
     def test_real_image_returns_none_or_string(self, tmp_path: Path, viewer: ComparisonViewer):
@@ -476,7 +480,7 @@ class TestGenerateAsciiPreview:
             return_value=mock_open_cm,
         ):
             result = viewer._generate_ascii_preview(
-                Path("/fake/img.png"), max_width=40, max_height=15
+                Path("/") / "fake" / "img.png", max_width=40, max_height=15
             )
 
         assert result is not None
@@ -524,7 +528,7 @@ class TestGenerateAsciiPreview:
             return_value=mock_cm,
         ):
             result = viewer._generate_ascii_preview(
-                Path("/fake/wide.png"), max_width=20, max_height=10
+                Path("/") / "fake" / "wide.png", max_width=20, max_height=10
             )
         assert result is not None
 
@@ -538,7 +542,7 @@ class TestGenerateAsciiPreview:
             return_value=mock_cm2,
         ):
             result = viewer._generate_ascii_preview(
-                Path("/fake/tall.png"), max_width=20, max_height=10
+                Path("/") / "fake" / "tall.png", max_width=20, max_height=10
             )
         assert result is not None
 
@@ -691,7 +695,7 @@ class TestAutoSelectBest:
 
     def test_handles_load_error(self, viewer: ComparisonViewer):
         with patch.object(viewer, "_get_image_metadata", side_effect=ValueError("boom")):
-            result = viewer._auto_select_best([Path("/fake/a.png")])
+            result = viewer._auto_select_best([Path("/") / "fake" / "a.png"])
         assert result.skipped is True
 
     def test_single_image(self, tmp_path: Path, viewer: ComparisonViewer):
@@ -719,7 +723,7 @@ class TestCalculateQualityScore:
 
     def test_png_preferred_over_gif(self, viewer: ComparisonViewer):
         png_meta = ImageMetadata(
-            path=Path("/x.png"),
+            path=Path("/") / "x.png",
             width=100,
             height=100,
             format="PNG",
@@ -728,7 +732,7 @@ class TestCalculateQualityScore:
             mode="RGB",
         )
         gif_meta = ImageMetadata(
-            path=Path("/x.gif"),
+            path=Path("/") / "x.gif",
             width=100,
             height=100,
             format="GIF",
@@ -740,7 +744,7 @@ class TestCalculateQualityScore:
 
     def test_unknown_format_gets_low_multiplier(self, viewer: ComparisonViewer):
         meta = ImageMetadata(
-            path=Path("/x.xyz"),
+            path=Path("/") / "x.xyz",
             width=100,
             height=100,
             format="XYZ",
@@ -766,7 +770,7 @@ class TestCalculateQualityScore:
     def test_format_scores(self, viewer: ComparisonViewer, fmt, expected_multiplier):
         """Each known format maps to the expected multiplier."""
         meta = ImageMetadata(
-            path=Path("/x"),
+            path=Path("/") / "x",
             width=1000,
             height=1000,
             format=fmt,
@@ -799,7 +803,10 @@ class TestDisplayReviewSummary:
 
     def test_delete_file_does_not_exist(self, viewer: ComparisonViewer):
         """If a file-to-delete no longer exists, summary should still work."""
-        decisions = {Path("/nonexistent/gone.png"): "delete", Path("/fake/keep.png"): "keep"}
+        decisions = {
+            Path("/") / "nonexistent" / "gone.png": "delete",
+            Path("/") / "fake" / "keep.png": "keep",
+        }
         viewer._display_review_summary(decisions)  # should not raise
 
     def test_space_savings_displayed(self, tmp_path: Path, viewer: ComparisonViewer):
@@ -826,7 +833,7 @@ class TestDisplayMetadata:
         viewer.display_metadata(img)  # should not raise
 
     def test_invalid_path(self, viewer: ComparisonViewer):
-        viewer.display_metadata(Path("/nonexistent/nope.png"))  # prints error, no raise
+        viewer.display_metadata(Path("/") / "nonexistent" / "nope.png")  # prints error, no raise
 
 
 # ===========================================================================
@@ -871,7 +878,7 @@ class TestInteractiveSelect:
         self, tmp_path: Path, viewer: ComparisonViewer
     ):
         """If metadata load fails for an image, fallback text is shown."""
-        imgs = [Path("/nonexistent/bad.png")]
+        imgs = [Path("/") / "nonexistent" / "bad.png"]
         with patch("file_organizer.services.deduplication.viewer.Prompt.ask", return_value="all"):
             result = viewer.interactive_select(imgs)
         assert result == imgs

--- a/tests/services/deduplication/test_document_dedup.py
+++ b/tests/services/deduplication/test_document_dedup.py
@@ -59,9 +59,9 @@ class TestDocumentDeduplicator(unittest.TestCase):
 
         # Mock extractor
         dedup.extractor.supports_format.return_value = True
-        dedup.extractor.extract_batch.return_value = {Path("/a.txt"): "short"}
+        dedup.extractor.extract_batch.return_value = {Path("/") / "a.txt": "short"}
 
-        result = dedup.find_duplicates([Path("/a.txt")], min_text_length=100)
+        result = dedup.find_duplicates([Path("/") / "a.txt"], min_text_length=100)
         self.assertEqual(result["duplicate_groups"], [])
         self.assertEqual(result["total_documents"], 1)
         self.assertEqual(result["analyzed_documents"], 0)
@@ -78,9 +78,9 @@ class TestDocumentDeduplicator(unittest.TestCase):
 
         dedup = DocumentDeduplicator()
 
-        p1 = Path("/doc1.txt")
-        p2 = Path("/doc2.txt")
-        p3 = Path("/doc3.txt")
+        p1 = Path("/") / "doc1.txt"
+        p2 = Path("/") / "doc2.txt"
+        p3 = Path("/") / "doc3.txt"
 
         # supports_format returns True for all
         dedup.extractor.supports_format.return_value = True
@@ -129,7 +129,7 @@ class TestDocumentDeduplicator(unittest.TestCase):
         dedup.extractor.supports_format.side_effect = lambda f: f.suffix == ".txt"
         dedup.extractor.extract_batch.return_value = {}
 
-        dedup.find_duplicates([Path("/a.txt"), Path("/b.exe")], min_text_length=100)
+        dedup.find_duplicates([Path("/") / "a.txt", Path("/") / "b.exe"], min_text_length=100)
         # Only .txt should be passed to extract_batch
         args = dedup.extractor.extract_batch.call_args[0][0]
         self.assertEqual(len(args), 1)
@@ -154,7 +154,7 @@ class TestDocumentDeduplicator(unittest.TestCase):
         dedup.embedder.fit_transform.return_value = mock_embeddings
         dedup.analyzer.compute_similarity.return_value = 0.87
 
-        result = dedup.compare_documents(Path("/a.txt"), Path("/b.txt"))
+        result = dedup.compare_documents(Path("/") / "a.txt", Path("/") / "b.txt")
         self.assertAlmostEqual(result, 0.87)
 
     @patch("file_organizer.services.deduplication.document_dedup.SemanticAnalyzer")
@@ -169,7 +169,7 @@ class TestDocumentDeduplicator(unittest.TestCase):
         dedup = DocumentDeduplicator()
         dedup.extractor.extract_text.side_effect = ["", "some text"]
 
-        result = dedup.compare_documents(Path("/a.txt"), Path("/b.txt"))
+        result = dedup.compare_documents(Path("/") / "a.txt", Path("/") / "b.txt")
         self.assertIsNone(result)
 
     @patch("file_organizer.services.deduplication.document_dedup.SemanticAnalyzer")
@@ -184,7 +184,7 @@ class TestDocumentDeduplicator(unittest.TestCase):
         dedup = DocumentDeduplicator()
         dedup.extractor.extract_text.side_effect = ValueError("boom")
 
-        result = dedup.compare_documents(Path("/a.txt"), Path("/b.txt"))
+        result = dedup.compare_documents(Path("/") / "a.txt", Path("/") / "b.txt")
         self.assertIsNone(result)
 
     @patch("file_organizer.services.deduplication.document_dedup.SemanticAnalyzer")

--- a/tests/services/deduplication/test_hasher.py
+++ b/tests/services/deduplication/test_hasher.py
@@ -134,7 +134,7 @@ class TestFileHasherComputeHash:
         """Test that computing hash of non-existent file raises error."""
         hasher = FileHasher()
         with pytest.raises(FileNotFoundError):
-            hasher.compute_hash(Path("/nonexistent/file.txt"))
+            hasher.compute_hash(Path("/") / "nonexistent" / "file.txt")
 
     def test_compute_hash_directory(self, tmp_path):
         """Test that computing hash of directory raises error."""
@@ -233,7 +233,7 @@ class TestFileHasherGetFileSize:
         """Test getting size of non-existent file."""
         hasher = FileHasher()
         with pytest.raises(FileNotFoundError):
-            hasher.get_file_size(Path("/nonexistent/file.txt"))
+            hasher.get_file_size(Path("/") / "nonexistent" / "file.txt")
 
 
 @pytest.mark.unit

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -367,7 +367,7 @@ class TestFindDuplicates:
         """Test FileNotFoundError for missing directory."""
         dedup = _make_dedup()
         with pytest.raises(FileNotFoundError, match="Directory not found"):
-            dedup.find_duplicates(Path("/no/such/dir"))
+            dedup.find_duplicates(Path("/") / "no" / "such" / "dir")
 
     def test_not_a_directory(self, tmp_path: Path):
         """Test ValueError for path that is a file, not a directory."""

--- a/tests/services/deduplication/test_index.py
+++ b/tests/services/deduplication/test_index.py
@@ -27,7 +27,7 @@ class TestFileMetadata:
     def test_create_file_metadata(self):
         """Test creating file metadata."""
         now = datetime.now(UTC)
-        path = Path("/test/file.txt")
+        path = Path("/") / "test" / "file.txt"
         metadata = FileMetadata(
             path=path,
             size=1024,
@@ -51,7 +51,7 @@ class TestFileMetadata:
         )
 
         assert isinstance(metadata.path, Path)
-        assert metadata.path == Path("/test/file.txt")
+        assert metadata.path == Path("/") / "test" / "file.txt"
 
 
 @pytest.mark.unit
@@ -72,14 +72,14 @@ class TestDuplicateGroup:
         group = DuplicateGroup(hash_value="hash123")
 
         file1 = FileMetadata(
-            path=Path("/file1.txt"),
+            path=Path("/") / "file1.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
             hash_value="hash123",
         )
         file2 = FileMetadata(
-            path=Path("/file2.txt"),
+            path=Path("/") / "file2.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
@@ -98,14 +98,14 @@ class TestDuplicateGroup:
         group = DuplicateGroup(hash_value="hash123")
 
         file1 = FileMetadata(
-            path=Path("/file1.txt"),
+            path=Path("/") / "file1.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
             hash_value="hash123",
         )
         file2 = FileMetadata(
-            path=Path("/file2.txt"),
+            path=Path("/") / "file2.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
@@ -121,21 +121,21 @@ class TestDuplicateGroup:
         group = DuplicateGroup(hash_value="hash123")
 
         file1 = FileMetadata(
-            path=Path("/file1.txt"),
+            path=Path("/") / "file1.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
             hash_value="hash123",
         )
         file2 = FileMetadata(
-            path=Path("/file2.txt"),
+            path=Path("/") / "file2.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
             hash_value="hash123",
         )
         file3 = FileMetadata(
-            path=Path("/file3.txt"),
+            path=Path("/") / "file3.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
@@ -152,7 +152,7 @@ class TestDuplicateGroup:
         group = DuplicateGroup(hash_value="hash123")
 
         file1 = FileMetadata(
-            path=Path("/file1.txt"),
+            path=Path("/") / "file1.txt",
             size=1000,
             modified_time=now,
             accessed_time=now,
@@ -532,7 +532,7 @@ class TestEdgeCases:
         now = datetime.now(UTC)
 
         file_metadata = FileMetadata(
-            path=Path("/test.txt"),
+            path=Path("/") / "test.txt",
             size=1_000_000_000_000,
             modified_time=now,
             accessed_time=now,
@@ -546,7 +546,7 @@ class TestEdgeCases:
         now = datetime.now(UTC)
 
         file_metadata = FileMetadata(
-            path=Path("/empty.txt"),
+            path=Path("/") / "empty.txt",
             size=0,
             modified_time=now,
             accessed_time=now,

--- a/tests/services/deduplication/test_quality.py
+++ b/tests/services/deduplication/test_quality.py
@@ -768,8 +768,8 @@ class TestIsLikelyCropped:
 
     def test_candidate_larger_returns_false(self, analyzer):
         """If candidate has equal or larger resolution, not a crop."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         self._mock_metrics(
             analyzer,
             {
@@ -781,8 +781,8 @@ class TestIsLikelyCropped:
 
     def test_different_aspect_ratio_is_crop(self, analyzer):
         """Large aspect ratio difference with smaller resolution = crop."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         self._mock_metrics(
             analyzer,
             {
@@ -794,8 +794,8 @@ class TestIsLikelyCropped:
 
     def test_proportional_resize_not_crop(self, analyzer):
         """Resolution reduced proportionally with same aspect = resize, not crop."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         # ratio = 900_000 / 1_000_000 = 0.9 > threshold (0.8)
         # aspect_diff = 0 < 0.1
         self._mock_metrics(
@@ -809,8 +809,8 @@ class TestIsLikelyCropped:
 
     def test_small_resolution_moderate_aspect_is_crop(self, analyzer):
         """Smaller resolution + moderate aspect change = likely crop."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         # ratio = 600_000 / 1_000_000 = 0.6 < threshold (0.8)
         # aspect_diff = 0.1 > 0.05
         self._mock_metrics(
@@ -824,8 +824,8 @@ class TestIsLikelyCropped:
 
     def test_small_resolution_tiny_aspect_diff_not_crop(self, analyzer):
         """Smaller resolution but very similar aspect ratio = ambiguous, returns False."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         # ratio = 600_000 / 1_000_000 = 0.6 < threshold (0.8)
         # aspect_diff = 0.02 < 0.05
         self._mock_metrics(
@@ -839,8 +839,8 @@ class TestIsLikelyCropped:
 
     def test_one_missing_metric_returns_false(self, analyzer):
         """If only one image has metrics, returns False."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         self._mock_metrics(
             analyzer,
             {
@@ -852,8 +852,8 @@ class TestIsLikelyCropped:
 
     def test_custom_threshold(self, analyzer):
         """Custom threshold parameter is respected."""
-        orig = Path("/fake/orig.jpg")
-        cand = Path("/fake/cand.jpg")
+        orig = Path("/") / "fake" / "orig.jpg"
+        cand = Path("/") / "fake" / "cand.jpg"
         # ratio = 700_000 / 1_000_000 = 0.7
         # With default threshold=0.8, ratio < threshold so it checks further
         # aspect_diff = 0.08 > 0.05, so it's a crop

--- a/tests/services/intelligence/test_directory_prefs.py
+++ b/tests/services/intelligence/test_directory_prefs.py
@@ -31,7 +31,7 @@ class TestDirectoryPrefs:
 
     def test_set_and_get_preference(self, dir_prefs):
         """Test setting and getting a single preference."""
-        test_path = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
         pref = {"folder_mappings": {"pdf": "PDFs"}, "confidence": 0.8}
 
         dir_prefs.set_preference(test_path, pref)
@@ -43,8 +43,8 @@ class TestDirectoryPrefs:
 
     def test_preference_inheritance(self, dir_prefs):
         """Test that child directories inherit parent preferences."""
-        parent_path = Path("/home/user")  # noqa: test-hardcoded-paths
-        child_path = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        parent_path = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        child_path = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
 
         parent_pref = {"global_setting": "parent_value"}
         child_pref = {"folder_mappings": {"pdf": "PDFs"}}
@@ -60,10 +60,10 @@ class TestDirectoryPrefs:
 
     def test_deep_inheritance_chain(self, dir_prefs):
         """Test inheritance across multiple directory levels."""
-        root = Path("/home/user")  # noqa: test-hardcoded-paths
-        level1 = Path("/home/user/documents")  # noqa: test-hardcoded-paths
-        level2 = Path("/home/user/documents/work")  # noqa: test-hardcoded-paths
-        level3 = Path("/home/user/documents/work/projects")  # noqa: test-hardcoded-paths
+        root = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        level1 = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
+        level2 = Path("/") / "home" / "user" / "documents" / "work"  # noqa: test-hardcoded-paths
+        level3 = Path("/") / "home" / "user" / "documents" / "work" / "projects"  # noqa: test-hardcoded-paths
 
         dir_prefs.set_preference(root, {"root_setting": "root"})
         dir_prefs.set_preference(level1, {"level1_setting": "l1"})
@@ -78,8 +78,8 @@ class TestDirectoryPrefs:
 
     def test_child_overrides_parent(self, dir_prefs):
         """Test that child preferences override parent for same keys."""
-        parent = Path("/home/user")  # noqa: test-hardcoded-paths
-        child = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        parent = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        child = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
 
         parent_pref = {"folder_mappings": {"pdf": "Documents"}}
         child_pref = {"folder_mappings": {"pdf": "PDFs"}}
@@ -94,8 +94,8 @@ class TestDirectoryPrefs:
 
     def test_override_parent_flag(self, dir_prefs):
         """Test override_parent flag stops inheritance."""
-        parent = Path("/home/user")  # noqa: test-hardcoded-paths
-        child = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        parent = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        child = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
 
         parent_pref = {"parent_setting": "should_not_inherit"}
         child_pref = {"child_setting": "only_this"}
@@ -111,8 +111,8 @@ class TestDirectoryPrefs:
 
     def test_deep_merge_nested_dicts(self, dir_prefs):
         """Test that nested dictionaries are merged properly."""
-        parent = Path("/home/user")  # noqa: test-hardcoded-paths
-        child = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        parent = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        child = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
 
         parent_pref = {"folder_mappings": {"pdf": "Documents", "txt": "TextFiles"}}
         child_pref = {
@@ -134,13 +134,13 @@ class TestDirectoryPrefs:
 
     def test_no_preference_returns_none(self, dir_prefs):
         """Test that querying a path with no preferences returns None."""
-        result = dir_prefs.get_preference_with_inheritance(Path("/nonexistent"))
+        result = dir_prefs.get_preference_with_inheritance(Path("/") / "nonexistent")
         assert result is None
 
     def test_list_directory_preferences(self, dir_prefs):
         """Test listing all directory preferences."""
-        path1 = Path("/home/user")  # noqa: test-hardcoded-paths
-        path2 = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        path1 = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        path2 = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
 
         dir_prefs.set_preference(path1, {"setting1": "value1"})
         dir_prefs.set_preference(path2, {"setting2": "value2"})
@@ -154,7 +154,7 @@ class TestDirectoryPrefs:
 
     def test_remove_preference(self, dir_prefs):
         """Test removing a preference."""
-        test_path = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(test_path, {"setting": "value"})
 
         # Verify it exists
@@ -169,13 +169,13 @@ class TestDirectoryPrefs:
 
     def test_remove_nonexistent_preference(self, dir_prefs):
         """Test removing a preference that doesn't exist."""
-        removed = dir_prefs.remove_preference(Path("/nonexistent"))
+        removed = dir_prefs.remove_preference(Path("/") / "nonexistent")
         assert removed is False
 
     def test_clear_all(self, dir_prefs):
         """Test clearing all preferences."""
-        dir_prefs.set_preference(Path("/path1"), {"setting": "value"})
-        dir_prefs.set_preference(Path("/path2"), {"setting": "value"})
+        dir_prefs.set_preference(Path("/") / "path1", {"setting": "value"})
+        dir_prefs.set_preference(Path("/") / "path2", {"setting": "value"})
 
         assert len(dir_prefs.list_directory_preferences()) == 2
 
@@ -185,9 +185,9 @@ class TestDirectoryPrefs:
 
     def test_statistics(self, dir_prefs):
         """Test preference statistics."""
-        dir_prefs.set_preference(Path("/path1"), {"s": "v"}, override_parent=False)
-        dir_prefs.set_preference(Path("/path2"), {"s": "v"}, override_parent=True)
-        dir_prefs.set_preference(Path("/path3"), {"s": "v"}, override_parent=False)
+        dir_prefs.set_preference(Path("/") / "path1", {"s": "v"}, override_parent=False)
+        dir_prefs.set_preference(Path("/") / "path2", {"s": "v"}, override_parent=True)
+        dir_prefs.set_preference(Path("/") / "path3", {"s": "v"}, override_parent=False)
 
         stats = dir_prefs.get_statistics()
 
@@ -208,7 +208,7 @@ class TestDirectoryPrefs:
 
     def test_metadata_not_in_result(self, dir_prefs):
         """Test that internal metadata is not included in results."""
-        test_path = Path("/home/user")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(test_path, {"setting": "value"})
 
         result = dir_prefs.get_preference_with_inheritance(test_path)
@@ -219,7 +219,7 @@ class TestDirectoryPrefs:
 
     def test_metadata_not_in_list(self, dir_prefs):
         """Test that internal metadata is not included in list results."""
-        dir_prefs.set_preference(Path("/home/user"), {"setting": "value"})  # noqa: test-hardcoded-paths
+        dir_prefs.set_preference(Path("/") / "home" / "user", {"setting": "value"})  # noqa: test-hardcoded-paths
 
         prefs_list = dir_prefs.list_directory_preferences()
         pref_dict = prefs_list[0][1]
@@ -230,7 +230,7 @@ class TestDirectoryPrefs:
 
     def test_empty_preference_dict(self, dir_prefs):
         """Test setting an empty preference dictionary."""
-        test_path = Path("/home/user")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(test_path, {})
 
         result = dir_prefs.get_preference_with_inheritance(test_path)
@@ -241,17 +241,17 @@ class TestDirectoryPrefs:
     def test_complex_inheritance_scenario(self, dir_prefs):
         """Test a complex real-world inheritance scenario."""
         # Setup: root has global settings
-        root = Path("/home/user")  # noqa: test-hardcoded-paths
+        root = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(root, {"naming_patterns": {"prefix": "user_"}, "confidence": 0.7})
 
         # Documents overrides naming, adds folder mappings
-        docs = Path("/home/user/documents")  # noqa: test-hardcoded-paths
+        docs = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(
             docs, {"naming_patterns": {"prefix": "doc_"}, "folder_mappings": {"pdf": "PDFs"}}
         )
 
         # Work documents adds more mappings
-        work = Path("/home/user/documents/work")  # noqa: test-hardcoded-paths
+        work = Path("/") / "home" / "user" / "documents" / "work"  # noqa: test-hardcoded-paths
         dir_prefs.set_preference(
             work, {"folder_mappings": {"xlsx": "Spreadsheets"}, "confidence": 0.9}
         )
@@ -266,9 +266,9 @@ class TestDirectoryPrefs:
 
     def test_inheritance_stops_at_override(self, dir_prefs):
         """Test that inheritance chain stops at override_parent=True."""
-        grandparent = Path("/home/user")  # noqa: test-hardcoded-paths
-        parent = Path("/home/user/documents")  # noqa: test-hardcoded-paths
-        child = Path("/home/user/documents/work")  # noqa: test-hardcoded-paths
+        grandparent = Path("/") / "home" / "user"  # noqa: test-hardcoded-paths
+        parent = Path("/") / "home" / "user" / "documents"  # noqa: test-hardcoded-paths
+        child = Path("/") / "home" / "user" / "documents" / "work"  # noqa: test-hardcoded-paths
 
         dir_prefs.set_preference(grandparent, {"gp": "value"})
         dir_prefs.set_preference(parent, {"p": "value"}, override_parent=True)

--- a/tests/services/intelligence/test_feedback_processor.py
+++ b/tests/services/intelligence/test_feedback_processor.py
@@ -54,8 +54,8 @@ class TestProcessCorrection:
 
     def test_basic_correction_same_location(self, processor):
         """Test processing a correction that only changes the filename."""
-        original = Path("/docs/old_name.txt")
-        corrected = Path("/docs/new_name.txt")
+        original = Path("/") / "docs" / "old_name.txt"
+        corrected = Path("/") / "docs" / "new_name.txt"
 
         result = processor.process_correction(original, corrected)
 
@@ -69,8 +69,8 @@ class TestProcessCorrection:
 
     def test_folder_change_only(self, processor):
         """Test processing a correction that only changes the folder."""
-        original = Path("/docs/report.pdf")
-        corrected = Path("/archives/report.pdf")
+        original = Path("/") / "docs" / "report.pdf"
+        corrected = Path("/") / "archives" / "report.pdf"
 
         result = processor.process_correction(original, corrected)
 
@@ -82,8 +82,8 @@ class TestProcessCorrection:
 
     def test_both_name_and_folder_change(self, processor):
         """Test correction with both name and folder change."""
-        original = Path("/docs/old.txt")
-        corrected = Path("/archives/new.txt")
+        original = Path("/") / "docs" / "old.txt"
+        corrected = Path("/") / "archives" / "new.txt"
 
         result = processor.process_correction(original, corrected)
 
@@ -93,7 +93,7 @@ class TestProcessCorrection:
 
     def test_no_change(self, processor):
         """Test correction with identical paths produces no signals."""
-        path = Path("/docs/file.txt")
+        path = Path("/") / "docs" / "file.txt"
 
         result = processor.process_correction(path, path)
 
@@ -101,8 +101,8 @@ class TestProcessCorrection:
 
     def test_correction_count_increments(self, processor):
         """Test that correction_count increments on each call."""
-        original = Path("/a/file.txt")
-        corrected = Path("/b/file.txt")
+        original = Path("/") / "a" / "file.txt"
+        corrected = Path("/") / "b" / "file.txt"
 
         for i in range(3):
             processor.process_correction(original, corrected)
@@ -110,8 +110,8 @@ class TestProcessCorrection:
 
     def test_retraining_trigger(self, processor):
         """Test retraining is triggered after threshold corrections."""
-        original = Path("/a/file.txt")
-        corrected = Path("/b/file.txt")
+        original = Path("/") / "a" / "file.txt"
+        corrected = Path("/") / "b" / "file.txt"
 
         # Process corrections up to threshold
         for _ in range(processor.learning_threshold - 1):
@@ -124,8 +124,8 @@ class TestProcessCorrection:
 
     def test_context_patterns_extracted(self, processor):
         """Test context patterns are extracted when context is provided."""
-        original = Path("/docs/file.txt")
-        corrected = Path("/docs/file.txt")
+        original = Path("/") / "docs" / "file.txt"
+        corrected = Path("/") / "docs" / "file.txt"
         context = {"operation": "rename", "suggested": "file_v2.txt", "actual": "report.txt"}
 
         result = processor.process_correction(original, corrected, context)
@@ -139,8 +139,8 @@ class TestProcessCorrection:
 
     def test_context_with_no_patterns(self, processor):
         """Test that empty context dict yields no context signal."""
-        original = Path("/docs/file.txt")
-        corrected = Path("/docs/file.txt")
+        original = Path("/") / "docs" / "file.txt"
+        corrected = Path("/") / "docs" / "file.txt"
         context = {"unrelated_key": "value"}
 
         result = processor.process_correction(original, corrected, context)
@@ -150,16 +150,16 @@ class TestProcessCorrection:
 
     def test_context_none(self, processor):
         """Test no context signal when context is None."""
-        original = Path("/docs/file.txt")
-        corrected = Path("/docs/file.txt")
+        original = Path("/") / "docs" / "file.txt"
+        corrected = Path("/") / "docs" / "file.txt"
 
         result = processor.process_correction(original, corrected, context=None)
         assert len(result["learning_signals"]) == 0
 
     def test_folder_correction_with_category_context(self, processor):
         """Test folder correction with category context."""
-        original = Path("/downloads/photo.jpg")
-        corrected = Path("/photos/vacations/photo.jpg")
+        original = Path("/") / "downloads" / "photo.jpg"
+        corrected = Path("/") / "photos" / "vacations" / "photo.jpg"
         context = {"category": "vacation_photos"}
 
         result = processor.process_correction(original, corrected, context)
@@ -445,8 +445,8 @@ class TestAnalyzeFolderCorrection:
 
     def test_basic_folder_change(self, processor):
         """Test basic folder correction analysis."""
-        original = Path("/downloads/file.pdf")
-        corrected = Path("/documents/file.pdf")
+        original = Path("/") / "downloads" / "file.pdf"
+        corrected = Path("/") / "documents" / "file.pdf"
 
         result = processor._analyze_folder_correction(original, corrected, None)
 
@@ -457,8 +457,8 @@ class TestAnalyzeFolderCorrection:
 
     def test_folder_change_with_category(self, processor):
         """Test folder correction with category context."""
-        original = Path("/downloads/file.jpg")
-        corrected = Path("/photos/file.jpg")
+        original = Path("/") / "downloads" / "file.jpg"
+        corrected = Path("/") / "photos" / "file.jpg"
         context = {"category": "photos"}
 
         result = processor._analyze_folder_correction(original, corrected, context)
@@ -468,8 +468,8 @@ class TestAnalyzeFolderCorrection:
 
     def test_subfolder_structure_detection(self, processor):
         """Test detection of subfolder structure patterns."""
-        original = Path("/downloads/file.txt")
-        corrected = Path("/projects/work/reports/file.txt")
+        original = Path("/") / "downloads" / "file.txt"
+        corrected = Path("/") / "projects" / "work" / "reports" / "file.txt"
 
         result = processor._analyze_folder_correction(original, corrected, None)
 
@@ -480,8 +480,8 @@ class TestAnalyzeFolderCorrection:
 
     def test_folder_change_with_common_ancestor(self, processor):
         """Test folder change with shared common ancestor."""
-        original = Path("/projects/work/drafts/file.txt")
-        corrected = Path("/projects/work/final/file.txt")
+        original = Path("/") / "projects" / "work" / "drafts" / "file.txt"
+        corrected = Path("/") / "projects" / "work" / "final" / "file.txt"
 
         result = processor._analyze_folder_correction(original, corrected, None)
 

--- a/tests/services/intelligence/test_pattern_learner.py
+++ b/tests/services/intelligence/test_pattern_learner.py
@@ -198,8 +198,8 @@ class TestLearnFromCorrection:
     def test_learning_disabled(self, learner):
         """Test that corrections are ignored when learning is disabled."""
         learner.learning_enabled = False
-        original = Path("/docs/old.txt")
-        corrected = Path("/docs/new.txt")
+        original = Path("/") / "docs" / "old.txt"
+        corrected = Path("/") / "docs" / "new.txt"
 
         result = learner.learn_from_correction(original, corrected)
 
@@ -207,8 +207,8 @@ class TestLearnFromCorrection:
 
     def test_name_change_learning(self, learner):
         """Test learning from a name change."""
-        original = Path("/docs/old_file.txt")
-        corrected = Path("/docs/new_file.txt")
+        original = Path("/") / "docs" / "old_file.txt"
+        corrected = Path("/") / "docs" / "new_file.txt"
 
         with patch.object(
             learner.feedback_processor,
@@ -227,8 +227,8 @@ class TestLearnFromCorrection:
 
     def test_folder_change_learning(self, learner):
         """Test learning from a folder change (same filename)."""
-        original = Path("/downloads/report.pdf")
-        corrected = Path("/documents/report.pdf")
+        original = Path("/") / "downloads" / "report.pdf"
+        corrected = Path("/") / "documents" / "report.pdf"
 
         result = learner.learn_from_correction(original, corrected)
 
@@ -238,8 +238,8 @@ class TestLearnFromCorrection:
 
     def test_both_name_and_folder_change(self, learner):
         """Test learning from both name and folder change."""
-        original = Path("/downloads/old.txt")
-        corrected = Path("/documents/new.txt")
+        original = Path("/") / "downloads" / "old.txt"
+        corrected = Path("/") / "documents" / "new.txt"
 
         result = learner.learn_from_correction(original, corrected)
 
@@ -249,8 +249,8 @@ class TestLearnFromCorrection:
 
     def test_retraining_triggered(self, learner):
         """Test that retraining flag is set after threshold corrections."""
-        original = Path("/a/file.txt")
-        corrected = Path("/b/file.txt")
+        original = Path("/") / "a" / "file.txt"
+        corrected = Path("/") / "b" / "file.txt"
 
         for _ in range(learner.feedback_processor.learning_threshold):
             result = learner.learn_from_correction(original, corrected)
@@ -259,7 +259,7 @@ class TestLearnFromCorrection:
 
     def test_no_change(self, learner):
         """Test learning from identical paths."""
-        path = Path("/docs/file.txt")
+        path = Path("/") / "docs" / "file.txt"
 
         result = learner.learn_from_correction(path, path)
 
@@ -267,8 +267,8 @@ class TestLearnFromCorrection:
 
     def test_with_context(self, learner):
         """Test learning with context information."""
-        original = Path("/docs/file.txt")
-        corrected = Path("/archive/file.txt")
+        original = Path("/") / "docs" / "file.txt"
+        corrected = Path("/") / "archive" / "file.txt"
         context = {"operation": "archive"}
 
         with patch.object(
@@ -283,8 +283,8 @@ class TestLearnFromCorrection:
 
     def test_preference_tracker_called(self, learner):
         """Test that preference tracker receives the operation."""
-        original = Path("/a/old.txt")
-        corrected = Path("/b/new.txt")
+        original = Path("/") / "a" / "old.txt"
+        corrected = Path("/") / "b" / "new.txt"
 
         learner.learn_from_correction(original, corrected)
 
@@ -511,8 +511,8 @@ class TestGetLearningStats:
 
     def test_stats_after_corrections(self, learner):
         """Test stats reflect corrections."""
-        original = Path("/a/file.txt")
-        corrected = Path("/b/file.txt")
+        original = Path("/") / "a" / "file.txt"
+        corrected = Path("/") / "b" / "file.txt"
 
         learner.learn_from_correction(original, corrected)
 
@@ -639,7 +639,9 @@ class TestLearningToggle:
         """Test that corrections are ignored when disabled."""
         learner.disable_learning()
 
-        result = learner.learn_from_correction(Path("/a/old.txt"), Path("/b/new.txt"))
+        result = learner.learn_from_correction(
+            Path("/") / "a" / "old.txt", Path("/") / "b" / "new.txt"
+        )
 
         assert result == {"learning_enabled": False}
 
@@ -648,7 +650,9 @@ class TestLearningToggle:
         learner.disable_learning()
         learner.enable_learning()
 
-        result = learner.learn_from_correction(Path("/a/old.txt"), Path("/b/new.txt"))
+        result = learner.learn_from_correction(
+            Path("/") / "a" / "old.txt", Path("/") / "b" / "new.txt"
+        )
 
         assert "timestamp" in result
         assert len(result["learned"]) > 0
@@ -754,8 +758,8 @@ class TestLearnFolderPreference:
 
     def test_basic_folder_learning(self, learner):
         """Test basic folder preference learning."""
-        original = Path("/downloads/file.pdf")
-        corrected = Path("/documents/file.pdf")
+        original = Path("/") / "downloads" / "file.pdf"
+        corrected = Path("/") / "documents" / "file.pdf"
 
         learner.folder_learner.get_folder_confidence.return_value = 0.85
 
@@ -769,8 +773,8 @@ class TestLearnFolderPreference:
 
     def test_folder_learning_with_context(self, learner):
         """Test folder preference learning with context."""
-        original = Path("/downloads/file.jpg")
-        corrected = Path("/photos/file.jpg")
+        original = Path("/") / "downloads" / "file.jpg"
+        corrected = Path("/") / "photos" / "file.jpg"
         context = {"category": "photos"}
 
         learner.folder_learner.get_folder_confidence.return_value = 0.9

--- a/tests/services/intelligence/test_preference_store.py
+++ b/tests/services/intelligence/test_preference_store.py
@@ -607,7 +607,7 @@ class TestStatistics:
 
         # Add multiple preferences
         for i in range(3):
-            path = Path(f"/test/dir{i}")
+            path = Path("/") / "test" / f"dir{i}"
             store.add_preference(path, {"confidence": 0.5 + i * 0.1, "correction_count": i + 1})
 
         stats = store.get_statistics()
@@ -620,7 +620,7 @@ class TestStatistics:
         """Test listing all directory preferences"""
         store.load_preferences()
 
-        paths = [Path(f"/test/dir{i}") for i in range(3)]
+        paths = [Path("/") / "test" / f"dir{i}" for i in range(3)]
         for path in paths:
             store.add_preference(path, {"folder_mappings": {"*.txt": f"Docs{path}"}})
 
@@ -641,7 +641,7 @@ class TestThreadSafety:
 
         def add_preferences(thread_id):
             for i in range(10):
-                path = Path(f"/test/thread{thread_id}/dir{i}")
+                path = Path("/") / "test" / f"thread{thread_id}" / f"dir{i}"
                 store.add_preference(
                     path, {"folder_mappings": {f"*.{thread_id}": f"Thread{thread_id}"}}
                 )
@@ -720,7 +720,7 @@ class TestPerformance:
 
         # Add 100 preferences
         for i in range(100):
-            path = Path(f"/test/perf/dir{i}")
+            path = Path("/") / "test" / "perf" / f"dir{i}"
             store.add_preference(path, {"folder_mappings": {"*.txt": f"Docs{i}"}})
 
         # Measure lookup time
@@ -739,7 +739,7 @@ class TestPerformance:
 
         # Add 100 preferences
         for i in range(100):
-            path = Path(f"/test/perf/dir{i}")
+            path = Path("/") / "test" / "perf" / f"dir{i}"
             store.add_preference(path, {"folder_mappings": {"*.txt": f"Docs{i}"}})
 
         # Measure save time
@@ -783,7 +783,7 @@ class TestClearPreferences:
 
         # Add some preferences
         for i in range(5):
-            path = Path(f"/test/dir{i}")
+            path = Path("/") / "test" / f"dir{i}"
             store.add_preference(path, {"folder_mappings": {"*.txt": f"Docs{i}"}})
 
         # Clear

--- a/tests/services/intelligence/test_preference_store.py
+++ b/tests/services/intelligence/test_preference_store.py
@@ -224,7 +224,7 @@ class TestLoadSave:
         store.load_preferences()
 
         # Add some data
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
         store.add_preference(
             test_path, {"folder_mappings": {"*.txt": "Documents"}, "confidence": 0.9}
         )
@@ -248,7 +248,7 @@ class TestLoadSave:
         store.save_preferences()
 
         # Modify and save again
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
         store.add_preference(test_path, {"folder_mappings": {"*.txt": "Docs"}})
         store.save_preferences()
 
@@ -259,7 +259,7 @@ class TestLoadSave:
         """Test that corrupted JSON falls back to backup"""
         # Create valid preferences
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
         store.add_preference(test_path, {"folder_mappings": {"*.txt": "Docs"}})
         store.save_preferences()
 
@@ -298,7 +298,7 @@ class TestPreferenceOperations:
     def test_add_preference_new_directory(self, store):
         """Test adding preference for new directory"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
 
         store.add_preference(
             test_path,
@@ -317,7 +317,7 @@ class TestPreferenceOperations:
     def test_add_preference_updates_existing(self, store):
         """Test adding preference updates existing directory"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
 
         # Add initial
         store.add_preference(test_path, {"folder_mappings": {"*.jpg": "Photos"}, "confidence": 0.7})
@@ -332,7 +332,7 @@ class TestPreferenceOperations:
     def test_get_preference_exact_match(self, store):
         """Test getting preference with exact path match"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
 
         store.add_preference(test_path, {"folder_mappings": {"*.txt": "Docs"}})
 
@@ -343,8 +343,8 @@ class TestPreferenceOperations:
     def test_get_preference_parent_fallback(self, store):
         """Test getting preference falls back to parent"""
         store.load_preferences()
-        parent_path = Path("/test")
-        child_path = Path("/test/child/grandchild")
+        parent_path = Path("/") / "test"
+        child_path = Path("/") / "test" / "child" / "grandchild"
 
         # Add preference to parent
         store.add_preference(parent_path, {"folder_mappings": {"*.txt": "ParentDocs"}})
@@ -357,7 +357,7 @@ class TestPreferenceOperations:
     def test_get_preference_no_fallback(self, store):
         """Test getting preference without fallback returns global"""
         store.load_preferences()
-        test_path = Path("/test/nonexistent")
+        test_path = Path("/") / "test" / "nonexistent"
 
         # Should return global preferences
         pref = store.get_preference(test_path, fallback_to_parent=False)
@@ -367,7 +367,7 @@ class TestPreferenceOperations:
     def test_update_confidence_success(self, store):
         """Test updating confidence on success"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
 
         store.add_preference(test_path, {"confidence": 0.5})
 
@@ -380,7 +380,7 @@ class TestPreferenceOperations:
     def test_update_confidence_failure(self, store):
         """Test updating confidence on failure"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
 
         store.add_preference(test_path, {"confidence": 0.8})
 
@@ -393,7 +393,7 @@ class TestPreferenceOperations:
     def test_update_confidence_clamped(self, store):
         """Test confidence is clamped to [0, 1]"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
 
         store.add_preference(test_path, {"confidence": 0.99})
 
@@ -491,7 +491,7 @@ class TestImportExport:
     def test_export_json(self, store, temp_storage):
         """Test exporting preferences to JSON"""
         store.load_preferences()
-        test_path = Path("/test/directory")
+        test_path = Path("/") / "test" / "directory"
         store.add_preference(test_path, {"folder_mappings": {"*.txt": "Docs"}})
 
         export_path = temp_storage / "export.json"
@@ -510,7 +510,7 @@ class TestImportExport:
         """Test importing preferences from JSON"""
         # Use a platform-native resolved key so the round-trip via
         # get_preference (which calls path.resolve()) works on all OSes.
-        import_key = str(Path("/imported/path").resolve())
+        import_key = str(Path("/") / "imported" / "path".resolve())
         # Create export file
         data = {
             "version": "1.0",
@@ -541,7 +541,9 @@ class TestImportExport:
 
         assert result is True
         assert store._preferences["user_id"] == "imported"
-        pref = store.get_preference(Path("/imported/path").resolve(), fallback_to_parent=False)
+        pref = store.get_preference(
+            Path("/") / "imported" / "path".resolve(), fallback_to_parent=False
+        )
         assert pref["folder_mappings"] == {"*.md": "Notes"}
 
     def test_import_invalid_json(self, store, temp_storage):
@@ -659,7 +661,7 @@ class TestThreadSafety:
         """Test concurrent reads and writes"""
         store.load_preferences()
 
-        test_path = Path("/test/concurrent")
+        test_path = Path("/") / "test" / "concurrent"
         store.add_preference(test_path, {"confidence": 0.5})
 
         results = []
@@ -722,7 +724,7 @@ class TestPerformance:
             store.add_preference(path, {"folder_mappings": {"*.txt": f"Docs{i}"}})
 
         # Measure lookup time
-        test_path = Path("/test/perf/dir50")
+        test_path = Path("/") / "test" / "perf" / "dir50"
         start = time.time()
         for _ in range(100):
             store.get_preference(test_path, fallback_to_parent=False)
@@ -797,7 +799,7 @@ class TestClearPreferences:
         store.load_preferences()
 
         # Add preferences
-        path = Path("/test/dir")
+        path = Path("/") / "test" / "dir"
         store.add_preference(path, {"folder_mappings": {"*.txt": "Docs"}})
 
         # Clear

--- a/tests/services/intelligence/test_preference_store.py
+++ b/tests/services/intelligence/test_preference_store.py
@@ -510,7 +510,7 @@ class TestImportExport:
         """Test importing preferences from JSON"""
         # Use a platform-native resolved key so the round-trip via
         # get_preference (which calls path.resolve()) works on all OSes.
-        import_key = str(Path("/") / "imported" / "path".resolve())
+        import_key = str((Path("/") / "imported" / "path").resolve())
         # Create export file
         data = {
             "version": "1.0",
@@ -542,7 +542,7 @@ class TestImportExport:
         assert result is True
         assert store._preferences["user_id"] == "imported"
         pref = store.get_preference(
-            Path("/") / "imported" / "path".resolve(), fallback_to_parent=False
+            (Path("/") / "imported" / "path").resolve(), fallback_to_parent=False
         )
         assert pref["folder_mappings"] == {"*.md": "Notes"}
 

--- a/tests/services/intelligence/test_preference_tracker.py
+++ b/tests/services/intelligence/test_preference_tracker.py
@@ -543,8 +543,8 @@ def test_get_recent_corrections_ordering_and_limit(tracker):
     """Test that recent corrections are ordered newest-first and respect limit."""
     for i in range(5):
         tracker.track_correction(
-            source=Path(f"/a/file{i}.txt"),
-            destination=Path(f"/b/file{i}.txt"),
+            source=Path("/") / "a" / f"file{i}.txt",
+            destination=Path("/") / "b" / f"file{i}.txt",
             correction_type=CorrectionType.FILE_MOVE,
         )
 

--- a/tests/services/intelligence/test_preference_tracker.py
+++ b/tests/services/intelligence/test_preference_tracker.py
@@ -112,8 +112,8 @@ def test_correction_get_pattern_key_with_extension():
     """Test pattern key generation for a file with an extension."""
     correction = Correction(
         correction_type=CorrectionType.FILE_MOVE,
-        source=Path("/docs/report.pdf"),
-        destination=Path("/archive/2024/report.pdf"),
+        source=Path("/") / "docs" / "report.pdf",
+        destination=Path("/") / "archive" / "2024" / "report.pdf",
         timestamp=datetime.now(UTC),
     )
     key = correction.get_pattern_key()
@@ -125,8 +125,8 @@ def test_correction_get_pattern_key_no_extension():
     """Test pattern key generation for a file without an extension."""
     correction = Correction(
         correction_type=CorrectionType.FILE_RENAME,
-        source=Path("/tmp/Makefile"),  # noqa: test-hardcoded-paths
-        destination=Path("/build/Makefile"),
+        source=Path("/") / "tmp" / "Makefile",  # noqa: test-hardcoded-paths
+        destination=Path("/") / "build" / "Makefile",
         timestamp=datetime.now(UTC),
     )
     key = correction.get_pattern_key()
@@ -156,14 +156,14 @@ def test_tracker_init_empty(tracker):
 def test_track_correction_file_move(tracker):
     """Test tracking a FILE_MOVE correction creates a FOLDER_MAPPING preference."""
     tracker.track_correction(
-        source=Path("/downloads/photo.jpg"),
-        destination=Path("/pictures/vacation/photo.jpg"),
+        source=Path("/") / "downloads" / "photo.jpg",
+        destination=Path("/") / "pictures" / "vacation" / "photo.jpg",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
     prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
     assert len(prefs) == 1
-    assert prefs[0].value == str(Path("/pictures/vacation"))
+    assert prefs[0].value == str(Path("/") / "pictures" / "vacation")
     assert prefs[0].metadata.confidence == 0.5
     assert prefs[0].metadata.frequency == 1
 
@@ -176,8 +176,8 @@ def test_track_correction_file_move(tracker):
 def test_track_correction_file_rename(tracker):
     """Test tracking a FILE_RENAME correction creates a NAMING_PATTERN preference."""
     tracker.track_correction(
-        source=Path("/docs/old_name.txt"),
-        destination=Path("/docs/new_name.txt"),
+        source=Path("/") / "docs" / "old_name.txt",
+        destination=Path("/") / "docs" / "new_name.txt",
         correction_type=CorrectionType.FILE_RENAME,
     )
 
@@ -194,8 +194,8 @@ def test_track_correction_file_rename(tracker):
 def test_track_correction_category_change(tracker):
     """Test tracking a CATEGORY_CHANGE correction creates a CATEGORY_OVERRIDE preference."""
     tracker.track_correction(
-        source=Path("/files/readme.md"),
-        destination=Path("/files/readme.md"),
+        source=Path("/") / "files" / "readme.md",
+        destination=Path("/") / "files" / "readme.md",
         correction_type=CorrectionType.CATEGORY_CHANGE,
         context={"old_category": "misc", "new_category": "documentation"},
     )
@@ -213,8 +213,8 @@ def test_track_correction_category_change(tracker):
 def test_track_correction_default_type(tracker):
     """Test tracking other correction types creates a CUSTOM preference."""
     tracker.track_correction(
-        source=Path("/a/file.log"),
-        destination=Path("/b/file.log"),
+        source=Path("/") / "a" / "file.log",
+        destination=Path("/") / "b" / "file.log",
         correction_type=CorrectionType.FOLDER_CREATION,
     )
 
@@ -234,8 +234,8 @@ def test_repeated_correction_increases_confidence(tracker):
     """Test that repeating the same correction increases confidence."""
     for _ in range(5):
         tracker.track_correction(
-            source=Path("/downloads/report.pdf"),
-            destination=Path("/archive/reports/report.pdf"),
+            source=Path("/") / "downloads" / "report.pdf",
+            destination=Path("/") / "archive" / "reports" / "report.pdf",
             correction_type=CorrectionType.FILE_MOVE,
         )
 
@@ -255,25 +255,25 @@ def test_repeated_correction_increases_confidence(tracker):
 def test_get_preference_folder_mapping(tracker):
     """Test getting a FOLDER_MAPPING preference by extension match."""
     tracker.track_correction(
-        source=Path("/downloads/image.png"),
-        destination=Path("/pictures/image.png"),
+        source=Path("/") / "downloads" / "image.png",
+        destination=Path("/") / "pictures" / "image.png",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
-    pref = tracker.get_preference(Path("/other/photo.png"), PreferenceType.FOLDER_MAPPING)
+    pref = tracker.get_preference(Path("/") / "other" / "photo.png", PreferenceType.FOLDER_MAPPING)
     assert pref is not None
-    assert pref.value == str(Path("/pictures"))
+    assert pref.value == str(Path("/") / "pictures")
 
 
 def test_get_preference_folder_mapping_no_match(tracker):
     """Test get_preference returns None when no matching extension exists."""
     tracker.track_correction(
-        source=Path("/downloads/image.png"),
-        destination=Path("/pictures/image.png"),
+        source=Path("/") / "downloads" / "image.png",
+        destination=Path("/") / "pictures" / "image.png",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
-    pref = tracker.get_preference(Path("/docs/readme.txt"), PreferenceType.FOLDER_MAPPING)
+    pref = tracker.get_preference(Path("/") / "docs" / "readme.txt", PreferenceType.FOLDER_MAPPING)
     assert pref is None
 
 
@@ -285,13 +285,13 @@ def test_get_preference_folder_mapping_no_match(tracker):
 def test_get_all_preferences_unfiltered(tracker):
     """Test getting all preferences without filter."""
     tracker.track_correction(
-        source=Path("/a/f.txt"),
-        destination=Path("/b/f.txt"),
+        source=Path("/") / "a" / "f.txt",
+        destination=Path("/") / "b" / "f.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
     tracker.track_correction(
-        source=Path("/a/g.txt"),
-        destination=Path("/a/renamed.txt"),
+        source=Path("/") / "a" / "g.txt",
+        destination=Path("/") / "a" / "renamed.txt",
         correction_type=CorrectionType.FILE_RENAME,
     )
 
@@ -302,13 +302,13 @@ def test_get_all_preferences_unfiltered(tracker):
 def test_get_all_preferences_filtered(tracker):
     """Test getting preferences filtered by type."""
     tracker.track_correction(
-        source=Path("/a/f.txt"),
-        destination=Path("/b/f.txt"),
+        source=Path("/") / "a" / "f.txt",
+        destination=Path("/") / "b" / "f.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
     tracker.track_correction(
-        source=Path("/a/g.txt"),
-        destination=Path("/a/renamed.txt"),
+        source=Path("/") / "a" / "g.txt",
+        destination=Path("/") / "a" / "renamed.txt",
         correction_type=CorrectionType.FILE_RENAME,
     )
 
@@ -325,8 +325,8 @@ def test_get_all_preferences_filtered(tracker):
 def test_update_preference_confidence_success(tracker):
     """Test that success increases confidence capped at 0.98."""
     tracker.track_correction(
-        source=Path("/a/f.pdf"),
-        destination=Path("/b/f.pdf"),
+        source=Path("/") / "a" / "f.pdf",
+        destination=Path("/") / "b" / "f.pdf",
         correction_type=CorrectionType.FILE_MOVE,
     )
     pref = tracker.get_all_preferences()[0]
@@ -344,8 +344,8 @@ def test_update_preference_confidence_success(tracker):
 def test_update_preference_confidence_failure(tracker):
     """Test that failure decreases confidence with floor at 0.1."""
     tracker.track_correction(
-        source=Path("/a/f.pdf"),
-        destination=Path("/b/f.pdf"),
+        source=Path("/") / "a" / "f.pdf",
+        destination=Path("/") / "b" / "f.pdf",
         correction_type=CorrectionType.FILE_MOVE,
     )
     pref = tracker.get_all_preferences()[0]
@@ -363,8 +363,8 @@ def test_update_preference_confidence_failure(tracker):
 def test_update_preference_confidence_cap_and_floor(tracker):
     """Test that confidence stays within [0.1, 0.98] boundaries."""
     tracker.track_correction(
-        source=Path("/a/f.pdf"),
-        destination=Path("/b/f.pdf"),
+        source=Path("/") / "a" / "f.pdf",
+        destination=Path("/") / "b" / "f.pdf",
         correction_type=CorrectionType.FILE_MOVE,
     )
     pref = tracker.get_all_preferences()[0]
@@ -396,13 +396,13 @@ def test_get_statistics_empty(tracker):
 def test_get_statistics_populated(tracker):
     """Test statistics after tracking corrections."""
     tracker.track_correction(
-        source=Path("/a/f.txt"),
-        destination=Path("/b/f.txt"),
+        source=Path("/") / "a" / "f.txt",
+        destination=Path("/") / "b" / "f.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
     tracker.track_correction(
-        source=Path("/a/g.pdf"),
-        destination=Path("/c/g.pdf"),
+        source=Path("/") / "a" / "g.pdf",
+        destination=Path("/") / "c" / "g.pdf",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
@@ -421,13 +421,13 @@ def test_get_statistics_populated(tracker):
 def test_clear_preferences_all(tracker):
     """Test clearing all preferences."""
     tracker.track_correction(
-        source=Path("/a/f.txt"),
-        destination=Path("/b/f.txt"),
+        source=Path("/") / "a" / "f.txt",
+        destination=Path("/") / "b" / "f.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
     tracker.track_correction(
-        source=Path("/a/g.txt"),
-        destination=Path("/a/renamed.txt"),
+        source=Path("/") / "a" / "g.txt",
+        destination=Path("/") / "a" / "renamed.txt",
         correction_type=CorrectionType.FILE_RENAME,
     )
 
@@ -439,13 +439,13 @@ def test_clear_preferences_all(tracker):
 def test_clear_preferences_by_type(tracker):
     """Test clearing preferences filtered by type."""
     tracker.track_correction(
-        source=Path("/a/f.txt"),
-        destination=Path("/b/f.txt"),
+        source=Path("/") / "a" / "f.txt",
+        destination=Path("/") / "b" / "f.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
     tracker.track_correction(
-        source=Path("/a/g.txt"),
-        destination=Path("/a/renamed.txt"),
+        source=Path("/") / "a" / "g.txt",
+        destination=Path("/") / "a" / "renamed.txt",
         correction_type=CorrectionType.FILE_RENAME,
     )
 
@@ -465,13 +465,13 @@ def test_clear_preferences_by_type(tracker):
 def test_export_import_round_trip(tracker):
     """Test that export then import restores the same state."""
     tracker.track_correction(
-        source=Path("/a/f.txt"),
-        destination=Path("/b/f.txt"),
+        source=Path("/") / "a" / "f.txt",
+        destination=Path("/") / "b" / "f.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
     tracker.track_correction(
-        source=Path("/a/g.pdf"),
-        destination=Path("/c/g.pdf"),
+        source=Path("/") / "a" / "g.pdf",
+        destination=Path("/") / "c" / "g.pdf",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
@@ -496,10 +496,10 @@ def test_export_import_round_trip(tracker):
 
 def test_get_corrections_for_file_source_match(tracker):
     """Test getting corrections that match by source path."""
-    src = Path("/downloads/file.txt")
+    src = Path("/") / "downloads" / "file.txt"
     tracker.track_correction(
         source=src,
-        destination=Path("/docs/file.txt"),
+        destination=Path("/") / "docs" / "file.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
@@ -510,9 +510,9 @@ def test_get_corrections_for_file_source_match(tracker):
 
 def test_get_corrections_for_file_destination_match(tracker):
     """Test getting corrections that match by destination path."""
-    dst = Path("/archive/report.pdf")
+    dst = Path("/") / "archive" / "report.pdf"
     tracker.track_correction(
-        source=Path("/docs/report.pdf"),
+        source=Path("/") / "docs" / "report.pdf",
         destination=dst,
         correction_type=CorrectionType.FILE_MOVE,
     )
@@ -525,12 +525,12 @@ def test_get_corrections_for_file_destination_match(tracker):
 def test_get_corrections_for_file_no_match(tracker):
     """Test getting corrections for a file with no related corrections."""
     tracker.track_correction(
-        source=Path("/a/x.txt"),
-        destination=Path("/b/x.txt"),
+        source=Path("/") / "a" / "x.txt",
+        destination=Path("/") / "b" / "x.txt",
         correction_type=CorrectionType.FILE_MOVE,
     )
 
-    corrections = tracker.get_corrections_for_file(Path("/unrelated/z.txt"))
+    corrections = tracker.get_corrections_for_file(Path("/") / "unrelated" / "z.txt")
     assert corrections == []
 
 
@@ -571,7 +571,7 @@ def test_create_tracker():
 def test_track_file_move_convenience():
     """Test the track_file_move convenience function."""
     t = create_tracker()
-    track_file_move(t, Path("/a/f.jpg"), Path("/b/f.jpg"))
+    track_file_move(t, Path("/") / "a" / "f.jpg", Path("/") / "b" / "f.jpg")
 
     prefs = t.get_all_preferences(PreferenceType.FOLDER_MAPPING)
     assert len(prefs) == 1
@@ -580,7 +580,7 @@ def test_track_file_move_convenience():
 def test_track_file_rename_convenience():
     """Test the track_file_rename convenience function."""
     t = create_tracker()
-    track_file_rename(t, Path("/a/old.txt"), Path("/a/new.txt"))
+    track_file_rename(t, Path("/") / "a" / "old.txt", Path("/") / "a" / "new.txt")
 
     prefs = t.get_all_preferences(PreferenceType.NAMING_PATTERN)
     assert len(prefs) == 1
@@ -589,7 +589,7 @@ def test_track_file_rename_convenience():
 def test_track_category_change_convenience():
     """Test the track_category_change convenience function."""
     t = create_tracker()
-    track_category_change(t, Path("/f/readme.md"), "misc", "docs")
+    track_category_change(t, Path("/") / "f" / "readme.md", "misc", "docs")
 
     prefs = t.get_all_preferences(PreferenceType.CATEGORY_OVERRIDE)
     assert len(prefs) == 1

--- a/tests/services/intelligence/test_profile_migrator.py
+++ b/tests/services/intelligence/test_profile_migrator.py
@@ -182,7 +182,9 @@ def test_rollback_migration_missing_backup(migrator, profile_manager):
     """Test rollback returns False when backup file does not exist."""
     profile_manager.create_profile("rollback_test2", "Test")
 
-    result = migrator.rollback_migration("rollback_test2", Path("/nonexistent/backup.json"))
+    result = migrator.rollback_migration(
+        "rollback_test2", Path("/") / "nonexistent" / "backup.json"
+    )
     assert result is False
 
 

--- a/tests/services/intelligence/test_profile_migrator_extended.py
+++ b/tests/services/intelligence/test_profile_migrator_extended.py
@@ -351,7 +351,7 @@ class TestRollbackMigrationExtended:
     def test_rollback_exception(self, migrator, profile_manager, temp_storage):
         """Test rollback handles exceptions gracefully."""
         profile_manager.create_profile("rb_exc", "Rollback exception")
-        result = migrator.rollback_migration("rb_exc", Path("/nonexistent/backup.json"))
+        result = migrator.rollback_migration("rb_exc", Path("/") / "nonexistent" / "backup.json")
         assert result is False
 
 

--- a/tests/services/test_misplacement_detector.py
+++ b/tests/services/test_misplacement_detector.py
@@ -25,9 +25,9 @@ class TestMisplacedFile:
 
     def test_create_misplaced_file(self):
         """Test creating a misplaced file record."""
-        file_path = Path("/test/photo.jpg")
-        current_loc = Path("/documents")
-        suggested_loc = Path("/pictures")
+        file_path = Path("/") / "test" / "photo.jpg"
+        current_loc = Path("/") / "documents"
+        suggested_loc = Path("/") / "pictures"
 
         misplaced = MisplacedFile(
             file_path=file_path,
@@ -44,9 +44,9 @@ class TestMisplacedFile:
     def test_misplaced_file_to_dict(self):
         """Test conversion to dictionary."""
         misplaced = MisplacedFile(
-            file_path=Path("/test/file.txt"),
-            current_location=Path("/images"),
-            suggested_location=Path("/documents"),
+            file_path=Path("/") / "test" / "file.txt",
+            current_location=Path("/") / "images",
+            suggested_location=Path("/") / "documents",
             mismatch_score=80.0,
             reasons=["Text file in image folder"],
         )
@@ -66,12 +66,15 @@ class TestContextAnalysis:
     def test_create_context_analysis(self):
         """Test creating a context analysis."""
         context = ContextAnalysis(
-            file_path=Path("/test/document.pdf"),
+            file_path=Path("/") / "test" / "document.pdf",
             file_type=".pdf",
             mime_type="application/pdf",
             size=1024000,
-            directory=Path("/documents"),
-            sibling_files=[Path("/documents/other.pdf"), Path("/documents/report.docx")],
+            directory=Path("/") / "documents",
+            sibling_files=[
+                Path("/") / "documents" / "other.pdf",
+                Path("/") / "documents" / "report.docx",
+            ],
             sibling_types={".pdf", ".docx"},
             parent_category="documents",
             naming_patterns=["date_prefix", "snake_case"],
@@ -84,11 +87,11 @@ class TestContextAnalysis:
     def test_context_analysis_to_dict(self):
         """Test context analysis conversion to dict."""
         context = ContextAnalysis(
-            file_path=Path("/test/image.jpg"),
+            file_path=Path("/") / "test" / "image.jpg",
             file_type=".jpg",
             mime_type="image/jpeg",
             size=2048000,
-            directory=Path("/images"),
+            directory=Path("/") / "images",
             sibling_files=[],
             sibling_types={".jpg"},
             parent_category="images",
@@ -307,7 +310,7 @@ class TestEdgeCases:
         detector = MisplacementDetector()
 
         with pytest.raises(ValueError):
-            detector.detect_misplaced(Path("/nonexistent/path"))
+            detector.detect_misplaced(Path("/") / "nonexistent" / "path")
 
     def test_file_instead_of_directory_raises_error(self):
         """Test that file path instead of directory raises error."""

--- a/tests/services/test_misplacement_detector_coverage.py
+++ b/tests/services/test_misplacement_detector_coverage.py
@@ -45,12 +45,12 @@ def _make_pattern_analysis(directory: Path, location_patterns=None, clusters=Non
 class TestDataclasses:
     def test_misplaced_file_to_dict(self):
         mf = MisplacedFile(
-            file_path=Path("/a/b.txt"),
-            current_location=Path("/a"),
-            suggested_location=Path("/c"),
+            file_path=Path("/") / "a" / "b.txt",
+            current_location=Path("/") / "a",
+            suggested_location=Path("/") / "c",
             mismatch_score=75.0,
             reasons=["type mismatch"],
-            similar_files=[Path("/c/d.txt")],
+            similar_files=[Path("/") / "c" / "d.txt"],
         )
         d = mf.to_dict()
         assert d["mismatch_score"] == 75.0
@@ -81,7 +81,7 @@ class TestDataclasses:
 class TestDetectMisplaced:
     def test_invalid_directory(self, detector):
         with pytest.raises(ValueError, match="Invalid directory"):
-            detector.detect_misplaced(Path("/nonexistent"))
+            detector.detect_misplaced(Path("/") / "nonexistent")
 
     def test_empty_directory(self, detector, tmp_path):
         result = detector.detect_misplaced(tmp_path)

--- a/tests/services/test_pattern_analyzer.py
+++ b/tests/services/test_pattern_analyzer.py
@@ -50,7 +50,7 @@ class TestLocationPattern:
     def test_create_location_pattern(self):
         """Test creating a location pattern."""
         pattern = LocationPattern(
-            directory=Path("/documents"),
+            directory=Path("/") / "documents",
             file_types={".pdf", ".docx"},
             naming_patterns=["DATE_PREFIX"],
             file_count=15,
@@ -58,7 +58,7 @@ class TestLocationPattern:
             category="documents",
         )
 
-        assert pattern.directory == Path("/documents")
+        assert pattern.directory == Path("/") / "documents"
         assert ".pdf" in pattern.file_types
         assert pattern.file_count == 15
 
@@ -71,7 +71,7 @@ class TestContentCluster:
         """Test creating a content cluster."""
         cluster = ContentCluster(
             cluster_id="cluster_001",
-            file_paths=[Path("/file1.txt"), Path("/file2.txt")],
+            file_paths=[Path("/") / "file1.txt", Path("/") / "file2.txt"],
             common_keywords=["report", "financial"],
             file_types={".txt", ".pdf"},
             size_range=(1000, 50000),
@@ -91,7 +91,7 @@ class TestPatternAnalysisDataclass:
     def test_create_pattern_analysis(self):
         """Test creating pattern analysis result."""
         analysis = PatternAnalysis(
-            directory=Path("/test"),
+            directory=Path("/") / "test",
             naming_patterns=[],
             location_patterns=[],
             content_clusters=[],
@@ -101,7 +101,7 @@ class TestPatternAnalysisDataclass:
             total_files=15,
         )
 
-        assert analysis.directory == Path("/test")
+        assert analysis.directory == Path("/") / "test"
         assert analysis.total_files == 15
         assert analysis.file_type_distribution[".txt"] == 10
 
@@ -167,7 +167,7 @@ class TestAnalyzeDirectory:
         analyzer = PatternAnalyzer()
 
         with pytest.raises(ValueError):
-            analyzer.analyze_directory(Path("/nonexistent/path"))
+            analyzer.analyze_directory(Path("/") / "nonexistent" / "path")
 
     def test_analyze_file_instead_of_directory(self):
         """Test analyzing a file instead of directory raises error."""

--- a/tests/services/test_service_facade.py
+++ b/tests/services/test_service_facade.py
@@ -671,8 +671,8 @@ class TestGetOperationHistory:
         mock_op.id = 1
         mock_op.operation_type = MagicMock()
         mock_op.operation_type.value = "move"
-        mock_op.source_path = Path("/tmp/src.txt")  # noqa: test-hardcoded-paths
-        mock_op.destination_path = Path("/tmp/dst.txt")  # noqa: test-hardcoded-paths
+        mock_op.source_path = Path("/") / "tmp" / "src.txt"  # noqa: test-hardcoded-paths
+        mock_op.destination_path = Path("/") / "tmp" / "dst.txt"  # noqa: test-hardcoded-paths
         mock_op.status = MagicMock()
         mock_op.status.value = "completed"
         mock_op.timestamp = MagicMock()
@@ -711,7 +711,7 @@ class TestGetOperationHistory:
         mock_op.id = 2
         mock_op.operation_type = MagicMock()
         mock_op.operation_type.value = "delete"
-        mock_op.source_path = Path("/tmp/gone.txt")  # noqa: test-hardcoded-paths
+        mock_op.source_path = Path("/") / "tmp" / "gone.txt"  # noqa: test-hardcoded-paths
         mock_op.destination_path = None
         mock_op.status = MagicMock()
         mock_op.status.value = "completed"

--- a/tests/services/test_smart_suggestions.py
+++ b/tests/services/test_smart_suggestions.py
@@ -44,7 +44,7 @@ class FakeNamingPattern:
 
 @dataclass
 class FakeLocationPattern:
-    directory: Path = field(default_factory=lambda: Path("/docs"))
+    directory: Path = field(default_factory=lambda: Path("/") / "docs")
     file_types: set[str] = field(default_factory=lambda: {".pdf", ".txt"})
     naming_patterns: list[str] = field(default_factory=lambda: ["report_*"])
     file_count: int = 10
@@ -65,7 +65,7 @@ class FakeContentCluster:
 
 @dataclass
 class FakePatternAnalysis:
-    directory: Path = field(default_factory=lambda: Path("/root"))
+    directory: Path = field(default_factory=lambda: Path("/") / "root")
     naming_patterns: list[FakeNamingPattern] = field(default_factory=list)
     location_patterns: list[FakeLocationPattern] = field(default_factory=list)
     content_clusters: list[FakeContentCluster] = field(default_factory=list)
@@ -87,7 +87,9 @@ class TestConfidenceScorerUserHistory:
 
     def test_no_target_returns_50(self):
         scorer = ConfidenceScorer()
-        result = scorer._calculate_user_history_score(Path("/a.txt"), None, {"move_history": {}})
+        result = scorer._calculate_user_history_score(
+            Path("/") / "a.txt", None, {"move_history": {}}
+        )
         assert result == 50.0
 
     def test_target_with_history(self, tmp_path):
@@ -155,15 +157,17 @@ class TestConfidenceScorerNamingMatch:
 
     def test_no_analysis(self):
         scorer = ConfidenceScorer()
-        result = scorer._calculate_naming_match(Path("/a.txt"), Path("/dest"), None)
+        result = scorer._calculate_naming_match(Path("/") / "a.txt", Path("/") / "dest", None)
         assert result == 50.0
 
     def test_no_target_patterns(self):
         scorer = ConfidenceScorer()
         analysis = FakePatternAnalysis(
-            location_patterns=[FakeLocationPattern(directory=Path("/other"))]
+            location_patterns=[FakeLocationPattern(directory=Path("/") / "other")]
         )
-        result = scorer._calculate_naming_match(Path("/a.txt"), Path("/dest/a.txt"), analysis)
+        result = scorer._calculate_naming_match(
+            Path("/") / "a.txt", Path("/") / "dest" / "a.txt", analysis
+        )
         assert result == 40.0
 
     def test_with_naming_patterns(self, tmp_path):
@@ -183,15 +187,17 @@ class TestConfidenceScorerFileTypeMatch:
 
     def test_no_analysis(self):
         scorer = ConfidenceScorer()
-        result = scorer._calculate_file_type_match(Path("/a.txt"), Path("/dest"), None)
+        result = scorer._calculate_file_type_match(Path("/") / "a.txt", Path("/") / "dest", None)
         assert result == 50.0
 
     def test_no_target_patterns(self):
         scorer = ConfidenceScorer()
         analysis = FakePatternAnalysis(
-            location_patterns=[FakeLocationPattern(directory=Path("/other"))]
+            location_patterns=[FakeLocationPattern(directory=Path("/") / "other")]
         )
-        result = scorer._calculate_file_type_match(Path("/a.txt"), Path("/dest/a.txt"), analysis)
+        result = scorer._calculate_file_type_match(
+            Path("/") / "a.txt", Path("/") / "dest" / "a.txt", analysis
+        )
         assert result == 40.0
 
     def test_matching_type(self, tmp_path):
@@ -335,7 +341,7 @@ class TestSuggestionEngineExplain:
         suggestion = Suggestion(
             suggestion_id="test",
             suggestion_type=SuggestionType.MOVE,
-            file_path=Path("/a.txt"),
+            file_path=Path("/") / "a.txt",
             confidence=70.0,
             reasoning="test reason",
             metadata={"factors": factors.to_dict()},
@@ -350,7 +356,7 @@ class TestSuggestionEngineExplain:
         suggestion = Suggestion(
             suggestion_id="test",
             suggestion_type=SuggestionType.RENAME,
-            file_path=Path("/a.txt"),
+            file_path=Path("/") / "a.txt",
             confidence=50.0,
             reasoning="rename reason",
             metadata={},
@@ -366,31 +372,31 @@ class TestSuggestionEngineMoveReasoning:
     def test_high_pattern_strength(self):
         engine = SuggestionEngine()
         factors = ConfidenceFactors(pattern_strength=80.0)
-        result = engine._generate_move_reasoning(Path("/a.txt"), Path("/dest"), factors)
+        result = engine._generate_move_reasoning(Path("/") / "a.txt", Path("/") / "dest", factors)
         assert "pattern" in result
 
     def test_high_file_type_match(self):
         engine = SuggestionEngine()
         factors = ConfidenceFactors(file_type_match=80.0)
-        result = engine._generate_move_reasoning(Path("/a.txt"), Path("/dest"), factors)
+        result = engine._generate_move_reasoning(Path("/") / "a.txt", Path("/") / "dest", factors)
         assert "file type" in result
 
     def test_high_content_similarity(self):
         engine = SuggestionEngine()
         factors = ConfidenceFactors(content_similarity=80.0)
-        result = engine._generate_move_reasoning(Path("/a.txt"), Path("/dest"), factors)
+        result = engine._generate_move_reasoning(Path("/") / "a.txt", Path("/") / "dest", factors)
         assert "similar files" in result
 
     def test_high_user_history(self):
         engine = SuggestionEngine()
         factors = ConfidenceFactors(user_history=80.0)
-        result = engine._generate_move_reasoning(Path("/a.txt"), Path("/dest"), factors)
+        result = engine._generate_move_reasoning(Path("/") / "a.txt", Path("/") / "dest", factors)
         assert "moved similar" in result
 
     def test_no_reasons_fallback(self):
         engine = SuggestionEngine()
         factors = ConfidenceFactors()
-        result = engine._generate_move_reasoning(Path("/a.txt"), Path("/dest"), factors)
+        result = engine._generate_move_reasoning(Path("/") / "a.txt", Path("/") / "dest", factors)
         assert "improve organization" in result
 
 
@@ -458,13 +464,13 @@ class TestSuggestionEngineRank:
         s1 = Suggestion(
             suggestion_id="1",
             suggestion_type=SuggestionType.MOVE,
-            file_path=Path("/a"),
+            file_path=Path("/") / "a",
             confidence=50.0,
         )
         s2 = Suggestion(
             suggestion_id="2",
             suggestion_type=SuggestionType.MOVE,
-            file_path=Path("/b"),
+            file_path=Path("/") / "b",
             confidence=90.0,
         )
         ranked = engine.rank_suggestions([s1, s2])
@@ -475,13 +481,13 @@ class TestSuggestionEngineRank:
         s1 = Suggestion(
             suggestion_id="1",
             suggestion_type=SuggestionType.RENAME,
-            file_path=Path("/a"),
+            file_path=Path("/") / "a",
             confidence=70.0,
         )
         s2 = Suggestion(
             suggestion_id="2",
             suggestion_type=SuggestionType.RESTRUCTURE,
-            file_path=Path("/b"),
+            file_path=Path("/") / "b",
             confidence=70.0,
         )
         ranked = engine.rank_suggestions([s1, s2])
@@ -725,7 +731,7 @@ class TestSuggestionFeedback:
             suggestion_id="test1",
             suggestion_type=SuggestionType.MOVE,
             file_path=Path("test.jpg"),
-            target_path=Path("images/test.jpg"),
+            target_path=Path("images") / "test.jpg",
             confidence=75.0,
             reasoning="Test",
         )

--- a/tests/services/test_smart_suggestions.py
+++ b/tests/services/test_smart_suggestions.py
@@ -55,7 +55,9 @@ class FakeLocationPattern:
 @dataclass
 class FakeContentCluster:
     cluster_id: str = "cluster-1"
-    file_paths: list[Path] = field(default_factory=lambda: [Path(f"/f{i}.txt") for i in range(6)])
+    file_paths: list[Path] = field(
+        default_factory=lambda: [Path("/") / f"f{i}.txt" for i in range(6)]
+    )
     common_keywords: list[str] = field(default_factory=lambda: ["report", "quarterly", "finance"])
     file_types: set[str] = field(default_factory=lambda: {".txt"})
     size_range: tuple[int, int] = (100, 5000)

--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -62,7 +62,7 @@ class TestProcessedFile:
     def test_all_fields(self) -> None:
         """Verify all fields are stored correctly."""
         pf = ProcessedFile(
-            file_path=Path("/tmp/b.pdf"),  # noqa: test-hardcoded-paths
+            file_path=Path("/") / "tmp" / "b.pdf",  # noqa: test-hardcoded-paths
             description="A summary",
             folder_name="science",
             filename="research_paper",
@@ -70,7 +70,7 @@ class TestProcessedFile:
             processing_time=1.23,
             error="some error",
         )
-        assert pf.file_path == Path("/tmp/b.pdf")  # noqa: test-hardcoded-paths
+        assert pf.file_path == Path("/") / "tmp" / "b.pdf"  # noqa: test-hardcoded-paths
         assert pf.description == "A summary"
         assert pf.folder_name == "science"
         assert pf.filename == "research_paper"
@@ -226,7 +226,7 @@ class TestTextProcessorFileProcessing:
 
         result = text_processor.process_file("/some/path/test.md")
 
-        assert result.file_path == Path("/some/path/test.md")
+        assert result.file_path == Path("/") / "some" / "path" / "test.md"
 
     @patch("file_organizer.services.text_processor.read_file")
     def test_process_file_unsupported(

--- a/tests/services/test_text_processor_scan_root.py
+++ b/tests/services/test_text_processor_scan_root.py
@@ -54,9 +54,9 @@ class TestReadContentRouting:
             ) as anchored,
         ):
             legacy.return_value = "content"
-            out = TextProcessor._read_content(Path("/x/doc.txt"), None)
+            out = TextProcessor._read_content(Path("/") / "x" / "doc.txt", None)
         assert out == "content"
-        legacy.assert_called_once_with(Path("/x/doc.txt"))
+        legacy.assert_called_once_with(Path("/") / "x" / "doc.txt")
         anchored.assert_not_called()
 
     @posix_only
@@ -68,9 +68,13 @@ class TestReadContentRouting:
             ) as anchored,
         ):
             anchored.return_value = "safe content"
-            out = TextProcessor._read_content(Path("/root/sub/doc.txt"), Path("/root"))
+            out = TextProcessor._read_content(
+                Path("/") / "root" / "sub" / "doc.txt", Path("/") / "root"
+            )
         assert out == "safe content"
-        anchored.assert_called_once_with(Path("/root/sub/doc.txt"), trusted_root=Path("/root"))
+        anchored.assert_called_once_with(
+            Path("/") / "root" / "sub" / "doc.txt", trusted_root=Path("/") / "root"
+        )
         legacy.assert_not_called()
 
     @posix_only
@@ -83,9 +87,9 @@ class TestReadContentRouting:
             ),
         ):
             legacy.return_value = "fallback"
-            out = TextProcessor._read_content(Path("/root/doc.txt"), Path("/root"))
+            out = TextProcessor._read_content(Path("/") / "root" / "doc.txt", Path("/") / "root")
         assert out == "fallback"
-        legacy.assert_called_once_with(Path("/root/doc.txt"))
+        legacy.assert_called_once_with(Path("/") / "root" / "doc.txt")
 
 
 class TestReadContentRealFilesystem:
@@ -165,7 +169,7 @@ class TestDispatcherForwardsScanRoot:
         console = MagicMock()
 
         dispatcher.process_text_files(
-            [Path("a.txt")], processor, parallel, console, scan_root=Path("/root")
+            [Path("a.txt")], processor, parallel, console, scan_root=Path("/") / "root"
         )
 
-        processor.process_file.assert_called_once_with(Path("a.txt"), scan_root=Path("/root"))
+        processor.process_file.assert_called_once_with(Path("a.txt"), scan_root=Path("/") / "root")

--- a/tests/services/test_vision_processor.py
+++ b/tests/services/test_vision_processor.py
@@ -39,7 +39,7 @@ class TestProcessedImage:
     def test_defaults(self) -> None:
         """Test ProcessedImage default values."""
         result = ProcessedImage(
-            file_path=Path("/img.jpg"),
+            file_path=Path("/") / "img.jpg",
             description="desc",
             folder_name="folder",
             filename="name",
@@ -52,7 +52,7 @@ class TestProcessedImage:
     def test_custom_values(self) -> None:
         """Test ProcessedImage with all fields set."""
         result = ProcessedImage(
-            file_path=Path("/img.jpg"),
+            file_path=Path("/") / "img.jpg",
             description="A photo",
             folder_name="nature",
             filename="sunset",

--- a/tests/services/video/test_metadata_extractor.py
+++ b/tests/services/video/test_metadata_extractor.py
@@ -222,7 +222,7 @@ class TestFilesystemFallback:
 
     def test_file_not_found_raises(self, extractor: VideoMetadataExtractor) -> None:
         with pytest.raises(FileNotFoundError):
-            extractor.extract(Path("/nonexistent/video.mp4"))
+            extractor.extract(Path("/") / "nonexistent" / "video.mp4")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui/test_analytics_view.py
+++ b/tests/tui/test_analytics_view.py
@@ -361,14 +361,14 @@ class TestAnalyticsView:
 
     def test_initialization_with_custom_directory(self) -> None:
         """Test AnalyticsView initialization with custom directory."""
-        test_path = Path("/tmp/test")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
         view = AnalyticsView(directory=test_path)
         assert view._directory == test_path
 
     def test_initialization_with_string_directory(self) -> None:
         """Test AnalyticsView initialization with string directory."""
         view = AnalyticsView(directory="/tmp/test")  # noqa: test-hardcoded-paths
-        assert view._directory == Path("/tmp/test")  # noqa: test-hardcoded-paths
+        assert view._directory == Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
 
     def test_has_compose_method(self) -> None:
         """Test that compose method is defined."""

--- a/tests/tui/test_audio_view.py
+++ b/tests/tui/test_audio_view.py
@@ -280,7 +280,7 @@ class TestAudioViewInit:
 
     def test_string_scan_dir(self):
         view = AudioView(scan_dir="/tmp")  # noqa: test-hardcoded-paths
-        assert view._scan_dir == Path("/tmp")  # noqa: test-hardcoded-paths
+        assert view._scan_dir == Path("/") / "tmp"  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.unit

--- a/tests/tui/test_audio_view_coverage.py
+++ b/tests/tui/test_audio_view_coverage.py
@@ -236,7 +236,7 @@ def test_audio_classification_panel_valid() -> None:
 def test_audio_view_initialization() -> None:
     """Verify AudioView fields on creation."""
     view = AudioView(scan_dir="/some/path")
-    assert view._scan_dir == Path("/some/path")
+    assert view._scan_dir == Path("/") / "some" / "path"
     assert view._files == []
     assert view._current_index == 0
 

--- a/tests/tui/test_file_browser_coverage.py
+++ b/tests/tui/test_file_browser_coverage.py
@@ -261,11 +261,11 @@ class TestFileBrowserView:
 
     def test_custom_path_init(self) -> None:
         view = FileBrowserView(path="tmp/test")
-        assert view._root_path == Path("tmp/test")
+        assert view._root_path == Path("tmp") / "test"
 
     def test_file_highlighted_message(self) -> None:
-        msg = FileBrowserView.FileHighlighted(Path("tmp/file.txt"))
-        assert msg.path == Path("tmp/file.txt")
+        msg = FileBrowserView.FileHighlighted(Path("tmp") / "file.txt")
+        assert msg.path == Path("tmp") / "file.txt"
 
     def test_bindings(self) -> None:
         keys = [b.key for b in FileBrowserView.BINDINGS]

--- a/tests/tui/test_file_preview.py
+++ b/tests/tui/test_file_preview.py
@@ -133,11 +133,11 @@ class TestFileSelectionManager:
         assert manager.count == 0
 
         for i in range(5):
-            manager.toggle(Path(f"/tmp/file{i}.txt"))  # noqa: test-hardcoded-paths
+            manager.toggle(Path("/") / "tmp" / f"file{i}.txt")  # noqa: test-hardcoded-paths
             assert manager.count == i + 1
 
         for i in range(5):
-            manager.toggle(Path(f"/tmp/file{i}.txt"))  # noqa: test-hardcoded-paths
+            manager.toggle(Path("/") / "tmp" / f"file{i}.txt")  # noqa: test-hardcoded-paths
             assert manager.count == 5 - i - 1
 
     def test_selected_files_returns_copy(self) -> None:
@@ -258,14 +258,14 @@ class TestFileSelectionManagerEdgeCases:
     def test_large_selection(self) -> None:
         """Test managing large number of selections."""
         manager = FileSelectionManager()
-        paths = {Path(f"/tmp/file{i}.txt") for i in range(1000)}  # noqa: test-hardcoded-paths
+        paths = {Path("/") / "tmp" / f"file{i}.txt" for i in range(1000)}  # noqa: test-hardcoded-paths
         manager.select_all(paths)
         assert manager.count == 1000
 
     def test_clear_after_large_selection(self) -> None:
         """Test clearing large selection."""
         manager = FileSelectionManager()
-        paths = {Path(f"/tmp/file{i}.txt") for i in range(100)}  # noqa: test-hardcoded-paths
+        paths = {Path("/") / "tmp" / f"file{i}.txt" for i in range(100)}  # noqa: test-hardcoded-paths
         manager.select_all(paths)
         manager.clear()
         assert manager.count == 0

--- a/tests/tui/test_file_preview.py
+++ b/tests/tui/test_file_preview.py
@@ -37,7 +37,7 @@ class TestFileSelectionManager:
     def test_toggle_adds_path(self) -> None:
         """Test that toggle adds a new path."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
         result = manager.toggle(path)
         assert result is True
         assert manager.count == 1
@@ -46,7 +46,7 @@ class TestFileSelectionManager:
     def test_toggle_removes_path(self) -> None:
         """Test that toggle removes a selected path."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
         manager.toggle(path)  # Add
         result = manager.toggle(path)  # Remove
         assert result is False
@@ -56,9 +56,9 @@ class TestFileSelectionManager:
     def test_toggle_multiple_paths(self) -> None:
         """Test toggling multiple paths."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file1.txt")  # noqa: test-hardcoded-paths
-        path2 = Path("/tmp/file2.txt")  # noqa: test-hardcoded-paths
-        path3 = Path("/tmp/file3.txt")  # noqa: test-hardcoded-paths
+        path1 = Path("/") / "tmp" / "file1.txt"  # noqa: test-hardcoded-paths
+        path2 = Path("/") / "tmp" / "file2.txt"  # noqa: test-hardcoded-paths
+        path3 = Path("/") / "tmp" / "file3.txt"  # noqa: test-hardcoded-paths
 
         manager.toggle(path1)
         manager.toggle(path2)
@@ -72,7 +72,7 @@ class TestFileSelectionManager:
     def test_toggle_returns_correct_state(self) -> None:
         """Test that toggle returns the new selection state."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
         assert manager.toggle(path) is True
         assert manager.toggle(path) is False
         assert manager.toggle(path) is True
@@ -81,9 +81,9 @@ class TestFileSelectionManager:
         """Test select_all adds all provided paths."""
         manager = FileSelectionManager()
         paths = {
-            Path("/tmp/file1.txt"),  # noqa: test-hardcoded-paths
-            Path("/tmp/file2.txt"),  # noqa: test-hardcoded-paths
-            Path("/tmp/file3.txt"),  # noqa: test-hardcoded-paths
+            Path("/") / "tmp" / "file1.txt",  # noqa: test-hardcoded-paths
+            Path("/") / "tmp" / "file2.txt",  # noqa: test-hardcoded-paths
+            Path("/") / "tmp" / "file3.txt",  # noqa: test-hardcoded-paths
         }
         manager.select_all(paths)
         assert manager.count == 3
@@ -92,12 +92,12 @@ class TestFileSelectionManager:
     def test_select_all_adds_to_existing(self) -> None:
         """Test that select_all adds to existing selections."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file1.txt")  # noqa: test-hardcoded-paths
+        path1 = Path("/") / "tmp" / "file1.txt"  # noqa: test-hardcoded-paths
         manager.toggle(path1)
 
         paths = {
-            Path("/tmp/file2.txt"),  # noqa: test-hardcoded-paths
-            Path("/tmp/file3.txt"),  # noqa: test-hardcoded-paths
+            Path("/") / "tmp" / "file2.txt",  # noqa: test-hardcoded-paths
+            Path("/") / "tmp" / "file3.txt",  # noqa: test-hardcoded-paths
         }
         manager.select_all(paths)
         assert manager.count == 3
@@ -112,9 +112,9 @@ class TestFileSelectionManager:
     def test_clear_removes_all_selections(self) -> None:
         """Test that clear removes all paths."""
         manager = FileSelectionManager()
-        manager.toggle(Path("/tmp/file1.txt"))  # noqa: test-hardcoded-paths
-        manager.toggle(Path("/tmp/file2.txt"))  # noqa: test-hardcoded-paths
-        manager.toggle(Path("/tmp/file3.txt"))  # noqa: test-hardcoded-paths
+        manager.toggle(Path("/") / "tmp" / "file1.txt")  # noqa: test-hardcoded-paths
+        manager.toggle(Path("/") / "tmp" / "file2.txt")  # noqa: test-hardcoded-paths
+        manager.toggle(Path("/") / "tmp" / "file3.txt")  # noqa: test-hardcoded-paths
         assert manager.count == 3
 
         manager.clear()
@@ -143,21 +143,23 @@ class TestFileSelectionManager:
     def test_selected_files_returns_copy(self) -> None:
         """Test that selected_files returns a copy, not the internal set."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
         manager.toggle(path)
 
         selected = manager.selected_files
-        selected.add(Path("/tmp/fake.txt"))  # Modify the returned set  # noqa: test-hardcoded-paths
+        selected.add(
+            Path("/") / "tmp" / "fake.txt"
+        )  # Modify the returned set  # noqa: test-hardcoded-paths
 
         # Original should not be modified
         assert manager.count == 1
-        assert Path("/tmp/fake.txt") not in manager.selected_files  # noqa: test-hardcoded-paths
+        assert Path("/") / "tmp" / "fake.txt" not in manager.selected_files  # noqa: test-hardcoded-paths
 
     def test_selected_files_immutability(self) -> None:
         """Test that modifying returned set doesn't affect manager."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file1.txt")  # noqa: test-hardcoded-paths
-        path2 = Path("/tmp/file2.txt")  # noqa: test-hardcoded-paths
+        path1 = Path("/") / "tmp" / "file1.txt"  # noqa: test-hardcoded-paths
+        path2 = Path("/") / "tmp" / "file2.txt"  # noqa: test-hardcoded-paths
         manager.toggle(path1)
 
         selected = manager.selected_files
@@ -228,8 +230,8 @@ class TestFileSelectionManagerEdgeCases:
     def test_same_path_object_vs_equal_paths(self) -> None:
         """Test that different Path objects to same file work correctly."""
         manager = FileSelectionManager()
-        path1 = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
-        path2 = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path1 = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
+        path2 = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
 
         manager.toggle(path1)
         # Both should refer to the same file
@@ -238,7 +240,7 @@ class TestFileSelectionManagerEdgeCases:
     def test_path_with_special_characters(self) -> None:
         """Test paths with special characters."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file with spaces (1).txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file with spaces (1).txt"  # noqa: test-hardcoded-paths
         manager.toggle(path)
         assert manager.count == 1
         assert path in manager.selected_files
@@ -246,7 +248,7 @@ class TestFileSelectionManagerEdgeCases:
     def test_absolute_vs_relative_paths(self) -> None:
         """Test that absolute and relative paths are distinct."""
         manager = FileSelectionManager()
-        abs_path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        abs_path = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
         rel_path = Path("file.txt")
 
         manager.toggle(abs_path)
@@ -271,7 +273,7 @@ class TestFileSelectionManagerEdgeCases:
     def test_toggle_repeatedly_same_path(self) -> None:
         """Test toggling same path multiple times."""
         manager = FileSelectionManager()
-        path = Path("/tmp/file.txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file.txt"  # noqa: test-hardcoded-paths
 
         for i in range(100):
             manager.toggle(path)

--- a/tests/tui/test_file_preview_coverage.py
+++ b/tests/tui/test_file_preview_coverage.py
@@ -259,7 +259,7 @@ class TestFilePreviewViewActions:
 
     def test_action_deselect_all(self) -> None:
         view = FilePreviewView()
-        view.selection._selected.add(Path("tmp/a.txt"))
+        view.selection._selected.add(Path("tmp") / "a.txt")
         view.post_message = MagicMock()
         view._notify_selection = MagicMock()
         view.action_deselect_all()
@@ -279,5 +279,5 @@ class TestFilePreviewViewActions:
 
     def test_init_custom_path(self) -> None:
         view = FilePreviewView(path="tmp/test")
-        assert view._root_path == Path("tmp/test")
+        assert view._root_path == Path("tmp") / "test"
         assert view._current_path is None

--- a/tests/tui/test_methodology_view.py
+++ b/tests/tui/test_methodology_view.py
@@ -258,14 +258,14 @@ class TestMethodologyView:
 
     def test_initialization_with_custom_directory(self) -> None:
         """Test MethodologyView initialization with custom directory."""
-        test_path = Path("/tmp/test")  # noqa: test-hardcoded-paths
+        test_path = Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
         view = MethodologyView(scan_dir=test_path)
         assert view._scan_dir == test_path
 
     def test_initialization_with_string_directory(self) -> None:
         """Test MethodologyView initialization with string directory."""
         view = MethodologyView(scan_dir="/tmp/test")  # noqa: test-hardcoded-paths
-        assert view._scan_dir == Path("/tmp/test")  # noqa: test-hardcoded-paths
+        assert view._scan_dir == Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
 
     def test_has_compose_method(self) -> None:
         """Test that compose method is defined."""

--- a/tests/tui/test_organization_preview.py
+++ b/tests/tui/test_organization_preview.py
@@ -238,8 +238,8 @@ class TestOrganizationPreviewView:
 
     def test_initialization_with_custom_directories(self) -> None:
         """Test OrganizationPreviewView with custom directories."""
-        input_path = Path("/home/user/files")  # noqa: test-hardcoded-paths
-        output_path = Path("/home/user/organized")  # noqa: test-hardcoded-paths
+        input_path = Path("/") / "home" / "user" / "files"  # noqa: test-hardcoded-paths
+        output_path = Path("/") / "home" / "user" / "organized"  # noqa: test-hardcoded-paths
         view = OrganizationPreviewView(input_dir=input_path, output_dir=output_path)
         assert view._input_dir == input_path
         assert view._output_dir == output_path
@@ -250,8 +250,8 @@ class TestOrganizationPreviewView:
             input_dir="/tmp/input",  # noqa: test-hardcoded-paths
             output_dir="/tmp/output",  # noqa: test-hardcoded-paths
         )
-        assert view._input_dir == Path("/tmp/input")  # noqa: test-hardcoded-paths
-        assert view._output_dir == Path("/tmp/output")  # noqa: test-hardcoded-paths
+        assert view._input_dir == Path("/") / "tmp" / "input"  # noqa: test-hardcoded-paths
+        assert view._output_dir == Path("/") / "tmp" / "output"  # noqa: test-hardcoded-paths
 
     def test_has_compose_method(self) -> None:
         """Test that compose method is defined."""

--- a/tests/tui/test_tui_audio_view.py
+++ b/tests/tui/test_tui_audio_view.py
@@ -51,7 +51,7 @@ def _make_metadata(
     m.sample_rate = sample_rate
     m.channels = channels
     m.format = fmt
-    m.file_path = Path("/audio/test.mp3")
+    m.file_path = Path("/") / "audio" / "test.mp3"
     m.file_size = 5_000_000
     return m
 
@@ -218,9 +218,9 @@ def test_audio_view_navigation() -> None:
         view = AudioView(scan_dir=".")
         # Simulate having files loaded (no panels to query, just test index logic)
         view._files = [
-            (Path("/a.mp3"), _make_metadata(), _make_classification()),
-            (Path("/b.mp3"), _make_metadata(), _make_classification()),
-            (Path("/c.mp3"), _make_metadata(), _make_classification()),
+            (Path("/") / "a.mp3", _make_metadata(), _make_classification()),
+            (Path("/") / "b.mp3", _make_metadata(), _make_classification()),
+            (Path("/") / "c.mp3", _make_metadata(), _make_classification()),
         ]
         # Patch _show_file_details to avoid query_one calls outside app context
         with patch.object(view, "_show_file_details"):

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -15,7 +15,7 @@ import os
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -1124,7 +1124,7 @@ class TestDurableMoveFailureModes:
         # ``os.path.normcase`` is a no-op on POSIX (where this test runs),
         # so we assert against the exact ``str(tmp_path / "target.txt")``.
         # On Windows the assertion uses normcase on both sides.
-        result = _normalized_path_str(Path("./sub/../target.txt"))
+        result = _normalized_path_str(Path("sub") / ".." / "target.txt")
         expected = os.path.normcase(str(tmp_path / "target.txt"))
         assert result == expected, result
 
@@ -1145,15 +1145,15 @@ class TestDurableMoveFailureModes:
 
         # POSIX no-op contract: a mixed-case path normalizes to itself.
         if os.name != "nt":
-            mixed = _normalized_path_str(Path("/Tmp/MixedCase/File.TXT"))
+            mixed = _normalized_path_str(Path("/") / "Tmp" / "MixedCase" / "File.TXT")
             assert mixed == "/Tmp/MixedCase/File.TXT", (
                 "os.path.normcase must be a no-op on POSIX so the wrapper "
                 "doesn't break case-sensitive paths"
             )
         else:  # pragma: no cover - exercised on Windows CI only
             # Windows: case-fold to lowercase + normalize separators.
-            mixed_a = _normalized_path_str(Path("C:/Foo/Bar.txt"))
-            mixed_b = _normalized_path_str(Path("c:/foo/BAR.TXT"))
+            mixed_a = _normalized_path_str(PureWindowsPath("C:/Foo/Bar.txt"))
+            mixed_b = _normalized_path_str(PureWindowsPath("c:/foo/BAR.TXT"))
             assert mixed_a == mixed_b, (
                 "Windows case-insensitive paths must normalize identically "
                 "(codex hp2G); journal lookups depend on it"
@@ -1904,7 +1904,7 @@ class TestIsPathInFlightSharedLock:
         def _reader() -> None:
             reader_entered.set()
             try:
-                result_holder[0] = is_path_in_flight(Path("/x"), journal=journal)
+                result_holder[0] = is_path_in_flight(Path("/") / "x", journal=journal)
             finally:
                 reader_done.set()
 
@@ -2612,7 +2612,7 @@ class TestJournalLockFile:
 
         def _reader() -> None:
             try:
-                result[0] = is_path_in_flight(Path("/x"), journal=journal)
+                result[0] = is_path_in_flight(Path("/") / "x", journal=journal)
             finally:
                 reader_done.set()
 

--- a/tests/undo/test_rollback_extended.py
+++ b/tests/undo/test_rollback_extended.py
@@ -82,7 +82,7 @@ class TestRollbackOperationDispatch:
 
     def test_dispatch_exception_caught(self, env):
         _, _, executor = env
-        op = _op(OperationType.MOVE, Path("/nope"), Path("/nope2"))
+        op = _op(OperationType.MOVE, Path("/") / "nope", Path("/") / "nope2")
         # rollback_move will fail because file doesn't exist → returns False
         result = executor.rollback_operation(op)
         assert result is False
@@ -117,7 +117,10 @@ class TestRedoOperationDispatch:
     def test_dispatch_exception_caught(self, env):
         _, _, executor = env
         op = _op(
-            OperationType.RENAME, Path("/nope"), Path("/nope2"), status=OperationStatus.ROLLED_BACK
+            OperationType.RENAME,
+            Path("/") / "nope",
+            Path("/") / "nope2",
+            status=OperationStatus.ROLLED_BACK,
         )
         result = executor.redo_operation(op)
         assert result is False
@@ -155,7 +158,7 @@ class TestRedoCreate:
     def test_redo_create_exception(self, env):
         _, _, executor = env
         # Provide a path whose parent can't be created
-        target = Path("/dev/null/impossible/file.txt")
+        target = Path("/") / "dev" / "null" / "impossible" / "file.txt"
         op = _op(OperationType.CREATE, target, status=OperationStatus.ROLLED_BACK)
         result = executor.redo_create(op)
         assert result is False
@@ -303,8 +306,8 @@ class TestRollbackTransactionEdges:
             _op(OperationType.MOVE, file1, dst1, op_id=1, txn_id="txn"),
             _op(
                 OperationType.MOVE,
-                Path("/nonexistent"),
-                Path("/also_nonexistent"),
+                Path("/") / "nonexistent",
+                Path("/") / "also_nonexistent",
                 op_id=2,
                 txn_id="txn",
             ),
@@ -362,6 +365,6 @@ class TestRollbackExceptionPaths:
     @pytest.mark.skipif(sys.platform == "win32", reason="/dev/null is writable on Windows")
     def test_rollback_create_exception(self, env):
         _, _, executor = env
-        op = _op(OperationType.CREATE, Path("/dev/null/impossible"))
+        op = _op(OperationType.CREATE, Path("/") / "dev" / "null" / "impossible")
         result = executor.rollback_create(op)
         assert result is False

--- a/tests/undo/test_trash_gc.py
+++ b/tests/undo/test_trash_gc.py
@@ -97,11 +97,11 @@ class TestTrashDeleteOutcome:
 
         outcome = TrashDeleteOutcome(
             result=TrashDeleteResult.DELETED,
-            path=Path("/some/path"),
+            path=Path("/") / "some" / "path",
             reason="cleaned",
         )
         assert outcome.result is TrashDeleteResult.DELETED
-        assert outcome.path == Path("/some/path")
+        assert outcome.path == Path("/") / "some" / "path"
         assert outcome.reason == "cleaned"
         assert outcome.error is None
 
@@ -114,7 +114,7 @@ class TestTrashDeleteOutcome:
         exc = OSError(13, "Permission denied")
         outcome = TrashDeleteOutcome(
             result=TrashDeleteResult.PERMISSION_ERROR,
-            path=Path("/p"),
+            path=Path("/") / "p",
             reason="unlink raised",
             error=exc,
         )
@@ -135,7 +135,7 @@ class TestTrashDeleteOutcome:
 
         outcome = TrashDeleteOutcome(
             result=TrashDeleteResult.DELETED,
-            path=Path("/p"),
+            path=Path("/") / "p",
             reason="ok",
         )
         with pytest.raises(dataclasses.FrozenInstanceError):

--- a/tests/undo/test_trash_gc_race.py
+++ b/tests/undo/test_trash_gc_race.py
@@ -58,26 +58,26 @@ class TestIsPathInFlight:
     """Journal-coordination predicate unit tests (#1248)."""
 
     def test_empty_journal_not_in_flight(self) -> None:
-        assert _path_in_flight_from_entries(Path("/trash/a.txt"), []) is False
+        assert _path_in_flight_from_entries(Path("/") / "trash" / "a.txt", []) is False
 
     def test_exact_src_match_in_flight(self) -> None:
         """A path that is the exact src of an active move is in-flight."""
         entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        assert _path_in_flight_from_entries(Path("/trash/a.txt"), entries) is True
+        assert _path_in_flight_from_entries(Path("/") / "trash" / "a.txt", entries) is True
 
     def test_exact_dst_match_in_flight(self) -> None:
         """A path that is the exact dst of an active move is in-flight."""
         entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_COPIED)]  # noqa: test-hardcoded-paths
-        assert _path_in_flight_from_entries(Path("/home/a.txt"), entries) is True  # noqa: test-hardcoded-paths
+        assert _path_in_flight_from_entries(Path("/") / "home" / "a.txt", entries) is True  # noqa: test-hardcoded-paths
 
     def test_unrelated_path_not_in_flight(self) -> None:
         entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        assert _path_in_flight_from_entries(Path("/trash/b.txt"), entries) is False
+        assert _path_in_flight_from_entries(Path("/") / "trash" / "b.txt", entries) is False
 
     def test_done_state_not_in_flight(self) -> None:
         """A completed move no longer protects its paths."""
         entries = [_move_entry("/trash/a.txt", "/home/a.txt", STATE_DONE)]  # noqa: test-hardcoded-paths
-        assert _path_in_flight_from_entries(Path("/trash/a.txt"), entries) is False
+        assert _path_in_flight_from_entries(Path("/") / "trash" / "a.txt", entries) is False
 
     def test_latest_state_wins_done_collapses(self) -> None:
         """started → copied → done collapses to done (same op_id): not in flight."""
@@ -86,7 +86,7 @@ class TestIsPathInFlight:
             _JournalEntry(OP_MOVE, _norm("/t/a"), _norm("/h/a"), STATE_COPIED, 2, "op1"),
             _JournalEntry(OP_MOVE, _norm("/t/a"), _norm("/h/a"), STATE_DONE, 2, "op1"),
         ]
-        assert _path_in_flight_from_entries(Path("/t/a"), entries) is False
+        assert _path_in_flight_from_entries(Path("/") / "t" / "a", entries) is False
 
     # ------------------------------------------------------------------
     # #1248 fix #4 — dir_move descendant protection (load-bearing)
@@ -97,38 +97,38 @@ class TestIsPathInFlight:
         in-flight. Without the fix, only the exact directory matched and
         a GC could delete ``trash/dir/child.txt`` mid-restore."""
         entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        child = Path("/trash/dir/child.txt")
+        child = Path("/") / "trash" / "dir" / "child.txt"
         assert _path_in_flight_from_entries(child, entries) is True
 
     def test_dir_move_protects_nested_descendant(self) -> None:
         """Deeply nested descendants are protected too."""
         entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        nested = Path("/trash/dir/sub/deep/file.txt")
+        nested = Path("/") / "trash" / "dir" / "sub" / "deep" / "file.txt"
         assert _path_in_flight_from_entries(nested, entries) is True
 
     def test_dir_move_protects_dst_descendant(self) -> None:
         """Descendants of the dir_move DESTINATION are protected too."""
         entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        dst_child = Path("/home/dir/child.txt")  # noqa: test-hardcoded-paths
+        dst_child = Path("/") / "home" / "dir" / "child.txt"  # noqa: test-hardcoded-paths
         assert _path_in_flight_from_entries(dst_child, entries) is True
 
     def test_dir_move_exact_directory_match(self) -> None:
         """The exact dir_move directory itself is in-flight (regression)."""
         entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        assert _path_in_flight_from_entries(Path("/trash/dir"), entries) is True
+        assert _path_in_flight_from_entries(Path("/") / "trash" / "dir", entries) is True
 
     def test_dir_move_sibling_prefix_not_in_flight(self) -> None:
         """A sibling sharing a name PREFIX is NOT a descendant: the
         separator-anchored check must reject ``/trash/dirXYZ`` against
         ancestor ``/trash/dir``."""
         entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_STARTED)]  # noqa: test-hardcoded-paths
-        sibling = Path("/trash/dirXYZ/file.txt")
+        sibling = Path("/") / "trash" / "dirXYZ" / "file.txt"
         assert _path_in_flight_from_entries(sibling, entries) is False
 
     def test_dir_move_done_does_not_protect_descendant(self) -> None:
         """A completed dir_move no longer protects descendants."""
         entries = [_dir_move_entry("/trash/dir", "/home/dir", STATE_DONE)]  # noqa: test-hardcoded-paths
-        child = Path("/trash/dir/child.txt")
+        child = Path("/") / "trash" / "dir" / "child.txt"
         assert _path_in_flight_from_entries(child, entries) is False
 
     def test_single_file_move_does_not_protect_descendant(self) -> None:
@@ -138,7 +138,9 @@ class TestIsPathInFlight:
         entries = [_move_entry("/trash/file", "/home/file", STATE_STARTED)]  # noqa: test-hardcoded-paths
         # A path that would be a "descendant" of the file path string must
         # not match for a single-file move.
-        assert _path_in_flight_from_entries(Path("/trash/file/child"), entries) is False
+        assert (
+            _path_in_flight_from_entries(Path("/") / "trash" / "file" / "child", entries) is False
+        )
 
     def test_relative_query_path_normalizes(self) -> None:
         """The predicate normalizes the query path so a relative path

--- a/tests/undo/test_viewer.py
+++ b/tests/undo/test_viewer.py
@@ -400,7 +400,7 @@ class TestHistoryViewer(unittest.TestCase):
         from unittest.mock import MagicMock
 
         mock_op = MagicMock()
-        mock_op.source_path = Path("/some/dir/file.txt")
+        mock_op.source_path = Path("/") / "some" / "dir" / "file.txt"
         mock_op.destination_path = None
 
         formatted = self.viewer._format_path(mock_op)

--- a/tests/unit/config/test_path_manager.py
+++ b/tests/unit/config/test_path_manager.py
@@ -23,9 +23,9 @@ def test_get_canonical_paths_uses_xdg_when_available():
     ):
         paths = get_canonical_paths()
 
-        assert paths["config"] == Path("/tmp/test-xdg-config/file-organizer")  # noqa: test-hardcoded-paths
-        assert paths["data"] == Path("/tmp/test-xdg-data/file-organizer")  # noqa: test-hardcoded-paths
-        assert paths["state"] == Path("/tmp/test-xdg-state/file-organizer")  # noqa: test-hardcoded-paths
+        assert paths["config"] == Path("/") / "tmp" / "test-xdg-config" / "file-organizer"  # noqa: test-hardcoded-paths
+        assert paths["data"] == Path("/") / "tmp" / "test-xdg-data" / "file-organizer"  # noqa: test-hardcoded-paths
+        assert paths["state"] == Path("/") / "tmp" / "test-xdg-state" / "file-organizer"  # noqa: test-hardcoded-paths
         # Cache uses platformdirs user_cache_dir, which is independent of XDG_DATA_HOME
         from platformdirs import user_cache_dir
 

--- a/tests/unit/review_regressions/test_api_compat_detectors.py
+++ b/tests/unit/review_regressions/test_api_compat_detectors.py
@@ -25,7 +25,7 @@ def test_api_compat_detector_flags_legacy_positional_prefix_changes() -> None:
     detector = PublicApiCompatibilityDetector(
         contracts=(
             PublicCallableContract(
-                path=Path("src/file_organizer/public/constructor_prefix_positive.py"),
+                path=Path("src") / "file_organizer" / "public" / "constructor_prefix_positive.py",
                 qualname="PipelineOrchestrator.__init__",
                 legacy_positional_params=("config", "stages", "prefetch_depth"),
             ),
@@ -47,7 +47,7 @@ def test_api_compat_detector_flags_new_optional_positional_params() -> None:
     detector = PublicApiCompatibilityDetector(
         contracts=(
             PublicCallableContract(
-                path=Path("src/file_organizer/public/optional_positional_positive.py"),
+                path=Path("src") / "file_organizer" / "public" / "optional_positional_positive.py",
                 qualname="FileOrganizer.__init__",
                 legacy_positional_params=("dry_run", "prefetch_depth"),
             ),
@@ -69,12 +69,12 @@ def test_api_compat_detector_allows_keyword_only_optional_extension() -> None:
     detector = PublicApiCompatibilityDetector(
         contracts=(
             PublicCallableContract(
-                path=Path("src/file_organizer/public/keyword_only_safe.py"),
+                path=Path("src") / "file_organizer" / "public" / "keyword_only_safe.py",
                 qualname="FileOrganizer.__init__",
                 legacy_positional_params=("dry_run", "prefetch_depth"),
             ),
             PublicCallableContract(
-                path=Path("src/file_organizer/public/process_batch_safe.py"),
+                path=Path("src") / "file_organizer" / "public" / "process_batch_safe.py",
                 qualname="PipelineOrchestrator.process_batch",
                 legacy_positional_params=("files",),
             ),
@@ -96,12 +96,12 @@ def test_api_compat_detector_flags_missing_allowlisted_targets() -> None:
     detector = PublicApiCompatibilityDetector(
         contracts=(
             PublicCallableContract(
-                path=Path("src/file_organizer/public/does_not_exist.py"),
+                path=Path("src") / "file_organizer" / "public" / "does_not_exist.py",
                 qualname="PipelineOrchestrator.__init__",
                 legacy_positional_params=("config",),
             ),
             PublicCallableContract(
-                path=Path("src/file_organizer/public/process_batch_safe.py"),
+                path=Path("src") / "file_organizer" / "public" / "process_batch_safe.py",
                 qualname="PipelineOrchestrator.missing_method",
                 legacy_positional_params=("files",),
             ),

--- a/tests/unit/review_regressions/test_framework.py
+++ b/tests/unit/review_regressions/test_framework.py
@@ -240,7 +240,7 @@ def test_violation_from_path_accepts_root_relative_paths(tmp_path: Path, monkeyp
         rule_class="correctness",
         rule_id="relative-path",
         root=root,
-        path=Path("pkg/module.py"),
+        path=Path("pkg") / "module.py",
         message="relative path",
     )
 
@@ -262,7 +262,7 @@ def test_violation_from_path_accepts_relative_paths_that_include_root(
         rule_class="correctness",
         rule_id="relative-with-root",
         root=Path("repo"),
-        path=Path("repo/pkg/module.py"),
+        path=Path("repo") / "pkg" / "module.py",
         message="root-prefixed relative path",
     )
 
@@ -285,7 +285,7 @@ def test_violation_from_path_accepts_root_prefixed_relative_paths_with_absolute_
         rule_class="correctness",
         rule_id="absolute-root-prefixed",
         root=root,
-        path=Path("repo/pkg/module.py"),
+        path=Path("repo") / "pkg" / "module.py",
         message="root-prefixed relative path with absolute root",
     )
 

--- a/tests/unit/services/intelligence/test_preference_tracker.py
+++ b/tests/unit/services/intelligence/test_preference_tracker.py
@@ -22,10 +22,10 @@ def tracker():
 @pytest.fixture
 def mock_paths():
     return {
-        "src_txt": Path("/docs/test.txt"),
-        "dst_txt": Path("/docs/text/test.txt"),
-        "src_img": Path("/images/pic.png"),
-        "dst_img": Path("/images/vacation/pic.png"),
+        "src_txt": Path("/") / "docs" / "test.txt",
+        "dst_txt": Path("/") / "docs" / "text" / "test.txt",
+        "src_img": Path("/") / "images" / "pic.png",
+        "dst_img": Path("/") / "images" / "vacation" / "pic.png",
     }
 
 class TestPreferenceMetadata:
@@ -89,8 +89,8 @@ class TestCorrection:
         now = datetime.now(UTC)
         correction = Correction(
             correction_type=CorrectionType.FILE_MOVE,
-            source=Path("/test/file"),
-            destination=Path("/test/dir/file"),
+            source=Path("/") / "test" / "file",
+            destination=Path("/") / "test" / "dir" / "file",
             timestamp=now
         )
         key = correction.get_pattern_key()
@@ -122,7 +122,7 @@ class TestPreferenceTracker:
     def test_track_file_rename(self, tracker, mock_paths):
         tracker.track_correction(
             mock_paths["src_txt"],
-            Path("/docs/renamed.txt"),
+            Path("/") / "docs" / "renamed.txt",
             CorrectionType.FILE_RENAME
         )
 
@@ -181,7 +181,7 @@ class TestPreferenceTracker:
         )
 
         # 2nd time, to a different dict
-        dst_2 = Path("/docs/other/test.txt")
+        dst_2 = Path("/") / "docs" / "other" / "test.txt"
         # Need to match the pattern_key though...
         # For FILE_MOVE, pattern key is: `file_move|.txt|<dest_parent_name>`
         # So changing the dest path changes the pattern key!
@@ -197,13 +197,13 @@ class TestPreferenceTracker:
 
     def test_get_preference_folder_mapping(self, tracker):
         # Train two models for .jpg
-        tracker.track_correction(Path("/src/a.jpg"), Path("/dst/photos/a.jpg"), CorrectionType.FILE_MOVE)
-        tracker.track_correction(Path("/src/b.jpg"), Path("/dst/images/b.jpg"), CorrectionType.FILE_MOVE)
+        tracker.track_correction(Path("/") / "src" / "a.jpg", Path("/") / "dst" / "photos" / "a.jpg", CorrectionType.FILE_MOVE)
+        tracker.track_correction(Path("/") / "src" / "b.jpg", Path("/") / "dst" / "images" / "b.jpg", CorrectionType.FILE_MOVE)
         # Train images twice to give it higher confidence
-        tracker.track_correction(Path("/src/c.jpg"), Path("/dst/images/c.jpg"), CorrectionType.FILE_MOVE)
+        tracker.track_correction(Path("/") / "src" / "c.jpg", Path("/") / "dst" / "images" / "c.jpg", CorrectionType.FILE_MOVE)
 
         # Should return the one with higher confidence (images)
-        pref = tracker.get_preference(Path("/src/unknown.jpg"), PreferenceType.FOLDER_MAPPING)
+        pref = tracker.get_preference(Path("/") / "src" / "unknown.jpg", PreferenceType.FOLDER_MAPPING)
         assert pref is not None
         assert "images" in pref.value
 
@@ -219,7 +219,7 @@ class TestPreferenceTracker:
         assert pref is not None
         assert pref.value == "Code"
 
-        pref = tracker.get_preference(Path("/unknown/path.txt"), PreferenceType.CATEGORY_OVERRIDE)
+        pref = tracker.get_preference(Path("/") / "unknown" / "path.txt", PreferenceType.CATEGORY_OVERRIDE)
         assert pref is None
 
     def test_update_preference_confidence(self, tracker, mock_paths):
@@ -303,7 +303,7 @@ class TestConvenienceFunctions:
         assert len(prefs) == 1
 
     def test_track_file_rename(self, tracker, mock_paths):
-        track_file_rename(tracker, mock_paths["src_txt"], Path("/docs/renamed.txt"))
+        track_file_rename(tracker, mock_paths["src_txt"], Path("/") / "docs" / "renamed.txt")
         prefs = tracker.get_all_preferences(PreferenceType.NAMING_PATTERN)
         assert len(prefs) == 1
 

--- a/tests/unit/services/intelligence/test_preference_tracker.py
+++ b/tests/unit/services/intelligence/test_preference_tracker.py
@@ -15,9 +15,11 @@ from file_organizer.services.intelligence.preference_tracker import (
     track_category_change,
 )
 
+
 @pytest.fixture
 def tracker():
     return PreferenceTracker()
+
 
 @pytest.fixture
 def mock_paths():
@@ -28,16 +30,12 @@ def mock_paths():
         "dst_img": Path("/") / "images" / "vacation" / "pic.png",
     }
 
+
 class TestPreferenceMetadata:
     def test_to_dict_and_from_dict(self):
         now = datetime.now(UTC)
         metadata = PreferenceMetadata(
-            created=now,
-            updated=now,
-            confidence=0.8,
-            frequency=5,
-            last_used=now,
-            source="test"
+            created=now, updated=now, confidence=0.8, frequency=5, last_used=now, source="test"
         )
 
         data = metadata.to_dict()
@@ -50,6 +48,7 @@ class TestPreferenceMetadata:
         assert restored.frequency == 5
         assert restored.source == "test"
 
+
 class TestPreference:
     def test_to_dict_and_from_dict(self):
         now = datetime.now(UTC)
@@ -59,7 +58,7 @@ class TestPreference:
             key="test_key",
             value="/test/path",
             metadata=metadata,
-            context={"test": "data"}
+            context={"test": "data"},
         )
 
         data = pref.to_dict()
@@ -73,6 +72,7 @@ class TestPreference:
         assert restored.key == "test_key"
         assert restored.value == "/test/path"
 
+
 class TestCorrection:
     def test_get_pattern_key(self, mock_paths):
         now = datetime.now(UTC)
@@ -80,7 +80,7 @@ class TestCorrection:
             correction_type=CorrectionType.FILE_MOVE,
             source=mock_paths["src_txt"],
             destination=mock_paths["dst_txt"],
-            timestamp=now
+            timestamp=now,
         )
         key = correction.get_pattern_key()
         assert key == "file_move|.txt|text"
@@ -91,10 +91,11 @@ class TestCorrection:
             correction_type=CorrectionType.FILE_MOVE,
             source=Path("/") / "test" / "file",
             destination=Path("/") / "test" / "dir" / "file",
-            timestamp=now
+            timestamp=now,
         )
         key = correction.get_pattern_key()
         assert key == "file_move|no_ext|dir"
+
 
 class TestPreferenceTracker:
     def test_init(self, tracker):
@@ -105,9 +106,7 @@ class TestPreferenceTracker:
 
     def test_track_file_move(self, tracker, mock_paths):
         tracker.track_correction(
-            mock_paths["src_txt"],
-            mock_paths["dst_txt"],
-            CorrectionType.FILE_MOVE
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
         )
 
         prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
@@ -121,9 +120,7 @@ class TestPreferenceTracker:
 
     def test_track_file_rename(self, tracker, mock_paths):
         tracker.track_correction(
-            mock_paths["src_txt"],
-            Path("/") / "docs" / "renamed.txt",
-            CorrectionType.FILE_RENAME
+            mock_paths["src_txt"], Path("/") / "docs" / "renamed.txt", CorrectionType.FILE_RENAME
         )
 
         prefs = tracker.get_all_preferences(PreferenceType.NAMING_PATTERN)
@@ -135,7 +132,7 @@ class TestPreferenceTracker:
             mock_paths["src_txt"],
             mock_paths["src_txt"],
             CorrectionType.CATEGORY_CHANGE,
-            context={"new_category": "Documents"}
+            context={"new_category": "Documents"},
         )
 
         prefs = tracker.get_all_preferences(PreferenceType.CATEGORY_OVERRIDE)
@@ -144,9 +141,7 @@ class TestPreferenceTracker:
 
     def test_track_other_correction(self, tracker, mock_paths):
         tracker.track_correction(
-            mock_paths["src_txt"],
-            mock_paths["dst_txt"],
-            CorrectionType.MANUAL_OVERRIDE
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.MANUAL_OVERRIDE
         )
 
         prefs = tracker.get_all_preferences(PreferenceType.CUSTOM)
@@ -159,9 +154,7 @@ class TestPreferenceTracker:
         # Apply the same correction 3 times
         for _ in range(3):
             tracker.track_correction(
-                mock_paths["src_txt"],
-                mock_paths["dst_txt"],
-                CorrectionType.FILE_MOVE
+                mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
             )
 
         prefs = tracker.get_all_preferences()
@@ -175,9 +168,7 @@ class TestPreferenceTracker:
     def test_extract_preferences_value_change(self, tracker, mock_paths):
         # 1st time
         tracker.track_correction(
-            mock_paths["src_txt"],
-            mock_paths["dst_txt"],
-            CorrectionType.FILE_MOVE
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
         )
 
         # 2nd time, to a different dict
@@ -186,24 +177,34 @@ class TestPreferenceTracker:
         # For FILE_MOVE, pattern key is: `file_move|.txt|<dest_parent_name>`
         # So changing the dest path changes the pattern key!
         # Thus it becomes a NEW preference. Let's verify that.
-        tracker.track_correction(
-            mock_paths["src_txt"],
-            dst_2,
-            CorrectionType.FILE_MOVE
-        )
+        tracker.track_correction(mock_paths["src_txt"], dst_2, CorrectionType.FILE_MOVE)
 
         prefs = tracker.get_all_preferences()
         assert len(prefs) == 2
 
     def test_get_preference_folder_mapping(self, tracker):
         # Train two models for .jpg
-        tracker.track_correction(Path("/") / "src" / "a.jpg", Path("/") / "dst" / "photos" / "a.jpg", CorrectionType.FILE_MOVE)
-        tracker.track_correction(Path("/") / "src" / "b.jpg", Path("/") / "dst" / "images" / "b.jpg", CorrectionType.FILE_MOVE)
+        tracker.track_correction(
+            Path("/") / "src" / "a.jpg",
+            Path("/") / "dst" / "photos" / "a.jpg",
+            CorrectionType.FILE_MOVE,
+        )
+        tracker.track_correction(
+            Path("/") / "src" / "b.jpg",
+            Path("/") / "dst" / "images" / "b.jpg",
+            CorrectionType.FILE_MOVE,
+        )
         # Train images twice to give it higher confidence
-        tracker.track_correction(Path("/") / "src" / "c.jpg", Path("/") / "dst" / "images" / "c.jpg", CorrectionType.FILE_MOVE)
+        tracker.track_correction(
+            Path("/") / "src" / "c.jpg",
+            Path("/") / "dst" / "images" / "c.jpg",
+            CorrectionType.FILE_MOVE,
+        )
 
         # Should return the one with higher confidence (images)
-        pref = tracker.get_preference(Path("/") / "src" / "unknown.jpg", PreferenceType.FOLDER_MAPPING)
+        pref = tracker.get_preference(
+            Path("/") / "src" / "unknown.jpg", PreferenceType.FOLDER_MAPPING
+        )
         assert pref is not None
         assert "images" in pref.value
 
@@ -212,18 +213,22 @@ class TestPreferenceTracker:
             mock_paths["src_txt"],
             mock_paths["src_txt"],
             CorrectionType.CATEGORY_CHANGE,
-            {"new_category": "Code"}
+            {"new_category": "Code"},
         )
         all_prefs = tracker.get_all_preferences()
         pref = tracker.get_preference(mock_paths["src_txt"], PreferenceType.CATEGORY_OVERRIDE)
         assert pref is not None
         assert pref.value == "Code"
 
-        pref = tracker.get_preference(Path("/") / "unknown" / "path.txt", PreferenceType.CATEGORY_OVERRIDE)
+        pref = tracker.get_preference(
+            Path("/") / "unknown" / "path.txt", PreferenceType.CATEGORY_OVERRIDE
+        )
         assert pref is None
 
     def test_update_preference_confidence(self, tracker, mock_paths):
-        tracker.track_correction(mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE)
+        tracker.track_correction(
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
+        )
         pref = tracker.get_all_preferences()[0]
 
         initial_confidence = pref.metadata.confidence
@@ -238,8 +243,15 @@ class TestPreferenceTracker:
         assert pref.metadata.confidence < confidence_after_success
 
     def test_clear_preferences(self, tracker, mock_paths):
-        tracker.track_correction(mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE)
-        tracker.track_correction(mock_paths["src_txt"], mock_paths["src_txt"], CorrectionType.CATEGORY_CHANGE, {"new_category": "Doc"})
+        tracker.track_correction(
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
+        )
+        tracker.track_correction(
+            mock_paths["src_txt"],
+            mock_paths["src_txt"],
+            CorrectionType.CATEGORY_CHANGE,
+            {"new_category": "Doc"},
+        )
 
         assert len(tracker.get_all_preferences()) == 2
 
@@ -255,7 +267,9 @@ class TestPreferenceTracker:
         assert len(tracker.get_all_preferences()) == 0
 
     def test_export_import_data(self, tracker, mock_paths):
-        tracker.track_correction(mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE)
+        tracker.track_correction(
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
+        )
 
         data = tracker.export_data()
         assert "preferences" in data
@@ -269,17 +283,18 @@ class TestPreferenceTracker:
         assert tracker2.get_statistics()["total_corrections"] == 1
 
     def test_import_data_no_statistics(self, tracker):
-        data = {
-            "preferences": {},
-            "corrections": []
-        }
+        data = {"preferences": {}, "corrections": []}
         tracker.import_data(data)
         stats = tracker.get_statistics()
         assert stats["total_corrections"] == 0
 
     def test_get_corrections_for_file(self, tracker, mock_paths):
-        tracker.track_correction(mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE)
-        tracker.track_correction(mock_paths["src_img"], mock_paths["dst_img"], CorrectionType.FILE_MOVE)
+        tracker.track_correction(
+            mock_paths["src_txt"], mock_paths["dst_txt"], CorrectionType.FILE_MOVE
+        )
+        tracker.track_correction(
+            mock_paths["src_img"], mock_paths["dst_img"], CorrectionType.FILE_MOVE
+        )
 
         corrs = tracker.get_corrections_for_file(mock_paths["src_txt"])
         assert len(corrs) == 1
@@ -287,10 +302,15 @@ class TestPreferenceTracker:
 
     def test_get_recent_corrections(self, tracker, mock_paths):
         for i in range(15):
-            tracker.track_correction(Path(f"/src/{i}.txt"), Path(f"/dst/{i}.txt"), CorrectionType.FILE_MOVE)
+            tracker.track_correction(
+                Path("/") / "src" / f"{i}.txt",
+                Path("/") / "dst" / f"{i}.txt",
+                CorrectionType.FILE_MOVE,
+            )
 
         recent = tracker.get_recent_corrections(limit=5)
         assert len(recent) == 5
+
 
 class TestConvenienceFunctions:
     def test_create_tracker(self):

--- a/tests/unit/services/intelligence/test_profile_migrator.py
+++ b/tests/unit/services/intelligence/test_profile_migrator.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.ci, pytest.mark.unit]
 @pytest.fixture
 def mock_profile_manager():
     manager = MagicMock(spec=ProfileManager)
-    manager.storage_path = Path("/mock/storage")
+    manager.storage_path = Path("/") / "mock" / "storage"
     return manager
 
 
@@ -87,7 +87,7 @@ class TestProfileMigrator:
     )
     def test_migrate_version_no_path(self, mock_backup, mock_profile_manager, sample_profile):
         mock_profile_manager.get_profile.return_value = sample_profile
-        mock_backup.return_value = Path("/mock/backup.json")
+        mock_backup.return_value = Path("/") / "mock" / "backup.json"
 
         migrator = ProfileMigrator(mock_profile_manager)
         migrator.SUPPORTED_VERSIONS.append("2.0")
@@ -102,7 +102,7 @@ class TestProfileMigrator:
         self, mock_profile_class, mock_backup, mock_profile_manager, sample_profile
     ):
         mock_profile_manager.get_profile.return_value = sample_profile
-        mock_backup.return_value = Path("/mock/backup.json")
+        mock_backup.return_value = Path("/") / "mock" / "backup.json"
         mock_profile_manager.update_profile.return_value = True
 
         migrator = ProfileMigrator(mock_profile_manager)
@@ -140,7 +140,7 @@ class TestProfileMigrator:
         self, mock_rollback, mock_backup, mock_profile_manager, sample_profile
     ):
         mock_profile_manager.get_profile.return_value = sample_profile
-        mock_backup.return_value = Path("/mock/backup.json")
+        mock_backup.return_value = Path("/") / "mock" / "backup.json"
 
         migrator = ProfileMigrator(mock_profile_manager)
         migrator.SUPPORTED_VERSIONS.append("2.0")
@@ -248,7 +248,7 @@ class TestProfileMigrator:
         self, mock_rollback, mock_profile_class, mock_backup, mock_profile_manager, sample_profile
     ):
         mock_profile_manager.get_profile.return_value = sample_profile
-        mock_backup.return_value = Path("/mock/backup.json")
+        mock_backup.return_value = Path("/") / "mock" / "backup.json"
 
         migrator = ProfileMigrator(mock_profile_manager)
         migrator.SUPPORTED_VERSIONS.append("2.0")
@@ -277,7 +277,7 @@ class TestProfileMigrator:
         self, mock_rollback, mock_profile_class, mock_backup, mock_profile_manager, sample_profile
     ):
         mock_profile_manager.get_profile.return_value = sample_profile
-        mock_backup.return_value = Path("/mock/backup.json")
+        mock_backup.return_value = Path("/") / "mock" / "backup.json"
         mock_profile_manager.update_profile.return_value = False
 
         migrator = ProfileMigrator(mock_profile_manager)

--- a/tests/unit/test_doctor_registry.py
+++ b/tests/unit/test_doctor_registry.py
@@ -280,50 +280,50 @@ def test_get_missing_groups_empty_input(mock_is_installed):
 
 def test_normalized_extension_simple():
     """_normalized_extension returns lowercase simple extension."""
-    path = Path("/test/file.MP3")
+    path = Path("/") / "test" / "file.MP3"
     assert _normalized_extension(path) == ".mp3"
 
 
 def test_normalized_extension_compound_tar_gz():
     """_normalized_extension preserves .tar.gz compound extension."""
-    path = Path("/test/archive.tar.gz")
+    path = Path("/") / "test" / "archive.tar.gz"
     assert _normalized_extension(path) == ".tar.gz"
 
 
 def test_normalized_extension_compound_tar_bz2():
     """_normalized_extension preserves .tar.bz2 compound extension."""
-    path = Path("/test/archive.tar.bz2")
+    path = Path("/") / "test" / "archive.tar.bz2"
     assert _normalized_extension(path) == ".tar.bz2"
 
 
 def test_normalized_extension_no_extension():
     """_normalized_extension returns empty string for files without extension."""
-    path = Path("/test/README")
+    path = Path("/") / "test" / "README"
     assert _normalized_extension(path) == ""
 
 
 def test_normalized_extension_multiple_dots_non_compound():
     """_normalized_extension returns last suffix for non-compound multi-dot files."""
-    path = Path("/test/my.file.name.txt")
+    path = Path("/") / "test" / "my.file.name.txt"
     assert _normalized_extension(path) == ".txt"
 
 
 def test_normalized_extension_uppercase_compound():
     """_normalized_extension normalizes compound extensions to lowercase."""
-    path = Path("/test/archive.TAR.GZ")
+    path = Path("/") / "test" / "archive.TAR.GZ"
     assert _normalized_extension(path) == ".tar.gz"
 
 
 def test_normalized_extension_hidden_file():
     """_normalized_extension handles hidden files correctly."""
-    path = Path("/test/.hidden")
+    path = Path("/") / "test" / ".hidden"
     # Hidden files without a real extension return empty string
     assert _normalized_extension(path) == ""
 
 
 def test_normalized_extension_hidden_file_with_extension():
     """_normalized_extension handles hidden files with extensions."""
-    path = Path("/test/.gitignore.txt")
+    path = Path("/") / "test" / ".gitignore.txt"
     assert _normalized_extension(path) == ".txt"
 
 

--- a/tests/updater/test_installer.py
+++ b/tests/updater/test_installer.py
@@ -247,7 +247,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Linux")
     @patch("platform.machine", return_value="x86_64")
     def test_select_linux_x64(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-linux-x86_64.AppImage",
@@ -262,7 +262,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Darwin")
     @patch("platform.machine", return_value="arm64")
     def test_select_macos_arm(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-macos-universal.tar.gz",
@@ -276,7 +276,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Windows")
     @patch("platform.machine", return_value="AMD64")
     def test_select_windows(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-windows-amd64.exe",
@@ -290,7 +290,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Linux")
     @patch("platform.machine", return_value="x86_64")
     def test_no_matching_asset(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = self._make_release(["app-macos-arm64.zip"])
         asset = inst.select_asset(release)
         assert asset is None
@@ -298,7 +298,7 @@ class TestSelectAsset:
     @patch("platform.system", return_value="Linux")
     @patch("platform.machine", return_value="x86_64")
     def test_skips_checksum_files(self, _m, _s):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = self._make_release(
             [
                 "app-linux-x86_64.sha256",
@@ -321,7 +321,7 @@ class TestFindChecksum:
 
     @patch.object(UpdateInstaller, "_download_text", return_value="abc123  app.bin")
     def test_dedicated_checksum_file(self, mock_dl):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -339,7 +339,7 @@ class TestFindChecksum:
         return_value="def456  app.bin\nghi789  other.bin",
     )
     def test_sha256sums_file(self, mock_dl):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -352,7 +352,7 @@ class TestFindChecksum:
         assert result == "def456"
 
     def test_no_checksum_file(self):
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -385,9 +385,9 @@ class TestResolveTarget:
 
     def test_appimage_target(self, tmp_path):
         inst = UpdateInstaller(install_dir=tmp_path)
-        inst._appimage_path = Path("/opt/app.AppImage")  # noqa: test-hardcoded-paths
+        inst._appimage_path = Path("/") / "opt" / "app.AppImage"  # noqa: test-hardcoded-paths
         target = inst._resolve_target("my-app")
-        assert target == Path("/opt/app.AppImage")  # noqa: test-hardcoded-paths
+        assert target == Path("/") / "opt" / "app.AppImage"  # noqa: test-hardcoded-paths
 
 
 # ---------------------------------------------------------------------------
@@ -613,7 +613,7 @@ class TestFindChecksumEdgeCases:
     )
     def test_sha256sums_no_match(self, mock_dl):
         """find_checksum returns empty string when SHA256SUMS exists but asset not listed."""
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",
@@ -632,7 +632,7 @@ class TestFindChecksumEdgeCases:
     )
     def test_sha256sums_short_lines(self, mock_dl):
         """find_checksum handles SHA256SUMS lines with < 2 parts."""
-        inst = UpdateInstaller(install_dir=Path("/tmp"))  # noqa: test-hardcoded-paths
+        inst = UpdateInstaller(install_dir=Path("/") / "tmp")  # noqa: test-hardcoded-paths
         release = ReleaseInfo(
             tag="v1",
             version="1.0",

--- a/tests/utils/test_epub_enhanced.py
+++ b/tests/utils/test_epub_enhanced.py
@@ -174,7 +174,7 @@ class TestEnhancedEPUBReader:
         reader = EnhancedEPUBReader()
 
         with pytest.raises(FileNotFoundError):
-            reader.read_epub(Path("/nonexistent/file.epub"))
+            reader.read_epub(Path("/") / "nonexistent" / "file.epub")
 
     @patch("file_organizer.utils.epub_enhanced.epub.read_epub")
     def test_extract_metadata(self, mock_read, mock_epub_book, tmp_path):

--- a/tests/utils/test_epub_enhanced_coverage.py
+++ b/tests/utils/test_epub_enhanced_coverage.py
@@ -225,7 +225,7 @@ class TestReadEpub:
 
             reader = EnhancedEPUBReader()
             with pytest.raises(FileNotFoundError):
-                reader.read_epub(Path("/nonexistent.epub"))
+                reader.read_epub(Path("/") / "nonexistent.epub")
 
 
 # ---------------------------------------------------------------------------
@@ -239,4 +239,4 @@ class TestGetEpubMetadata:
             from file_organizer.utils.epub_enhanced import get_epub_metadata
 
             with pytest.raises(ImportError, match="ebooklib"):
-                get_epub_metadata(Path("/test.epub"))
+                get_epub_metadata(Path("/") / "test.epub")

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -517,7 +517,7 @@ class TestResourceLifetime:
         """Return the number of open fds for this process, or None on platforms
         where ``/proc/self/fd`` is unavailable (e.g. macOS).
         """
-        proc = Path("/proc/self/fd")
+        proc = Path("/") / "proc" / "self" / "fd"
         if not proc.is_dir():
             return None
         return len(list(proc.iterdir()))

--- a/tests/utils/test_safedir_anchored.py
+++ b/tests/utils/test_safedir_anchored.py
@@ -354,7 +354,7 @@ class TestOpenAnchoredWriter:
         with SafeDir.open_root(tmp_path) as root:
             before = len(list(proc.iterdir()))
             for i in range(20):
-                fd = root.open_anchored_writer(Path(f"a/b/c/file_{i}.txt"))
+                fd = root.open_anchored_writer(Path("a") / "b" / "c" / f"file_{i}.txt")
                 os.close(fd)
             after = len(list(proc.iterdir()))
         assert after - before <= 2, f"fd leak: before={before} after={after}"

--- a/tests/utils/test_safedir_anchored.py
+++ b/tests/utils/test_safedir_anchored.py
@@ -70,7 +70,7 @@ class TestOpenAnchoredReader:
         (tmp_path / "a" / "b" / "c").mkdir(parents=True)
         (tmp_path / "a" / "b" / "c" / "doc.txt").write_text("nested")
         with SafeDir.open_root(tmp_path) as root:
-            fd = root.open_anchored_reader(Path("a/b/c/doc.txt"))
+            fd = root.open_anchored_reader(Path("a") / "b" / "c" / "doc.txt")
             try:
                 fileobj = os.fdopen(fd, "rb", closefd=True)
             except OSError:
@@ -104,7 +104,7 @@ class TestOpenAnchoredReader:
             # Walking 'a/secret.txt' should refuse at 'a' (the symlink),
             # not dereference and open 'outside/secret.txt'.
             with pytest.raises(SymlinkRejected):
-                root.open_anchored_reader(Path("a/secret.txt"))
+                root.open_anchored_reader(Path("a") / "secret.txt")
 
     def test_final_component_symlink_refused(self, tmp_path: Path) -> None:
         """Leaf symlink is refused too (the existing final-component guard)."""
@@ -126,7 +126,7 @@ class TestOpenAnchoredReader:
         """Absolute relative_path is a programmer error — reject early."""
         with SafeDir.open_root(tmp_path) as root:
             with pytest.raises(ValueError, match="relative"):
-                root.open_anchored_reader(Path("/etc/passwd"))  # noqa: test-hardcoded-paths
+                root.open_anchored_reader(Path("/") / "etc" / "passwd")  # noqa: test-hardcoded-paths
 
     def test_parent_traversal_rejected(self, tmp_path: Path) -> None:
         """``..`` components would escape — must be refused before any open."""
@@ -134,7 +134,7 @@ class TestOpenAnchoredReader:
         (tmp_path / "doc.txt").write_text("data")
         with SafeDir.open_root(tmp_path / "child") as root:
             with pytest.raises(ValueError, match=r"\.\."):
-                root.open_anchored_reader(Path("../doc.txt"))
+                root.open_anchored_reader(Path("..") / "doc.txt")
 
     def test_empty_path_rejected(self, tmp_path: Path) -> None:
         """Empty relative_path doesn't identify any file."""
@@ -251,7 +251,7 @@ class TestOpenAnchoredWriter:
     def test_creates_nested_dirs_and_writes_leaf(self, tmp_path: Path) -> None:
         """A multi-component relative path creates each intermediate dir."""
         with SafeDir.open_root(tmp_path) as root:
-            fd = root.open_anchored_writer(Path("Docs/2026/report.txt"))
+            fd = root.open_anchored_writer(Path("Docs") / "2026" / "report.txt")
             self._write(fd, b"nested write")
         leaf = tmp_path / "Docs" / "2026" / "report.txt"
         assert leaf.read_bytes() == b"nested write"
@@ -269,7 +269,7 @@ class TestOpenAnchoredWriter:
         """Pre-existing real intermediate directories are reused, not rejected."""
         (tmp_path / "Docs").mkdir()
         with SafeDir.open_root(tmp_path) as root:
-            fd = root.open_anchored_writer(Path("Docs/report.txt"))
+            fd = root.open_anchored_writer(Path("Docs") / "report.txt")
             self._write(fd, b"reuse")
         assert (tmp_path / "Docs" / "report.txt").read_bytes() == b"reuse"
 
@@ -288,7 +288,7 @@ class TestOpenAnchoredWriter:
 
         with SafeDir.open_root(out_root) as root:
             with pytest.raises(SymlinkRejected):
-                root.open_anchored_writer(Path("Docs/report.txt"))
+                root.open_anchored_writer(Path("Docs") / "report.txt")
         # Nothing leaked into the symlink target.
         assert list(outside.iterdir()) == []
 
@@ -316,18 +316,18 @@ class TestOpenAnchoredWriter:
 
         with SafeDir.open_root(out_root) as root:
             with pytest.raises(SymlinkRejected):
-                root.open_anchored_writer(Path("a/b/c.txt"))
+                root.open_anchored_writer(Path("a") / "b" / "c.txt")
 
     def test_absolute_path_rejected(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as root:
             with pytest.raises(ValueError, match="relative"):
-                root.open_anchored_writer(Path("/etc/passwd"))  # noqa: test-hardcoded-paths
+                root.open_anchored_writer(Path("/") / "etc" / "passwd")  # noqa: test-hardcoded-paths
 
     def test_parent_traversal_rejected(self, tmp_path: Path) -> None:
         (tmp_path / "child").mkdir()
         with SafeDir.open_root(tmp_path / "child") as root:
             with pytest.raises(ValueError, match=r"\.\."):
-                root.open_anchored_writer(Path("../escape.txt"))
+                root.open_anchored_writer(Path("..") / "escape.txt")
 
     def test_empty_path_rejected(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as root:
@@ -342,13 +342,13 @@ class TestOpenAnchoredWriter:
         with SafeDir.open_root(tmp_path) as root:
             with pytest.raises(FileExistsError):
                 root.open_anchored_writer(
-                    Path("Docs/report.txt"),
+                    Path("Docs") / "report.txt",
                     flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL,
                 )
 
     def test_intermediate_fds_released(self, tmp_path: Path) -> None:
         """Intermediate subdir fds opened during the walk must not leak."""
-        proc = Path("/proc/self/fd")
+        proc = Path("/") / "proc" / "self" / "fd"
         if not proc.is_dir():
             pytest.skip("/proc/self/fd not available on this platform")
         with SafeDir.open_root(tmp_path) as root:

--- a/tests/utils/test_scientific_coverage.py
+++ b/tests/utils/test_scientific_coverage.py
@@ -22,7 +22,7 @@ class TestReadHdf5:
             from file_organizer.utils.readers.scientific import read_hdf5_file
 
             with pytest.raises(ImportError, match="h5py"):
-                read_hdf5_file(Path("/test.h5"))
+                read_hdf5_file(Path("/") / "test.h5")
 
     def test_file_error_raises(self):
         with patch("file_organizer.utils.readers.scientific.H5PY_AVAILABLE", True):
@@ -36,7 +36,7 @@ class TestReadHdf5:
                 from file_organizer.utils.readers.scientific import read_hdf5_file
 
                 with pytest.raises(FileReadError):
-                    read_hdf5_file(Path("/test.h5"))
+                    read_hdf5_file(Path("/") / "test.h5")
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +50,7 @@ class TestReadNetcdf:
             from file_organizer.utils.readers.scientific import read_netcdf_file
 
             with pytest.raises(ImportError, match="netCDF4"):
-                read_netcdf_file(Path("/test.nc"))
+                read_netcdf_file(Path("/") / "test.nc")
 
     def test_file_error_raises(self):
         with patch("file_organizer.utils.readers.scientific.NETCDF4_AVAILABLE", True):
@@ -64,7 +64,7 @@ class TestReadNetcdf:
                 from file_organizer.utils.readers.scientific import read_netcdf_file
 
                 with pytest.raises(FileReadError):
-                    read_netcdf_file(Path("/test.nc"))
+                    read_netcdf_file(Path("/") / "test.nc")
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +78,7 @@ class TestReadMat:
             from file_organizer.utils.readers.scientific import read_mat_file
 
             with pytest.raises(ImportError, match="scipy"):
-                read_mat_file(Path("/test.mat"))
+                read_mat_file(Path("/") / "test.mat")
 
     def test_file_error_raises(self):
         with patch("file_organizer.utils.readers.scientific.SCIPY_AVAILABLE", True):
@@ -91,7 +91,7 @@ class TestReadMat:
                 from file_organizer.utils.readers.scientific import read_mat_file
 
                 with pytest.raises(FileReadError):
-                    read_mat_file(Path("/test.mat"))
+                    read_mat_file(Path("/") / "test.mat")
 
     def test_successful_read(self):
         # Use a lightweight fake instead of numpy to avoid an undeclared dependency.
@@ -119,7 +119,7 @@ class TestReadMat:
             ):
                 from file_organizer.utils.readers.scientific import read_mat_file
 
-                result = read_mat_file(Path("/test.mat"))
+                result = read_mat_file(Path("/") / "test.mat")
                 assert "MATLAB File" in result
                 assert "matrix" in result
                 assert "scalar" in result

--- a/tests/watcher/test_config.py
+++ b/tests/watcher/test_config.py
@@ -100,38 +100,38 @@ class TestWatcherConfigShouldIncludeFile:
 
     def test_includes_normal_file_by_default(self):
         config = WatcherConfig()
-        path = Path("/home/user/document.txt")  # noqa: test-hardcoded-paths
+        path = Path("/") / "home" / "user" / "document.txt"  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is True
 
     def test_excludes_tmp_files(self):
         config = WatcherConfig()
-        path = Path("/home/user/file.tmp")  # noqa: test-hardcoded-paths
+        path = Path("/") / "home" / "user" / "file.tmp"  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_excludes_temp_files(self):
         config = WatcherConfig()
-        path = Path("/tmp/file.temp")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "file.temp"  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_excludes_git_directory(self):
         config = WatcherConfig()
-        path = Path("/project/.git/config")
+        path = Path("/") / "project" / ".git" / "config"
         assert config.should_include_file(path) is False
 
     def test_excludes_pycache(self):
         config = WatcherConfig()
-        path = Path("/project/__pycache__/module.pyc")
+        path = Path("/") / "project" / "__pycache__" / "module.pyc"
         assert config.should_include_file(path) is False
 
     def test_excludes_ds_store(self):
         config = WatcherConfig()
-        path = Path("/home/user/.DS_Store")  # noqa: test-hardcoded-paths
+        path = Path("/") / "home" / "user" / ".DS_Store"  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_excludes_node_modules(self):
         config = WatcherConfig()
         # "node_modules/*" pattern in defaults doesn't match this path due to pattern matching logic
-        path = Path("/project/node_modules/package/index.js")
+        path = Path("/") / "project" / "node_modules" / "package" / "index.js"
         # The pattern "node_modules/*" doesn't match individual path components
         result = config.should_include_file(path)
         # This path is included because no exclude pattern matches it
@@ -139,7 +139,7 @@ class TestWatcherConfigShouldIncludeFile:
 
     def test_excludes_by_suffix(self):
         config = WatcherConfig()
-        path = Path("/home/user/file.pyc")  # noqa: test-hardcoded-paths
+        path = Path("/") / "home" / "user" / "file.pyc"  # noqa: test-hardcoded-paths
         assert config.should_include_file(path) is False
 
     def test_with_custom_exclude_patterns(self):

--- a/tests/watcher/test_handler.py
+++ b/tests/watcher/test_handler.py
@@ -240,7 +240,7 @@ class TestFileEventHandlerEventTypes:
 
         events = queue.dequeue_batch(1)
         assert events[0].event_type == EventType.MOVED
-        assert events[0].dest_path == Path("/tmp/new.txt")  # noqa: test-hardcoded-paths
+        assert events[0].dest_path == Path("/") / "tmp" / "new.txt"  # noqa: test-hardcoded-paths
 
     def test_directory_deletion_event(
         self, default_config: WatcherConfig, queue: EventQueue
@@ -394,7 +394,7 @@ class TestFileEventHandlerMovedEdgeCases:
         assert len(events) == 1
         assert events[0].is_directory is True
         assert events[0].event_type == EventType.MOVED
-        assert events[0].dest_path == Path("/tmp/newdir")  # noqa: test-hardcoded-paths
+        assert events[0].dest_path == Path("/") / "tmp" / "newdir"  # noqa: test-hardcoded-paths
 
 
 @pytest.mark.unit
@@ -489,7 +489,7 @@ class TestFileEventHandlerCallbackEdgeCases:
         handler.on_moved(event)
 
         assert len(received_events) == 1
-        assert received_events[0].dest_path == Path("/tmp/new.txt")  # noqa: test-hardcoded-paths
+        assert received_events[0].dest_path == Path("/") / "tmp" / "new.txt"  # noqa: test-hardcoded-paths
 
     def test_second_callback_runs_when_first_fails(
         self, default_config: WatcherConfig, queue: EventQueue

--- a/tests/watcher/test_queue.py
+++ b/tests/watcher/test_queue.py
@@ -32,11 +32,11 @@ class TestFileEvent:
         now = datetime.now(UTC)
         event = FileEvent(
             event_type=EventType.CREATED,
-            path=Path("/tmp/test.txt"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "test.txt",  # noqa: test-hardcoded-paths
             timestamp=now,
         )
         assert event.event_type == EventType.CREATED
-        assert event.path == Path("/tmp/test.txt")  # noqa: test-hardcoded-paths
+        assert event.path == Path("/") / "tmp" / "test.txt"  # noqa: test-hardcoded-paths
         assert event.timestamp == now
         assert event.is_directory is False
         assert event.dest_path is None
@@ -45,7 +45,7 @@ class TestFileEvent:
         """Test FileEvent for directory events."""
         event = FileEvent(
             event_type=EventType.CREATED,
-            path=Path("/tmp/newdir"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "newdir",  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
             is_directory=True,
         )
@@ -55,17 +55,17 @@ class TestFileEvent:
         """Test FileEvent for move events with destination."""
         event = FileEvent(
             event_type=EventType.MOVED,
-            path=Path("/tmp/old.txt"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "old.txt",  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
-            dest_path=Path("/tmp/new.txt"),  # noqa: test-hardcoded-paths
+            dest_path=Path("/") / "tmp" / "new.txt",  # noqa: test-hardcoded-paths
         )
-        assert event.dest_path == Path("/tmp/new.txt")  # noqa: test-hardcoded-paths
+        assert event.dest_path == Path("/") / "tmp" / "new.txt"  # noqa: test-hardcoded-paths
 
     def test_file_event_is_frozen(self) -> None:
         """Test that FileEvent instances are immutable."""
         event = FileEvent(
             event_type=EventType.CREATED,
-            path=Path("/tmp/test.txt"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / "test.txt",  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
         with pytest.raises(AttributeError):
@@ -370,15 +370,15 @@ class TestEventQueueEdgeCases:
     def test_file_event_equality(self) -> None:
         """Test that identical FileEvent instances are equal (frozen dataclass)."""
         ts = datetime.now(UTC)
-        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
-        e2 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
+        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/") / "tmp" / "a.txt", timestamp=ts)  # noqa: test-hardcoded-paths
+        e2 = FileEvent(event_type=EventType.CREATED, path=Path("/") / "tmp" / "a.txt", timestamp=ts)  # noqa: test-hardcoded-paths
         assert e1 == e2
 
     def test_file_event_inequality(self) -> None:
         """Test that different FileEvent instances are not equal."""
         ts = datetime.now(UTC)
-        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
-        e2 = FileEvent(event_type=EventType.DELETED, path=Path("/tmp/a.txt"), timestamp=ts)  # noqa: test-hardcoded-paths
+        e1 = FileEvent(event_type=EventType.CREATED, path=Path("/") / "tmp" / "a.txt", timestamp=ts)  # noqa: test-hardcoded-paths
+        e2 = FileEvent(event_type=EventType.DELETED, path=Path("/") / "tmp" / "a.txt", timestamp=ts)  # noqa: test-hardcoded-paths
         assert e1 != e2
 
     def test_event_type_is_str_enum(self) -> None:

--- a/tests/watcher/test_queue.py
+++ b/tests/watcher/test_queue.py
@@ -94,7 +94,7 @@ class TestEventQueue:
         """Helper to create a FileEvent."""
         return FileEvent(
             event_type=event_type,
-            path=Path(f"/tmp/{name}"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / f"{name}",  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
 
@@ -252,7 +252,7 @@ class TestEventQueueEdgeCases:
         """Helper to create a FileEvent."""
         return FileEvent(
             event_type=event_type,
-            path=Path(f"/tmp/{name}"),  # noqa: test-hardcoded-paths
+            path=Path("/") / "tmp" / f"{name}",  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
 

--- a/tests/web/test_extracted_helpers.py
+++ b/tests/web/test_extracted_helpers.py
@@ -145,7 +145,7 @@ class TestDirEntry:
         assert entry["kind"] == "folder"
 
     def test_oserror_fallback(self) -> None:
-        missing = Path("/nonexistent/dir")
+        missing = Path("/") / "nonexistent" / "dir"
         entry = _dir_entry(missing)
         assert entry["name"] == "dir"
         assert entry["is_dir"] is True

--- a/tests/web/test_file_operations_helpers.py
+++ b/tests/web/test_file_operations_helpers.py
@@ -58,7 +58,7 @@ class TestBuildTreeContext:
 
 class TestGenerateThumbnail:
     def test_missing_file_raises_api_error(self, settings: ApiSettings) -> None:
-        missing = Path("/missing")
+        missing = Path("/") / "missing"
         with patch("file_organizer.web.file_operations.resolve_path", return_value=missing):
             with pytest.raises(ApiError, match="File not found"):
                 generate_thumbnail(str(missing), "file", settings)

--- a/tests/web/test_helpers.py
+++ b/tests/web/test_helpers.py
@@ -380,25 +380,25 @@ class TestPathId:
 
     def test_returns_string(self):
         """Should return a 10-character hex string."""
-        result = path_id(Path("/tmp/test"))  # noqa: test-hardcoded-paths
+        result = path_id(Path("/") / "tmp" / "test")  # noqa: test-hardcoded-paths
         assert isinstance(result, str) and len(result) == 10
 
     def test_returns_short_hash(self):
         """Should return a 10-character hash."""
-        result = path_id(Path("/tmp/test"))  # noqa: test-hardcoded-paths
+        result = path_id(Path("/") / "tmp" / "test")  # noqa: test-hardcoded-paths
         assert len(result) == 10
 
     def test_same_path_same_id(self):
         """Same path should produce same ID."""
-        path = Path("/tmp/test")  # noqa: test-hardcoded-paths
+        path = Path("/") / "tmp" / "test"  # noqa: test-hardcoded-paths
         id1 = path_id(path)
         id2 = path_id(path)
         assert id1 == id2
 
     def test_different_paths_different_ids(self):
         """Different paths should produce different IDs."""
-        id1 = path_id(Path("/tmp/test1"))  # noqa: test-hardcoded-paths
-        id2 = path_id(Path("/tmp/test2"))  # noqa: test-hardcoded-paths
+        id1 = path_id(Path("/") / "tmp" / "test1")  # noqa: test-hardcoded-paths
+        id2 = path_id(Path("/") / "tmp" / "test2")  # noqa: test-hardcoded-paths
         assert id1 != id2
 
 
@@ -430,7 +430,7 @@ class TestSelectRootForPath:
 
     def test_returns_path_when_no_match(self, file_tree):
         """Should return path when no root matches."""
-        roots = [Path("/other/path")]
+        roots = [Path("/") / "other" / "path"]
         path = file_tree / "dir_a"
         result = select_root_for_path(path, roots)
         assert result == path
@@ -498,7 +498,7 @@ class TestHasChildren:
 
     def test_nonexistent_directory(self):
         """Nonexistent directory should return False."""
-        assert has_children(Path("/nonexistent/path")) is False
+        assert has_children(Path("/") / "nonexistent" / "path") is False
 
     def test_ignores_hidden_directories(self, tmp_path):
         """Should ignore hidden directories."""
@@ -540,7 +540,7 @@ class TestIsProbablyText:
 
     def test_nonexistent_file(self):
         """Should return False for nonexistent files."""
-        assert is_probably_text(Path("/nonexistent.txt")) is False
+        assert is_probably_text(Path("/") / "nonexistent.txt") is False
 
     def test_empty_file(self, tmp_path):
         """Should return True for empty files."""

--- a/tests/web/test_profile_routes_coverage.py
+++ b/tests/web/test_profile_routes_coverage.py
@@ -128,7 +128,7 @@ class TestProfileHelpers:
 
         with patch(
             "pathlib.Path.resolve",
-            side_effect=[Path("/tmp/outside.png"), Path("/tmp/avatars")],  # noqa: test-hardcoded-paths
+            side_effect=[Path("/") / "tmp" / "outside.png", Path("/") / "tmp" / "avatars"],  # noqa: test-hardcoded-paths
         ):
             with pytest.raises(ValueError, match="Invalid user_id"):
                 _avatar_path("user-123")


### PR DESCRIPTION
## Summary
- harden `check_test_separator_paths` suppression parsing to only honor real comment-token markers for `noqa: test-separator-paths`
- add dedicated guardrail coverage in `tests/ci/test_check_test_separator_paths.py` (targeted/noisy-noqa behavior, hash-in-string bypass prevention, separators, syntax handling)
- mechanically remediate `Path("...")` test literals with embedded separators across `tests/` to `/`-operator composition
- promote `test-separator-paths` from `advisory` to `enforce` in `scripts/ci/rails.toml`
- update rail mode expectations and guardrail docs for enforcement
- preserve Windows path semantics in durable move regression test with `PureWindowsPath`

## Validation
- `python scripts/ci/guardrails/check_test_separator_paths.py`
- `pytest tests/ci/test_check_test_separator_paths.py -q --override-ini="addopts="`
- `pytest tests/undo/test_durable_move.py -q --override-ini="addopts="`
- `pytest tests/ci -q --override-ini="addopts="`
- pre-commit hooks passed during commit (including `ci rails`)

Closes #1368
