### PR TITLE
Harden atomic-write CI rail and fixture coverage

### DIFF
--- a/scripts/ci/guardrails/check_atomic_write.py
+++ b/scripts/ci/guardrails/check_atomic_write.py
@@ -25,6 +25,31 @@ ALLOWED_PATHS = {
 }
 
 
+def _is_write_mode(node: ast.Call, positional_index: int) -> bool:
+    """Check if the call node uses a write, append, or exclusive mode.
+
+    Inspects both positional arguments at the specified index and keyword
+    arguments for 'mode'. Returns True if any write-mode character ('w', 'a',
+    'x', or '+') is present.
+    """
+    # Check positional args
+    if len(node.args) > positional_index:
+        mode_arg = node.args[positional_index]
+        if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
+            if any(char in mode_arg.value for char in "wax+"):
+                return True
+    # Check keyword args (mode=...)
+    for kw in node.keywords:
+        if (
+            kw.arg == "mode"
+            and isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, str)
+        ):
+            if any(char in kw.value.value for char in "wax+"):
+                return True
+    return False
+
+
 class AtomicWriteVisitor(ast.NodeVisitor):
     """AST visitor to find raw file write operations."""
 
@@ -34,48 +59,15 @@ class AtomicWriteVisitor(ast.NodeVisitor):
         self.violations: list[tuple[int, str, str]] = []
 
     def visit_Call(self, node: ast.Call) -> None:
+        """Visit Call AST nodes to inspect write operations."""
         # 1. Check for built-in open() with write/append/exclusive modes
         if isinstance(node.func, ast.Name) and node.func.id == "open":
-            is_write = False
-            # Check positional args (second arg is usually the mode)
-            if len(node.args) >= 2:
-                mode_arg = node.args[1]
-                if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
-                    if any(char in mode_arg.value for char in "wax+"):
-                        is_write = True
-            # Check keyword args (mode=...)
-            for kw in node.keywords:
-                if (
-                    kw.arg == "mode"
-                    and isinstance(kw.value, ast.Constant)
-                    and isinstance(kw.value.value, str)
-                ):
-                    if any(char in kw.value.value for char in "wax+"):
-                        is_write = True
-
-            if is_write:
+            if _is_write_mode(node, positional_index=1):
                 self.add_violation(node, "raw open() with write/append/exclusive mode")
 
         # 2. Check for Path.open() with write/append/exclusive modes
         elif isinstance(node.func, ast.Attribute) and node.func.attr == "open":
-            is_write = False
-            # Check positional args (first arg is usually the mode for Path.open())
-            if len(node.args) >= 1:
-                mode_arg = node.args[0]
-                if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
-                    if any(char in mode_arg.value for char in "wax+"):
-                        is_write = True
-            # Check keyword args (mode=...)
-            for kw in node.keywords:
-                if (
-                    kw.arg == "mode"
-                    and isinstance(kw.value, ast.Constant)
-                    and isinstance(kw.value.value, str)
-                ):
-                    if any(char in kw.value.value for char in "wax+"):
-                        is_write = True
-
-            if is_write:
+            if _is_write_mode(node, positional_index=0):
                 self.add_violation(node, "raw Path.open() with write/append/exclusive mode")
 
         # 3. Check for Path.write_text() or Path.write_bytes()
@@ -88,6 +80,7 @@ class AtomicWriteVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def add_violation(self, node: ast.AST, message: str) -> None:
+        """Record a raw file write violation if not suppressed by noqa."""
         lineno = node.lineno
         line_idx = lineno - 1
         if 0 <= line_idx < len(self.lines):

--- a/scripts/ci/guardrails/check_atomic_write.py
+++ b/scripts/ci/guardrails/check_atomic_write.py
@@ -56,7 +56,29 @@ class AtomicWriteVisitor(ast.NodeVisitor):
             if is_write:
                 self.add_violation(node, "raw open() with write/append/exclusive mode")
 
-        # 2. Check for Path.write_text() or Path.write_bytes()
+        # 2. Check for Path.open() with write/append/exclusive modes
+        elif isinstance(node.func, ast.Attribute) and node.func.attr == "open":
+            is_write = False
+            # Check positional args (first arg is usually the mode for Path.open())
+            if len(node.args) >= 1:
+                mode_arg = node.args[0]
+                if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
+                    if any(char in mode_arg.value for char in "wax+"):
+                        is_write = True
+            # Check keyword args (mode=...)
+            for kw in node.keywords:
+                if (
+                    kw.arg == "mode"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ):
+                    if any(char in kw.value.value for char in "wax+"):
+                        is_write = True
+
+            if is_write:
+                self.add_violation(node, "raw Path.open() with write/append/exclusive mode")
+
+        # 3. Check for Path.write_text() or Path.write_bytes()
         elif isinstance(node.func, ast.Attribute) and node.func.attr in {
             "write_text",
             "write_bytes",

--- a/src/file_organizer/integrations/vscode.py
+++ b/src/file_organizer/integrations/vscode.py
@@ -75,7 +75,7 @@ class VSCodeIntegration(Integration):
             "metadata": metadata or {},
             "created_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
-        with output.open("a", encoding="utf-8") as handle:  # noqa: safedir-required  # VSCode integration — output path is an internal workspace file
+        with output.open("a", encoding="utf-8") as handle:  # noqa: safedir-required, atomic-write  # VSCode integration — output path is an internal workspace file
             handle.write(json.dumps(payload, sort_keys=True) + "\n")
         return True
 

--- a/src/file_organizer/plugins/marketplace/installer.py
+++ b/src/file_organizer/plugins/marketplace/installer.py
@@ -206,7 +206,7 @@ class PluginInstaller:
                         "Plugin archive extraction escaped target path."
                     ) from exc
                 target.parent.mkdir(parents=True, exist_ok=True)
-                with archive.open(info, "r") as source, target.open("wb") as handle:  # noqa: safedir-required  # plugin installer — archive.open/target.open within trusted zip extraction
+                with archive.open(info, "r") as source, target.open("wb") as handle:  # noqa: safedir-required, atomic-write  # plugin installer — archive.open/target.open within trusted zip extraction
                     shutil.copyfileobj(source, handle)
 
     def _locate_plugin_root(self, extracted_dir: Path) -> Path:

--- a/src/file_organizer/plugins/marketplace/repository.py
+++ b/src/file_organizer/plugins/marketplace/repository.py
@@ -177,7 +177,7 @@ class PluginRepository:
             with httpx.Client(timeout=self.timeout_seconds, follow_redirects=True) as client:
                 with client.stream("GET", source_url) as response:
                     response.raise_for_status()
-                    with destination_path.open("wb") as handle:  # noqa: safedir-required  # plugin repository — destination path is an internal cache location
+                    with destination_path.open("wb") as handle:  # noqa: safedir-required, atomic-write  # plugin repository — destination path is an internal cache location
                         for chunk in response.iter_bytes(chunk_size=65536):
                             if chunk:
                                 handle.write(chunk)

--- a/src/file_organizer/web/file_operations.py
+++ b/src/file_organizer/web/file_operations.py
@@ -589,7 +589,7 @@ def _write_upload_chunks(upload: UploadFile, destination: Path, safe_name: str) 
     from file_organizer.web.file_validators import validate_file_size
 
     total_bytes = 0
-    with destination.open("wb") as handle:  # noqa: safedir-required  # web file op — destination path validated by the web-layer access control
+    with destination.open("wb") as handle:  # noqa: safedir-required, atomic-write  # web file op — destination path validated by the web-layer access control
         while True:
             chunk = upload.file.read(UPLOAD_CHUNK_SIZE)
             if not chunk:

--- a/tests/ci/test_check_atomic_write.py
+++ b/tests/ci/test_check_atomic_write.py
@@ -55,6 +55,7 @@ def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None
 
 
 def test_flags_path_open_write_modes(tmp_path: Path) -> None:
+    """Verify that Path.open() write/append modes are correctly flagged."""
     for mode in ["w", "wb", "a", "ab", "x", "w+", "r+"]:
         src = tmp_path / f"bad_open_{mode}.py"
         src.write_text(f"Path('x').open('{mode}')\n", encoding="utf-8")
@@ -71,6 +72,7 @@ def test_flags_path_open_write_modes(tmp_path: Path) -> None:
 
 
 def test_allows_path_open_read_modes(tmp_path: Path) -> None:
+    """Verify that Path.open() read/binary-read modes are allowed."""
     # No args (default is read)
     src_default = tmp_path / "default_open.py"
     src_default.write_text("Path('x').open()\n", encoding="utf-8")
@@ -87,6 +89,7 @@ def test_allows_path_open_read_modes(tmp_path: Path) -> None:
 
 
 def test_path_open_noqa_suppressions(tmp_path: Path) -> None:
+    """Verify that noqa comments on Path.open() work as expected."""
     # Bare noqa on Path.open
     src_bare = tmp_path / "open_bare.py"
     src_bare.write_text("Path('x').open('w')  # noqa\n", encoding="utf-8")

--- a/tests/ci/test_check_atomic_write.py
+++ b/tests/ci/test_check_atomic_write.py
@@ -52,3 +52,58 @@ def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None
         encoding="utf-8",
     )
     assert len(checker.check_file(src)) == 1
+
+
+def test_flags_path_open_write_modes(tmp_path: Path) -> None:
+    for mode in ["w", "wb", "a", "ab", "x", "w+", "r+"]:
+        src = tmp_path / f"bad_open_{mode}.py"
+        src.write_text(f"Path('x').open('{mode}')\n", encoding="utf-8")
+        violations = checker.check_file(src)
+        assert len(violations) == 1, f"Failed to flag Path.open with mode {mode}"
+        assert "Path.open" in violations[0][1]
+
+        # test with keyword argument
+        src_kw = tmp_path / f"bad_open_kw_{mode}.py"
+        src_kw.write_text(f"Path('x').open(mode='{mode}')\n", encoding="utf-8")
+        violations_kw = checker.check_file(src_kw)
+        assert len(violations_kw) == 1, f"Failed to flag Path.open with mode kw {mode}"
+        assert "Path.open" in violations_kw[0][1]
+
+
+def test_allows_path_open_read_modes(tmp_path: Path) -> None:
+    # No args (default is read)
+    src_default = tmp_path / "default_open.py"
+    src_default.write_text("Path('x').open()\n", encoding="utf-8")
+    assert checker.check_file(src_default) == []
+
+    for mode in ["r", "rb", "rt"]:
+        src = tmp_path / f"good_open_{mode}.py"
+        src.write_text(f"Path('x').open('{mode}')\n", encoding="utf-8")
+        assert checker.check_file(src) == [], f"Incorrectly flagged Path.open with mode {mode}"
+
+        src_kw = tmp_path / f"good_open_kw_{mode}.py"
+        src_kw.write_text(f"Path('x').open(mode='{mode}')\n", encoding="utf-8")
+        assert checker.check_file(src_kw) == [], f"Incorrectly flagged Path.open with mode kw {mode}"
+
+
+def test_path_open_noqa_suppressions(tmp_path: Path) -> None:
+    # Bare noqa on Path.open
+    src_bare = tmp_path / "open_bare.py"
+    src_bare.write_text("Path('x').open('w')  # noqa\n", encoding="utf-8")
+    assert len(checker.check_file(src_bare)) == 1
+
+    # Unrelated noqa on Path.open
+    src_unrelated = tmp_path / "open_unrelated.py"
+    src_unrelated.write_text("Path('x').open('w')  # noqa: F401\n", encoding="utf-8")
+    assert len(checker.check_file(src_unrelated)) == 1
+
+    # Targeted noqa on Path.open
+    src_exempt = tmp_path / "open_exempt.py"
+    src_exempt.write_text("Path('x').open('w')  # noqa: atomic-write\n", encoding="utf-8")
+    assert checker.check_file(src_exempt) == []
+
+    # Mixed noqa list with atomic-write on Path.open
+    src_mixed = tmp_path / "open_mixed.py"
+    src_mixed.write_text("Path('x').open('w')  # noqa: F401, atomic-write\n", encoding="utf-8")
+    assert checker.check_file(src_mixed) == []
+

--- a/tests/ci/test_check_atomic_write.py
+++ b/tests/ci/test_check_atomic_write.py
@@ -85,7 +85,9 @@ def test_allows_path_open_read_modes(tmp_path: Path) -> None:
 
         src_kw = tmp_path / f"good_open_kw_{mode}.py"
         src_kw.write_text(f"Path('x').open(mode='{mode}')\n", encoding="utf-8")
-        assert checker.check_file(src_kw) == [], f"Incorrectly flagged Path.open with mode kw {mode}"
+        assert checker.check_file(src_kw) == [], (
+            f"Incorrectly flagged Path.open with mode kw {mode}"
+        )
 
 
 def test_path_open_noqa_suppressions(tmp_path: Path) -> None:
@@ -109,4 +111,3 @@ def test_path_open_noqa_suppressions(tmp_path: Path) -> None:
     src_mixed = tmp_path / "open_mixed.py"
     src_mixed.write_text("Path('x').open('w')  # noqa: F401, atomic-write\n", encoding="utf-8")
     assert checker.check_file(src_mixed) == []
-


### PR DESCRIPTION
# Harden Atomic-Write CI Guardrail & Fixture Coverage

This PR hardens the `atomic-write` CI guardrail to detect write-mode `.open()` calls (such as `Path.open()`) in addition to built-in `open()`, and resolves newly flagged occurrences in the codebase.

Closes #1411

## Proposed Changes

### CI Guardrail Hardening & Refactoring
- **Check `.open()` Calls**: Updated `scripts/ci/guardrails/check_atomic_write.py` to check for `.open()` method calls where the mode parameter contains write/append/exclusive characters (`"wax+"`). Both positional arguments and keyword `mode=` arguments are checked.
- **Helper Extraction**: Extracted the shared positional and keyword mode scanning logic into a private module-level helper `_is_write_mode(...)` to avoid duplicate scanning logic.
- **Docstring Coverage**: Added comprehensive docstrings to the visitor methods and helper functions to maintain 100% `interrogate` coverage on the file.

### Source Code Mitigations (Accepted Exceptions)
Added targeted `# noqa: atomic-write` comments with explanations to existing acceptable raw writes (e.g. streaming or logging):
- `src/file_organizer/integrations/vscode.py`: VSCode integration log appender.
- `src/file_organizer/plugins/marketplace/installer.py`: Plugin marketplace ZIP extraction path.
- `src/file_organizer/plugins/marketplace/repository.py`: Internal marketplace package caching.
- `src/file_organizer/web/file_operations.py`: Chunked file uploads storage.

### Testing
- **New Unit Tests**: Added coverage in `tests/ci/test_check_atomic_write.py` verifying:
  - Detection of `.open()` write/append modes (`"w"`, `"wb"`, `"a"`, `"ab"`, `"x"`, `"w+"`, `"r+"`).
  - Allowed read/binary-read modes (`"r"`, `"rb"`, `"rt"`) or no-argument defaults.
  - Bare / unrelated `# noqa` comments do not suppress violations.
  - Targeted `# noqa: atomic-write` successfully suppresses the violations.

## Verification & Validation

- `python3 scripts/ci/guardrails/check_atomic_write.py` runs successfully.
- `pytest tests/ci -q --override-ini="addopts="` passes cleanly (850 passed, 1 skipped).
- Verified that `atomic-write` remains `mode = "enforce"` in `scripts/ci/rails.toml`.
- Running `interrogate` on the guardrail script returns 100% docstring coverage.