### PR TITLE
Harden guardrail suppression handling for pytest.raises

### DIFF
--- a/scripts/ci/guardrails/check_pytest_raises_hygiene.py
+++ b/scripts/ci/guardrails/check_pytest_raises_hygiene.py
@@ -11,6 +11,11 @@ import ast
 import sys
 from pathlib import Path
 
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
 # Exceptions that are too generic to raise without a match pattern
 GENERIC_EXCEPTIONS = {
     "Exception",
@@ -77,8 +82,7 @@ class PytestRaisesHygieneVisitor(ast.NodeVisitor):
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):
             line_content = self.lines[line_idx]
-            # Support noqa override
-            if "noqa: pytest-raises-hygiene" in line_content or "noqa" in line_content:
+            if has_targeted_noqa(line_content, "pytest-raises-hygiene"):
                 return
             self.violations.append((lineno, message, line_content.strip()))
 

--- a/tests/ci/test_check_pytest_raises_hygiene.py
+++ b/tests/ci/test_check_pytest_raises_hygiene.py
@@ -1,0 +1,86 @@
+"""Tests for the WP-6.2 pytest-raises-hygiene CI rail."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.guardrails import check_pytest_raises_hygiene as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def test_flags_generic_pytest_raises_without_match(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text(
+        "import pytest\n\n"
+        "def test_x():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "missing 'match' parameter" in violations[0][1]
+
+
+def test_allows_generic_pytest_raises_with_match(tmp_path: Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text(
+        "import pytest\n\n"
+        "def test_x():\n"
+        "    with pytest.raises(ValueError, match='boom'):\n"
+        "        raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_targeted_noqa_suppression(tmp_path: Path) -> None:
+    src = tmp_path / "targeted.py"
+    src.write_text(
+        "import pytest\n\n"
+        "def test_x():\n"
+        "    with pytest.raises(ValueError):  # noqa: pytest-raises-hygiene\n"
+        "        raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress(tmp_path: Path) -> None:
+    src = tmp_path / "bare.py"
+    src.write_text(
+        "import pytest\n\n"
+        "def test_x():\n"
+        "    with pytest.raises(ValueError):  # noqa\n"
+        "        raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_unrelated_noqa_code_does_not_suppress(tmp_path: Path) -> None:
+    src = tmp_path / "other.py"
+    src.write_text(
+        "import pytest\n\n"
+        "def test_x():\n"
+        "    with pytest.raises(ValueError):  # noqa: F401\n"
+        "        raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_string_literal_noqa_does_not_suppress(tmp_path: Path) -> None:
+    src = tmp_path / "string_literal.py"
+    src.write_text(
+        "import pytest\n\n"
+        "def test_x():\n"
+        "    marker = 'noqa: pytest-raises-hygiene'\n"
+        "    with pytest.raises(ValueError):\n"
+        "        raise ValueError('boom')\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1

--- a/tests/ci/test_guardrail_suppressions.py
+++ b/tests/ci/test_guardrail_suppressions.py
@@ -1,0 +1,43 @@
+"""Regression tests for CI guardrail suppression parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci.guardrails.suppressions import has_comment_marker, has_targeted_noqa
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def test_has_targeted_noqa_accepts_exact_rail() -> None:
+    assert has_targeted_noqa("x = 1  # noqa: pytest-raises-hygiene", "pytest-raises-hygiene")
+
+
+def test_has_targeted_noqa_rejects_bare_noqa() -> None:
+    assert not has_targeted_noqa("x = 1  # noqa", "pytest-raises-hygiene")
+
+
+def test_has_targeted_noqa_rejects_unrelated_codes() -> None:
+    assert not has_targeted_noqa("x = 1  # noqa: F401, E501", "pytest-raises-hygiene")
+
+
+def test_has_targeted_noqa_accepts_mixed_codes_when_target_present() -> None:
+    assert has_targeted_noqa(
+        "x = 1  # noqa: F401, pytest-raises-hygiene, E501",
+        "pytest-raises-hygiene",
+    )
+
+
+def test_has_targeted_noqa_ignores_string_literals() -> None:
+    assert not has_targeted_noqa(
+        "marker = 'noqa: pytest-raises-hygiene'",
+        "pytest-raises-hygiene",
+    )
+
+
+def test_has_comment_marker_ignores_string_literals() -> None:
+    assert not has_comment_marker("marker = 'copilot: wontfix'", "copilot: wontfix")
+
+
+def test_has_comment_marker_matches_real_comment() -> None:
+    assert has_comment_marker("x = 1  # copilot: wontfix", "copilot: wontfix")

--- a/tests/integration/test_api_web_coverage.py
+++ b/tests/integration/test_api_web_coverage.py
@@ -319,12 +319,12 @@ class TestRealtimeWebSocket:
         client = TestClient(app)
 
         # 1. Connect without token -> should fail
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(Exception):  # noqa: B017, pytest-raises-hygiene
             with client.websocket_connect("/ws/client_1") as websocket:
                 pass
 
         # 2. Connect with invalid token -> should fail
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(Exception):  # noqa: B017, pytest-raises-hygiene
             with client.websocket_connect("/ws/client_1?token=wrong") as websocket:
                 pass
 
@@ -376,14 +376,14 @@ class TestRealtimeWebSocket:
 
                 # Invalid User or inactive
                 mock_user.is_active = False
-                with pytest.raises(Exception):  # noqa: B017
+                with pytest.raises(Exception):  # noqa: B017, pytest-raises-hygiene
                     with client.websocket_connect("/ws/client_1?token=valid_jwt") as websocket:
                         pass
 
                 # Revoked token
                 mock_user.is_active = True
                 mock_token_store.is_access_revoked.return_value = True
-                with pytest.raises(Exception):  # noqa: B017
+                with pytest.raises(Exception):  # noqa: B017, pytest-raises-hygiene
                     with client.websocket_connect("/ws/client_1?token=valid_jwt") as websocket:
                         pass
 


### PR DESCRIPTION
## Description
This hardens the `pytest-raises-hygiene` CI rail so it cannot be bypassed by broad or unrelated `# noqa` comments. The goal is to enforce targeted suppressions only, while keeping legitimate exemptions explicit and reviewable.

The checker now uses the shared suppression parser (`has_targeted_noqa`) instead of substring matching. I also added parser-level and checker-level regression tests for bare `# noqa`, unrelated codes, mixed suppression lists, and string-literal pseudo-suppressions. During review, existing websocket tests that intentionally use broad exception assertions were updated to include explicit `pytest-raises-hygiene` suppressions alongside `B017`.

Fixes #1405

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `pytest tests/ci/test_check_pytest_raises_hygiene.py tests/ci/test_check_atomic_write.py tests/ci/test_check_called_attribute_assertion.py tests/ci/test_ci_rails_framework.py -q --override-ini="addopts="`
- [x] `pytest tests/ci/test_guardrail_suppressions.py tests/ci/test_check_pytest_raises_hygiene.py tests/ci/test_check_atomic_write.py tests/ci/test_check_called_attribute_assertion.py tests/ci/test_ci_rails_framework.py -q --override-ini="addopts="`
- [x] `python scripts/ci/guardrails/check_pytest_raises_hygiene.py`
- [x] `pytest tests/integration/test_api_web_coverage.py -q --override-ini="addopts=" -k "websocket_auth_token_required_in_settings or websocket_jwt_auth_enabled"`
- [x] `ruff check scripts/ci/guardrails/check_pytest_raises_hygiene.py tests/ci/test_check_pytest_raises_hygiene.py tests/ci/test_guardrail_suppressions.py tests/integration/test_api_web_coverage.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inline exception-test suppression comments so only the intended targeted comment code is recognized.
  * Updated websocket test suppressions to match the current guardrail expectations.

* **Tests**
  * Added coverage for exception assertions, targeted suppression behavior, and comment detection edge cases.
  * Added regression tests to verify that unrelated or in-string `noqa` text does not affect checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->