### PR TITLE
feat(ci): subprocess-returncode advisory guardrail (#1408)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,7 @@ are **enforced**; rails with pre-existing violation backlogs remain
 | `safedir-valueerror` | A broad `except Exception`/bare `except` around a `SafeDir` call that doesn't re-raise or catch `ValueError` explicitly | enforced |
 | `textiowrapper-detach` | An `io.TextIOWrapper` that is never `.detach()`-ed before going out of scope (use-after-close risk on the wrapped buffer/fd) | enforced |
 | `called-attribute-assertion` | Weak `assert mock.called` / bare `assert mock.call_count` test assertions | enforced |
+| `subprocess-returncode` | `subprocess.run()` call without `check=True` or `.returncode` inspection (issue #1408) | advisory |
 | `xdist-loadgroup` | A test using the xdist-wide `tmp_path_factory.getbasetemp()` without an `xdist_group` marker | enforced |
 
 Per-file coverage floors (`check-integration-floors.py` for the

--- a/scripts/ci/guardrails/check_subprocess_returncode.py
+++ b/scripts/ci/guardrails/check_subprocess_returncode.py
@@ -78,6 +78,18 @@ def _block_accesses_returncode(block: list[ast.stmt], name: str) -> bool:
                 self.found = True
             self.generic_visit(node)
 
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            pass  # Do not traverse into nested function definitions
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            pass  # Do not traverse into nested async function definitions
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            pass  # Do not traverse into nested class definitions
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            pass  # Do not traverse into nested lambda expressions
+
     checker = _ReturnCodeChecker()
     for stmt in block:
         checker.visit(stmt)
@@ -133,7 +145,7 @@ class SubprocessReturncodeVisitor(ast.NodeVisitor):
 
     def _check_block(self, block: list[ast.stmt]) -> None:
         """Check every statement in *block* for unchecked subprocess.run()."""
-        for stmt in block:
+        for idx, stmt in enumerate(block):
             # Look for an Expr node (call result discarded) or an Assign/AnnAssign
             call_node: ast.Call | None = None
             assigned_name: str | None = None
@@ -153,10 +165,8 @@ class SubprocessReturncodeVisitor(ast.NodeVisitor):
                     pass  # compliant
 
                 # 2. .returncode accessed on the assigned variable within this
-                #    block → compliant.  Scanning the full block (not just the
-                #    suffix) handles try/finally patterns where the check may
-                #    appear before the call in a textual sense.
-                elif assigned_name and _block_accesses_returncode(block, assigned_name):
+                #    block after the call statement → compliant.
+                elif assigned_name and _block_accesses_returncode(block[idx + 1 :], assigned_name):
                     pass  # compliant
 
                 else:
@@ -226,6 +236,9 @@ class SubprocessReturncodeVisitor(ast.NodeVisitor):
                 self._check_block(stmt.orelse)
         elif isinstance(stmt, (ast.With, ast.AsyncWith)):
             self._check_block(stmt.body)
+        elif hasattr(ast, "Match") and isinstance(stmt, ast.Match):
+            for case in stmt.cases:
+                self._check_block(case.body)
 
     # ------------------------------------------------------------------
     # Entry points for different AST scopes

--- a/scripts/ci/guardrails/check_subprocess_returncode.py
+++ b/scripts/ci/guardrails/check_subprocess_returncode.py
@@ -108,7 +108,19 @@ def _is_subprocess_run(node: ast.Call) -> bool:
 
 
 class SubprocessReturncodeVisitor(ast.NodeVisitor):
-    """Walk a module AST and collect non-compliant subprocess.run() sites."""
+    """Walk a module AST and collect non-compliant subprocess.run() sites.
+
+    Compliance rules (see issue #1408 comment):
+    - ``check=True`` with CalledProcessError propagating to the caller: compliant.
+    - Assigned result with ``.returncode`` accessed in the **same enclosing block**
+      (including a try body): compliant.
+    - ``# noqa: subprocess-returncode`` on the call line: accepted exception.
+    - Discarded result (no assignment): always flagged unless noqa is present.
+    - Result assigned but ``.returncode`` never inspected: flagged.
+    - Compound statements (try/if/for/while/with) are recursed into as
+      independent blocks, so a ``returncode`` check in a sibling branch does
+      NOT satisfy the requirement.
+    """
 
     def __init__(self, filepath: Path, lines: list[str]) -> None:
         self.filepath = filepath
@@ -116,7 +128,7 @@ class SubprocessReturncodeVisitor(ast.NodeVisitor):
         self.violations: list[tuple[int, str, str]] = []
 
     # ------------------------------------------------------------------
-    # Helpers to find the enclosing block for a given statement index
+    # Core block checker
     # ------------------------------------------------------------------
 
     def _check_block(self, block: list[ast.stmt]) -> None:
@@ -138,9 +150,12 @@ class SubprocessReturncodeVisitor(ast.NodeVisitor):
             if call_node is not None and _is_subprocess_run(call_node):
                 # 1. check=True → compliant
                 if _has_check_true(call_node):
-                    pass  # compliant; still recurse into nested scopes below
+                    pass  # compliant
 
-                # 2. .returncode accessed on the assigned variable → compliant
+                # 2. .returncode accessed on the assigned variable within this
+                #    block → compliant.  Scanning the full block (not just the
+                #    suffix) handles try/finally patterns where the check may
+                #    appear before the call in a textual sense.
                 elif assigned_name and _block_accesses_returncode(block, assigned_name):
                     pass  # compliant
 
@@ -167,16 +182,50 @@ class SubprocessReturncodeVisitor(ast.NodeVisitor):
                             )
                         )
 
-            # Recurse into nested scopes using visit() so visit_FunctionDef /
-            # visit_AsyncFunctionDef / visit_ClassDef are dispatched correctly.
-            # (generic_visit() only traverses children, it does NOT dispatch to
-            # the typed visitor for the node itself.)
-            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                self.visit(stmt)
-            else:
-                # For control-flow blocks (if/for/while/try/with) recurse into
-                # their sub-blocks so we catch nested subprocess.run() calls.
-                self.generic_visit(stmt)
+            # Recurse into nested scopes.
+            self._check_compound(stmt)
+
+    def _check_try_like(
+        self,
+        stmt: ast.Try,
+    ) -> None:  # pragma: no branch
+        """Recurse into every sub-block of a try/except/else/finally node."""
+        self._check_block(stmt.body)
+        for handler in stmt.handlers:
+            self._check_block(handler.body)
+        if stmt.orelse:
+            self._check_block(stmt.orelse)
+        if stmt.finalbody:
+            self._check_block(stmt.finalbody)
+
+    def _check_compound(self, stmt: ast.stmt) -> None:
+        """Recurse into compound statement sub-blocks.
+
+        Each sub-block is treated as an independent scope: a ``returncode``
+        check in one branch does NOT satisfy the requirement for a call in a
+        sibling branch.
+
+        Function/class definitions create a new named scope and are dispatched
+        via ``self.visit()`` so the normal ``visit_FunctionDef`` / ``visit_ClassDef``
+        entry-points fire.  All other compound statements are handled inline by
+        iterating their body/handler/orelse/finalbody lists.
+        """
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            # Named scope — dispatch to the typed visitor so the correct
+            # entry-point fires (avoids double-processing).
+            self.visit(stmt)
+        elif isinstance(stmt, (ast.Try, ast.TryStar)):
+            self._check_try_like(stmt)  # type: ignore[arg-type]
+        elif isinstance(stmt, ast.If):
+            self._check_block(stmt.body)
+            if stmt.orelse:
+                self._check_block(stmt.orelse)
+        elif isinstance(stmt, (ast.For, ast.AsyncFor, ast.While)):
+            self._check_block(stmt.body)
+            if stmt.orelse:
+                self._check_block(stmt.orelse)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            self._check_block(stmt.body)
 
     # ------------------------------------------------------------------
     # Entry points for different AST scopes

--- a/scripts/ci/guardrails/check_subprocess_returncode.py
+++ b/scripts/ci/guardrails/check_subprocess_returncode.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""CI-rail: Flag subprocess.run() calls without return-code handling (issue #1408).
+
+A ``subprocess.run()`` call site is considered compliant when **at least one**
+of the following is true in the immediately enclosing function (or at module
+scope):
+
+* ``check=True`` is passed as a keyword argument — Python raises
+  ``CalledProcessError`` on non-zero exit automatically.
+* The return value is assigned to a name and ``.returncode`` is accessed on
+  that same name anywhere in the enclosing block.
+* The call line carries a targeted ``# noqa: subprocess-returncode``
+  suppression comment.
+
+Scope
+-----
+Only ``src/file_organizer/`` is scanned.  Developer scripts under
+``scripts/`` are excluded (detector overreach boundary — those are not
+user-visible success paths).
+
+This rail starts **advisory** (mode = "advisory" in rails.toml) so that any
+remaining fire-and-forget call sites can be classified before enforcement.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
+RAIL_ID = "subprocess-returncode"
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_check_true(call_node: ast.Call) -> bool:
+    """Return True if the call has ``check=True`` as a keyword argument."""
+    for kw in call_node.keywords:
+        if kw.arg == "check" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+            return True
+    return False
+
+
+def _assigned_name(call_node: ast.Call, parent: ast.stmt) -> str | None:
+    """Return the variable name the call result is assigned to, or None.
+
+    Handles:  ``result = subprocess.run(...)``
+    and:      ``result = subprocess.run(...); result.returncode``
+    """
+    if isinstance(parent, ast.Assign):
+        targets = parent.targets
+        if len(targets) == 1 and isinstance(targets[0], ast.Name):
+            return targets[0].id
+    if isinstance(parent, ast.AnnAssign) and isinstance(parent.target, ast.Name):
+        return parent.target.id
+    return None
+
+
+def _block_accesses_returncode(block: list[ast.stmt], name: str) -> bool:
+    """Return True if any statement in *block* accesses ``<name>.returncode``."""
+
+    class _ReturnCodeChecker(ast.NodeVisitor):
+        found = False
+
+        def visit_Attribute(self, node: ast.Attribute) -> None:
+            if (
+                node.attr == "returncode"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == name
+            ):
+                self.found = True
+            self.generic_visit(node)
+
+    checker = _ReturnCodeChecker()
+    for stmt in block:
+        checker.visit(stmt)
+        if checker.found:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-file visitor
+# ---------------------------------------------------------------------------
+
+
+def _is_subprocess_run(node: ast.Call) -> bool:
+    """Return True if *node* is a ``subprocess.run(...)`` call."""
+    func = node.func
+    # subprocess.run(...)
+    if isinstance(func, ast.Attribute) and func.attr == "run":
+        if isinstance(func.value, ast.Name) and func.value.id == "subprocess":
+            return True
+    # run(...) after ``from subprocess import run``
+    if isinstance(func, ast.Name) and func.id == "run":
+        # We accept a small false-negative risk here: bare ``run()`` is
+        # uncommon and would require import tracking.  Restrict to attribute
+        # form only to stay low-noise.
+        return False
+    return False
+
+
+class SubprocessReturncodeVisitor(ast.NodeVisitor):
+    """Walk a module AST and collect non-compliant subprocess.run() sites."""
+
+    def __init__(self, filepath: Path, lines: list[str]) -> None:
+        self.filepath = filepath
+        self.lines = lines
+        self.violations: list[tuple[int, str, str]] = []
+
+    # ------------------------------------------------------------------
+    # Helpers to find the enclosing block for a given statement index
+    # ------------------------------------------------------------------
+
+    def _check_block(self, block: list[ast.stmt]) -> None:
+        """Check every statement in *block* for unchecked subprocess.run()."""
+        for stmt in block:
+            # Look for an Expr node (call result discarded) or an Assign/AnnAssign
+            call_node: ast.Call | None = None
+            assigned_name: str | None = None
+
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                call_node = stmt.value
+            elif isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
+                call_node = stmt.value
+                assigned_name = _assigned_name(call_node, stmt)
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.value, ast.Call):
+                call_node = stmt.value
+                assigned_name = _assigned_name(call_node, stmt)
+
+            if call_node is not None and _is_subprocess_run(call_node):
+                # 1. check=True → compliant
+                if _has_check_true(call_node):
+                    pass  # compliant; still recurse into nested scopes below
+
+                # 2. .returncode accessed on the assigned variable → compliant
+                elif assigned_name and _block_accesses_returncode(block, assigned_name):
+                    pass  # compliant
+
+                else:
+                    # 3. Targeted noqa suppression on the call line → compliant
+                    lineno = call_node.lineno
+                    line_idx = lineno - 1
+                    if 0 <= line_idx < len(self.lines):
+                        line_content = self.lines[line_idx]
+                        if not has_targeted_noqa(line_content, RAIL_ID):
+                            self.violations.append(
+                                (
+                                    lineno,
+                                    "subprocess.run() without returncode check or check=True",
+                                    line_content.strip(),
+                                )
+                            )
+                    else:
+                        self.violations.append(
+                            (
+                                call_node.lineno,
+                                "subprocess.run() without returncode check or check=True",
+                                "",
+                            )
+                        )
+
+            # Recurse into nested scopes using visit() so visit_FunctionDef /
+            # visit_AsyncFunctionDef / visit_ClassDef are dispatched correctly.
+            # (generic_visit() only traverses children, it does NOT dispatch to
+            # the typed visitor for the node itself.)
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                self.visit(stmt)
+            else:
+                # For control-flow blocks (if/for/while/try/with) recurse into
+                # their sub-blocks so we catch nested subprocess.run() calls.
+                self.generic_visit(stmt)
+
+    # ------------------------------------------------------------------
+    # Entry points for different AST scopes
+    # ------------------------------------------------------------------
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._check_block(node.body)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_block(node.body)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        # A class body may contain method defs; check it as a block so that
+        # nested method-level subprocess.run() calls are processed correctly.
+        self._check_block(node.body)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_file(filepath: Path) -> list[tuple[int, str, str]]:
+    """Parse and check a single Python file.
+
+    Returns a list of ``(lineno, message, line_content)`` tuples.
+    """
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading {filepath}: {exc}", file=sys.stderr)
+        return []
+
+    lines = content.splitlines()
+    try:
+        tree = ast.parse(content, filename=str(filepath))
+    except SyntaxError as exc:
+        print(f"Syntax error in {filepath}: {exc}", file=sys.stderr)
+        return []
+
+    visitor = SubprocessReturncodeVisitor(filepath, lines)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def main() -> int:
+    """Scan all source files under src/file_organizer/."""
+    package_root = Path("src/file_organizer")
+    if not package_root.exists():
+        print(
+            "Error: src/file_organizer directory not found. Run from the repository root.",
+            file=sys.stderr,
+        )
+        return 1
+
+    all_violations: list[tuple[str, int, str, str]] = []
+    for path in sorted(package_root.rglob("*.py")):
+        violations = check_file(path)
+        rel_path = path.as_posix()
+        for lineno, msg, line in violations:
+            all_violations.append((rel_path, lineno, msg, line))
+
+    if all_violations:
+        print(
+            f"❌ [{RAIL_ID}] Violations found (subprocess.run() without return-code handling):",
+            file=sys.stderr,
+        )
+        for file_path, lineno, msg, line in all_violations:
+            print(f"  {file_path}:{lineno}: {msg} -> `{line}`", file=sys.stderr)
+        print(
+            f"\nFix: add check=True, inspect .returncode, or add '# noqa: {RAIL_ID}' if exempt.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅ [{RAIL_ID}] No violations found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -83,3 +83,9 @@ name = "xdist-loadgroup"
 command = ["python", "scripts/ci/guardrails/check_xdist_loadgroup.py"]
 mode = "enforce"
 description = "Reminds to mark tests sharing xdist-wide temp state with xdist_group (WP-6.2)."
+
+[[rail]]
+name = "subprocess-returncode"
+command = ["python", "scripts/ci/guardrails/check_subprocess_returncode.py"]
+mode = "advisory"
+description = "Flags subprocess.run() calls where returncode is not checked and check=True is absent (issue #1408)."

--- a/src/file_organizer/api/routers/setup.py
+++ b/src/file_organizer/api/routers/setup.py
@@ -282,7 +282,10 @@ def browse_folder(
         return BrowseFolderResponse(path="", available=False)
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: subprocess-returncode
+            # returncode is checked in the outer function body after this
+            # try/except block; the detector treats the try body as a separate
+            # scope so cannot follow the cross-block reference.
             ["/usr/bin/osascript", "-e", "POSIX path of (choose folder)"],
             capture_output=True,
             text=True,

--- a/src/file_organizer/core/backend_detector.py
+++ b/src/file_organizer/core/backend_detector.py
@@ -244,7 +244,10 @@ def _parse_ollama_list_text() -> list[InstalledModel]:
         List of InstalledModel objects with minimal metadata.
     """
     try:
-        result = subprocess.run(
+        # Accepted fire-and-forget: non-zero exit leaves stdout empty or
+        # truncated, so the loop below silently yields [] — the correct
+        # fallback.  returncode is intentionally not checked here.
+        result = subprocess.run(  # noqa: subprocess-returncode
             ["ollama", "list"],
             capture_output=True,
             text=True,

--- a/src/file_organizer/desktop/app.py
+++ b/src/file_organizer/desktop/app.py
@@ -161,13 +161,17 @@ class DesktopAPI:
         try:
             resolved = str(Path(path).resolve())
             if sys.platform == "darwin":
-                proc = subprocess.run(
+                proc = subprocess.run(  # noqa: subprocess-returncode
+                    # proc.returncode is checked at the bottom of the enclosing
+                    # try body; detector can't follow the cross-branch reference.
                     ["open", "-R", resolved],
                     check=False,
                     timeout=5,
                 )
             elif sys.platform == "win32":
-                proc = subprocess.run(
+                proc = subprocess.run(  # noqa: subprocess-returncode
+                    # proc.returncode is checked at the bottom of the enclosing
+                    # try body; detector can't follow the cross-branch reference.
                     ["explorer", f"/select,{resolved}"],
                     check=False,
                     timeout=5,
@@ -175,7 +179,9 @@ class DesktopAPI:
             elif sys.platform.startswith("linux"):
                 # Open the directory itself; fall back to parent for files.
                 target = resolved if Path(resolved).is_dir() else str(Path(resolved).parent)
-                proc = subprocess.run(
+                proc = subprocess.run(  # noqa: subprocess-returncode
+                    # proc.returncode is checked at the bottom of the enclosing
+                    # try body; detector can't follow the cross-branch reference.
                     ["xdg-open", target],
                     check=False,
                     timeout=5,

--- a/src/file_organizer/models/model_manager.py
+++ b/src/file_organizer/models/model_manager.py
@@ -81,7 +81,10 @@ class ModelManager:
     def _parse_ollama_list_text(self) -> set[str]:
         """Fallback: parse ``ollama list`` plain text output."""
         try:
-            result = subprocess.run(
+            # Accepted fire-and-forget: non-zero exit leaves stdout empty,
+            # so the loop yields an empty set — the correct fallback behaviour.
+            # returncode is intentionally not checked here.
+            result = subprocess.run(  # noqa: subprocess-returncode
                 ["ollama", "list"],
                 capture_output=True,
                 text=True,

--- a/tests/ci/test_check_subprocess_returncode.py
+++ b/tests/ci/test_check_subprocess_returncode.py
@@ -247,6 +247,62 @@ def test_allows_returncode_check_inside_try_body(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Additional Edge Cases: nested scopes, statement order, and match/case blocks
+# ---------------------------------------------------------------------------
+
+
+def test_flags_if_returncode_accessed_only_in_nested_scope(tmp_path: Path) -> None:
+    """A subprocess.run() is a violation if the returncode is only checked in a nested scope (like an inner function or lambda)."""
+    src = tmp_path / "nested_scope_check.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd():\n"
+        "    result = subprocess.run(['ls'])\n"
+        "    def check_later():\n"
+        "        print(result.returncode)\n"
+        "    return result\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_flags_if_returncode_accessed_before_subprocess_run(tmp_path: Path) -> None:
+    """A subprocess.run() is a violation if the returncode access is earlier in the block (associated with a previous assignment)."""
+    src = tmp_path / "before_check.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd():\n"
+        "    result = None\n"
+        "    print(result.returncode)\n"
+        "    result = subprocess.run(['ls'])\n"
+        "    return result\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_checks_match_case_body(tmp_path: Path) -> None:
+    """A subprocess.run() inside a match/case body is checked and flagged if unchecked."""
+    src = tmp_path / "match_case.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd(val):\n"
+        "    match val:\n"
+        "        case 1:\n"
+        "            subprocess.run(['ls'])\n"
+        "        case 2:\n"
+        "            subprocess.run(['ls'], check=True)\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    # The first case has unchecked subprocess.run(), the second is check=True (compliant)
+    assert len(violations) == 1
+    assert violations[0][0] == 6  # Line 6 should be the failure line
+
+
+# ---------------------------------------------------------------------------
 # End-to-end: the production src/ tree has zero violations after noqa annotations
 # ---------------------------------------------------------------------------
 

--- a/tests/ci/test_check_subprocess_returncode.py
+++ b/tests/ci/test_check_subprocess_returncode.py
@@ -174,6 +174,79 @@ def test_flags_subprocess_run_in_function_with_no_returncode_check(tmp_path: Pat
 
 
 # ---------------------------------------------------------------------------
+# Try-block scope: subprocess.run() inside try/except bodies (issue #1408 addendum)
+# ---------------------------------------------------------------------------
+
+
+def test_flags_discarded_result_inside_try_block(tmp_path: Path) -> None:
+    """A discarded subprocess.run() inside a try body is a violation."""
+    src = tmp_path / "try_discard.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd():\n"
+        "    try:\n"
+        "        subprocess.run(['ls'])\n"
+        "        return True\n"
+        "    except Exception:\n"
+        "        return False\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_flags_assigned_result_in_try_body_without_returncode_check(tmp_path: Path) -> None:
+    """Result assigned in try body with no returncode check is a violation."""
+    src = tmp_path / "try_assign_no_rc.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd():\n"
+        "    try:\n"
+        "        result = subprocess.run(['ls'])\n"
+        "        return True\n"
+        "    except Exception:\n"
+        "        return False\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_allows_check_true_inside_try_block(tmp_path: Path) -> None:
+    """check=True inside a try block is compliant (CalledProcessError propagates)."""
+    src = tmp_path / "try_check_true.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd():\n"
+        "    try:\n"
+        "        subprocess.run(['ls'], check=True)\n"
+        "    except subprocess.CalledProcessError:\n"
+        "        return False\n"
+        "    return True\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_returncode_check_inside_try_body(tmp_path: Path) -> None:
+    """returncode inspected within the same try body is compliant."""
+    src = tmp_path / "try_rc_in_body.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_cmd():\n"
+        "    try:\n"
+        "        result = subprocess.run(['ls'])\n"
+        "        if result.returncode != 0:\n"
+        "            raise RuntimeError('failed')\n"
+        "        return True\n"
+        "    except RuntimeError:\n"
+        "        return False\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+# ---------------------------------------------------------------------------
 # End-to-end: the production src/ tree has zero violations after noqa annotations
 # ---------------------------------------------------------------------------
 

--- a/tests/ci/test_check_subprocess_returncode.py
+++ b/tests/ci/test_check_subprocess_returncode.py
@@ -1,0 +1,192 @@
+"""Tests for the subprocess-returncode CI rail (issue #1408)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.guardrails import check_subprocess_returncode as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+# ---------------------------------------------------------------------------
+# True-positive: bare subprocess.run() with no returncode handling
+# ---------------------------------------------------------------------------
+
+
+def test_flags_discarded_result(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text(
+        "import subprocess\nsubprocess.run(['ls'])\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "subprocess.run()" in violations[0][1]
+
+
+def test_flags_assigned_result_without_returncode_check(tmp_path: Path) -> None:
+    src = tmp_path / "bad2.py"
+    src.write_text(
+        "import subprocess\nresult = subprocess.run(['ls'])\nprint(result.stdout)\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Compliant: check=True
+# ---------------------------------------------------------------------------
+
+
+def test_allows_check_true(tmp_path: Path) -> None:
+    src = tmp_path / "ok_check.py"
+    src.write_text(
+        "import subprocess\nsubprocess.run(['ls'], check=True)\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Compliant: returncode inspected on the assigned variable
+# ---------------------------------------------------------------------------
+
+
+def test_allows_returncode_equality_check(tmp_path: Path) -> None:
+    src = tmp_path / "ok_rc.py"
+    src.write_text(
+        "import subprocess\n"
+        "result = subprocess.run(['ls'])\n"
+        "if result.returncode != 0:\n"
+        "    raise RuntimeError('failed')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_returncode_equality_zero(tmp_path: Path) -> None:
+    src = tmp_path / "ok_rc_zero.py"
+    src.write_text(
+        "import subprocess\nresult = subprocess.run(['ls'])\nok = result.returncode == 0\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_returncode_in_conditional_expression(tmp_path: Path) -> None:
+    src = tmp_path / "ok_ternary.py"
+    src.write_text(
+        "import subprocess\n"
+        "r = subprocess.run(['ls'])\n"
+        "val = 'ok' if r.returncode == 0 else 'fail'\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Suppression behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "suppressed.py"
+    src.write_text(
+        "import subprocess\nsubprocess.run(['ls'])  # noqa: subprocess-returncode\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "bare_noqa.py"
+    src.write_text(
+        "import subprocess\nsubprocess.run(['ls'])  # noqa\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_unrelated_noqa_code_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "wrong_noqa.py"
+    src.write_text(
+        "import subprocess\nsubprocess.run(['ls'])  # noqa: F401\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_mixed_noqa_list_with_correct_code_suppresses_violation(tmp_path: Path) -> None:
+    src = tmp_path / "mixed_noqa.py"
+    src.write_text(
+        "import subprocess\nsubprocess.run(['ls'])  # noqa: F401, subprocess-returncode\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "str_noqa.py"
+    src.write_text(
+        "import subprocess\nmsg = 'noqa: subprocess-returncode'\nsubprocess.run(['ls'])\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Function-scope: returncode check anywhere in the function body is compliant
+# ---------------------------------------------------------------------------
+
+
+def test_allows_returncode_check_in_same_function_body(tmp_path: Path) -> None:
+    src = tmp_path / "fn_body.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_it():\n"
+        "    result = subprocess.run(['ls'])\n"
+        "    if result.returncode != 0:\n"
+        "        return False\n"
+        "    return True\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_flags_subprocess_run_in_function_with_no_returncode_check(tmp_path: Path) -> None:
+    src = tmp_path / "fn_bad.py"
+    src.write_text(
+        "import subprocess\n\n"
+        "def run_it():\n"
+        "    result = subprocess.run(['ls'])\n"
+        "    return result.stdout\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the production src/ tree has zero violations after noqa annotations
+# ---------------------------------------------------------------------------
+
+
+def test_production_source_has_no_unchecked_subprocess_run_calls() -> None:
+    """All subprocess.run() call sites in src/ are compliant or noqa-annotated."""
+    package_root = Path("src") / "file_organizer"
+    all_violations: list[tuple[str, int, str, str]] = []
+    for path in sorted(package_root.rglob("*.py")):
+        for lineno, msg, line in checker.check_file(path):
+            all_violations.append((path.as_posix(), lineno, msg, line))
+
+    assert all_violations == [], (
+        "Unchecked subprocess.run() call sites found in production source:\n"
+        + "\n".join(f"  {f}:{ln}: {m}" for f, ln, m, _ in all_violations)
+    )

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -143,5 +143,6 @@ def test_repo_registry_loads_registered_rails() -> None:
         "textiowrapper-detach": "enforce",
         "called-attribute-assertion": "enforce",
         "xdist-loadgroup": "enforce",
+        "subprocess-returncode": "advisory",
     }
     assert {rail.name: rail.mode for rail in rails} == expected_modes


### PR DESCRIPTION
## Summary

Implements the CI semantic guardrail described in issue #1408.

Adds an AST-based advisory rail that flags `subprocess.run()` call sites where the return code is neither checked (`.returncode` inspection) nor automatically raised (`check=True`).

---

## Changes

### New guardrail
**`scripts/ci/guardrails/check_subprocess_returncode.py`**

- Walks `src/file_organizer/` via AST, checking every `subprocess.run()` call site.
- A site is **compliant** when: `check=True` is passed, OR `.returncode` is accessed on the assigned variable within the same enclosing block, OR a targeted `# noqa: subprocess-returncode` suppression is present.
- Recurses correctly into all compound statement bodies: **try/except/else/finally**, if, for, while, with, async variants, and Python 3.11+ `except*`.
- Registered as `mode = "advisory"` — reports but does not gate CI yet.

### Test coverage (18 tests)
**`tests/ci/test_check_subprocess_returncode.py`**

Covers: discarded result, assigned-without-returncode, `check=True`, `.returncode` equality/conditional, try-body discarded, try-body assigned no check, `check=True` in try, `.returncode` in try body, all four noqa semantics (targeted, bare, unrelated, mixed-list), function-scope, production-source sweep.

### Rail registration
- **`scripts/ci/rails.toml`**: `mode = "advisory"`
- **`tests/ci/test_ci_rails_framework.py`**: `expected_modes` dict updated
- **`SECURITY.md`**: advisory row added to CI-Enforced Lint Rails table

### Production source annotations (6 accepted exceptions)
All 6 are correctly written code that the block-scoped static detector cannot follow:

| File | Lines | Reason |
|---|---|---|
| `backend_detector.py` | ~250 | fire-and-forget: non-zero exit → empty stdout → empty set (correct fallback) |
| `model_manager.py` | ~87 | same pattern |
| `api/routers/setup.py` | 285 | `result` assigned in try body, `.returncode` checked in outer function scope after try/except |
| `desktop/app.py` | 164, 170, 178 | `proc` assigned in platform if/elif branches, `.returncode` checked at bottom of enclosing try body |

---

## Testing

```
pytest tests/ci/test_check_subprocess_returncode.py   # 18 passed
pytest tests/ci -q --override-ini='addopts='           # 829 passed, 1 skipped
python scripts/ci/guardrails/check_subprocess_returncode.py  # ✅ No violations
```

---

## Path to enforcement
Once the advisory phase confirms zero new violations over a sprint, flip `mode = "advisory"` → `mode = "enforce"` in `rails.toml`.

Closes #1408