### PR TITLE
feat: add diff-cover as pre-commit hook for early coverage regression detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,40 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
+      # Diff-coverage gate: changed lines must have ≥80% test coverage.
+      # Mirrors the CI gate in .github/workflows/ci.yml ("Diff coverage gate").
+      #
+      # Prerequisites:
+      #   git fetch-depth: 0 is required so that origin/main is resolvable
+      #   as a merge base. Shallow clones (fetch-depth: 1) will cause
+      #   "fatal: no merge base" and the hook gracefully skips rather than
+      #   blocking the commit.
+      #
+      # The hook only fires when src/ or tests/ Python files are staged,
+      # so documentation-only or config-only commits are unaffected.
+      # ----------------------------------------------------------------
+      - id: diff-cover
+        name: diff-cover gate (80%)
+        entry: >
+          bash -c '
+          CHANGED=$(git diff --cached --name-only -- "src/**/*.py" "src/*.py" "tests/**/*.py" "tests/*.py")
+          if [ -z "$CHANGED" ]; then exit 0; fi
+          MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null) || {
+            echo "diff-cover: skipping — origin/main merge base unavailable (shallow clone or offline)." >&2
+            exit 0
+          }
+          pytest tests/ -q --override-ini="addopts=" \
+            --cov=file_organizer --cov-report=xml:coverage.xml \
+            --no-header -m "not benchmark and not e2e and not integration" \
+            2>/dev/null
+          diff-cover coverage.xml --compare-branch="$MERGE_BASE" --fail-under=80 --quiet
+          '
+        language: system
+        pass_filenames: false
+        files: ^(src|tests)/.*\.py$
+        stages: [pre-commit]
+
+      # ----------------------------------------------------------------
       # Spelling
       # ----------------------------------------------------------------
       - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,31 +107,17 @@ repos:
       # Diff-coverage gate: changed lines must have ≥80% test coverage.
       # Mirrors the CI gate in .github/workflows/ci.yml ("Diff coverage gate").
       #
-      # Prerequisites:
-      #   git fetch-depth: 0 is required so that origin/main is resolvable
-      #   as a merge base. Shallow clones (fetch-depth: 1) will cause
-      #   "fatal: no merge base" and the hook gracefully skips rather than
-      #   blocking the commit.
+      # Logic lives in scripts/dev/run-diff-cover.sh so that it can use
+      # set -euo pipefail for fail-fast behaviour and avoid YAML folded-scalar
+      # newline-collapse bugs with inline bash -c scripts.
       #
       # The hook only fires when src/ or tests/ Python files are staged,
       # so documentation-only or config-only commits are unaffected.
+      # See CONTRIBUTING.md for the fetch-depth requirement.
       # ----------------------------------------------------------------
       - id: diff-cover
         name: diff-cover gate (80%)
-        entry: >
-          bash -c '
-          CHANGED=$(git diff --cached --name-only -- "src/**/*.py" "src/*.py" "tests/**/*.py" "tests/*.py")
-          if [ -z "$CHANGED" ]; then exit 0; fi
-          MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null) || {
-            echo "diff-cover: skipping — origin/main merge base unavailable (shallow clone or offline)." >&2
-            exit 0
-          }
-          pytest tests/ -q --override-ini="addopts=" \
-            --cov=file_organizer --cov-report=xml:coverage.xml \
-            --no-header -m "not benchmark and not e2e and not integration" \
-            2>/dev/null
-          diff-cover coverage.xml --compare-branch="$MERGE_BASE" --fail-under=80 --quiet
-          '
+        entry: bash scripts/dev/run-diff-cover.sh
         language: system
         pass_filenames: false
         files: ^(src|tests)/.*\.py$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,16 @@ pre-commit install
 | **codespell** | Spelling consistency | Typos, spelling inconsistencies |
 | **absolute-path-check** | Hardcoded absolute paths | `/Users/`, `/home/`, `C:\Users\` paths |
 | **pytest** (multiple) | CI guardrails, web UI, websocket tests | Test failures block commit |
+| **diff-cover** | Changed-line coverage gate (≥80%) | New/modified lines not covered by tests |
+
+> **Note — `diff-cover` and git history**: The `diff-cover` hook computes a
+> merge base against `origin/main`, which requires full git history.  If you
+> cloned with `--depth 1` (a shallow clone), the hook gracefully skips with a
+> warning rather than blocking the commit.  To enable it, run:
+>
+> ```bash
+> git fetch --unshallow
+> ```
 
 **Pre-PR Orchestration** (via `bash scripts/dev/pre-commit-validation.sh`):
 

--- a/scripts/dev/run-diff-cover.sh
+++ b/scripts/dev/run-diff-cover.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/dev/run-diff-cover.sh
+#
+# Pre-commit diff-coverage gate (mirrors CI "Diff coverage gate" step).
+# Called by the diff-cover hook in .pre-commit-config.yaml.
+#
+# Behaviour:
+#   1. Exits 0 immediately if no src/ or tests/ Python files are staged.
+#   2. Exits 0 with a warning if origin/main merge base is unavailable
+#      (shallow clone, offline, no remote).  Never blocks in that case.
+#   3. Runs pytest with coverage — fails fast on any pytest error so that
+#      diff-cover never runs against stale or incomplete coverage data.
+#   4. Runs diff-cover; exits non-zero if changed lines are <80% covered.
+#
+# Prerequisites:
+#   git fetch-depth: 0  (full history so origin/main is resolvable as a
+#   merge base).  Shallow-clone users: run `git fetch --unshallow` once.
+set -euo pipefail
+
+# ----------------------------------------------------------------
+# 1. Skip early when no src/ or tests/ Python files are staged
+# ----------------------------------------------------------------
+CHANGED=$(git diff --cached --name-only -- \
+    'src/*.py' 'src/**/*.py' \
+    'tests/*.py' 'tests/**/*.py' 2>/dev/null || true)
+
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# ----------------------------------------------------------------
+# 2. Resolve merge base; skip gracefully if unavailable
+# ----------------------------------------------------------------
+if ! MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null); then
+    echo "diff-cover: skipping — origin/main merge base unavailable" \
+         "(shallow clone or offline). Run 'git fetch --unshallow' to enable." >&2
+    exit 0
+fi
+
+# ----------------------------------------------------------------
+# 3. Generate coverage — fail fast; never suppress pytest output
+# ----------------------------------------------------------------
+pytest tests/ -q \
+    --override-ini="addopts=" \
+    --cov=file_organizer \
+    --cov-report=xml:coverage.xml \
+    --no-header \
+    -m "not benchmark and not e2e and not integration"
+
+# ----------------------------------------------------------------
+# 4. Diff-cover gate
+# ----------------------------------------------------------------
+diff-cover coverage.xml \
+    --compare-branch="$MERGE_BASE" \
+    --fail-under=80 \
+    --quiet


### PR DESCRIPTION
## Summary

Closes #1421.

Adds  as a local pre-commit hook so coverage regressions on changed lines are caught **before** commit, shifting the feedback loop left instead of waiting for CI.

## Changes

### `.pre-commit-config.yaml`
- New **`diff-cover`** hook positioned after the existing pytest gates
- **Files filter** (`^(src|tests)/.*\.py$`): only fires when `src/` or `tests/` Python files are staged — documentation-only or config-only commits are unaffected
- **Fast subset**: runs pytest with `-m 'not benchmark and not e2e and not integration'` to mirror the PR CI lane, keeping overhead manageable
- **Threshold**: `--fail-under=80` — matches the CI gate in `.github/workflows/ci.yml`
- **Merge-base comparison**: uses `git merge-base HEAD origin/main` for correctness (same as CI intent)
- **Graceful degradation**: if `origin/main` is unreachable (shallow clone, offline, no remote), the hook prints a human-readable warning and exits 0 — it never blocks a commit

### `CONTRIBUTING.md`
- Added `diff-cover` to the pre-commit hooks reference table
- Added a callout documenting the `fetch-depth: 0` / `git fetch --unshallow` requirement for contributors on shallow clones

## How it was tested
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- Committed the changes through the full pre-commit stack — all hooks passed; the new `diff-cover` hook correctly self-skipped (no `.py` files in the staged set for that commit)

## Notes for reviewers
- The hook mirrors the existing CI step exactly (same threshold, same comparison branch) — no new policy, just an earlier enforcement point
- Developers with shallow clones (`--depth 1`) get a warning but are not blocked; `git fetch --unshallow` opts them in
