### PR TITLE
Add PID and filesystem race guardrails

### DIFF
--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -147,6 +147,7 @@ therefore belong in CI tests, not shell-script heuristics.
 
 | Rule ID | Canonical enforced layer | Why this home |
 |---------|--------------------------|---------------|
+| `daemon.pid-claim-atomic-exclusive-create` | `tests/ci/test_daemon_pid_guardrails.py` | Requires atomic `O_CREAT|O_EXCL` PID-file claims to close startup check-then-act races |
 | `daemon.pid-record-create-time` | `tests/ci/test_daemon_pid_guardrails.py` | Ensures PID records include creation time where available |
 | `daemon.pid-remove-revalidates-expected-record` | `tests/ci/test_daemon_pid_guardrails.py` | Requires PID file removal to re-read and compare the on-disk record before unlinking |
 | `daemon.start-background-propagates-startup-failure` | `tests/ci/test_daemon_pid_guardrails.py` | Ensures background startup failures reach callers instead of being swallowed |
@@ -164,6 +165,7 @@ invariants and therefore belong in CI tests, not shell-script heuristics.
 |---------|--------------------------|---------------|
 | `filesystem.resolve-conflict-revalidates-before-unlink` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Keeps unlink operations behind current existence/symlink checks |
 | `filesystem.copy-destination-atomic-reservation` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Requires exclusive destination reservation for copy operations |
+| `filesystem.link-helpers-route-through-conflict-resolution` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Ensures hardlink/symlink helpers route through shared conflict handling before mutation |
 | `filesystem.target-root-containment` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Revalidates destination paths stay inside the intended root |
 | `filesystem.move-identity-verification` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Requires post-mutation identity checks in rollback move helpers |
 

--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -140,6 +140,37 @@ Implementation detail:
 - Detector implementation lives in `src/file_organizer/review_regressions/memory_lifecycle.py`.
 - Deterministic positive/safe proofs live in `tests/unit/review_regressions/test_memory_lifecycle_detectors.py`.
 
+## Daemon PID Lifecycle Rule Index
+
+Issue `#1409` adds PID lifecycle race checks. These are semantic invariants and
+therefore belong in CI tests, not shell-script heuristics.
+
+| Rule ID | Canonical enforced layer | Why this home |
+|---------|--------------------------|---------------|
+| `daemon.pid-record-create-time` | `tests/ci/test_daemon_pid_guardrails.py` | Ensures PID records include creation time where available |
+| `daemon.pid-remove-revalidates-expected-record` | `tests/ci/test_daemon_pid_guardrails.py` | Requires PID file removal to re-read and compare the on-disk record before unlinking |
+| `daemon.start-background-propagates-startup-failure` | `tests/ci/test_daemon_pid_guardrails.py` | Ensures background startup failures reach callers instead of being swallowed |
+
+Implementation detail:
+
+- Guardrail logic lives in `tests/ci/test_daemon_pid_guardrails.py`.
+
+## Filesystem Link/Copy Rule Index
+
+Issue `#1410` adds filesystem link/copy race checks. These are semantic
+invariants and therefore belong in CI tests, not shell-script heuristics.
+
+| Rule ID | Canonical enforced layer | Why this home |
+|---------|--------------------------|---------------|
+| `filesystem.resolve-conflict-revalidates-before-unlink` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Keeps unlink operations behind current existence/symlink checks |
+| `filesystem.copy-destination-atomic-reservation` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Requires exclusive destination reservation for copy operations |
+| `filesystem.target-root-containment` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Revalidates destination paths stay inside the intended root |
+| `filesystem.move-identity-verification` | `tests/ci/test_filesystem_link_copy_guardrails.py` | Requires post-mutation identity checks in rollback move helpers |
+
+Implementation detail:
+
+- Guardrail logic lives in `tests/ci/test_filesystem_link_copy_guardrails.py`.
+
 ## Search Guardrail Rule Index
 
 Issue `#869` adds corpus-safety checks for the search service. These are

--- a/tests/ci/test_daemon_pid_guardrails.py
+++ b/tests/ci/test_daemon_pid_guardrails.py
@@ -1,0 +1,53 @@
+"""CI guardrails for daemon PID lifecycle contracts."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+FO_ROOT = Path(__file__).resolve().parents[2]
+PID_MODULE = FO_ROOT / "src" / "file_organizer" / "daemon" / "pid.py"
+SERVICE_MODULE = FO_ROOT / "src" / "file_organizer" / "daemon" / "service.py"
+
+
+def _method_source(path: Path, class_name: str, method_name: str) -> str:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                segment = ast.get_source_segment(source, item)
+                assert segment is not None
+                return segment
+    raise AssertionError(f"Missing {class_name}.{method_name} in {path}")
+
+
+def test_pid_record_write_includes_creation_time() -> None:
+    source = _method_source(PID_MODULE, "PidFileManager", "write_pid_record")
+    assert "psutil.Process(pid).create_time()" in source
+    assert 'json.dumps({"pid": pid, "create_time": create_time})' in source
+
+
+def test_pid_removal_revalidates_expected_record_before_unlink() -> None:
+    source = _method_source(PID_MODULE, "PidFileManager", "remove_pid")
+    assert "current_record = self.read_pid_record(pid_file)" in source
+    assert "if current_record != expected_record:" in source
+    assert "pid_file.unlink()" in source
+
+
+def test_pid_claim_uses_atomic_exclusive_create() -> None:
+    source = _method_source(PID_MODULE, "PidFileManager", "claim_pid_file")
+    assert "os.O_CREAT | os.O_EXCL | os.O_WRONLY" in source
+    assert "pid_file.unlink()" in source
+
+
+def test_background_startup_failures_propagate_to_callers() -> None:
+    source = _method_source(SERVICE_MODULE, "DaemonService", "start_background")
+    assert 'raise RuntimeError("Daemon failed to start") from exc' in source
+    assert "self._start_exception = None" in source

--- a/tests/ci/test_daemon_pid_guardrails.py
+++ b/tests/ci/test_daemon_pid_guardrails.py
@@ -14,40 +14,166 @@ PID_MODULE = FO_ROOT / "src" / "file_organizer" / "daemon" / "pid.py"
 SERVICE_MODULE = FO_ROOT / "src" / "file_organizer" / "daemon" / "service.py"
 
 
-def _method_source(path: Path, class_name: str, method_name: str) -> str:
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source, filename=str(path))
+def _method_node(path: Path, class_name: str, method_name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     for node in tree.body:
         if not isinstance(node, ast.ClassDef) or node.name != class_name:
             continue
         for item in node.body:
             if isinstance(item, ast.FunctionDef) and item.name == method_name:
-                segment = ast.get_source_segment(source, item)
-                assert segment is not None
-                return segment
+                return item
     raise AssertionError(f"Missing {class_name}.{method_name} in {path}")
 
 
+def _is_name(node: ast.AST, name: str) -> bool:
+    return isinstance(node, ast.Name) and node.id == name
+
+
+def _is_attr(node: ast.AST, base: str, attr: str) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == base
+        and node.attr == attr
+    )
+
+
+def _iter_calls(node: ast.AST) -> list[ast.Call]:
+    return [item for item in ast.walk(node) if isinstance(item, ast.Call)]
+
+
+def _flag_members(expr: ast.AST) -> set[str]:
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.BitOr):
+        return _flag_members(expr.left) | _flag_members(expr.right)
+    if (
+        isinstance(expr, ast.Attribute)
+        and isinstance(expr.value, ast.Name)
+        and expr.value.id == "os"
+    ):
+        return {expr.attr}
+    return set()
+
+
 def test_pid_record_write_includes_creation_time() -> None:
-    source = _method_source(PID_MODULE, "PidFileManager", "write_pid_record")
-    assert "psutil.Process(pid).create_time()" in source
-    assert 'json.dumps({"pid": pid, "create_time": create_time})' in source
+    method = _method_node(PID_MODULE, "PidFileManager", "write_pid_record")
+
+    has_create_time_assignment = any(
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _is_name(node.targets[0], "create_time")
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "create_time"
+        and isinstance(node.value.func.value, ast.Call)
+        and _is_attr(node.value.func.value.func, "psutil", "Process")
+        and len(node.value.func.value.args) == 1
+        and _is_name(node.value.func.value.args[0], "pid")
+        for node in ast.walk(method)
+    )
+    assert has_create_time_assignment
+
+    has_json_payload = any(
+        _is_attr(call.func, "json", "dumps")
+        and call.args
+        and isinstance(call.args[0], ast.Dict)
+        and {"pid", "create_time"}
+        <= {
+            key.value
+            for key in call.args[0].keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        for call in _iter_calls(method)
+    )
+    assert has_json_payload
 
 
 def test_pid_removal_revalidates_expected_record_before_unlink() -> None:
-    source = _method_source(PID_MODULE, "PidFileManager", "remove_pid")
-    assert "current_record = self.read_pid_record(pid_file)" in source
-    assert "if current_record != expected_record:" in source
-    assert "pid_file.unlink()" in source
+    method = _method_node(PID_MODULE, "PidFileManager", "remove_pid")
+
+    has_read_before_compare = any(
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _is_name(node.targets[0], "current_record")
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and _is_name(node.value.func.value, "self")
+        and node.value.func.attr == "read_pid_record"
+        and len(node.value.args) == 1
+        and _is_name(node.value.args[0], "pid_file")
+        for node in ast.walk(method)
+    )
+    assert has_read_before_compare
+
+    has_mismatch_guard = any(
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and len(node.test.ops) == 1
+        and isinstance(node.test.ops[0], ast.NotEq)
+        and _is_name(node.test.left, "current_record")
+        and len(node.test.comparators) == 1
+        and _is_name(node.test.comparators[0], "expected_record")
+        for node in ast.walk(method)
+    )
+    assert has_mismatch_guard
+
+    has_unlink_call = any(
+        isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "pid_file")
+        and call.func.attr == "unlink"
+        for call in _iter_calls(method)
+    )
+    assert has_unlink_call
 
 
 def test_pid_claim_uses_atomic_exclusive_create() -> None:
-    source = _method_source(PID_MODULE, "PidFileManager", "claim_pid_file")
-    assert "os.O_CREAT | os.O_EXCL | os.O_WRONLY" in source
-    assert "pid_file.unlink()" in source
+    method = _method_node(PID_MODULE, "PidFileManager", "claim_pid_file")
+
+    open_calls = [
+        call
+        for call in _iter_calls(method)
+        if isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "os")
+        and call.func.attr == "open"
+    ]
+    assert open_calls
+    assert any(
+        len(call.args) >= 2 and {"O_CREAT", "O_EXCL", "O_WRONLY"} <= _flag_members(call.args[1])
+        for call in open_calls
+    )
+
+    has_cleanup_unlink = any(
+        isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "pid_file")
+        and call.func.attr == "unlink"
+        for call in _iter_calls(method)
+    )
+    assert has_cleanup_unlink
 
 
 def test_background_startup_failures_propagate_to_callers() -> None:
-    source = _method_source(SERVICE_MODULE, "DaemonService", "start_background")
-    assert 'raise RuntimeError("Daemon failed to start") from exc' in source
-    assert "self._start_exception = None" in source
+    method = _method_node(SERVICE_MODULE, "DaemonService", "start_background")
+
+    has_reset_start_exception = any(
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Attribute)
+        and _is_name(node.targets[0].value, "self")
+        and node.targets[0].attr == "_start_exception"
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is None
+        for node in ast.walk(method)
+    )
+    assert has_reset_start_exception
+
+    has_runtime_reraise = any(
+        isinstance(node, ast.Raise)
+        and isinstance(node.exc, ast.Call)
+        and _is_name(node.exc.func, "RuntimeError")
+        and node.exc.args
+        and isinstance(node.exc.args[0], ast.Constant)
+        and node.exc.args[0].value == "Daemon failed to start"
+        and isinstance(node.cause, ast.Name)
+        and node.cause.id == "exc"
+        for node in ast.walk(method)
+    )
+    assert has_runtime_reraise

--- a/tests/ci/test_filesystem_link_copy_guardrails.py
+++ b/tests/ci/test_filesystem_link_copy_guardrails.py
@@ -20,65 +20,289 @@ ROLLBACK_MODULE = FO_ROOT / "src" / "file_organizer" / "undo" / "rollback.py"
 DURABLE_MOVE_MODULE = FO_ROOT / "src" / "file_organizer" / "undo" / "durable_move.py"
 
 
-def _method_source(path: Path, method_name: str, *, class_name: str | None = None) -> str:
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source, filename=str(path))
-
-    def _segment(node: ast.AST) -> str:
-        segment = ast.get_source_segment(source, node)
-        assert segment is not None
-        return segment
-
+def _method_node(path: Path, method_name: str, *, class_name: str | None = None) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     for node in tree.body:
         if class_name is None and isinstance(node, ast.FunctionDef) and node.name == method_name:
-            return _segment(node)
+            return node
         if class_name is not None and isinstance(node, ast.ClassDef) and node.name == class_name:
             for item in node.body:
                 if isinstance(item, ast.FunctionDef) and item.name == method_name:
-                    return _segment(item)
+                    return item
     raise AssertionError(f"Missing {method_name} in {path}")
 
 
+def _is_name(node: ast.AST, name: str) -> bool:
+    return isinstance(node, ast.Name) and node.id == name
+
+
+def _is_attr(node: ast.AST, base: str, attr: str) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == base
+        and node.attr == attr
+    )
+
+
+def _iter_calls(node: ast.AST) -> list[ast.Call]:
+    return [item for item in ast.walk(node) if isinstance(item, ast.Call)]
+
+
+def _flag_members(expr: ast.AST) -> set[str]:
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.BitOr):
+        return _flag_members(expr.left) | _flag_members(expr.right)
+    if (
+        isinstance(expr, ast.Attribute)
+        and isinstance(expr.value, ast.Name)
+        and expr.value.id == "os"
+    ):
+        return {expr.attr}
+    return set()
+
+
 def test_resolve_conflict_rechecks_symlink_and_directory_state_before_unlink() -> None:
-    source = _method_source(ACTIONS_MODULE, "resolve_conflict")
-    assert "if not path.exists() and not path.is_symlink():" in source
-    assert "if path.is_dir() and not path.is_symlink():" in source
-    assert "path.unlink()" in source
+    method = _method_node(ACTIONS_MODULE, "resolve_conflict")
+
+    has_exists_and_symlink_guard = any(
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.BoolOp)
+        and isinstance(node.test.op, ast.And)
+        and len(node.test.values) == 2
+        and all(
+            isinstance(part, ast.UnaryOp) and isinstance(part.op, ast.Not)
+            for part in node.test.values
+        )
+        and isinstance(node.test.values[0].operand, ast.Call)
+        and isinstance(node.test.values[1].operand, ast.Call)
+        and isinstance(node.test.values[0].operand.func, ast.Attribute)
+        and isinstance(node.test.values[1].operand.func, ast.Attribute)
+        and _is_name(node.test.values[0].operand.func.value, "path")
+        and _is_name(node.test.values[1].operand.func.value, "path")
+        and node.test.values[0].operand.func.attr == "exists"
+        and node.test.values[1].operand.func.attr == "is_symlink"
+        for node in ast.walk(method)
+    )
+    assert has_exists_and_symlink_guard
+
+    has_dir_guard = any(
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.BoolOp)
+        and isinstance(node.test.op, ast.And)
+        and len(node.test.values) == 2
+        and isinstance(node.test.values[0], ast.Call)
+        and isinstance(node.test.values[0].func, ast.Attribute)
+        and _is_name(node.test.values[0].func.value, "path")
+        and node.test.values[0].func.attr == "is_dir"
+        and isinstance(node.test.values[1], ast.UnaryOp)
+        and isinstance(node.test.values[1].op, ast.Not)
+        and isinstance(node.test.values[1].operand, ast.Call)
+        and isinstance(node.test.values[1].operand.func, ast.Attribute)
+        and _is_name(node.test.values[1].operand.func.value, "path")
+        and node.test.values[1].operand.func.attr == "is_symlink"
+        for node in ast.walk(method)
+    )
+    assert has_dir_guard
+
+    has_unlink = any(
+        isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "path")
+        and call.func.attr == "unlink"
+        for call in _iter_calls(method)
+    )
+    assert has_unlink
 
 
 def test_copy_file_reserves_destination_atomically() -> None:
-    source = _method_source(ACTIONS_MODULE, "copy_file")
-    assert "SafeDir.open_root(source.parent)" in source
-    assert "os.O_CREAT | os.O_EXCL | os.O_WRONLY" in source
-    assert "shutil.copyfileobj(src_file, dst_file)" in source
+    method = _method_node(ACTIONS_MODULE, "copy_file")
+
+    has_safedir_root_open = any(
+        isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "SafeDir"
+        and call.func.attr == "open_root"
+        and len(call.args) == 1
+        and isinstance(call.args[0], ast.Attribute)
+        and _is_name(call.args[0].value, "source")
+        and call.args[0].attr == "parent"
+        for call in _iter_calls(method)
+    )
+    assert has_safedir_root_open
+
+    has_atomic_open_flags = any(
+        isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "os")
+        and call.func.attr == "open"
+        and len(call.args) >= 2
+        and {"O_CREAT", "O_EXCL", "O_WRONLY"} <= _flag_members(call.args[1])
+        for call in _iter_calls(method)
+    )
+    assert has_atomic_open_flags
+
+    has_copyfileobj = any(
+        _is_attr(call.func, "shutil", "copyfileobj")
+        and len(call.args) == 2
+        and _is_name(call.args[0], "src_file")
+        and _is_name(call.args[1], "dst_file")
+        for call in _iter_calls(method)
+    )
+    assert has_copyfileobj
 
 
 def test_link_helpers_route_mutations_through_conflict_resolution() -> None:
-    hardlink_source = _method_source(ACTIONS_MODULE, "apply_hardlink")
-    symlink_source = _method_source(ACTIONS_MODULE, "apply_symlink")
+    hardlink = _method_node(ACTIONS_MODULE, "apply_hardlink")
+    symlink = _method_node(ACTIONS_MODULE, "apply_symlink")
 
-    assert "resolve_conflict(destination, strategy)" in hardlink_source
-    assert "os.link(source, resolved)" in hardlink_source
-    assert "resolve_conflict(destination, strategy)" in symlink_source
-    assert "resolved.symlink_to(source)" in symlink_source
+    has_hardlink_conflict_routing = any(
+        _is_name(call.func, "resolve_conflict")
+        and len(call.args) == 2
+        and _is_name(call.args[0], "destination")
+        and _is_name(call.args[1], "strategy")
+        for call in _iter_calls(hardlink)
+    )
+    assert has_hardlink_conflict_routing
+    has_hardlink_call = any(
+        _is_attr(call.func, "os", "link")
+        and len(call.args) == 2
+        and _is_name(call.args[0], "source")
+        and _is_name(call.args[1], "resolved")
+        for call in _iter_calls(hardlink)
+    )
+    assert has_hardlink_call
+
+    has_symlink_conflict_routing = any(
+        _is_name(call.func, "resolve_conflict")
+        and len(call.args) == 2
+        and _is_name(call.args[0], "destination")
+        and _is_name(call.args[1], "strategy")
+        for call in _iter_calls(symlink)
+    )
+    assert has_symlink_conflict_routing
+    has_symlink_call = any(
+        isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "resolved")
+        and call.func.attr == "symlink_to"
+        and len(call.args) == 1
+        and _is_name(call.args[0], "source")
+        for call in _iter_calls(symlink)
+    )
+    assert has_symlink_call
 
 
 def test_rule_executor_revalidates_destination_root_containment() -> None:
-    source = _method_source(EXECUTOR_MODULE, "_target_path", class_name="RuleExecutor")
-    assert "if raw.is_absolute():" in source
-    assert "resolved_candidate.relative_to(resolved_base)" in source
-    assert "Path traversal detected:" in source
+    method = _method_node(EXECUTOR_MODULE, "_target_path", class_name="RuleExecutor")
+
+    has_absolute_guard = any(
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.Call)
+        and isinstance(node.test.func, ast.Attribute)
+        and _is_name(node.test.func.value, "raw")
+        and node.test.func.attr == "is_absolute"
+        and any(
+            isinstance(stmt, ast.Raise)
+            and isinstance(stmt.exc, ast.Call)
+            and _is_name(stmt.exc.func, "ValueError")
+            for stmt in node.body
+        )
+        for node in ast.walk(method)
+    )
+    assert has_absolute_guard
+
+    has_relative_to_check = any(
+        isinstance(call.func, ast.Attribute)
+        and _is_name(call.func.value, "resolved_candidate")
+        and call.func.attr == "relative_to"
+        and len(call.args) == 1
+        and _is_name(call.args[0], "resolved_base")
+        for call in _iter_calls(method)
+    )
+    assert has_relative_to_check
 
 
 def test_rollback_move_revalidates_identity_close_to_mutation() -> None:
-    source = _method_source(ROLLBACK_MODULE, "_durable_move", class_name="RollbackExecutor")
-    assert "if stat_mod.S_ISLNK(src_stat.st_mode):" in source
-    assert "if stat_mod.S_ISLNK(os.lstat(src).st_mode):" in source
-    assert "shutil.move(str(src), str(dst))" in source
-    assert "if not cross_device and (dst_stat.st_dev, dst_stat.st_ino) != src_identity:" in source
+    method = _method_node(ROLLBACK_MODULE, "_durable_move", class_name="RollbackExecutor")
+
+    has_src_symlink_guard = any(
+        _is_attr(call.func, "stat_mod", "S_ISLNK")
+        and len(call.args) == 1
+        and isinstance(call.args[0], ast.Attribute)
+        and _is_name(call.args[0].value, "src_stat")
+        and call.args[0].attr == "st_mode"
+        for call in _iter_calls(method)
+    )
+    assert has_src_symlink_guard
+
+    has_exdev_recheck = any(
+        _is_attr(call.func, "stat_mod", "S_ISLNK")
+        and len(call.args) == 1
+        and isinstance(call.args[0], ast.Attribute)
+        and call.args[0].attr == "st_mode"
+        and isinstance(call.args[0].value, ast.Call)
+        and _is_attr(call.args[0].value.func, "os", "lstat")
+        and len(call.args[0].value.args) == 1
+        and _is_name(call.args[0].value.args[0], "src")
+        for call in _iter_calls(method)
+    )
+    assert has_exdev_recheck
+
+    has_shutil_move = any(
+        _is_attr(call.func, "shutil", "move")
+        and len(call.args) == 2
+        and isinstance(call.args[0], ast.Call)
+        and isinstance(call.args[1], ast.Call)
+        and _is_name(call.args[0].func, "str")
+        and _is_name(call.args[1].func, "str")
+        and len(call.args[0].args) == 1
+        and len(call.args[1].args) == 1
+        and _is_name(call.args[0].args[0], "src")
+        and _is_name(call.args[1].args[0], "dst")
+        for call in _iter_calls(method)
+    )
+    assert has_shutil_move
+
+    has_inode_identity_compare = any(
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.BoolOp)
+        and isinstance(node.test.op, ast.And)
+        and len(node.test.values) == 2
+        and isinstance(node.test.values[0], ast.UnaryOp)
+        and isinstance(node.test.values[0].op, ast.Not)
+        and _is_name(node.test.values[0].operand, "cross_device")
+        and isinstance(node.test.values[1], ast.Compare)
+        and len(node.test.values[1].ops) == 1
+        and isinstance(node.test.values[1].ops[0], ast.NotEq)
+        and isinstance(node.test.values[1].left, ast.Tuple)
+        and len(node.test.values[1].left.elts) == 2
+        and isinstance(node.test.values[1].left.elts[0], ast.Attribute)
+        and isinstance(node.test.values[1].left.elts[1], ast.Attribute)
+        and _is_name(node.test.values[1].left.elts[0].value, "dst_stat")
+        and _is_name(node.test.values[1].left.elts[1].value, "dst_stat")
+        and node.test.values[1].left.elts[0].attr == "st_dev"
+        and node.test.values[1].left.elts[1].attr == "st_ino"
+        and len(node.test.values[1].comparators) == 1
+        and _is_name(node.test.values[1].comparators[0], "src_identity")
+        for node in ast.walk(method)
+    )
+    assert has_inode_identity_compare
 
 
 def test_durable_move_preserves_inode_identity_and_symlink_handling() -> None:
-    source = _method_source(DURABLE_MOVE_MODULE, "_capture_dst_inode")
-    assert "os.lstat(dst)" in source
-    assert "return st.st_dev, st.st_ino, st.st_size" in source
+    method = _method_node(DURABLE_MOVE_MODULE, "_capture_dst_inode")
+
+    has_lstat_call = any(
+        _is_attr(call.func, "os", "lstat") and len(call.args) == 1 and _is_name(call.args[0], "dst")
+        for call in _iter_calls(method)
+    )
+    assert has_lstat_call
+
+    has_inode_return = any(
+        isinstance(node, ast.Return)
+        and isinstance(node.value, ast.Tuple)
+        and len(node.value.elts) == 3
+        and all(
+            isinstance(elt, ast.Attribute) and _is_name(elt.value, "st") for elt in node.value.elts
+        )
+        and [elt.attr for elt in node.value.elts] == ["st_dev", "st_ino", "st_size"]
+        for node in ast.walk(method)
+    )
+    assert has_inode_return

--- a/tests/ci/test_filesystem_link_copy_guardrails.py
+++ b/tests/ci/test_filesystem_link_copy_guardrails.py
@@ -1,0 +1,84 @@
+"""CI guardrails for filesystem link/copy/move race safety."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+FO_ROOT = Path(__file__).resolve().parents[2]
+ACTIONS_MODULE = (
+    FO_ROOT / "src" / "file_organizer" / "services" / "copilot" / "rules" / "actions.py"
+)
+EXECUTOR_MODULE = (
+    FO_ROOT / "src" / "file_organizer" / "services" / "copilot" / "rules" / "executor.py"
+)
+ROLLBACK_MODULE = FO_ROOT / "src" / "file_organizer" / "undo" / "rollback.py"
+DURABLE_MOVE_MODULE = FO_ROOT / "src" / "file_organizer" / "undo" / "durable_move.py"
+
+
+def _method_source(path: Path, method_name: str, *, class_name: str | None = None) -> str:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+
+    def _segment(node: ast.AST) -> str:
+        segment = ast.get_source_segment(source, node)
+        assert segment is not None
+        return segment
+
+    for node in tree.body:
+        if class_name is None and isinstance(node, ast.FunctionDef) and node.name == method_name:
+            return _segment(node)
+        if class_name is not None and isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    return _segment(item)
+    raise AssertionError(f"Missing {method_name} in {path}")
+
+
+def test_resolve_conflict_rechecks_symlink_and_directory_state_before_unlink() -> None:
+    source = _method_source(ACTIONS_MODULE, "resolve_conflict")
+    assert "if not path.exists() and not path.is_symlink():" in source
+    assert "if path.is_dir() and not path.is_symlink():" in source
+    assert "path.unlink()" in source
+
+
+def test_copy_file_reserves_destination_atomically() -> None:
+    source = _method_source(ACTIONS_MODULE, "copy_file")
+    assert "SafeDir.open_root(source.parent)" in source
+    assert "os.O_CREAT | os.O_EXCL | os.O_WRONLY" in source
+    assert "shutil.copyfileobj(src_file, dst_file)" in source
+
+
+def test_link_helpers_route_mutations_through_conflict_resolution() -> None:
+    hardlink_source = _method_source(ACTIONS_MODULE, "apply_hardlink")
+    symlink_source = _method_source(ACTIONS_MODULE, "apply_symlink")
+
+    assert "resolve_conflict(destination, strategy)" in hardlink_source
+    assert "os.link(source, resolved)" in hardlink_source
+    assert "resolve_conflict(destination, strategy)" in symlink_source
+    assert "resolved.symlink_to(source)" in symlink_source
+
+
+def test_rule_executor_revalidates_destination_root_containment() -> None:
+    source = _method_source(EXECUTOR_MODULE, "_target_path", class_name="RuleExecutor")
+    assert "if raw.is_absolute():" in source
+    assert "resolved_candidate.relative_to(resolved_base)" in source
+    assert "Path traversal detected:" in source
+
+
+def test_rollback_move_revalidates_identity_close_to_mutation() -> None:
+    source = _method_source(ROLLBACK_MODULE, "_durable_move", class_name="RollbackExecutor")
+    assert "if stat_mod.S_ISLNK(src_stat.st_mode):" in source
+    assert "if stat_mod.S_ISLNK(os.lstat(src).st_mode):" in source
+    assert "shutil.move(str(src), str(dst))" in source
+    assert "if not cross_device and (dst_stat.st_dev, dst_stat.st_ino) != src_identity:" in source
+
+
+def test_durable_move_preserves_inode_identity_and_symlink_handling() -> None:
+    source = _method_source(DURABLE_MOVE_MODULE, "_capture_dst_inode")
+    assert "os.lstat(dst)" in source
+    assert "return st.st_dev, st.st_ino, st.st_size" in source

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -96,6 +96,8 @@ def test_guardrail_docs_define_canonical_homes_and_conventions() -> None:
         ".github/workflows/ci.yml",
         "scripts/dev/pre-commit-validation.sh",
         "tests/ci/test_api_compat_guardrails.py",
+        "tests/ci/test_daemon_pid_guardrails.py",
+        "tests/ci/test_filesystem_link_copy_guardrails.py",
         "from file_organizer.review_regressions.api_compat import",
         "legacy-positional-prefix-changed",
         "new-optional-param-must-be-keyword-only",


### PR DESCRIPTION
Implements the CI-only guardrails for #1409 and #1410 with targeted daemon and filesystem contract tests, plus docs updates for the new rule indices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the developer guardrails guide with new Memory Lifecycle rule-index references for daemon PID handling and filesystem link/copy safety, including canonical CI check mappings.

* **Tests**
  * Added CI guardrail tests for daemon PID lifecycle contracts (PID record contents, revalidation on removal, atomic PID claiming, and startup failure propagation).
  * Added CI guardrail tests for filesystem link/copy/move race-safety contracts (recheck-before-unlink, atomic reservation, containment validation, rollback identity checks, and durable move metadata).
  * Updated guardrail governance checks to require the new canonical CI test entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->