### PR TITLE
Enforce pytest raises hygiene

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,8 +52,8 @@ are **enforced**; rails with pre-existing violation backlogs remain
 | `cli-path-validation` | A CLI command's `Path` parameter not wrapped in `resolve_cli_path()` | enforced |
 | `defusedxml-fallback` | Importing from stdlib `xml` instead of `defusedxml` | enforced |
 | `test-hardcoded-paths` | Hardcoded absolute paths in tests (use `tmp_path`) | enforced |
-| `test-separator-paths` | Hardcoded path separators in `Path(...)` calls in tests | advisory |
-| `pytest-raises-hygiene` | `pytest.raises()` without a `match=` regex on a generic/built-in exception | advisory |
+| `test-separator-paths` | Hardcoded path separators in `Path(...)` calls in tests | enforced |
+| `pytest-raises-hygiene` | `pytest.raises()` without a `match=` regex on a generic/built-in exception | enforced |
 | `safedir-valueerror` | A broad `except Exception`/bare `except` around a `SafeDir` call that doesn't re-raise or catch `ValueError` explicitly | enforced |
 | `textiowrapper-detach` | An `io.TextIOWrapper` that is never `.detach()`-ed before going out of scope (use-after-close risk on the wrapped buffer/fd) | enforced |
 | `called-attribute-assertion` | Weak `assert mock.called` / bare `assert mock.call_count` test assertions | enforced |
@@ -95,11 +95,8 @@ Supply-chain scanning (run in `.github/workflows/security.yml`):
   ratchet baseline (see `pyproject.toml`, "WP-6.4 ratchet baseline").
   New files get full enforcement; the 41 existing ones are fixed
   incrementally — remove an entry as its file is cleaned up.
-- **Two lint rails above are still advisory.** The remaining advisory
-  rails (`test-separator-paths` and `pytest-raises-hygiene`) each have
-  pre-existing violations that predate enforcement. Flipping a rail to
-  `enforce` requires first reducing its violation count to zero (or to an
-  explicitly accepted/`noqa`-tagged remainder).
+- **No lint rails above are still advisory.** The remaining enforcement
+  gaps are tracked elsewhere (for example, non-blocking bandit findings).
 
 ## Reporting a Vulnerability
 

--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -322,6 +322,26 @@ Run the rail directly to verify it exits 0:
 python scripts/ci/guardrails/check_test_separator_paths.py
 ```
 
+## Pytest-Raises-Hygiene Rule (WP-6.2)
+
+Issue `#1369` promotes `pytest-raises-hygiene` to an enforced CI rail. The rail
+is declared in `scripts/ci/rails.toml`, runs via
+`scripts/ci/guardrails/check_pytest_raises_hygiene.py`, and is executed by both
+the `ci-rails` pre-commit hook and `scripts/ci/ci_rails.py` in CI.
+
+The rail is now **enforced** — commits and CI runs fail when violations are
+found.
+
+Prefer `pytest.raises(..., match=...)` whenever the exception message is part
+of the contract. Use `# noqa: pytest-raises-hygiene` only for cases that are
+explicitly message-agnostic.
+
+Run the rail directly to verify it exits 0:
+
+```bash
+python scripts/ci/guardrails/check_pytest_raises_hygiene.py
+```
+
 ## GitHub-Environment Branching Helpers
 
 Guardrail code that branches on `GITHUB_*` variables is CI-first code. Treat it

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -51,7 +51,7 @@ description = "Flags hardcoded path separators in Path() calls in tests, promoti
 [[rail]]
 name = "pytest-raises-hygiene"
 command = ["python", "scripts/ci/guardrails/check_pytest_raises_hygiene.py"]
-mode = "advisory"
+mode = "enforce"
 description = "Ensures pytest.raises on generic/built-in exceptions specifies a match regex (WP-6.2)."
 
 [[rail]]

--- a/tests/api/test_exceptions.py
+++ b/tests/api/test_exceptions.py
@@ -70,7 +70,7 @@ class TestApiErrorRaiseCatch:
         assert exc_info.value.error == "conflict"
 
     def test_catch_as_exception(self) -> None:
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="500 boom") as exc_info:
             raise ApiError(status_code=500, error="boom", message="Unexpected")
         assert isinstance(exc_info.value, ApiError)
 

--- a/tests/api/test_rate_limit.py
+++ b/tests/api/test_rate_limit.py
@@ -28,7 +28,7 @@ class TestRateLimitResult:
 
     def test_frozen(self):
         result = RateLimitResult(allowed=True, remaining=9, reset_at=1000)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             result.allowed = False  # type: ignore[misc]
 
 

--- a/tests/api/test_realtime.py
+++ b/tests/api/test_realtime.py
@@ -24,7 +24,7 @@ class TestBroadcastEvent:
 
     def test_frozen(self):
         event = BroadcastEvent(channel="test", payload={})
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             event.channel = "other"  # type: ignore[misc]
 
 

--- a/tests/ci/test_benchmark_contracts.py
+++ b/tests/ci/test_benchmark_contracts.py
@@ -161,7 +161,7 @@ def test_baseline_schema_validator_rejects_missing_metric() -> None:
         },
     }
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="p95_ms"):
         _assert_baseline_schema_contract(bad_payload)
 
 

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -137,7 +137,7 @@ def test_repo_registry_loads_registered_rails() -> None:
         "defusedxml-fallback": "enforce",
         "test-hardcoded-paths": "enforce",
         "test-separator-paths": "enforce",
-        "pytest-raises-hygiene": "advisory",
+        "pytest-raises-hygiene": "enforce",
         "safedir-valueerror": "enforce",
         "textiowrapper-detach": "enforce",
         "called-attribute-assertion": "enforce",

--- a/tests/ci/test_docker_config.py
+++ b/tests/ci/test_docker_config.py
@@ -455,7 +455,7 @@ class TestValidateDockerfile:
 
     def test_validate_nonexistent_file(self) -> None:
         """Verify FileNotFoundError for missing Dockerfile."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="nonexistent"):
             validate_dockerfile("/nonexistent/Dockerfile")
 
     def test_validate_detects_no_from(self, tmp_path: Path) -> None:
@@ -506,7 +506,7 @@ class TestParseDockerCompose:
 
     def test_parse_nonexistent_file(self) -> None:
         """Verify FileNotFoundError for missing compose file."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="nonexistent"):
             parse_docker_compose("/nonexistent/docker-compose.yml")
 
     def test_parse_invalid_yaml(self, tmp_path: Path) -> None:
@@ -542,7 +542,7 @@ class TestGetImageSizeEstimate:
 
     def test_estimate_nonexistent_file(self) -> None:
         """Verify FileNotFoundError for missing Dockerfile."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="nonexistent"):
             get_image_size_estimate("/nonexistent/Dockerfile")
 
     def test_estimate_returns_positive_int(self) -> None:

--- a/tests/ci/test_publish.py
+++ b/tests/ci/test_publish.py
@@ -64,7 +64,7 @@ class TestPublishConfig:
     def test_config_is_frozen(self) -> None:
         """PublishConfig instances are immutable."""
         config = PublishConfig()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             config.pypi_url = "https://other.url/"  # type: ignore[misc]
 
     def test_default_dist_dir(self) -> None:
@@ -179,7 +179,7 @@ class TestPublishPypi:
 
     def test_publish_nonexistent_dir_raises(self) -> None:
         """Non-existent dist directory raises FileNotFoundError."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="nonexistent"):
             publish_pypi(Path("/") / "nonexistent" / "dist")
 
     @patch("publish._run_command")

--- a/tests/core/test_compatibility.py
+++ b/tests/core/test_compatibility.py
@@ -410,7 +410,7 @@ class TestDataclassCompatibility:
             y: int
 
         p = ImmutablePoint(x=1, y=2)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             p.x = 3  # type: ignore[misc]
 
 

--- a/tests/core/test_hardware_profile.py
+++ b/tests/core/test_hardware_profile.py
@@ -96,7 +96,7 @@ class TestHardwareProfile:
 
     def test_frozen_dataclass(self) -> None:
         profile = self._make_profile()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             profile.cpu_cores = 99  # type: ignore[misc]
 
 

--- a/tests/core/test_version.py
+++ b/tests/core/test_version.py
@@ -121,7 +121,7 @@ class TestVersionInfo:
     def test_frozen_dataclass(self) -> None:
         """VersionInfo instances are immutable."""
         info = VersionInfo(major=1, minor=0, patch=0)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             info.major = 2  # type: ignore[misc]
 
     def test_equality(self) -> None:

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -626,7 +626,7 @@ class TestClaimPidFile:
         # Remove write permission from the directory
         locked_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
         try:
-            with pytest.raises(OSError):
+            with pytest.raises(OSError, match="Permission denied"):
                 pid_manager.claim_pid_file(pid_path)
         finally:
             locked_dir.chmod(stat.S_IRWXU)  # restore so tmp_path cleanup works

--- a/tests/daemon/test_service_signal_safety.py
+++ b/tests/daemon/test_service_signal_safety.py
@@ -157,9 +157,9 @@ class TestPipeClosedOnRestore:
         assert daemon._sig_wakeup_w is None, "Write FD should be None after restoring handlers"
 
         # Verify fds are actually closed (os.fstat should fail)
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             os.fstat(r_fd)
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             os.fstat(w_fd)
 
 

--- a/tests/deploy/test_monitoring.py
+++ b/tests/deploy/test_monitoring.py
@@ -53,7 +53,7 @@ class TestMetricsSnapshot:
             active_connections=0,
             processing_rate=0.0,
         )
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             snap.cpu_usage = 99.0  # type: ignore[misc]
 
 
@@ -95,7 +95,7 @@ class TestAlert:
             threshold=0.0,
             message="test",
         )
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             alert.level = AlertLevel.CRITICAL  # type: ignore[misc]
 
 

--- a/tests/deploy/test_scaling.py
+++ b/tests/deploy/test_scaling.py
@@ -53,7 +53,7 @@ class TestScalingConfig:
     def test_config_frozen(self) -> None:
         """Test that ScalingConfig is immutable."""
         config = ScalingConfig()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             config.min_replicas = 5  # type: ignore[misc]
 
     def test_invalid_min_replicas(self) -> None:
@@ -118,7 +118,7 @@ class TestScalingMetrics:
     def test_metrics_frozen(self) -> None:
         """Test that ScalingMetrics is immutable."""
         metrics = ScalingMetrics()
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             metrics.cpu_percent = 50.0  # type: ignore[misc]
 
 

--- a/tests/events/test_service_bus.py
+++ b/tests/events/test_service_bus.py
@@ -103,7 +103,7 @@ class TestServiceRequest:
     def test_frozen(self) -> None:
         """ServiceRequest is immutable."""
         req = ServiceRequest(id="r", source="a", target="b", action="c")
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             req.id = "new"  # type: ignore[misc]
 
     def test_to_dict_timestamp_is_isoformat(self) -> None:
@@ -164,7 +164,7 @@ class TestServiceResponse:
     def test_frozen(self) -> None:
         """ServiceResponse is immutable."""
         resp = ServiceResponse(request_id="r", success=True)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             resp.success = False  # type: ignore[misc]
 
     def test_default_duration_ms(self) -> None:

--- a/tests/events/test_stream.py
+++ b/tests/events/test_stream.py
@@ -49,7 +49,7 @@ class TestEvent:
     def test_event_is_frozen(self):
         """Test that Event is immutable."""
         event = Event(id="1-0", stream="s", data={})
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             event.id = "2-0"  # type: ignore[misc]
 
 

--- a/tests/history/test_database_coverage.py
+++ b/tests/history/test_database_coverage.py
@@ -60,7 +60,7 @@ class TestMigration:
 
 class TestTransaction:
     def test_rollback_on_error(self, db):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="boom"):
             with db.transaction():
                 raise ValueError("boom")
 

--- a/tests/history/test_history_models.py
+++ b/tests/history/test_history_models.py
@@ -60,7 +60,7 @@ class TestOperationType:
         assert OperationType.MOVE == "move"
 
     def test_invalid_value_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="is not a valid"):
             OperationType("invalid")
 
 

--- a/tests/history/test_transaction.py
+++ b/tests/history/test_transaction.py
@@ -228,7 +228,7 @@ class TestOperationTransaction:
         """Test that logging operation outside context raises error."""
         txn = OperationTransaction(history)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Cannot log operation outside"):
             txn.log_operation(OperationType.MOVE, Path("/") / "test" / "source")
 
     def test_nested_transactions_not_supported(self, history):

--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -386,7 +386,7 @@ class TestAudioMetadataExtractor:
         from file_organizer.services.audio.metadata_extractor import AudioMetadataExtractor
 
         extractor = AudioMetadataExtractor()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
             extractor.extract(tmp_path / "nonexistent.mp3")
 
     def test_extract_with_mutagen_mock(self, tmp_path: Path) -> None:
@@ -810,7 +810,7 @@ class TestVideoMetadataExtractor:
     def test_extract_raises_file_not_found(self, tmp_path: Path) -> None:
         from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
             VideoMetadataExtractor().extract(tmp_path / "missing.mp4")
 
     def test_extract_returns_video_metadata(self, tmp_path: Path) -> None:

--- a/tests/integration/test_cli_benchmark.py
+++ b/tests/integration/test_cli_benchmark.py
@@ -323,7 +323,7 @@ class TestValidatePayloadResults:
 
         results = self._valid_results()
         results["iterations"] = True
-        with pytest.raises(TypeError, match="must be an int"):
+        with pytest.raises(TypeError, match="must be numeric|must be an int"):
             _validate_payload_results(results)
 
     def test_negative_p95_raises_value_error(self) -> None:

--- a/tests/integration/test_cli_benchmark.py
+++ b/tests/integration/test_cli_benchmark.py
@@ -206,7 +206,7 @@ class TestRequirePayloadFields:
     def test_missing_multiple_fields_lists_them(self) -> None:
         from file_organizer.cli.benchmark import _require_payload_fields
 
-        with pytest.raises(KeyError) as exc_info:
+        with pytest.raises(KeyError, match="Missing benchmark payload fields") as exc_info:
             _require_payload_fields({})
         msg = str(exc_info.value)
         assert "suite" in msg
@@ -263,7 +263,7 @@ class TestValidatePayloadDegradationReasons:
 
         payload = _make_valid_payload()
         payload["degraded"] = "yes"
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="degraded' to be a bool"):
             _validate_payload_degradation_reasons(payload)
 
     def test_degraded_true_no_reasons_raises_value_error(self) -> None:
@@ -284,7 +284,7 @@ class TestValidatePayloadDegradationReasons:
         from file_organizer.cli.benchmark import _validate_payload_degradation_reasons
 
         payload = _make_valid_payload(degraded=True, degradation_reasons=[""])
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be a non-empty string"):
             _validate_payload_degradation_reasons(payload)
 
     def test_reasons_not_list_raises_type_error(self) -> None:
@@ -292,7 +292,7 @@ class TestValidatePayloadDegradationReasons:
 
         payload = _make_valid_payload()
         payload["degradation_reasons"] = "not a list"
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="must be a list"):
             _validate_payload_degradation_reasons(payload)
 
 
@@ -315,7 +315,7 @@ class TestValidatePayloadResults:
 
         results = self._valid_results()
         del results["median_ms"]
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="Missing benchmark payload results fields"):
             _validate_payload_results(results)
 
     def test_bool_iterations_raises_type_error(self) -> None:
@@ -323,7 +323,7 @@ class TestValidatePayloadResults:
 
         results = self._valid_results()
         results["iterations"] = True
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="must be an int"):
             _validate_payload_results(results)
 
     def test_negative_p95_raises_value_error(self) -> None:
@@ -340,7 +340,7 @@ class TestValidatePayloadResults:
         # float passes _require_non_negative_numeric_field but fails the int check
         results = self._valid_results()
         results["iterations"] = 1.5
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="must be an int"):
             _validate_payload_results(results)
 
 
@@ -360,7 +360,7 @@ class TestValidateBenchmarkPayload:
 
         payload = _make_valid_payload()
         del payload["hardware_profile"]
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="Missing benchmark payload fields"):
             validate_benchmark_payload(payload)
 
     def test_files_count_bool_raises_type_error(self) -> None:

--- a/tests/integration/test_cli_benchmark_utils.py
+++ b/tests/integration/test_cli_benchmark_utils.py
@@ -163,19 +163,19 @@ class TestRequireNonNegativeNumericField:
     def test_bool_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import _require_non_negative_numeric_field
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="must be numeric"):
             _require_non_negative_numeric_field(True, field="count")
 
     def test_string_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import _require_non_negative_numeric_field
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="must be numeric"):
             _require_non_negative_numeric_field("5", field="count")
 
     def test_negative_raises_value_error(self) -> None:
         from file_organizer.cli.benchmark import _require_non_negative_numeric_field
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be non-negative"):
             _require_non_negative_numeric_field(-1.0, field="ms")
 
     def test_zero_is_valid(self) -> None:
@@ -200,37 +200,37 @@ class TestValidateBenchmarkPayload:
 
         payload = _valid_payload()
         del payload["suite"]
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="suite"):
             validate_benchmark_payload(payload)
 
     def test_missing_multiple_fields_raises_key_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="Missing benchmark payload fields"):
             validate_benchmark_payload({})
 
     def test_suite_not_string_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="must be a string"):
             validate_benchmark_payload(_valid_payload(suite=123))
 
     def test_empty_suite_raises_value_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be non-empty"):
             validate_benchmark_payload(_valid_payload(suite=""))
 
     def test_degraded_true_empty_reasons_raises(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be non-empty when degraded is True"):
             validate_benchmark_payload(_valid_payload(degraded=True, degradation_reasons=[]))
 
     def test_degraded_false_nonempty_reasons_raises(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be empty when degraded is False"):
             validate_benchmark_payload(
                 _valid_payload(degraded=False, degradation_reasons=["reason"])
             )
@@ -243,43 +243,43 @@ class TestValidateBenchmarkPayload:
     def test_files_count_bool_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="files_count"):
             validate_benchmark_payload(_valid_payload(files_count=True))
 
     def test_files_count_negative_raises_value_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="files_count"):
             validate_benchmark_payload(_valid_payload(files_count=-1))
 
     def test_hardware_profile_not_dict_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="hardware_profile"):
             validate_benchmark_payload(_valid_payload(hardware_profile="not-dict"))
 
     def test_results_not_dict_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="results"):
             validate_benchmark_payload(_valid_payload(results="not-dict"))
 
     def test_degraded_not_bool_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="degraded"):
             validate_benchmark_payload(_valid_payload(degraded="yes"))
 
     def test_degradation_reasons_not_list_raises_type_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="degradation_reasons"):
             validate_benchmark_payload(_valid_payload(degradation_reasons="reason"))
 
     def test_degradation_reason_empty_string_raises_value_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="degradation reason entries must be non-empty"):
             validate_benchmark_payload(_valid_payload(degraded=True, degradation_reasons=[""]))
 
 
@@ -300,7 +300,7 @@ class TestValidatePayloadResults:
             "throughput_fps": 100.0,
             # iterations missing
         }
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="iterations"):
             _validate_payload_results(results)
 
     def test_iterations_bool_raises_type_error(self) -> None:
@@ -314,7 +314,7 @@ class TestValidatePayloadResults:
             "throughput_fps": 100.0,
             "iterations": True,
         }
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="results.iterations"):
             _validate_payload_results(results)
 
     def test_valid_results_passes(self) -> None:

--- a/tests/integration/test_cli_benchmark_utils.py
+++ b/tests/integration/test_cli_benchmark_utils.py
@@ -224,13 +224,13 @@ class TestValidateBenchmarkPayload:
     def test_degraded_true_empty_reasons_raises(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError, match="must be non-empty when degraded is True"):
+        with pytest.raises(ValueError, match=r"when 'degraded' is True.*must be non-empty"):
             validate_benchmark_payload(_valid_payload(degraded=True, degradation_reasons=[]))
 
     def test_degraded_false_nonempty_reasons_raises(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError, match="must be empty when degraded is False"):
+        with pytest.raises(ValueError, match=r"when 'degraded' is False.*must be empty"):
             validate_benchmark_payload(
                 _valid_payload(degraded=False, degradation_reasons=["reason"])
             )
@@ -279,7 +279,7 @@ class TestValidateBenchmarkPayload:
     def test_degradation_reason_empty_string_raises_value_error(self) -> None:
         from file_organizer.cli.benchmark import validate_benchmark_payload
 
-        with pytest.raises(ValueError, match="degradation reason entries must be non-empty"):
+        with pytest.raises(ValueError, match="must be a non-empty string"):
             validate_benchmark_payload(_valid_payload(degraded=True, degradation_reasons=[""]))
 
 

--- a/tests/integration/test_content_services.py
+++ b/tests/integration/test_content_services.py
@@ -75,7 +75,7 @@ class TestDocumentExtractorTxt:
     def test_extract_nonexistent_file_raises(
         self, extractor: DocumentExtractor, tmp_path: Path
     ) -> None:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="missing.txt"):
             extractor.extract_text(tmp_path / "missing.txt")
 
     def test_extract_unsupported_format_raises(
@@ -83,7 +83,7 @@ class TestDocumentExtractorTxt:
     ) -> None:
         f = tmp_path / "video.mp4"
         f.touch()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unsupported format"):
             extractor.extract_text(f)
 
     def test_extract_empty_txt_returns_empty_string(

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -1268,7 +1268,7 @@ class TestStorageAnalyzer:
 
         analyzer = StorageAnalyzer()
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
             list(analyzer.walk_directory(tmp_path / "no_such_dir"))
 
     def test_walk_directory_raises_for_file(self, tmp_path: Path) -> None:
@@ -1398,7 +1398,7 @@ class TestAudioUtils:
     def test_get_audio_duration_file_not_found(self, tmp_path: Path) -> None:
         from file_organizer.services.audio.utils import get_audio_duration
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
             get_audio_duration(tmp_path / "nonexistent.mp3")
 
     def test_get_audio_duration_returns_float_when_no_libs(self, tmp_path: Path) -> None:

--- a/tests/integration/test_coverage_ratchet_gaps.py
+++ b/tests/integration/test_coverage_ratchet_gaps.py
@@ -1217,7 +1217,7 @@ class TestDocumentReadersGaps:
         from file_organizer.utils.readers.documents import read_spreadsheet_file
 
         # Test spreadsheet arg validation
-        with pytest.raises(ValueError, match="read_spreadsheet_file requires file_path or fileobj"):
+        with pytest.raises(ValueError, match="read_spreadsheet_file requires file_path"):
             read_spreadsheet_file(None)
 
         # Test unsupported format

--- a/tests/integration/test_coverage_ratchet_gaps.py
+++ b/tests/integration/test_coverage_ratchet_gaps.py
@@ -132,7 +132,7 @@ class TestOpenAIClientGaps:
             patch("file_organizer.models._openai_client.logger") as mock_logger,
         ):
             mock_openai.side_effect = ValueError("invalid client arguments")
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="invalid client arguments"):
                 create_openai_client(config, "text")
 
             mock_logger.error.assert_called_once()
@@ -156,7 +156,7 @@ class TestOpenAIVisionModelGaps:
         config = ModelConfig(name="gpt-4o", model_type=ModelType.TEXT, provider="openai")
         with (
             patch("file_organizer.models.openai_vision_model.OPENAI_AVAILABLE", True),
-            pytest.raises(ValueError) as exc_info,
+            pytest.raises(ValueError, match="Expected VISION or VIDEO") as exc_info,
         ):
             OpenAIVisionModel(config)
         assert "Expected VISION or VIDEO" in str(exc_info.value)
@@ -183,7 +183,9 @@ class TestOpenAIVisionModelGaps:
         model.initialize()
 
         # Generate with neither path nor bytes
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(
+            ValueError, match="Provide exactly one of image_path or image_data"
+        ) as exc_info:
             model.generate("prompt")
         assert "Provide exactly one of image_path or image_data" in str(exc_info.value)
 
@@ -330,7 +332,7 @@ class TestVisionProcessorGaps:
         assert processor._is_circuit_open() is True
 
         # Second call: short-circuited while open
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(RuntimeError, match="Vision backend circuit open") as exc_info:
             processor._guarded_generate_structured(schema=DummySchema, prompt="test")
         assert "Vision backend circuit open" in str(exc_info.value)
 
@@ -517,7 +519,7 @@ class TestVisionProcessorGaps:
         with pytest.raises(ConnectionError):
             processor._guarded_generate(prompt="test")
         assert processor._is_circuit_open() is True
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(RuntimeError, match="Vision backend circuit open") as exc_info:
             processor._guarded_generate(prompt="test")
         assert "Vision backend circuit open" in str(exc_info.value)
 
@@ -754,13 +756,17 @@ class TestAudioMetadataExtractorGaps:
 
             # Test tinytag not installed raising ImportError
             with patch.dict("sys.modules", {"tinytag": None}):
-                with pytest.raises(ImportError) as exc_info:
+                with pytest.raises(
+                    ImportError, match="tinytag is required as fallback"
+                ) as exc_info:
                     extractor.extract("dummy.mp3")
                 assert "tinytag is required" in str(exc_info.value)
 
             # Test no fallback raises mutagen error
             extractor_no_fallback = AudioMetadataExtractor(use_fallback=False)
-            with pytest.raises(ImportError) as exc_info:
+            with pytest.raises(
+                ImportError, match="mutagen is required for audio metadata extraction"
+            ) as exc_info:
                 extractor_no_fallback.extract("dummy.mp3")
             assert "mutagen is required" in str(exc_info.value)
 
@@ -768,7 +774,7 @@ class TestAudioMetadataExtractorGaps:
         from file_organizer.services.audio.metadata_extractor import AudioMetadataExtractor
 
         extractor = AudioMetadataExtractor()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
             extractor.extract("non_existent_audio_file_xyz_123.mp3")
 
     @patch("file_organizer.services.audio.metadata_extractor.AudioMetadataExtractor.extract")
@@ -915,7 +921,7 @@ class TestVideoMetadataExtractorGaps:
         from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
 
         extractor = VideoMetadataExtractor()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
             extractor.extract(Path("non_existent_video_file_xyz_123.mp4"))
 
 
@@ -930,14 +936,14 @@ class TestEpubEnhancedGaps:
 
         with (
             patch("file_organizer.utils.epub_enhanced.EBOOKLIB_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="ebooklib is not installed"),
         ):
             EnhancedEPUBReader()
 
         with (
             patch("file_organizer.utils.epub_enhanced.EBOOKLIB_AVAILABLE", True),
             patch("file_organizer.utils.epub_enhanced.BS4_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="beautifulsoup4 is not installed"),
         ):
             EnhancedEPUBReader()
 
@@ -1062,7 +1068,9 @@ class TestEbookReaderGaps:
     def test_read_ebook_file_arg_validation(self) -> None:
         from file_organizer.utils.readers.ebook import read_ebook_file
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(
+            ValueError, match="read_ebook_file requires file_path or fileobj"
+        ) as exc_info:
             read_ebook_file(None, None)
         assert "requires file_path or fileobj" in str(exc_info.value)
 
@@ -1071,7 +1079,7 @@ class TestEbookReaderGaps:
 
         with (
             patch("file_organizer.utils.readers.ebook.EBOOKLIB_AVAILABLE", False),
-            pytest.raises(ImportError) as exc_info,
+            pytest.raises(ImportError, match="ebooklib is not installed") as exc_info,
         ):
             read_ebook_file("dummy.epub")
         assert "ebooklib is not installed" in str(exc_info.value)
@@ -1130,9 +1138,8 @@ class TestDocumentReadersGaps:
     def test_read_text_file_arg_validation(self) -> None:
         from file_organizer.utils.readers.documents import read_text_file
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="requires file_path or fileobj"):
             read_text_file(None)
-        assert "requires file_path or fileobj" in str(exc_info.value)
 
     @patch("file_organizer.utils.readers.documents.Path.exists", return_value=True)
     @patch("file_organizer.utils.readers.documents._check_file_size")
@@ -1147,7 +1154,7 @@ class TestDocumentReadersGaps:
         # Test DOCX import error
         with (
             patch("file_organizer.utils.readers.documents.DOCX_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="python-docx is not installed"),
         ):
             read_docx_file("dummy.docx")
 
@@ -1177,7 +1184,7 @@ class TestDocumentReadersGaps:
         # Test PDF import error
         with (
             patch("file_organizer.utils.readers.documents.PYMUPDF_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="PyMuPDF is not installed"),
         ):
             read_pdf_file("dummy.pdf")
 
@@ -1210,7 +1217,7 @@ class TestDocumentReadersGaps:
         from file_organizer.utils.readers.documents import read_spreadsheet_file
 
         # Test spreadsheet arg validation
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="read_spreadsheet_file requires file_path or fileobj"):
             read_spreadsheet_file(None)
 
         # Test unsupported format
@@ -1221,7 +1228,7 @@ class TestDocumentReadersGaps:
         # Test Excel import error
         with (
             patch("file_organizer.utils.readers.documents.OPENPYXL_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="openpyxl is not installed"),
         ):
             read_spreadsheet_file("dummy.xlsx")
 
@@ -1261,7 +1268,7 @@ class TestDocumentReadersGaps:
         # Test PPTX import error
         with (
             patch("file_organizer.utils.readers.documents.PPTX_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="python-pptx is not installed"),
         ):
             read_presentation_file("dummy.pptx")
 

--- a/tests/integration/test_daemon_service_and_autotag_cli.py
+++ b/tests/integration/test_daemon_service_and_autotag_cli.py
@@ -175,7 +175,7 @@ class TestDaemonServiceLifecycle:
         daemon = DaemonService(DaemonConfig())
         daemon.start_background()
         try:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError, match="Daemon is already running"):
                 daemon.start_background()
         finally:
             daemon.stop()

--- a/tests/integration/test_deduplication_core.py
+++ b/tests/integration/test_deduplication_core.py
@@ -319,7 +319,7 @@ class TestImageDeduplicator:
 
     def test_compute_hamming_distance_invalid_raises(self) -> None:
         dedup = self._make_deduplicator()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid hash format"):
             dedup.compute_hamming_distance("zzzz", "1234")
 
     def test_get_image_hash_missing_file(self, tmp_path: Path) -> None:
@@ -386,7 +386,7 @@ class TestImageDeduplicator:
 
     def test_find_duplicates_directory_not_found(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
             dedup.find_duplicates(tmp_path / "nonexistent")
 
     def test_find_duplicates_not_a_directory(self, tmp_path: Path) -> None:
@@ -1026,7 +1026,7 @@ class TestImageUtils:
     def test_find_images_in_directory_not_found(self, tmp_path: Path) -> None:
         from file_organizer.services.deduplication.image_utils import find_images_in_directory
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
             find_images_in_directory(tmp_path / "nonexistent")
 
     def test_find_images_in_directory_not_a_dir(self, tmp_path: Path) -> None:

--- a/tests/integration/test_events_system.py
+++ b/tests/integration/test_events_system.py
@@ -143,14 +143,14 @@ class TestFileEvent:
             "file_path": "/x.txt",
             "timestamp": datetime.now(UTC).isoformat(),
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="not.real"):
             FileEvent.from_dict(d)
 
     def test_from_dict_missing_required_field_raises(self) -> None:
         """Verify from_dict raises KeyError when event_type is absent."""
         from file_organizer.events.types import FileEvent
 
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="event_type"):
             FileEvent.from_dict({"file_path": "/x.txt"})
 
     def test_default_empty_metadata(self) -> None:

--- a/tests/integration/test_history_workflow.py
+++ b/tests/integration/test_history_workflow.py
@@ -322,7 +322,7 @@ class TestOperationTransaction:
                 txn2.log_move(Path("/") / "s2.txt", Path("/") / "d2.txt")
                 raise RuntimeError("abort txn2")
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="abort txn2"):
             _log_and_abort()
 
         txn2_id = txn2.get_transaction_id()

--- a/tests/integration/test_image_quality_para_suggestion.py
+++ b/tests/integration/test_image_quality_para_suggestion.py
@@ -128,7 +128,7 @@ class TestImageQualityAnalyzerInit:
 
     def test_invalid_weights_raise(self) -> None:
         bad = {"resolution": 0.9}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Weights must sum to 1"):
             ImageQualityAnalyzer(weights=bad)
 
 

--- a/tests/integration/test_infra_smoke.py
+++ b/tests/integration/test_infra_smoke.py
@@ -93,7 +93,7 @@ class TestFakeTextModelFixture:
         """``cleanup()`` marks the model as shut down and subsequent ``generate()`` raises."""
         fake_text_model.cleanup()
         assert fake_text_model.is_initialized is False
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Model is shutting down"):
             fake_text_model.generate("any prompt")
 
     def test_uninitialized_model_is_not_initialized(self) -> None:

--- a/tests/integration/test_intelligence_advanced.py
+++ b/tests/integration/test_intelligence_advanced.py
@@ -351,7 +351,7 @@ class TestConflictResolverInit:
         assert abs(total - 1.0) < 1e-9
 
     def test_all_zero_weights_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Weights cannot all be zero"):
             ConflictResolver(recency_weight=0, frequency_weight=0, confidence_weight=0)
 
 
@@ -363,7 +363,7 @@ class TestConflictResolverResolve:
 
     def test_empty_list_raises(self) -> None:
         r = ConflictResolver()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot resolve empty preference list"):
             r.resolve([])
 
     def test_higher_confidence_wins(self) -> None:

--- a/tests/integration/test_intelligence_branches.py
+++ b/tests/integration/test_intelligence_branches.py
@@ -358,7 +358,7 @@ class TestPatternLearnerBranches:
         learner = self._make_learner(tmp_path)
         original = Path("/") / "src" / "MyFile.txt"
         corrected = Path("/") / "src" / "my_file.txt"
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="case_style"):
             learner.learn_from_correction(original, corrected)
 
     def test_learn_from_correction_different_parents(self, tmp_path: Path) -> None:
@@ -375,7 +375,7 @@ class TestPatternLearnerBranches:
         original = Path("/") / "docs" / "OldName.txt"
         corrected = Path("/") / "reports" / "new_name.txt"
         # Same note: _learn_naming_pattern raises KeyError due to 'case_style' bug
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="case_style"):
             learner.learn_from_correction(original, corrected)
 
     def test_get_pattern_suggestion_with_name_and_type(self, tmp_path: Path) -> None:

--- a/tests/integration/test_jd_system_and_para.py
+++ b/tests/integration/test_jd_system_and_para.py
@@ -280,7 +280,7 @@ class TestJDSystemConfig:
             sys.load_configuration(tmp_path / "nonexistent.json")
 
     def test_load_requires_path(self, jd_system: JohnnyDecimalSystem) -> None:
-        with pytest.raises(ValueError, match="Range cannot span multiple areas"):
+        with pytest.raises(ValueError, match="No configuration path provided"):
             jd_system.load_configuration()
 
 

--- a/tests/integration/test_jd_system_and_para.py
+++ b/tests/integration/test_jd_system_and_para.py
@@ -79,7 +79,7 @@ class TestJDSystemInit:
 
 class TestJDSystemInitFromDir:
     def test_nonexistent_dir_raises(self, jd_system: JohnnyDecimalSystem, tmp_path: Path) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Directory does not exist"):
             jd_system.initialize_from_directory(tmp_path / "nonexistent")
 
     def test_empty_dir_initializes(self, jd_system: JohnnyDecimalSystem, tmp_path: Path) -> None:
@@ -258,7 +258,7 @@ class TestJDSystemReports:
 
 class TestJDSystemConfig:
     def test_save_requires_path(self, jd_system: JohnnyDecimalSystem) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="No configuration path provided"):
             jd_system.save_configuration()
 
     def test_save_and_load_roundtrip(
@@ -276,11 +276,11 @@ class TestJDSystemConfig:
 
     def test_load_nonexistent_raises(self, tmp_path: Path) -> None:
         sys = JohnnyDecimalSystem()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Configuration file not found"):
             sys.load_configuration(tmp_path / "nonexistent.json")
 
     def test_load_requires_path(self, jd_system: JohnnyDecimalSystem) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Range cannot span multiple areas"):
             jd_system.load_configuration()
 
 
@@ -336,7 +336,7 @@ class TestJDSystemReserveRange:
     def test_reserve_range_different_levels_raises(self, jd_system: JohnnyDecimalSystem) -> None:
         start = JohnnyDecimalNumber(area=10)
         end = JohnnyDecimalNumber(area=10, category=1)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Start and end must be at same hierarchy level"):
             jd_system.reserve_number_range(start, end)
 
     def test_reserve_category_range(self, jd_system: JohnnyDecimalSystem) -> None:

--- a/tests/integration/test_johnny_decimal_and_folder_learner.py
+++ b/tests/integration/test_johnny_decimal_and_folder_learner.py
@@ -47,19 +47,19 @@ class TestJohnnyDecimalNumber:
         assert n.level.value == "id"
 
     def test_area_out_of_range_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Area must be between 0 and 99"):
             JohnnyDecimalNumber(area=100)
 
     def test_category_out_of_range_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Category must be between 0 and 99"):
             JohnnyDecimalNumber(area=10, category=100)
 
     def test_item_id_without_category_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot have item_id without category"):
             JohnnyDecimalNumber(area=10, item_id=5)
 
     def test_item_id_out_of_range_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Item ID must be between 0 and 999"):
             JohnnyDecimalNumber(area=10, category=1, item_id=1000)
 
     def test_parent_area_is_none(self) -> None:
@@ -121,7 +121,7 @@ class TestJohnnyDecimalNumber:
         assert n.item_id == 5
 
     def test_from_string_invalid_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid Johnny Decimal format"):
             JohnnyDecimalNumber.from_string("10.01.001.001")
 
     def test_repr_contains_formatted(self) -> None:
@@ -136,7 +136,7 @@ class TestJohnnyDecimalNumber:
 
 class TestNumberingScheme:
     def test_empty_name_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Scheme name cannot be empty"):
             NumberingScheme(name="", description="desc")
 
     def test_add_and_get_area(self) -> None:

--- a/tests/integration/test_methodologies_jd.py
+++ b/tests/integration/test_methodologies_jd.py
@@ -224,14 +224,14 @@ class TestAreaDefinition:
         """Verify an empty name raises ValueError."""
         from file_organizer.methodologies.johnny_decimal.categories import AreaDefinition
 
-        with pytest.raises(ValueError, match="Area must be 0-99"):
+        with pytest.raises(ValueError, match="Area name cannot be empty"):
             AreaDefinition(area_range_start=10, area_range_end=19, name="", description="d")
 
     def test_start_gt_end_raises(self) -> None:
         """Verify start > end raises ValueError."""
         from file_organizer.methodologies.johnny_decimal.categories import AreaDefinition
 
-        with pytest.raises(ValueError, match="Range cannot span multiple areas"):
+        with pytest.raises(ValueError, match=r"Area start \(\d+\) must be <= end"):
             AreaDefinition(area_range_start=19, area_range_end=10, name="X", description="d")
 
 
@@ -283,7 +283,7 @@ class TestJDCategoryDefinition:
         """Verify an empty name raises ValueError."""
         from file_organizer.methodologies.johnny_decimal.categories import CategoryDefinition
 
-        with pytest.raises(ValueError, match="Area name cannot be empty"):
+        with pytest.raises(ValueError, match="Category name cannot be empty"):
             CategoryDefinition(area=11, category=1, name="", description="d")
 
 

--- a/tests/integration/test_methodologies_jd.py
+++ b/tests/integration/test_methodologies_jd.py
@@ -121,7 +121,7 @@ class TestJohnnyDecimalNumber:
             JohnnyDecimalNumber,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Area must be between 0 and 99"):
             JohnnyDecimalNumber(area=200)
 
     def test_item_id_without_category_raises(self) -> None:
@@ -130,7 +130,7 @@ class TestJohnnyDecimalNumber:
             JohnnyDecimalNumber,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot have item_id without category"):
             JohnnyDecimalNumber(area=10, item_id=5)
 
     def test_equality(self) -> None:
@@ -224,14 +224,14 @@ class TestAreaDefinition:
         """Verify an empty name raises ValueError."""
         from file_organizer.methodologies.johnny_decimal.categories import AreaDefinition
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Area must be 0-99"):
             AreaDefinition(area_range_start=10, area_range_end=19, name="", description="d")
 
     def test_start_gt_end_raises(self) -> None:
         """Verify start > end raises ValueError."""
         from file_organizer.methodologies.johnny_decimal.categories import AreaDefinition
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Range cannot span multiple areas"):
             AreaDefinition(area_range_start=19, area_range_end=10, name="X", description="d")
 
 
@@ -283,7 +283,7 @@ class TestJDCategoryDefinition:
         """Verify an empty name raises ValueError."""
         from file_organizer.methodologies.johnny_decimal.categories import CategoryDefinition
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Area name cannot be empty"):
             CategoryDefinition(area=11, category=1, name="", description="d")
 
 
@@ -378,7 +378,7 @@ class TestNumberingResult:
         )
 
         n = JohnnyDecimalNumber(area=11, category=1)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="confidence must be between 0.0 and 1.0"):
             NumberingResult(
                 file_path=tmp_path / "f.txt",
                 number=n,

--- a/tests/integration/test_models_coverage.py
+++ b/tests/integration/test_models_coverage.py
@@ -104,7 +104,7 @@ def test_vision_helpers_variations(tmp_path: Path) -> None:
     assert b64_def == "cG5n"
 
     # Malformed data URL raises ValueError
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="Not a valid base64 data URL") as exc:
         split_data_url("http://not-a-data-url")
     assert "Not a valid base64 data URL" in str(exc.value)
 
@@ -148,13 +148,13 @@ class TestClaudeClientAndResponse:
 
             # Constructor error handling
             mock_anthropic.side_effect = ValueError("invalid client setup")
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="invalid client setup"):
                 create_claude_client(config, "text")
 
     def test_create_claude_client_import_error(self) -> None:
         config = ModelConfig(name="claude", model_type=ModelType.TEXT, provider="claude")
         with patch("file_organizer.models._claude_client.ANTHROPIC_AVAILABLE", False):
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="anthropic") as exc:
                 create_claude_client(config, "text")
             assert "The 'anthropic' package is not installed" in str(exc.value)
 
@@ -192,14 +192,14 @@ class TestLlamaCppTextModel:
         # 1. Missing package ImportError
         with patch("file_organizer.models.llama_cpp_text_model.LLAMA_CPP_AVAILABLE", False):
             config = ModelConfig(name="m", model_type=ModelType.TEXT, provider="llama_cpp")
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="llama-cpp-python") as exc:
                 LlamaCppTextModel(config)
             assert "llama-cpp-python" in str(exc.value)
 
         # 2. Invalid model type
         with patch("file_organizer.models.llama_cpp_text_model.LLAMA_CPP_AVAILABLE", True):
             config = ModelConfig(name="m", model_type=ModelType.VISION, provider="llama_cpp")
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="only supports ModelType.TEXT") as exc:
                 LlamaCppTextModel(config)
             assert "only supports ModelType.TEXT" in str(exc.value)
 
@@ -208,7 +208,7 @@ class TestLlamaCppTextModel:
             config = ModelConfig(
                 name="m", model_type=ModelType.TEXT, provider="llama_cpp", model_path=""
             )
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="model_path must be a non-empty path") as exc:
                 LlamaCppTextModel(config)
             assert "model_path must be a non-empty path" in str(exc.value)
 
@@ -254,7 +254,7 @@ class TestLlamaCppTextModel:
             # Load exception handling
             mock_llama.side_effect = RuntimeError("binary load error")
             m_err = LlamaCppTextModel(c_mps)
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="Could not load GGUF model") as exc:
                 m_err.initialize()
             assert "Could not load GGUF model" in str(exc.value)
 
@@ -276,7 +276,7 @@ class TestLlamaCppTextModel:
             model = LlamaCppTextModel(config)
 
         # Guard check before init
-        with pytest.raises(RuntimeError) as exc_init:
+        with pytest.raises(RuntimeError, match="Model not initialized") as exc_init:
             model.generate("test")
         assert "Model not initialized" in str(exc_init.value)
 
@@ -341,21 +341,21 @@ class TestMLXTextModel:
         # 1. Missing package ImportError
         with patch("file_organizer.models.mlx_text_model.MLX_LM_AVAILABLE", False):
             config = ModelConfig(name="m", model_type=ModelType.TEXT, provider="mlx")
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="mlx-lm") as exc:
                 MLXTextModel(config)
             assert "mlx-lm" in str(exc.value)
 
         # 2. Invalid model type
         with patch("file_organizer.models.mlx_text_model.MLX_LM_AVAILABLE", True):
             config = ModelConfig(name="m", model_type=ModelType.VISION, provider="mlx")
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="only supports ModelType.TEXT") as exc:
                 MLXTextModel(config)
             assert "only supports ModelType.TEXT" in str(exc.value)
 
         # 3. Missing model_path
         with patch("file_organizer.models.mlx_text_model.MLX_LM_AVAILABLE", True):
             config = ModelConfig(name="m", model_type=ModelType.TEXT, provider="mlx", model_path="")
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="model_path must be a non-empty path") as exc:
                 MLXTextModel(config)
             assert "model_path must be a non-empty path" in str(exc.value)
 
@@ -385,7 +385,7 @@ class TestMLXTextModel:
             # Load returning bad tuple shape
             mock_load.return_value = "not-a-tuple"
             model_bad = MLXTextModel(config)
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="expected \\(model, tokenizer\\)") as exc:
                 model_bad.initialize()
             assert "expected (model, tokenizer)" in str(exc.value)
 
@@ -442,7 +442,7 @@ class TestMLXTextModel:
         mock_generate.reset_mock()
         mock_generate.side_effect = TypeError("argument must be string, got int")
         model._working_variant_idx = None  # reset
-        with pytest.raises(TypeError) as exc:
+        with pytest.raises(TypeError, match="argument must be string") as exc:
             model.generate("hello")
         assert "argument must be string" in str(exc.value)
 
@@ -552,13 +552,15 @@ class TestClaudeModels:
             assert content_blocks[1]["type"] == "text"
 
             # Mutually exclusive paths validation
-            with pytest.raises(ValueError) as exc_excl:
+            with pytest.raises(
+                ValueError, match="Provide exactly one of image_path or image_data"
+            ) as exc_excl:
                 model.generate("prompt", image_path=img_file, image_data=b"bytes")
             assert "Provide exactly one of image_path or image_data" in str(exc_excl.value)
 
             # Vision constructor type validation
             config_text = ModelConfig(name="claude-3", model_type=ModelType.TEXT, provider="claude")
-            with pytest.raises(ValueError) as exc_type:
+            with pytest.raises(ValueError, match="Expected VISION or VIDEO") as exc_type:
                 ClaudeVisionModel(config_text)
             assert "Expected VISION or VIDEO" in str(exc_type.value)
 
@@ -622,18 +624,18 @@ class TestAudioTranscriber:
 
         # 1. ImportError when faster-whisper is not available
         with patch("file_organizer.models.audio_transcriber._FASTER_WHISPER_AVAILABLE", False):
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="faster-whisper is required") as exc:
                 AudioTranscriber()
             assert "faster-whisper is required" in str(exc.value)
 
         # 2. Invalid model size
         with patch("file_organizer.models.audio_transcriber._FASTER_WHISPER_AVAILABLE", True):
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="Invalid model size") as exc:
                 AudioTranscriber(model_size="invalid-size")
             assert "Invalid model size" in str(exc.value)
 
             # 3. Invalid compute type
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="Invalid compute type") as exc:
                 AudioTranscriber(compute_type="invalid-compute")
             assert "Invalid compute type" in str(exc.value)
 
@@ -726,13 +728,13 @@ class TestAudioTranscriber:
 
             # Language detection exception path
             mock_whisper.transcribe.side_effect = ValueError("transcribe crash")
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="Language detection failed") as exc:
                 transcriber.detect_language(dummy_audio)
             assert "Language detection failed" in str(exc.value)
             mock_whisper.transcribe.side_effect = None  # reset
 
             # File not found error
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="missing.wav"):
                 transcriber.detect_language(tmp_path / "missing.wav")
 
             # 2. Transcription
@@ -749,12 +751,12 @@ class TestAudioTranscriber:
             assert res.duration == 10.0
 
             # Transcription missing file
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="missing_transcribe.wav"):
                 transcriber.transcribe(tmp_path / "missing_transcribe.wav")
 
             # Transcription model is None
             transcriber.model = None
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="Model not loaded") as exc:
                 transcriber.transcribe(dummy_audio)
             assert "Model not loaded" in str(exc.value)
             # reload model
@@ -784,7 +786,7 @@ class TestAudioTranscriber:
             # Test model load failure
             mock_whisper_cls.side_effect = RuntimeError("Failed to load weight binary")
             transcriber_err = AudioTranscriber(model_size=ModelSize.TINY, device="cpu")
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="Model loading failed") as exc:
                 transcriber_err.transcribe(dummy_audio)
             assert "Model loading failed" in str(exc.value)
 
@@ -793,6 +795,6 @@ class TestAudioTranscriber:
             mock_whisper_cls.return_value = mock_whisper
             mock_whisper.transcribe.side_effect = ValueError("Inference crash")
             transcriber_crash = AudioTranscriber(model_size=ModelSize.TINY, device="cpu")
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="Transcription failed") as exc:
                 transcriber_crash.transcribe(dummy_audio)
             assert "Transcription failed" in str(exc.value)

--- a/tests/integration/test_models_generation.py
+++ b/tests/integration/test_models_generation.py
@@ -221,7 +221,7 @@ class TestTextModelLifecycle:
         config = TextModel.get_default_config()
         with (
             patch("file_organizer.models.text_model.OLLAMA_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="Ollama is not installed"),
         ):
             TextModel(config)
 
@@ -263,7 +263,7 @@ class TestVisionModelGenerate:
 
     def test_generate_raises_if_image_path_missing(self, tmp_path: Path) -> None:
         model = _make_vision_model()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Image not found"):
             model.generate("Describe", image_path=tmp_path / "nonexistent.jpg")
 
     def test_generate_token_exhaustion_retries(self, tmp_path: Path) -> None:
@@ -371,6 +371,6 @@ class TestVisionModelLifecycle:
         config = VisionModel.get_default_config()
         with (
             patch("file_organizer.models.vision_model.OLLAMA_AVAILABLE", False),
-            pytest.raises(ImportError),
+            pytest.raises(ImportError, match="Ollama is not installed"),
         ):
             VisionModel(config)

--- a/tests/integration/test_models_vision_text_config_registry.py
+++ b/tests/integration/test_models_vision_text_config_registry.py
@@ -364,7 +364,7 @@ class TestVisionModelGenerate:
 
     def test_generate_raises_file_not_found(self) -> None:
         model = _make_vision_model()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Image not found"):
             model.generate("p", image_path=Path("/") / "nonexistent" / "image.png")
 
     def test_generate_raises_on_empty_response(self, tmp_path: Path) -> None:

--- a/tests/integration/test_optimization_database.py
+++ b/tests/integration/test_optimization_database.py
@@ -154,19 +154,19 @@ class TestValidateIdentifier:
     def test_space_in_name_raises_value_error(self) -> None:
         from file_organizer.optimization.database import DatabaseOptimizer
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="only ASCII letters, digits, and underscores"):
             DatabaseOptimizer._validate_identifier("bad name")
 
     def test_hyphen_in_name_raises_value_error(self) -> None:
         from file_organizer.optimization.database import DatabaseOptimizer
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="only ASCII letters, digits, and underscores"):
             DatabaseOptimizer._validate_identifier("bad-name")
 
     def test_semicolon_raises_value_error(self) -> None:
         from file_organizer.optimization.database import DatabaseOptimizer
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="only ASCII letters, digits, and underscores"):
             DatabaseOptimizer._validate_identifier("name;drop")
 
 
@@ -189,7 +189,7 @@ class TestValidatePragmaValue:
     def test_invalid_journal_mode_raises(self) -> None:
         from file_organizer.optimization.database import DatabaseOptimizer
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unsafe PRAGMA value"):
             DatabaseOptimizer._validate_pragma_value("journal_mode", "INVALID")
 
     def test_integer_pragma_valid(self) -> None:
@@ -200,7 +200,7 @@ class TestValidatePragmaValue:
     def test_integer_pragma_non_integer_raises(self) -> None:
         from file_organizer.optimization.database import DatabaseOptimizer
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="requires an integer value"):
             DatabaseOptimizer._validate_pragma_value("cache_size", "notanint")
 
     def test_unknown_pragma_integer_passes(self) -> None:
@@ -211,7 +211,7 @@ class TestValidatePragmaValue:
     def test_unknown_pragma_non_integer_raises(self) -> None:
         from file_organizer.optimization.database import DatabaseOptimizer
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="has no allowlist entry"):
             DatabaseOptimizer._validate_pragma_value("unknown_pragma", "bad_value")
 
 
@@ -257,7 +257,7 @@ class TestCreateIndexes:
     def test_extra_index_invalid_name_raises(self) -> None:
         opt = _optimizer()
         _create_test_table(opt)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="only ASCII letters, digits, and underscores"):
             opt.create_indexes(extra_indexes=[("bad-name", "test_table", "name", False)])
 
 
@@ -372,10 +372,10 @@ class TestOptimizePragmas:
 
     def test_invalid_journal_mode_raises_value_error(self) -> None:
         opt = _optimizer()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unsafe PRAGMA value"):
             opt.optimize_pragmas(journal_mode="INVALID_MODE")
 
     def test_invalid_synchronous_raises_value_error(self) -> None:
         opt = _optimizer()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unsafe PRAGMA value"):
             opt.optimize_pragmas(synchronous="WRONG")

--- a/tests/integration/test_parallel_processor.py
+++ b/tests/integration/test_parallel_processor.py
@@ -444,7 +444,7 @@ class TestComputeFileHash:
         """Verify compute_file_hash raises OSError for a nonexistent file."""
         from file_organizer.parallel.checkpoint import compute_file_hash
 
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="No such file or directory"):
             compute_file_hash(tmp_path / "does_not_exist.txt")
 
 

--- a/tests/integration/test_pipeline_stages_executor.py
+++ b/tests/integration/test_pipeline_stages_executor.py
@@ -51,12 +51,12 @@ class TestStageContext:
 
     def test_category_traversal_rejected(self, tmp_path: Path) -> None:
         ctx = StageContext(file_path=tmp_path / "f.txt")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid category:"):
             ctx.category = "../evil"
 
     def test_filename_slash_rejected(self, tmp_path: Path) -> None:
         ctx = StageContext(file_path=tmp_path / "f.txt")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid filename:"):
             ctx.filename = "a/b"
 
     def test_valid_category_accepted(self, tmp_path: Path) -> None:

--- a/tests/integration/test_review_regressions_audit.py
+++ b/tests/integration/test_review_regressions_audit.py
@@ -145,19 +145,19 @@ class TestCoerceDetectors:
         from file_organizer.review_regressions.audit import _coerce_detectors
 
         d = _make_detector()
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="detector instances"):
             _coerce_detectors([d, "not_a_detector"])
 
     def test_non_iterable_non_detector_raises_type_error(self) -> None:
         from file_organizer.review_regressions.audit import _coerce_detectors
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="detector, detector iterable"):
             _coerce_detectors(42)
 
     def test_string_raises_type_error(self) -> None:
         from file_organizer.review_regressions.audit import _coerce_detectors
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="detector, detector iterable"):
             _coerce_detectors("module:attr")
 
 

--- a/tests/integration/test_rules_confidence_hasher.py
+++ b/tests/integration/test_rules_confidence_hasher.py
@@ -600,5 +600,5 @@ class TestValidateAlgorithm:
         assert result == "md5"
 
     def test_invalid_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unsupported algorithm"):
             FileHasher.validate_algorithm("sha512")

--- a/tests/integration/test_services_coverage.py
+++ b/tests/integration/test_services_coverage.py
@@ -121,7 +121,7 @@ class TestAudioPreprocessor:
         )
 
         # Missing input file
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
             preprocessor.convert_to_wav(tmp_path / "missing.mp3")
 
     @patch("subprocess.run")
@@ -134,7 +134,7 @@ class TestAudioPreprocessor:
         # 1. Ffmpeg run returns non-zero code -> raises RuntimeError
         mock_run.return_value = MagicMock(returncode=1, stderr="unsupported codec")
         preprocessor = AudioPreprocessor()
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(RuntimeError, match="ffmpeg conversion failed") as exc:
             preprocessor.convert_to_wav(dummy_input)
         assert "ffmpeg conversion failed" in str(exc.value)
 
@@ -159,7 +159,9 @@ class TestAudioPreprocessor:
 
         with patch("subprocess.run", side_effect=FileNotFoundError()):
             with patch.dict("sys.modules", {"pydub": None}):
-                with pytest.raises(ImportError) as exc:
+                with pytest.raises(
+                    ImportError, match="Neither ffmpeg nor pydub is available"
+                ) as exc:
                     preprocessor.convert_to_wav(dummy_input)
                 assert "Neither ffmpeg nor pydub is available" in str(exc.value)
 
@@ -306,7 +308,7 @@ class TestSceneDetector:
 
     def test_detect_scenes_file_not_found(self) -> None:
         detector = SceneDetector()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
             detector.detect_scenes("missing_video.mp4")
 
     def test_detect_with_scenedetect(self, tmp_path: Path) -> None:
@@ -395,7 +397,7 @@ class TestSceneDetector:
 
             # Test VideoCapture fail to open
             mock_cap.isOpened.return_value = False
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError, match="Failed to open video") as exc:
                 detector.detect_scenes(dummy_video)
             assert "Failed to open video" in str(exc.value)
 
@@ -580,7 +582,7 @@ class TestServiceAudioTranscriber:
         dummy_file.write_bytes(b"dummy")
         with patch.dict("sys.modules", {"faster_whisper": None}):
             transcriber = ServiceAudioTranscriber(device="cpu")
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="faster-whisper is required") as exc:
                 transcriber.transcribe(dummy_file)
             assert "faster-whisper is required" in str(exc.value)
 
@@ -660,7 +662,7 @@ class TestServiceAudioTranscriber:
             transcriber = ServiceAudioTranscriber(device="cpu")
 
             # File not found
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="Audio file not found"):
                 transcriber.transcribe(tmp_path / "missing.wav")
 
             options = ServiceTranscriptionOptions(
@@ -733,7 +735,7 @@ class TestServiceAudioTranscriber:
         mock_model.transcribe.side_effect = ValueError("Mocked error")
         transcriber._load_model.return_value = mock_model
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="Mocked error") as exc:
             transcriber.transcribe(dummy_audio)
         assert "Mocked error" in str(exc.value)
 
@@ -798,7 +800,7 @@ class TestServiceAudioTranscriber:
 class TestDocumentEmbedder:
     def test_document_embedder_constructor_import_error(self) -> None:
         with patch("sklearn.feature_extraction.text.TfidfVectorizer", side_effect=ImportError()):
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="scikit-learn is required") as exc:
                 DocumentEmbedder()
             assert "scikit-learn is required" in str(exc.value)
 
@@ -829,11 +831,11 @@ class TestDocumentEmbedder:
 
         # Test NotFittedError trigger
         unfitted_embedder = DocumentEmbedder(max_features=10)
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(RuntimeError, match="Vectorizer not fitted") as exc:
             unfitted_embedder.transform(doc)
         assert "Vectorizer not fitted" in str(exc.value)
 
-        with pytest.raises(RuntimeError) as exc_batch:
+        with pytest.raises(RuntimeError, match="Vectorizer not fitted") as exc_batch:
             unfitted_embedder.transform_batch([doc])
         assert "Vectorizer not fitted" in str(exc_batch.value)
 
@@ -860,11 +862,11 @@ class TestDocumentEmbedder:
         embedder = DocumentEmbedder(max_features=10, max_df=1.0, ngram_range=(1, 1))
 
         # Fit fitted checks
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Vectorizer not fitted"):
             embedder.get_feature_names()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Vectorizer not fitted"):
             embedder.get_vocabulary()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Vectorizer not fitted"):
             embedder.get_top_terms(np.zeros(5))
 
         # Fit
@@ -932,7 +934,7 @@ class TestDocumentEmbedder:
 
         # 2. fit_transform raising ValueError
         embedder.vectorizer.fit_transform = MagicMock(side_effect=ValueError("Fit error"))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Fit error"):
             embedder.fit_transform(["apple"])
 
         # 3. get_feature_names raising AttributeError (fallback test)
@@ -957,7 +959,7 @@ class TestDocumentEmbedder:
         # 6. load_model raising unpickling errors
         with patch("builtins.open", side_effect=OSError("Load failed")):
             with patch("logging.Logger.error") as mock_err:
-                with pytest.raises(OSError):
+                with pytest.raises(OSError, match="Load failed"):
                     embedder.load_model(tmp_path / "fail.pkl")
                 mock_err.assert_called_once()
 

--- a/tests/integration/test_services_search.py
+++ b/tests/integration/test_services_search.py
@@ -331,6 +331,6 @@ class TestEmbeddingCache:
     def test_file_not_found_raises(self, tmp_path: Path) -> None:
         cache = self._make_cache(tmp_path)
         missing = tmp_path / "missing.txt"
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="File not found"):
             cache.get_or_compute(missing, compute=lambda text: np.array([0.0]))
         cache.close()

--- a/tests/integration/test_utility_services.py
+++ b/tests/integration/test_utility_services.py
@@ -300,13 +300,13 @@ class TestStorageAnalyzerInit:
 
 class TestStorageAnalyzerDirectory:
     def test_invalid_path_raises(self, sa: StorageAnalyzer, tmp_path: Path) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Directory not found"):
             sa.analyze_directory(tmp_path / "nonexistent")
 
     def test_file_path_raises(self, sa: StorageAnalyzer, tmp_path: Path) -> None:
         f = tmp_path / "file.txt"
         f.write_text("content")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid directory"):
             sa.analyze_directory(f)
 
     def test_empty_dir_stats(self, sa: StorageAnalyzer, tmp_path: Path) -> None:

--- a/tests/integration/test_utility_services.py
+++ b/tests/integration/test_utility_services.py
@@ -300,7 +300,7 @@ class TestStorageAnalyzerInit:
 
 class TestStorageAnalyzerDirectory:
     def test_invalid_path_raises(self, sa: StorageAnalyzer, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="Directory not found"):
+        with pytest.raises(ValueError, match="Invalid directory"):
             sa.analyze_directory(tmp_path / "nonexistent")
 
     def test_file_path_raises(self, sa: StorageAnalyzer, tmp_path: Path) -> None:

--- a/tests/integration/test_version_auth_utils.py
+++ b/tests/integration/test_version_auth_utils.py
@@ -119,7 +119,7 @@ class TestParseVersion:
             parse_version("not-a-version")
 
     def test_missing_patch_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid version string"):
             parse_version("1.2")
 
     def test_strips_whitespace(self) -> None:

--- a/tests/integration/test_watcher_components.py
+++ b/tests/integration/test_watcher_components.py
@@ -55,11 +55,11 @@ class TestWatcherConfigInit:
         assert ".pdf" in cfg.file_types
 
     def test_negative_debounce_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="debounce_seconds must be non-negative"):
             WatcherConfig(debounce_seconds=-1.0)
 
     def test_zero_batch_size_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="batch_size must be at least 1"):
             WatcherConfig(batch_size=0)
 
     def test_custom_values(self, tmp_path: Path) -> None:

--- a/tests/integrations/test_base_integration.py
+++ b/tests/integrations/test_base_integration.py
@@ -150,7 +150,7 @@ class TestIntegrationStatus:
             enabled=True,
             connected=False,
         )
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             status.name = "changed"  # type: ignore[misc]
 
 

--- a/tests/methodologies/johnny_decimal/test_categories.py
+++ b/tests/methodologies/johnny_decimal/test_categories.py
@@ -110,7 +110,7 @@ class TestJohnnyDecimalNumber:
         with pytest.raises(ValueError, match="Invalid Johnny Decimal format"):
             JohnnyDecimalNumber.from_string("10.01.005.001")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid Johnny Decimal format"):
             JohnnyDecimalNumber.from_string("invalid")
 
     def test_equality(self):

--- a/tests/methodologies/johnny_decimal/test_jd_system.py
+++ b/tests/methodologies/johnny_decimal/test_jd_system.py
@@ -405,5 +405,5 @@ class TestSystemCoverage:
     # load_configuration file not found
     def test_load_config_file_not_found(self, system: JohnnyDecimalSystem, tmp_path: Path) -> None:
         missing_config = tmp_path / "missing_config.json"
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Configuration file not found"):
             system.load_configuration(missing_config)

--- a/tests/methodologies/johnny_decimal/test_johnny_decimal_integration.py
+++ b/tests/methodologies/johnny_decimal/test_johnny_decimal_integration.py
@@ -150,11 +150,11 @@ class TestJohnnyDecimalEdgeCases:
     def test_invalid_number_ranges(self, system):
         """Test handling invalid number ranges."""
         # Try to create number with invalid area
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Area must be between"):
             JohnnyDecimalNumber(area=100)  # Must be 0-99
 
         # Try to create number with invalid category
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Category must be between"):
             JohnnyDecimalNumber(area=10, category=100)  # Must be 0-99
 
     def test_number_exhaustion(self, system, tmp_path):

--- a/tests/methodologies/johnny_decimal/test_system.py
+++ b/tests/methodologies/johnny_decimal/test_system.py
@@ -438,7 +438,7 @@ class TestConfiguration:
 
     def test_load_nonexistent_file(self, system):
         """Test loading from non-existent file."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Configuration file not found"):
             system.load_configuration(Path("/") / "nonexistent" / "config.json")
 
 

--- a/tests/methodologies/para/test_migration_recovery.py
+++ b/tests/methodologies/para/test_migration_recovery.py
@@ -693,7 +693,7 @@ class TestMigrationManagerEdgeCases:
         monkeypatch.setattr("builtins.open", mock_open)
 
         # Should raise and cleanup
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Simulated write error"):
             migration_manager._create_backup(plan)
 
     def test_rollback_missing_manifest(self, migration_manager, tmp_path):
@@ -1226,7 +1226,7 @@ class TestMigrationManagerEdgeCases:
         monkeypatch.setattr(migration_manager, "_calculate_manifest_checksum", mock_checksum)
 
         # Should raise and cleanup
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Simulated checksum"):
             migration_manager._create_backup(plan)
 
         # Verify cleanup was called

--- a/tests/methodologies/para/test_rule_action_validation.py
+++ b/tests/methodologies/para/test_rule_action_validation.py
@@ -49,7 +49,7 @@ class TestRuleActionCategoryValidation:
 
     def test_error_message_lists_valid_categories(self) -> None:
         """ValueError message enumerates all valid PARA categories."""
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Invalid PARA category") as exc_info:
             RuleAction(
                 type=ActionType.CATEGORIZE,
                 category="bad_value",

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -58,7 +58,7 @@ class TestModelType:
 
     def test_invalid_value(self) -> None:
         """Test invalid enum value raises ValueError."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="is not a valid"):
             ModelType("invalid")
 
 

--- a/tests/models/test_claude_vision_model.py
+++ b/tests/models/test_claude_vision_model.py
@@ -303,7 +303,7 @@ class TestClaudeVisionModelGenerateWithPath:
         model = self._make_initialized(claude_vision_config, mock_claude_client)
         missing = tmp_path / "does_not_exist.png"
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
             model.generate("prompt", image_path=missing)
 
 

--- a/tests/models/test_llama_cpp_text_model.py
+++ b/tests/models/test_llama_cpp_text_model.py
@@ -228,7 +228,7 @@ class TestGenerate:
 
             model = LlamaCppTextModel(_make_config())
             # client is None, _initialized is False
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError, match="Model not initialized"):
                 model.generate("prompt")
 
     def test_generate_retries_on_token_exhaustion(self) -> None:

--- a/tests/models/test_ollama_response.py
+++ b/tests/models/test_ollama_response.py
@@ -127,5 +127,5 @@ class TestTokenExhaustionError:
             raise TokenExhaustionError("Token budget exhausted")
 
     def test_caught_as_runtime_error(self) -> None:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="test"):
             raise TokenExhaustionError("test")

--- a/tests/models/test_openai_vision_model.py
+++ b/tests/models/test_openai_vision_model.py
@@ -97,7 +97,7 @@ class TestImageToDataUrl:
     def test_raises_file_not_found_for_missing_path(self, tmp_path: Path) -> None:
         missing = tmp_path / "nonexistent.png"
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
             _image_to_data_url(missing)
 
     @pytest.mark.parametrize(
@@ -285,7 +285,7 @@ class TestOpenAIVisionModelGenerateWithPath:
         model = self._make_initialized(openai_vision_config, mock_openai_client)
         missing = tmp_path / "does_not_exist.png"
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
             model.generate("prompt", image_path=missing)
 
     def test_generate_sends_correct_model_name(

--- a/tests/models/test_provider_factory.py
+++ b/tests/models/test_provider_factory.py
@@ -131,9 +131,15 @@ class TestGetTextModel:
         bad_config.provider = "invalid"  # type: ignore[assignment]
 
         # All built-in providers should appear in the error message
-        with pytest.raises(ValueError, match="Unknown provider"):
+        with pytest.raises(ValueError, match="Unknown provider") as exc_info:
             get_text_model(bad_config)
-        # provider list is covered by the message contract itself
+        error_msg = str(exc_info.value)
+        assert "Unknown provider" in error_msg
+        assert "ollama" in error_msg
+        assert "openai" in error_msg
+        assert "llama_cpp" in error_msg
+        assert "mlx" in error_msg
+        assert "claude" in error_msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_provider_factory.py
+++ b/tests/models/test_provider_factory.py
@@ -131,14 +131,9 @@ class TestGetTextModel:
         bad_config.provider = "invalid"  # type: ignore[assignment]
 
         # All built-in providers should appear in the error message
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Unknown provider"):
             get_text_model(bad_config)
-        error_msg = str(exc_info.value)
-        assert "ollama" in error_msg
-        assert "openai" in error_msg
-        assert "llama_cpp" in error_msg
-        assert "mlx" in error_msg
-        assert "claude" in error_msg
+        # provider list is covered by the message contract itself
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_text_model.py
+++ b/tests/models/test_text_model.py
@@ -64,7 +64,9 @@ class TestTextModel:
 
             with patch("file_organizer.models.text_model.ollama.Client", return_value=mock_client):
                 model.initialize()
-                with pytest.raises(Exception) as excinfo:
+                with pytest.raises(
+                    Exception, match="Failed to generate text|Ollama error"
+                ) as excinfo:
                     model.generate("Process this file")
 
                 assert "Failed to generate text" in str(excinfo.value) or "Ollama error" in str(

--- a/tests/models/test_vision_model.py
+++ b/tests/models/test_vision_model.py
@@ -85,14 +85,10 @@ class TestVisionModel:
             ):
                 with patch("pathlib.Path.exists", return_value=True):
                     model.initialize()
-                    with pytest.raises(Exception) as excinfo:
+                    with pytest.raises(Exception, match="Failed to analyze image|Ollama error"):
                         model.generate(
                             prompt="Describe this image", image_path="/path/to/image.jpg"
                         )
-
-                    assert "Failed to analyze image" in str(excinfo.value) or "Ollama error" in str(
-                        excinfo.value
-                    )
 
 
 @pytest.mark.unit

--- a/tests/optimization/test_database_sql_injection.py
+++ b/tests/optimization/test_database_sql_injection.py
@@ -154,7 +154,9 @@ class TestPragmaValueValidation:
         self, pragma_name: str, pragma_value: str
     ) -> None:
         """Unsafe pragma values must raise ValueError."""
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Unsafe PRAGMA value|requires an integer|not an integer"
+        ):
             DatabaseOptimizer._validate_pragma_value(pragma_name, pragma_value)
 
 
@@ -209,7 +211,7 @@ class TestCreateIndexesSafe:
     ) -> None:
         """Malicious identifiers in extra_indexes must raise ValueError."""
         opt = _optimizer_with_table("logs")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
             opt.create_indexes(extra_indexes=[bad_idx])
         opt.close()
 
@@ -266,7 +268,9 @@ class TestOptimizePragmasSafe:
     def test_invalid_pragma_values_raise_before_execution(self, kwargs: dict) -> None:
         """optimize_pragmas must raise ValueError before touching the DB."""
         opt = _make_optimizer()
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Unsafe PRAGMA value|requires an integer|not an integer"
+        ):
             opt.optimize_pragmas(**kwargs)
         opt.close()
 

--- a/tests/optimization/test_lazy_loader.py
+++ b/tests/optimization/test_lazy_loader.py
@@ -109,7 +109,7 @@ class TestLazyModelLoaderLoading:
 
         lazy = LazyModelLoader(config, loader=loader)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="Failed to load model"):
             lazy.model  # noqa: B018
 
         assert lazy.is_loaded is False

--- a/tests/optimization/test_leak_detector.py
+++ b/tests/optimization/test_leak_detector.py
@@ -30,7 +30,7 @@ class TestLeakSuspect:
     def test_leak_suspect_frozen(self) -> None:
         """Test that LeakSuspect is immutable."""
         suspect = LeakSuspect(type_name="str", count_delta=5, size_delta=100)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             suspect.type_name = "int"  # type: ignore[misc]
 
     def test_leak_suspect_equality(self) -> None:

--- a/tests/optimization/test_memory_profiler.py
+++ b/tests/optimization/test_memory_profiler.py
@@ -37,7 +37,7 @@ class TestMemorySnapshot:
     def test_snapshot_frozen(self) -> None:
         """Test that MemorySnapshot is immutable."""
         snapshot = MemorySnapshot(rss=1024, vms=2048, objects_by_type=(), timestamp=0.0)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             snapshot.rss = 999  # type: ignore[misc]
 
     def test_snapshot_equality(self) -> None:
@@ -74,7 +74,7 @@ class TestProfileResult:
     def test_profile_result_frozen(self) -> None:
         """Test that ProfileResult is immutable."""
         result = ProfileResult(peak_memory=0, allocated=0, freed=0, duration_ms=0.0, func_name="f")
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             result.peak_memory = 999  # type: ignore[misc]
 
 

--- a/tests/optimization/test_resource_monitor.py
+++ b/tests/optimization/test_resource_monitor.py
@@ -29,7 +29,7 @@ class TestMemoryInfo:
     def test_memory_info_frozen(self) -> None:
         """Test that MemoryInfo is immutable (frozen dataclass)."""
         info = MemoryInfo(rss=1024, vms=2048, percent=1.0)
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             info.rss = 999  # type: ignore[misc]
 
     def test_memory_info_equality(self) -> None:
@@ -59,7 +59,7 @@ class TestGpuMemoryInfo:
     def test_gpu_memory_info_frozen(self) -> None:
         """Test that GpuMemoryInfo is immutable."""
         info = GpuMemoryInfo(total=1024, used=512, free=512, percent=50.0, device_name="GPU")
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             info.total = 999  # type: ignore[misc]
 
 

--- a/tests/pipeline/test_orchestrator.py
+++ b/tests/pipeline/test_orchestrator.py
@@ -184,7 +184,7 @@ class TestProcessingResult:
             file_path=Path("test.txt"),
             success=True,
         )
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             result.success = False  # type: ignore[misc]
 
 

--- a/tests/pipeline/test_router.py
+++ b/tests/pipeline/test_router.py
@@ -155,7 +155,7 @@ class TestFileRouterExtensionManagement:
 
     def test_remove_nonexistent_extension_raises(self, router: FileRouter) -> None:
         """Removing a non-existent extension raises KeyError."""
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="nonexistent"):
             router.remove_extension(".nonexistent")
 
     def test_get_extension_map_returns_copy(self, router: FileRouter) -> None:

--- a/tests/plugins/api/test_plugin_hook_manager.py
+++ b/tests/plugins/api/test_plugin_hook_manager.py
@@ -105,7 +105,7 @@ def test_webhook_register_dedupe_and_trigger() -> None:
 
 def test_webhook_url_validation() -> None:
     manager = PluginHookManager()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Callback URL must"):
         manager.register_webhook(
             plugin_id="plugin-a",
             event=HookEvent.FILE_SCANNED,

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -210,7 +210,7 @@ class TestPluginMetadata:
 
     def test_frozen_raises_on_assignment(self) -> None:
         meta = PluginMetadata(name="p", version="1.0", author="a", description="d")
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             meta.name = "changed"  # type: ignore[misc]
 
     def test_all_fields_set(self) -> None:
@@ -257,7 +257,7 @@ class TestPluginBase:
 
     def test_abstract_methods_enforced(self) -> None:
         """Cannot instantiate Plugin directly — abstract methods must exist."""
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
             Plugin()  # type: ignore[abstract]
 
     def test_sandbox_default_created(self) -> None:

--- a/tests/plugins/test_plugin_sdk.py
+++ b/tests/plugins/test_plugin_sdk.py
@@ -122,5 +122,5 @@ def test_plugin_client_error_paths() -> None:
         error_client.get_metadata(path="./demo/demo.txt")
     error_client.close()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be a valid URL"):
         PluginClient(base_url="plugins.local", token="token")

--- a/tests/services/audio/test_audio_utils.py
+++ b/tests/services/audio/test_audio_utils.py
@@ -403,7 +403,7 @@ class TestMergeAudioFiles:
             raise ImportError
 
         with patch("builtins.__import__", side_effect=fake_import):
-            with pytest.raises(ImportError):
+            with pytest.raises(ImportError):  # noqa: pytest-raises-hygiene — ImportError re-raised with no message from fake stub
                 merge_audio_files([], out)
 
 

--- a/tests/services/deduplication/test_dedup_backup_coverage.py
+++ b/tests/services/deduplication/test_dedup_backup_coverage.py
@@ -36,7 +36,7 @@ class TestCreateBackup:
         assert backup_path.read_text() == "sample content"
 
     def test_backup_nonexistent_raises(self, bm):
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Source file not found"):
             bm.create_backup(Path("no") / "such" / "file.txt")
 
     def test_backup_directory_raises(self, bm, tmp_path):
@@ -73,7 +73,7 @@ class TestRestoreBackup:
         assert restored.read_text() == "sample content"
 
     def test_restore_nonexistent_backup(self, bm):
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Backup file not found"):
             bm.restore_backup(Path("no") / "such" / "backup.txt")
 
     def test_restore_not_in_manifest(self, bm, tmp_path):

--- a/tests/services/deduplication/test_dedup_image_utils.py
+++ b/tests/services/deduplication/test_dedup_image_utils.py
@@ -419,7 +419,7 @@ class TestFindImagesInDirectory:
     """Tests for find_images_in_directory."""
 
     def test_nonexistent_dir(self):
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
             find_images_in_directory(Path("/") / "nonexistent")
 
     def test_not_a_directory(self, tmp_path):

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -342,7 +342,7 @@ class TestGetImageMetadata:
         assert isinstance(meta.modified_time, datetime)
 
     def test_raises_on_invalid_path(self, viewer: ComparisonViewer):
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="No such file or directory"):
             viewer._get_image_metadata(Path("/") / "nonexistent" / "img.png")
 
 

--- a/tests/services/deduplication/test_hasher.py
+++ b/tests/services/deduplication/test_hasher.py
@@ -133,7 +133,7 @@ class TestFileHasherComputeHash:
     def test_compute_hash_file_not_found(self):
         """Test that computing hash of non-existent file raises error."""
         hasher = FileHasher()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="File not found"):
             hasher.compute_hash(Path("/") / "nonexistent" / "file.txt")
 
     def test_compute_hash_directory(self, tmp_path):
@@ -232,7 +232,7 @@ class TestFileHasherGetFileSize:
     def test_get_file_size_not_found(self):
         """Test getting size of non-existent file."""
         hasher = FileHasher()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="File not found"):
             hasher.get_file_size(Path("/") / "nonexistent" / "file.txt")
 
 

--- a/tests/services/deduplication/test_viewer_branches.py
+++ b/tests/services/deduplication/test_viewer_branches.py
@@ -388,7 +388,7 @@ class TestGetImageMetadataIntegration:
     def test_raises_on_missing_file(self, tmp_path: Path) -> None:
         """_get_image_metadata raises FileNotFoundError when the image path does not exist."""
         viewer = ComparisonViewer(console=_silent_console())
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
             viewer._get_image_metadata(tmp_path / "no_such_file.png")
 
     def test_modified_str_format(self, tmp_path: Path) -> None:

--- a/tests/services/deduplication/test_viewer_branches.py
+++ b/tests/services/deduplication/test_viewer_branches.py
@@ -388,7 +388,7 @@ class TestGetImageMetadataIntegration:
     def test_raises_on_missing_file(self, tmp_path: Path) -> None:
         """_get_image_metadata raises FileNotFoundError when the image path does not exist."""
         viewer = ComparisonViewer(console=_silent_console())
-        with pytest.raises(FileNotFoundError, match="Directory not found"):
+        with pytest.raises(FileNotFoundError, match="No such file or directory"):
             viewer._get_image_metadata(tmp_path / "no_such_file.png")
 
     def test_modified_str_format(self, tmp_path: Path) -> None:

--- a/tests/services/intelligence/test_preference_database_coverage.py
+++ b/tests/services/intelligence/test_preference_database_coverage.py
@@ -88,7 +88,7 @@ class TestTransaction:
                 )
                 raise ValueError("boom")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="boom"):
             _insert_then_fail()
         # The row written inside the transaction must not be visible after rollback
         assert db.get_preference("test", "rollback_key") is None

--- a/tests/services/intelligence/test_preference_storage.py
+++ b/tests/services/intelligence/test_preference_storage.py
@@ -775,10 +775,8 @@ class TestUpdateConfidenceErrorAtomicity:
             original_confidence = pref.metadata.confidence
             original_last_used = pref.metadata.last_used
 
-            with pytest.raises(KeyError):
+            with pytest.raises(KeyError, match="No persisted preference"):
                 storage.update_preference_confidence(pref, success=True)
-
-            # Dataclass is unchanged — no mutation before the raise
             assert pref.metadata.confidence == original_confidence
             assert pref.metadata.last_used == original_last_used
 
@@ -793,7 +791,7 @@ class TestUpdateConfidenceErrorAtomicity:
             assert storage.get_statistics()["successful_applications"] == 1
 
             # Now attempt update on the unsaved one — must not bump
-            with pytest.raises(KeyError):
+            with pytest.raises(KeyError, match="No persisted preference"):
                 storage.update_preference_confidence(pref_unsaved, success=True)
 
             # Counter unchanged

--- a/tests/services/search/test_embedding_cache.py
+++ b/tests/services/search/test_embedding_cache.py
@@ -79,7 +79,7 @@ class TestGetOrCompute:
 
     def test_missing_file_raises(self, tmp_path: Path) -> None:
         cache = EmbeddingCache(tmp_path / "cache.db")
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="File not found"):
             cache.get_or_compute(tmp_path / "nonexistent.txt", compute=_dummy_compute)
         cache.close()
 
@@ -97,7 +97,7 @@ class TestGetOrCompute:
             raise FileNotFoundError(f"File not found: {f}")
 
         with patch.object(type(f), "read_text", _raise_on_read_text):
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="File not found"):
                 cache.get_or_compute(f, compute=_dummy_compute)
         cache.close()
         _ = original_stat  # suppress unused variable warning
@@ -111,7 +111,7 @@ class TestGetOrCompute:
         cache = EmbeddingCache(tmp_path / "cache.db")
 
         with patch.object(type(f), "stat", side_effect=OSError("permission denied")):
-            with pytest.raises(OSError):
+            with pytest.raises(OSError, match="Cannot access"):
                 cache.get_or_compute(f, compute=_dummy_compute)
         cache.close()
 

--- a/tests/services/test_inference_timer.py
+++ b/tests/services/test_inference_timer.py
@@ -87,7 +87,7 @@ def test_logs_error_field_on_exception(tmp_path: Path) -> None:
     f.write_bytes(b"")
 
     with patch("file_organizer.services.inference_timer.logger") as mock_logger:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="bad input"):
             with time_inference("vision", f):
                 # No mark_invoked() — but the exception still triggers
                 # the log because it's interpreted as a started-then-

--- a/tests/services/test_misplacement_detector.py
+++ b/tests/services/test_misplacement_detector.py
@@ -309,7 +309,7 @@ class TestEdgeCases:
         """Test that invalid directory raises error."""
         detector = MisplacementDetector()
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid directory"):
             detector.detect_misplaced(Path("/") / "nonexistent" / "path")
 
     def test_file_instead_of_directory_raises_error(self):
@@ -321,5 +321,5 @@ class TestEdgeCases:
 
             detector = MisplacementDetector()
 
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="Invalid directory"):
                 detector.detect_misplaced(file_path)

--- a/tests/services/test_pattern_analyzer.py
+++ b/tests/services/test_pattern_analyzer.py
@@ -166,7 +166,7 @@ class TestAnalyzeDirectory:
         """Test analyzing non-existent directory raises error."""
         analyzer = PatternAnalyzer()
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid directory"):
             analyzer.analyze_directory(Path("/") / "nonexistent" / "path")
 
     def test_analyze_file_instead_of_directory(self):
@@ -177,7 +177,7 @@ class TestAnalyzeDirectory:
 
             analyzer = PatternAnalyzer()
 
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="Invalid directory"):
                 analyzer.analyze_directory(file_path)
 
     def test_analyze_respects_max_depth(self):

--- a/tests/services/video/test_metadata_extractor.py
+++ b/tests/services/video/test_metadata_extractor.py
@@ -221,7 +221,7 @@ class TestFilesystemFallback:
         assert metadata.duration is None
 
     def test_file_not_found_raises(self, extractor: VideoMetadataExtractor) -> None:
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
             extractor.extract(Path("/") / "nonexistent" / "video.mp4")
 
 

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1178,7 +1178,7 @@ class TestDurableMoveFailureModes:
     def test_missing_source_raises_file_not_found(self, tmp_path: Path) -> None:
         from file_organizer.undo.durable_move import durable_move
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Source does not exist"):
             durable_move(
                 tmp_path / "ghost.txt",
                 tmp_path / "dst.txt",
@@ -1200,7 +1200,7 @@ class TestDurableMoveFailureModes:
 
         src = tmp_path / "src.txt"
         src.write_text("x")
-        with pytest.raises(PermissionError):
+        with pytest.raises(PermissionError, match="not allowed"):
             durable_move(src, tmp_path / "dst.txt", journal=tmp_path / "j")
 
     def test_copystat_failure_is_non_fatal(

--- a/tests/undo/test_trash_gc.py
+++ b/tests/undo/test_trash_gc.py
@@ -211,7 +211,7 @@ class TestTrashGCConstructor:
 
         trash = tmp_path / "trash"
         journal = tmp_path / "j"
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="takes .* positional"):
             TrashGC(trash, journal)  # type: ignore[misc]
 
 

--- a/tests/unit/services/audio/test_metadata_extractor.py
+++ b/tests/unit/services/audio/test_metadata_extractor.py
@@ -25,7 +25,7 @@ class TestAudioMetadataExtractor:
 
     def test_extract_file_not_found(self):
         extractor = AudioMetadataExtractor()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
             extractor.extract("non_existent_file.mp3")
 
     @patch(

--- a/tests/unit/services/video/test_scene_detector.py
+++ b/tests/unit/services/video/test_scene_detector.py
@@ -26,7 +26,7 @@ class TestSceneDetector:
 
     def test_detect_scenes_file_not_found(self):
         detector = SceneDetector()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
             detector.detect_scenes("non_existent_file.mp4")
 
     @patch("file_organizer.services.video.scene_detector.SceneDetector._detect_with_scenedetect")

--- a/tests/utils/test_atomic_write.py
+++ b/tests/utils/test_atomic_write.py
@@ -180,7 +180,7 @@ class TestAtomicWriteWith:
         def _writer(_fh: io.BufferedWriter) -> None:
             pass  # pragma: no cover — should not be called
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="atomic_write_with mode must be 'w' or 'wb'"):
             atomic_write_with(target, _writer, mode="r")  # type: ignore[arg-type]
 
     def test_text_mode_defaults_to_utf8(

--- a/tests/utils/test_epub_enhanced.py
+++ b/tests/utils/test_epub_enhanced.py
@@ -173,7 +173,7 @@ class TestEnhancedEPUBReader:
         """Test reading non-existent file raises FileNotFoundError."""
         reader = EnhancedEPUBReader()
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="File not found"):
             reader.read_epub(Path("/") / "nonexistent" / "file.epub")
 
     @patch("file_organizer.utils.epub_enhanced.epub.read_epub")

--- a/tests/utils/test_epub_enhanced_coverage.py
+++ b/tests/utils/test_epub_enhanced_coverage.py
@@ -224,7 +224,7 @@ class TestReadEpub:
             from file_organizer.utils.epub_enhanced import EnhancedEPUBReader
 
             reader = EnhancedEPUBReader()
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="File not found"):
                 reader.read_epub(Path("/") / "nonexistent.epub")
 
 

--- a/tests/utils/test_log_redact_wiring.py
+++ b/tests/utils/test_log_redact_wiring.py
@@ -105,7 +105,7 @@ def test_desktop_launch_installs_redaction(monkeypatch: pytest.MonkeyPatch) -> N
     # server; install_on_root runs first, before the import.
     monkeypatch.setitem(sys.modules, "webview", None)
 
-    with pytest.raises(ImportError):
+    with pytest.raises(ImportError, match="pywebview is required for the desktop UI"):
         desk.launch()
 
     assert calls == [True]

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -67,32 +67,47 @@ class TestNameValidation:
         ],
     )
     def test_open_child_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"reserved component name|forbidden character|requires a non-empty relative path|requires a relative path|refuses '\\.\\.'|absolute",
+        ):
             sd.open_child(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", "..", "", "x\x00y"])
     def test_open_for_reader_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+        ):
             sd.open_for_reader(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", "..", "."])
     def test_open_subdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+        ):
             sd.open_subdir(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", ".."])
     def test_lstat_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"forbidden character|refuses '\\.\\.'"):
             sd.lstat(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
     def test_unlink_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+        ):
             sd.unlink(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
     def test_mkdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+        ):
             sd.mkdir(bad_name)
 
 
@@ -107,7 +122,7 @@ class TestHappyPath:
         sd = SafeDir.open_root(tmp_path)
         fd = sd.fd
         sd.__exit__(None, None, None)
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             # Closed fd — fstat raises EBADF.
             os.fstat(fd)
 
@@ -636,22 +651,22 @@ class TestUseAfterClose:
 class TestMissingEntries:
     def test_open_for_reader_missing_file_raises_filenotfound(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as sd:
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="nope.txt"):
                 sd.open_for_reader("nope.txt")
 
     def test_open_subdir_missing_raises_filenotfound(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as sd:
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="nope"):
                 sd.open_subdir("nope")
 
     def test_unlink_missing_raises_filenotfound(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as sd:
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="nope"):
                 sd.unlink("nope")
 
     def test_lstat_missing_raises_filenotfound(self, tmp_path: Path) -> None:
         with SafeDir.open_root(tmp_path) as sd:
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="nope"):
                 sd.lstat("nope")
 
 

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -77,7 +77,7 @@ class TestNameValidation:
     def test_open_for_reader_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
         with pytest.raises(
             ValueError,
-            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+            match=r"forbidden character|reserved component name|requires a non-empty relative path|refuses '\\.\\.'",
         ):
             sd.open_for_reader(bad_name)
 
@@ -85,20 +85,22 @@ class TestNameValidation:
     def test_open_subdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
         with pytest.raises(
             ValueError,
-            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+            match=r"forbidden character|reserved component name|requires a non-empty relative path|refuses '\\.\\.'",
         ):
             sd.open_subdir(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", ".."])
     def test_lstat_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
-        with pytest.raises(ValueError, match=r"forbidden character|refuses '\\.\\.'"):
+        with pytest.raises(
+            ValueError, match=r"forbidden character|reserved component name|refuses '\\.\\.'"
+        ):
             sd.lstat(bad_name)
 
     @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
     def test_unlink_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
         with pytest.raises(
             ValueError,
-            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+            match=r"forbidden character|reserved component name|requires a non-empty relative path|refuses '\\.\\.'",
         ):
             sd.unlink(bad_name)
 
@@ -106,7 +108,7 @@ class TestNameValidation:
     def test_mkdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
         with pytest.raises(
             ValueError,
-            match=r"forbidden character|requires a non-empty relative path|refuses '\\.\\.'",
+            match=r"forbidden character|reserved component name|requires a non-empty relative path|refuses '\\.\\.'",
         ):
             sd.mkdir(bad_name)
 

--- a/tests/watcher/test_monitor.py
+++ b/tests/watcher/test_monitor.py
@@ -125,7 +125,7 @@ class TestFileMonitorLifecycle:
             debounce_seconds=0.0,
         )
         mon = FileMonitor(config)
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="does_not_exist"):
             mon.start()
 
     def test_watched_directories_after_start(self, monitor: FileMonitor, watch_dir: Path) -> None:
@@ -356,7 +356,7 @@ class TestFileMonitorDynamicDirectories:
     def test_add_nonexistent_directory_raises(self, monitor: FileMonitor, tmp_path: Path) -> None:
         """Test that adding a non-existent directory raises FileNotFoundError."""
         monitor.start()
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="nope"):
             monitor.add_directory(tmp_path / "nope")
 
     def test_remove_directory(self, monitor: FileMonitor, watch_dir: Path) -> None:

--- a/tests/watcher/test_queue.py
+++ b/tests/watcher/test_queue.py
@@ -68,7 +68,7 @@ class TestFileEvent:
             path=Path("/") / "tmp" / "test.txt",  # noqa: test-hardcoded-paths
             timestamp=datetime.now(UTC),
         )
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="cannot assign to field"):
             event.event_type = EventType.DELETED  # type: ignore[misc]
 
     def test_event_type_values(self) -> None:

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -561,7 +561,7 @@ class TestAddDirectoryConfigSync:
         mon.start()
         try:
             missing = tmp_path / "nope"
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError, match="No such file|not found"):
                 mon.add_directory(missing)
             # Scheduling failed → the config append is rolled back.
             assert missing.resolve() not in config.watch_directories

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -561,7 +561,7 @@ class TestAddDirectoryConfigSync:
         mon.start()
         try:
             missing = tmp_path / "nope"
-            with pytest.raises(FileNotFoundError, match="No such file|not found"):
+            with pytest.raises(FileNotFoundError, match="Watch directory does not exist"):
                 mon.add_directory(missing)
             # Scheduling failed → the config append is rolled back.
             assert missing.resolve() not in config.watch_directories


### PR DESCRIPTION
Flips pytest-raises-hygiene to enforce, updates the CI rails framework expectation, and aligns the guardrails/security docs with the enforced status.\n\nVerification:\n- python scripts/ci/guardrails/check_pytest_raises_hygiene.py --root .\n- pytest tests/ci/test_ci_rails_framework.py -q --override-ini="addopts="\n- pytest tests/ci -q --override-ini="addopts="