### PR TITLE
[codex] Harden guardrail suppression handling

### DIFF
--- a/docs/developer/guardrail-promotion-backlog.md
+++ b/docs/developer/guardrail-promotion-backlog.md
@@ -1,0 +1,48 @@
+# Guardrail Promotion Backlog
+
+This backlog converts recurring PR-review anti-patterns into remediation and
+enforcement issues. Each issue should follow the same shape as #1369: current
+state, representative examples, remediation guidance, and acceptance criteria.
+
+## Promotion Rules
+
+- Promote only repeated, objective patterns with a low-noise detector path.
+- Put fast changed-file checks in pre-commit or `ci-rails`.
+- Put semantic, repository-wide, or high-context checks in `tests/ci` first.
+- Keep existing enforced rails enforced; hardening work should improve their
+  reliability, not reopen enforcement.
+
+## MECE Issue Drafts
+
+| Issue | Anti-pattern | Canonical home | Enforcement target |
+|---|---|---|---|
+| [#1405](https://github.com/curdriceaurora/Local-File-Organizer/issues/1405) Guardrail suppression bypasses | Broad `noqa`, string-literal suppressions, or unrelated suppression codes disable rails | `scripts/ci/guardrails` shared suppression parser | `ci-rails` enforced |
+| [#1406](https://github.com/curdriceaurora/Local-File-Organizer/issues/1406) CLI file-kind validation gaps | CLI paths are resolved but directories pass where files are required | `cli-path-validation` | `ci-rails` enforced |
+| [#1407](https://github.com/curdriceaurora/Local-File-Organizer/issues/1407) Template JavaScript interpolation | Jinja values, especially paths, are interpolated into inline JS handlers | `tests/ci` semantic template check | CI-only first |
+| [#1408](https://github.com/curdriceaurora/Local-File-Organizer/issues/1408) Subprocess return-code gaps | `subprocess.run` success is reported without checking non-zero exits | `tests/ci` semantic process check | CI-only first |
+| [#1409](https://github.com/curdriceaurora/Local-File-Organizer/issues/1409) PID lifecycle races | PID files are signaled/unlinked after stale checks without ownership revalidation | daemon regression tests plus `tests/ci` | CI-only first |
+| [#1410](https://github.com/curdriceaurora/Local-File-Organizer/issues/1410) Filesystem link/copy races | Symlink, hardlink, copy, move, or unlink operations mutate without identity/root validation | protected-module semantic check | CI-only first |
+| [#1411](https://github.com/curdriceaurora/Local-File-Organizer/issues/1411) Raw persistence writes | Production writes bypass atomic helpers | existing `atomic-write` rail | `ci-rails` enforced |
+| [#1412](https://github.com/curdriceaurora/Local-File-Organizer/issues/1412) SafeDir bypasses | Caller-controlled reads/copies/moves bypass SafeDir or swallow its `ValueError` | existing `safedir-required` and `safedir-valueerror` rails | `ci-rails` enforced |
+| [#1413](https://github.com/curdriceaurora/Local-File-Organizer/issues/1413) Weak mock assertions | Tests assert only `mock.called` or bare `mock.call_count` | existing `called-attribute-assertion` rail | `ci-rails` enforced |
+| [#1369](https://github.com/curdriceaurora/Local-File-Organizer/issues/1369) Generic `pytest.raises` | Built-in/generic exception assertions omit `match=` | existing `pytest-raises-hygiene` rail | enforced by #1404 |
+| [#1414](https://github.com/curdriceaurora/Local-File-Organizer/issues/1414) Test environment leakage | Tests mutate globals, class attributes, or `sys.modules` without scoped restoration | `tests/ci` semantic test-quality check | advisory first |
+| [#1415](https://github.com/curdriceaurora/Local-File-Organizer/issues/1415) Test path portability | Tests hardcode absolute paths or separators | existing `test-hardcoded-paths` and `test-separator-paths` rails | `ci-rails` enforced |
+| [#1416](https://github.com/curdriceaurora/Local-File-Organizer/issues/1416) xdist shared state | Tests use xdist-wide temp state without grouping | existing `xdist-loadgroup` rail | `ci-rails` enforced |
+| [#1417](https://github.com/curdriceaurora/Local-File-Organizer/issues/1417) XML parser fallback gaps | XML parsing falls back unsafely or mishandles missing `defusedxml` | existing `defusedxml-fallback` rail | `ci-rails` enforced |
+| [#1418](https://github.com/curdriceaurora/Local-File-Organizer/issues/1418) Guardrail docs drift | Docs, registry, and expected rail modes disagree | `tests/ci/test_guardrail_governance.py` | pre-commit via `pytest-ci-lint` |
+
+## Issue Acceptance Template
+
+Use this checklist when opening one of the issues above:
+
+- Current rail/check reports the measured number of findings, or the issue
+  states that the new checker starts advisory because the count is not yet zero.
+- Representative examples include file paths and line numbers.
+- Findings are classified as true positive, accepted exception, or detector
+  overreach before broad cleanup.
+- Direct rail/check command exits 0 before enforcement.
+- `scripts/ci/rails.toml`, guardrail docs, `SECURITY.md`, and
+  `tests/ci/test_ci_rails_framework.py` are updated when enforcement changes.
+- `pytest tests/ci -q --override-ini="addopts="` passes.
+- `pre-commit run --all-files` passes before the PR is marked ready.

--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -48,6 +48,10 @@ Add a new rule to the narrowest layer that can enforce it cleanly:
 
 Do not add new blocking policy directly to `scripts/dev/pre-commit-validation.sh`.
 
+The MECE backlog for review anti-patterns that should become remediation and
+enforcement issues lives in
+[`guardrail-promotion-backlog.md`](guardrail-promotion-backlog.md).
+
 ## Blocking Guardrails
 
 Once a rail's backlog reaches zero, flip its registry mode to `enforce`.

--- a/scripts/ci/guardrails/check_atomic_write.py
+++ b/scripts/ci/guardrails/check_atomic_write.py
@@ -8,9 +8,13 @@ operations except in designated primitive/utility modules.
 from __future__ import annotations
 
 import ast
-import re
 import sys
 from pathlib import Path
+
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
 
 # Paths that are allowed to perform raw write operations (the primitives themselves)
 ALLOWED_PATHS = {
@@ -67,20 +71,9 @@ class AtomicWriteVisitor(ast.NodeVisitor):
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
             # Only allow targeted suppression for this rail.
-            if _has_atomic_write_noqa(line_content):
+            if has_targeted_noqa(line_content, "atomic-write"):
                 return
             self.violations.append((lineno, message, line_content.strip()))
-
-
-def _has_atomic_write_noqa(line_content: str) -> bool:
-    """Return True when the line has an explicit noqa for atomic-write."""
-    match = re.search(r"#\s*noqa(?::\s*([a-z0-9_\-,\s]+))?", line_content.lower())
-    if match is None:
-        return False
-    codes = match.group(1)
-    if not codes:
-        return False
-    return "atomic-write" in {code.strip() for code in codes.split(",")}
 
 
 def check_file(filepath: Path) -> list[tuple[int, str, str]]:

--- a/scripts/ci/guardrails/check_called_attribute_assertion.py
+++ b/scripts/ci/guardrails/check_called_attribute_assertion.py
@@ -12,6 +12,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 _WEAK_ATTRS = {"called", "call_count"}
 
 
@@ -31,7 +36,9 @@ class _Visitor(ast.NodeVisitor):
         # and is intentionally not flagged.
         if _is_weak_attribute_expr(test):
             line_idx = node.lineno - 1
-            if 0 <= line_idx < len(self.lines) and "noqa" in self.lines[line_idx]:
+            if 0 <= line_idx < len(self.lines) and has_targeted_noqa(
+                self.lines[line_idx], "called-attribute-assertion"
+            ):
                 self.generic_visit(node)
                 return
             self.violations.append(

--- a/scripts/ci/guardrails/check_cli_path_validation.py
+++ b/scripts/ci/guardrails/check_cli_path_validation.py
@@ -11,6 +11,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_comment_marker, has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_comment_marker, has_targeted_noqa
+
 VALIDATION_FUNCTIONS = {
     "resolve_cli_path",
     "validate_within_roots",
@@ -151,12 +156,8 @@ class CliPathValidationVisitor(ast.NodeVisitor):
                 line_idx = lineno - 1
                 line_content = self.lines[line_idx] if 0 <= line_idx < len(self.lines) else ""
 
-                # Check for noqa override
-                line_content_lower = line_content.lower()
-                if (
-                    "copilot: wontfix" in line_content_lower
-                    or "noqa: cli-path-validation" in line_content_lower
-                    or "noqa" in line_content_lower
+                if has_comment_marker(line_content, "copilot: wontfix") or has_targeted_noqa(
+                    line_content, "cli-path-validation"
                 ):
                     continue
 

--- a/scripts/ci/guardrails/check_defusedxml_fallback.py
+++ b/scripts/ci/guardrails/check_defusedxml_fallback.py
@@ -11,6 +11,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 
 class DefusedXmlVisitor(ast.NodeVisitor):
     """AST visitor to find standard xml module imports."""
@@ -36,8 +41,7 @@ class DefusedXmlVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support noqa override
-            if "noqa: defusedxml-fallback" in line_content or "noqa" in line_content:
+            if has_targeted_noqa(line_content, "defusedxml-fallback"):
                 return
             self.violations.append((lineno, message, line_content.strip()))
 

--- a/scripts/ci/guardrails/check_safedir_required.py
+++ b/scripts/ci/guardrails/check_safedir_required.py
@@ -11,6 +11,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 # Paths that are allowed to perform raw file operations (the primitives themselves)
 ALLOWED_PATHS = {
     "src/file_organizer/utils/safedir.py",
@@ -100,8 +105,7 @@ class SafeDirVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support noqa override
-            if "noqa: safedir-required" in line_content or "noqa" in line_content:
+            if has_targeted_noqa(line_content, "safedir-required"):
                 return
             self.violations.append((lineno, message, line_content.strip()))
 

--- a/scripts/ci/guardrails/check_safedir_valueerror.py
+++ b/scripts/ci/guardrails/check_safedir_valueerror.py
@@ -31,6 +31,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 _SAFEDIR_METHODS = {
     "open_child",
     "open_for_reader",
@@ -171,8 +176,7 @@ class _Visitor(ast.NodeVisitor):
                         line_idx = handler.lineno - 1
                         if 0 <= line_idx < len(self.lines):
                             line_content = self.lines[line_idx]
-                            # Support noqa override
-                            if "noqa: safedir-valueerror" in line_content or "noqa" in line_content:
+                            if has_targeted_noqa(line_content, "safedir-valueerror"):
                                 continue
                         self.violations.append(
                             (

--- a/scripts/ci/guardrails/check_test_hardcoded_paths.py
+++ b/scripts/ci/guardrails/check_test_hardcoded_paths.py
@@ -12,6 +12,11 @@ import re
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 # Match absolute paths:
 # 1. Unix absolute paths starting with common system roots (to avoid URL paths like /api/v1)
 UNIX_ABS_PATH_PAT = re.compile(r"^/(tmp|usr|var|etc|private|Users|home|bin|opt|var|srv)(/|$)")
@@ -40,12 +45,8 @@ class TestHardcodedPathVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support targeted override only (requires specific code like noqa: test-hardcoded-paths)
-            # Extract only the comment part (after #) to avoid false positives from string literals
-            if "#" in line_content:
-                comment = line_content.split("#", 1)[1]
-                if "noqa: test-hardcoded-paths" in comment:
-                    return
+            if has_targeted_noqa(line_content, "test-hardcoded-paths"):
+                return
             self.violations.append((lineno, message, line_content.strip()))
 
 

--- a/scripts/ci/guardrails/check_test_separator_paths.py
+++ b/scripts/ci/guardrails/check_test_separator_paths.py
@@ -8,10 +8,13 @@ Ensures cross-platform compatibility by discouraging hardcoded path separators
 from __future__ import annotations
 
 import ast
-import io
 import sys
-import tokenize
 from pathlib import Path
+
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
 
 
 class TestSeparatorPathVisitor(ast.NodeVisitor):
@@ -48,27 +51,9 @@ class TestSeparatorPathVisitor(ast.NodeVisitor):
             line_content = self.lines[line_idx]
             # Support targeted override only by parsing actual comment tokens.
             # This avoids treating '#' inside string literals as comments.
-            if _has_targeted_noqa(line_content):
+            if has_targeted_noqa(line_content, "test-separator-paths"):
                 return
             self.violations.append((lineno, message, line_content.strip()))
-
-
-def _has_targeted_noqa(line_content: str) -> bool:
-    try:
-        tokens = tokenize.generate_tokens(io.StringIO(line_content).readline)
-    except (tokenize.TokenError, IndentationError):
-        return False
-    for token in tokens:
-        if token.type != tokenize.COMMENT:
-            continue
-        comment_body = token.string.lstrip("#").strip()
-        if not comment_body.lower().startswith("noqa:"):
-            continue
-        _, _, code_list = comment_body.partition(":")
-        codes = [code.strip() for code in code_list.split(",")]
-        if "test-separator-paths" in codes:
-            return True
-    return False
 
 
 def _extract_path_literal(arg: ast.AST) -> str | None:

--- a/scripts/ci/guardrails/check_textiowrapper_detach.py
+++ b/scripts/ci/guardrails/check_textiowrapper_detach.py
@@ -12,6 +12,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 
 def _walk_excluding_nested_functions(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.AST]:
     """Like ast.walk(func), but does not descend into nested function defs.
@@ -88,7 +93,9 @@ class _Visitor(ast.NodeVisitor):
         for name, lineno in wrapped.items():
             if name not in detached:
                 line_idx = lineno - 1
-                if 0 <= line_idx < len(self.lines) and "noqa" in self.lines[line_idx]:
+                if 0 <= line_idx < len(self.lines) and has_targeted_noqa(
+                    self.lines[line_idx], "textiowrapper-detach"
+                ):
                     continue
                 self.violations.append(
                     (

--- a/scripts/ci/guardrails/check_xdist_loadgroup.py
+++ b/scripts/ci/guardrails/check_xdist_loadgroup.py
@@ -14,6 +14,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 
 def _calls_getbasetemp(node: ast.AST) -> bool:
     for child in ast.walk(node):
@@ -66,7 +71,9 @@ class _Visitor(ast.NodeVisitor):
             return
 
         line_idx = node.lineno - 1
-        if 0 <= line_idx < len(self.lines) and "noqa" in self.lines[line_idx]:
+        if 0 <= line_idx < len(self.lines) and has_targeted_noqa(
+            self.lines[line_idx], "xdist-loadgroup"
+        ):
             return
 
         self.violations.append(

--- a/scripts/ci/guardrails/suppressions.py
+++ b/scripts/ci/guardrails/suppressions.py
@@ -1,0 +1,78 @@
+"""Shared suppression parsing helpers for CI guardrails."""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+
+
+def _comment_tokens(line_content: str) -> list[str]:
+    """Return actual Python comment tokens from one source line."""
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(line_content).readline)
+        return [token.string for token in tokens if token.type == tokenize.COMMENT]
+    except (IndentationError, tokenize.TokenError):
+        comment = _manual_comment_token(line_content)
+        return [comment] if comment else []
+
+
+def _manual_comment_token(line_content: str) -> str | None:
+    """Find a comment marker outside simple string literals on incomplete lines."""
+    quote: str | None = None
+    triple_quote: str | None = None
+    escaped = False
+
+    for idx, char in enumerate(line_content):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+
+        if triple_quote is not None:
+            if line_content.startswith(triple_quote, idx):
+                triple_quote = None
+            continue
+
+        if quote is not None:
+            if char == quote:
+                quote = None
+            continue
+
+        if char in {'"', "'"}:
+            if line_content.startswith(char * 3, idx):
+                triple_quote = char * 3
+            else:
+                quote = char
+            continue
+
+        if char == "#":
+            return line_content[idx:]
+
+    return None
+
+
+def has_targeted_noqa(line_content: str, rail_name: str) -> bool:
+    """Return True when an inline comment has ``noqa`` for ``rail_name``.
+
+    The parser only inspects COMMENT tokens, so strings such as
+    ``"noqa: rail-name"`` never suppress a violation.
+    """
+    target = rail_name.lower()
+    for comment in _comment_tokens(line_content):
+        body = comment.lstrip("#").strip()
+        for match in re.finditer(r"(?:^|#|\s)noqa\s*:\s*([^#]+)", body, flags=re.IGNORECASE):
+            code_list = match.group(1)
+            for raw_code in code_list.split(","):
+                code = raw_code.strip().split(maxsplit=1)[0].lower()
+                if code == target:
+                    return True
+    return False
+
+
+def has_comment_marker(line_content: str, marker: str) -> bool:
+    """Return True when an exact marker appears in an actual comment token."""
+    target = marker.lower()
+    return any(target in comment.lower() for comment in _comment_tokens(line_content))

--- a/tests/ci/test_check_atomic_write.py
+++ b/tests/ci/test_check_atomic_write.py
@@ -43,3 +43,12 @@ def test_mixed_noqa_list_with_atomic_write_suppresses_violation(tmp_path: Path) 
     src = tmp_path / "mixed.py"
     src.write_text("Path('x').write_text('data')  # noqa: F401, atomic-write\n", encoding="utf-8")
     assert checker.check_file(src) == []
+
+
+def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        "msg = 'noqa: atomic-write'\nPath('x').write_text('data')\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_called_attribute_assertion.py
+++ b/tests/ci/test_check_called_attribute_assertion.py
@@ -62,9 +62,7 @@ def test_noqa_suppresses_violation(tmp_path: Path) -> None:
 def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
     src = tmp_path / "bare.py"
     src.write_text(
-        "def test_x(mock_fn):\n"
-        "    subject(mock_fn)\n"
-        "    assert mock_fn.called  # noqa\n",
+        "def test_x(mock_fn):\n    subject(mock_fn)\n    assert mock_fn.called  # noqa\n",
         encoding="utf-8",
     )
     assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_called_attribute_assertion.py
+++ b/tests/ci/test_check_called_attribute_assertion.py
@@ -57,3 +57,26 @@ def test_noqa_suppresses_violation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text(
+        "def test_x(mock_fn):\n"
+        "    subject(mock_fn)\n"
+        "    assert mock_fn.called  # noqa\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        "def test_x(mock_fn):\n"
+        "    msg = 'noqa: called-attribute-assertion'\n"
+        "    subject(mock_fn)\n"
+        "    assert mock_fn.called\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_cli_path_validation.py
+++ b/tests/ci/test_check_cli_path_validation.py
@@ -129,3 +129,43 @@ def run(directory: Path) -> None:  # copilot: wontfix
     )
     violations = checker.check_file(src)
     assert len(violations) == 0
+
+
+def test_allows_targeted_noqa_override(tmp_path: Path) -> None:
+    src = tmp_path / "app.py"
+    src.write_text(
+        """
+@app.command()
+def run(directory: Path) -> None:  # noqa: cli-path-validation
+    pass
+""",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "app.py"
+    src.write_text(
+        """
+@app.command()
+def run(directory: Path) -> None:  # noqa
+    pass
+""",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "app.py"
+    src.write_text(
+        """
+@app.command()
+def run(directory: Path) -> None:
+    msg = "noqa: cli-path-validation"
+    pass
+""",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_defusedxml_fallback.py
+++ b/tests/ci/test_check_defusedxml_fallback.py
@@ -1,0 +1,43 @@
+"""Tests for the WP-6.1 defusedxml-fallback CI rail."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.guardrails import check_defusedxml_fallback as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def test_flags_stdlib_xml_import(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("import xml.etree.ElementTree as ET\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "xml.etree" in violations[0][1]
+
+
+def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "exempt.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text("import xml.etree.ElementTree as ET  # noqa\n", encoding="utf-8")
+    assert len(checker.check_file(src)) == 1
+
+
+def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        "msg = 'noqa: defusedxml-fallback'\nimport xml.etree.ElementTree as ET\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_safedir_required.py
+++ b/tests/ci/test_check_safedir_required.py
@@ -151,13 +151,22 @@ def test_noqa_safedir_required_suppresses_open(tmp_path: Path) -> None:
     assert checker.check_file(src) == []
 
 
-def test_bare_noqa_suppresses_open(tmp_path: Path) -> None:
-    src = tmp_path / "exempt_bare.py"
+def test_bare_noqa_does_not_suppress_open(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
     src.write_text(
         "with open('file.txt') as f:  # noqa\n    pass\n",
         encoding="utf-8",
     )
-    assert checker.check_file(src) == []
+    assert len(checker.check_file(src)) == 1
+
+
+def test_string_literal_noqa_does_not_suppress_open(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        "msg = 'noqa: safedir-required'\nwith open('file.txt') as f:\n    pass\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_check_safedir_valueerror.py
+++ b/tests/ci/test_check_safedir_valueerror.py
@@ -134,3 +134,17 @@ def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert len(checker.check_file(src)) == 1
+
+
+def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        "msg = 'noqa: safedir-valueerror'\n"
+        "def f(safedir: SafeDir):\n"
+        "    try:\n"
+        "        return safedir.open_child('x')\n"
+        "    except Exception:\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_safedir_valueerror.py
+++ b/tests/ci/test_check_safedir_valueerror.py
@@ -121,3 +121,16 @@ def test_noqa_suppresses_violation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    try:\n"
+        "        return safedir.open_child('x')\n"
+        "    except Exception:  # noqa\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_test_hardcoded_paths.py
+++ b/tests/ci/test_check_test_hardcoded_paths.py
@@ -70,6 +70,15 @@ def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
     assert checker.check_file(src) == []
 
 
+def test_targeted_noqa_after_type_ignore_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "type_ignore_exempt.py"
+    src.write_text(
+        'path = Path("/home/user/docs")  # type: ignore[arg-type]  # noqa: test-hardcoded-paths\n',
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
 def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
     src = tmp_path / "bare.py"
     src.write_text('path = Path("/home/user/docs")  # noqa\n', encoding="utf-8")

--- a/tests/ci/test_check_test_separator_paths.py
+++ b/tests/ci/test_check_test_separator_paths.py
@@ -87,6 +87,16 @@ def test_string_literal_noqa_text_does_not_suppress_violation(tmp_path: Path) ->
     assert len(violations) == 1
 
 
+def test_string_literal_noqa_directive_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal_directive.py"
+    src.write_text(
+        'message = "noqa: test-separator-paths"\nvalue = Path("docs/report.pdf")\n',
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
 def test_hash_in_string_literal_does_not_suppress_violation(tmp_path: Path) -> None:
     src = tmp_path / "hash_string.py"
     src.write_text(

--- a/tests/ci/test_check_textiowrapper_detach.py
+++ b/tests/ci/test_check_textiowrapper_detach.py
@@ -77,3 +77,15 @@ def test_noqa_suppresses_violation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text(
+        "import io\n"
+        "def f(buf):\n"
+        "    wrapper = io.TextIOWrapper(buf)  # noqa\n"
+        "    return wrapper.read()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_check_xdist_loadgroup.py
+++ b/tests/ci/test_check_xdist_loadgroup.py
@@ -68,3 +68,14 @@ def test_noqa_suppresses_violation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text(
+        "def test_x(tmp_path_factory):  # noqa\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import shlex
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PRE_PR_SCRIPT = PROJECT_ROOT / "scripts" / "dev" / "pre-commit-validation.sh"
 GUARDRAIL_DOC = PROJECT_ROOT / "docs" / "developer" / "guardrails.md"
 CONTRIBUTING_DOC = PROJECT_ROOT / "CONTRIBUTING.md"
+RAILS_REGISTRY = PROJECT_ROOT / "scripts" / "ci" / "rails.toml"
+SECURITY_DOC = PROJECT_ROOT / "SECURITY.md"
 
 pytestmark = pytest.mark.ci
 
@@ -115,6 +118,32 @@ def test_contributing_points_to_guardrail_workflow() -> None:
 
     assert "docs/developer/guardrails.md" in source
     assert "canonical pre-PR guardrail orchestrator" in source
+
+
+def test_security_rail_status_table_matches_registry() -> None:
+    assert RAILS_REGISTRY.exists(), f"Rail registry not found: {RAILS_REGISTRY}"
+    assert SECURITY_DOC.exists(), f"Security doc not found: {SECURITY_DOC}"
+
+    registry = tomllib.loads(RAILS_REGISTRY.read_text(encoding="utf-8"))
+    expected_modes = {rail["name"]: rail["mode"] for rail in registry["rail"]}
+
+    source = SECURITY_DOC.read_text(encoding="utf-8")
+    section_match = re.search(
+        r"## CI-Enforced Lint Rails\n(?P<section>.*?)(?:\n\n[A-Z#]|\Z)",
+        source,
+        flags=re.DOTALL,
+    )
+    assert section_match, "SECURITY.md must define a CI-Enforced Lint Rails section"
+
+    table_modes = {
+        name: ("enforce" if status == "enforced" else status)
+        for name, status in re.findall(
+            r"^\| `([^`]+)` \| [^|]+ \| (advisory|enforced) \|$",
+            section_match.group("section"),
+            flags=re.MULTILINE,
+        )
+    }
+    assert table_modes == expected_modes
 
 
 def test_api_compat_rules_are_not_duplicated_in_shell_orchestrator() -> None:


### PR DESCRIPTION
## Summary

- centralize guardrail suppression parsing so enforced rails only honor targeted inline comments
- add regression coverage for bare `noqa`, unrelated codes, string-literal bypass attempts, and multiline comment cases
- document the guardrail promotion backlog and add governance coverage for SECURITY.md rail status drift

## Validation

- `python scripts/ci/guardrails/check_pytest_raises_hygiene.py`
- `python scripts/ci/ci_rails.py`
- `pytest tests/ci/test_check_atomic_write.py tests/ci/test_check_called_attribute_assertion.py tests/ci/test_check_cli_path_validation.py tests/ci/test_check_defusedxml_fallback.py tests/ci/test_check_safedir_required.py tests/ci/test_check_safedir_valueerror.py tests/ci/test_check_test_hardcoded_paths.py tests/ci/test_check_test_separator_paths.py tests/ci/test_check_textiowrapper_detach.py tests/ci/test_check_xdist_loadgroup.py tests/ci/test_guardrail_governance.py -q --override-ini='addopts='`
- `ruff check scripts/ci/guardrails tests/ci/test_check_atomic_write.py tests/ci/test_check_called_attribute_assertion.py tests/ci/test_check_cli_path_validation.py tests/ci/test_check_defusedxml_fallback.py tests/ci/test_check_safedir_required.py tests/ci/test_check_safedir_valueerror.py tests/ci/test_check_test_hardcoded_paths.py tests/ci/test_check_test_separator_paths.py tests/ci/test_check_textiowrapper_detach.py tests/ci/test_check_xdist_loadgroup.py tests/ci/test_guardrail_governance.py`

## Risk

Low to moderate. The shared suppression parser changes how existing enforced rails interpret exemptions, but focused tests cover targeted suppressions, unrelated `noqa`, string-literal text, and multiline comment patterns. This PR does not implement the future semantic rails tracked in the backlog issues.