### PR TITLE
harden SafeDir rails suppression and bypass coverage (#1412)

### DIFF
--- a/scripts/ci/guardrails/check_safedir_required.py
+++ b/scripts/ci/guardrails/check_safedir_required.py
@@ -64,14 +64,58 @@ def _open_receiver_name(node: ast.Attribute) -> str | None:
 class SafeDirVisitor(ast.NodeVisitor):
     """AST visitor to find raw file operations."""
 
-    def __init__(self, filepath: Path, lines: list[str]) -> None:
+    def __init__(self, filepath: Path, lines: list[str], tree: ast.AST) -> None:
         self.filepath = filepath
         self.lines = lines
         self.violations: list[tuple[int, str, str]] = []
+        self.shutil_names = {"shutil"}
+        self.shutil_funcs = {}
+        self.open_names = {"open"}
+        self.builtins_names = {"builtins"}
+        self._collect_imports(tree)
+
+    def _collect_imports(self, tree: ast.AST) -> None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "shutil":
+                        self.shutil_names.add(alias.asname or alias.name)
+                    elif alias.name == "builtins":
+                        self.builtins_names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module == "shutil":
+                    for alias in node.names:
+                        name = alias.name
+                        local_name = alias.asname or name
+                        if name in {
+                            "copy",
+                            "copy2",
+                            "move",
+                            "copyfile",
+                            "copytree",
+                            "copymode",
+                            "copystat",
+                        }:
+                            self.shutil_funcs[local_name] = name
+                elif node.module == "builtins":
+                    for alias in node.names:
+                        if alias.name == "open":
+                            self.open_names.add(alias.asname or alias.name)
 
     def visit_Call(self, node: ast.Call) -> None:
-        # 1. Check for raw built-in open()
-        if isinstance(node.func, ast.Name) and node.func.id == "open":
+        # 1. Check for raw built-in open() or alias, or builtins.open()
+        is_raw_open = False
+        if isinstance(node.func, ast.Name) and node.func.id in self.open_names:
+            is_raw_open = True
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in self.builtins_names
+            and node.func.attr == "open"
+        ):
+            is_raw_open = True
+
+        if is_raw_open:
             self.add_violation(node, "raw open() call")
 
         # 2. Check for Path.open() — but exclude known library namespaces whose
@@ -82,10 +126,12 @@ class SafeDirVisitor(ast.NodeVisitor):
                 self.add_violation(node, "raw Path.open() call")
 
         # 3. Check for shutil copy/move/etc.
-        elif (
+        is_shutil_call = False
+        shutil_func_name = None
+        if (
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "shutil"
+            and node.func.value.id in self.shutil_names
         ):
             if node.func.attr in {
                 "copy",
@@ -96,7 +142,14 @@ class SafeDirVisitor(ast.NodeVisitor):
                 "copymode",
                 "copystat",
             }:
-                self.add_violation(node, f"raw shutil.{node.func.attr}() call")
+                is_shutil_call = True
+                shutil_func_name = node.func.attr
+        elif isinstance(node.func, ast.Name) and node.func.id in self.shutil_funcs:
+            is_shutil_call = True
+            shutil_func_name = self.shutil_funcs[node.func.id]
+
+        if is_shutil_call:
+            self.add_violation(node, f"raw shutil.{shutil_func_name}() call")
 
         self.generic_visit(node)
 
@@ -125,7 +178,7 @@ def check_file(filepath: Path) -> list[tuple[int, str, str]]:
         print(f"Syntax error in {filepath}: {exc}", file=sys.stderr)
         return []
 
-    visitor = SafeDirVisitor(filepath, lines)
+    visitor = SafeDirVisitor(filepath, lines, tree)
     visitor.visit(tree)
     return visitor.violations
 

--- a/scripts/ci/guardrails/check_safedir_required.py
+++ b/scripts/ci/guardrails/check_safedir_required.py
@@ -43,6 +43,18 @@ _OPEN_EXEMPT_NAMESPACES: frozenset[str] = frozenset(
     }
 )
 
+_SHUTIL_RAW_FUNCS: frozenset[str] = frozenset(
+    {
+        "copy",
+        "copy2",
+        "move",
+        "copyfile",
+        "copytree",
+        "copymode",
+        "copystat",
+    }
+)
+
 
 def _open_receiver_name(node: ast.Attribute) -> str | None:
     """Return the simple name of the receiver of a `.open()` attribute call.
@@ -87,15 +99,7 @@ class SafeDirVisitor(ast.NodeVisitor):
                     for alias in node.names:
                         name = alias.name
                         local_name = alias.asname or name
-                        if name in {
-                            "copy",
-                            "copy2",
-                            "move",
-                            "copyfile",
-                            "copytree",
-                            "copymode",
-                            "copystat",
-                        }:
+                        if name in _SHUTIL_RAW_FUNCS:
                             self.shutil_funcs[local_name] = name
                 elif node.module == "builtins":
                     for alias in node.names:
@@ -133,15 +137,7 @@ class SafeDirVisitor(ast.NodeVisitor):
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id in self.shutil_names
         ):
-            if node.func.attr in {
-                "copy",
-                "copy2",
-                "move",
-                "copyfile",
-                "copytree",
-                "copymode",
-                "copystat",
-            }:
+            if node.func.attr in _SHUTIL_RAW_FUNCS:
                 is_shutil_call = True
                 shutil_func_name = node.func.attr
         elif isinstance(node.func, ast.Name) and node.func.id in self.shutil_funcs:

--- a/scripts/ci/guardrails/check_safedir_valueerror.py
+++ b/scripts/ci/guardrails/check_safedir_valueerror.py
@@ -49,17 +49,34 @@ _SAFEDIR_METHODS = {
 }
 
 
-def _is_safedir_constructor_call(call: ast.Call) -> bool:
-    return isinstance(call.func, ast.Name) and call.func.id == "SafeDir"
+def _is_safedir_constructor_call(call: ast.Call, aliases: set[str]) -> bool:
+    return isinstance(call.func, ast.Name) and call.func.id in aliases
 
 
-def _is_annotated_safedir(annotation: ast.expr | None) -> bool:
-    return isinstance(annotation, ast.Name) and annotation.id == "SafeDir"
+def _is_annotated_safedir(annotation: ast.expr | None, aliases: set[str]) -> bool:
+    return isinstance(annotation, ast.Name) and annotation.id in aliases
 
 
-def _collect_safedir_names(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
-    """Collect local names within `func` that are plausibly SafeDir instances."""
+def _collect_safedir_aliases(tree: ast.AST) -> set[str]:
+    aliases = {"SafeDir"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "SafeDir":
+                    aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "SafeDir":
+                    aliases.add(alias.asname or alias.name)
+    return aliases
+
+
+def _collect_safedir_and_other_names(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, aliases: set[str]
+) -> tuple[set[str], set[str]]:
+    """Collect local names within `func` that are SafeDir instances and other assigned names."""
     safedir_names: set[str] = set()
+    other_assigned_names: set[str] = set()
 
     # Parameters annotated as SafeDir.
     all_args = (
@@ -70,10 +87,20 @@ def _collect_safedir_names(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[
         + ([func.args.kwarg] if func.args.kwarg else [])
     )
     for arg in all_args:
-        if _is_annotated_safedir(arg.annotation):
+        if _is_annotated_safedir(arg.annotation, aliases):
             safedir_names.add(arg.arg)
+        else:
+            other_assigned_names.add(arg.arg)
 
     # Assignments: `x = SafeDir(...)` or `x = <tracked>.open_subdir(...)`.
+    # First, collect all names assigned in this function scope (excluding nested functions)
+    assigned_names: set[str] = set()
+    for node in _walk_excluding_nested_functions(func):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assigned_names.add(target.id)
+
     # Walk repeatedly so one level of open_subdir() propagation from a
     # newly discovered name is picked up regardless of statement order.
     changed = True
@@ -89,7 +116,7 @@ def _collect_safedir_names(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[
                 continue
             value = node.value
             if isinstance(value, ast.Call):
-                if _is_safedir_constructor_call(value):
+                if _is_safedir_constructor_call(value, aliases):
                     safedir_names.add(target.id)
                     changed = True
                 elif (
@@ -101,7 +128,8 @@ def _collect_safedir_names(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[
                     safedir_names.add(target.id)
                     changed = True
 
-    return safedir_names
+    other_assigned_names.update(assigned_names - safedir_names)
+    return safedir_names, other_assigned_names
 
 
 def _walk_excluding_nested_functions(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.AST]:
@@ -154,24 +182,44 @@ def _handler_reraises(handler: ast.ExceptHandler) -> bool:
     return bool(handler.body) and isinstance(handler.body[0], ast.Raise)
 
 
+def _has_explicit_valueerror_handler(try_node: ast.Try) -> bool:
+    for handler in try_node.handlers:
+        names = _handler_names(handler)
+        if "ValueError" in names and "Exception" not in names and "bare" not in names:
+            return True
+    return False
+
+
 class _Visitor(ast.NodeVisitor):
-    def __init__(self, lines: list[str]) -> None:
+    def __init__(self, lines: list[str], aliases: set[str]) -> None:
         self.lines = lines
+        self.aliases = aliases
         self.violations: list[tuple[int, str]] = []
+        self.safedir_scopes: list[set[str]] = []
 
     def _visit_function(self, func: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
-        safedir_names = _collect_safedir_names(func)
+        local_safedir, local_other = _collect_safedir_and_other_names(func, self.aliases)
+
+        # Inherit from outer/enclosing scopes
+        inherited_safedir: set[str] = set()
+        for scope_set in self.safedir_scopes:
+            inherited_safedir.update(scope_set)
+
+        # Subtract local shadowed variables and union with local SafeDir variables
+        active_safedir_names = (inherited_safedir - local_other) | local_safedir
+
         for node in _walk_excluding_nested_functions(func):
             if isinstance(node, ast.Try) and _calls_safedir_method(
-                ast.Module(body=node.body, type_ignores=[]), safedir_names
+                ast.Module(body=node.body, type_ignores=[]), active_safedir_names
             ):
+                has_explicit_val_err = _has_explicit_valueerror_handler(node)
                 for handler in node.handlers:
                     names = _handler_names(handler)
                     catches_broadly = "Exception" in names or "bare" in names
                     if (
                         catches_broadly
-                        and "ValueError" not in names
                         and not _handler_reraises(handler)
+                        and not has_explicit_val_err
                     ):
                         line_idx = handler.lineno - 1
                         if 0 <= line_idx < len(self.lines):
@@ -186,10 +234,11 @@ class _Visitor(ast.NodeVisitor):
                                 "ValueError explicitly or re-raise",
                             )
                         )
-        # Recurse into nested function/class defs (but not back into `func`
-        # itself) so they get their own independent SafeDir-name tracking.
+        # Recurse with current active_safedir_names pushed on the stack
+        self.safedir_scopes.append(active_safedir_names)
         for child in ast.iter_child_nodes(func):
             self.visit(child)
+        self.safedir_scopes.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._visit_function(node)
@@ -213,7 +262,8 @@ def check_file(filepath: Path) -> list[tuple[int, str]]:
         print(f"Syntax error in {filepath}: {exc}", file=sys.stderr)
         return []
 
-    visitor = _Visitor(lines)
+    aliases = _collect_safedir_aliases(tree)
+    visitor = _Visitor(lines, aliases)
     visitor.visit(tree)
     return visitor.violations
 

--- a/scripts/ci/guardrails/check_safedir_valueerror.py
+++ b/scripts/ci/guardrails/check_safedir_valueerror.py
@@ -71,12 +71,55 @@ def _collect_safedir_aliases(tree: ast.AST) -> set[str]:
     return aliases
 
 
+def _extract_names(node: ast.AST) -> set[str]:
+    """Recursively extract all Name ID targets from a binding pattern."""
+    names: set[str] = set()
+    if isinstance(node, ast.Name):
+        names.add(node.id)
+    elif isinstance(node, (ast.Tuple, ast.List)):
+        for elt in node.elts:
+            names.update(_extract_names(elt))
+    return names
+
+
+def _collect_local_binders(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Collect all local binder names in the function scope (excluding nested functions)."""
+    binders: set[str] = set()
+    # 1. Parameters
+    all_args = (
+        func.args.posonlyargs
+        + func.args.args
+        + func.args.kwonlyargs
+        + ([func.args.vararg] if func.args.vararg else [])
+        + ([func.args.kwarg] if func.args.kwarg else [])
+    )
+    for arg in all_args:
+        binders.add(arg.arg)
+
+    # 2. Local bindings in body (assignments, for loops, with statements)
+    for node in _walk_excluding_nested_functions(func):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                binders.update(_extract_names(target))
+        elif isinstance(node, ast.AnnAssign):
+            binders.update(_extract_names(node.target))
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            binders.update(_extract_names(node.target))
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars:
+                    binders.update(_extract_names(item.optional_vars))
+    return binders
+
+
 def _collect_safedir_and_other_names(
-    func: ast.FunctionDef | ast.AsyncFunctionDef, aliases: set[str]
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    aliases: set[str],
+    non_shadowed_inherited: set[str],
 ) -> tuple[set[str], set[str]]:
     """Collect local names within `func` that are SafeDir instances and other assigned names."""
-    safedir_names: set[str] = set()
-    other_assigned_names: set[str] = set()
+    safedir_names: set[str] = set(non_shadowed_inherited)
+    local_binders = _collect_local_binders(func)
 
     # Parameters annotated as SafeDir.
     all_args = (
@@ -89,17 +132,6 @@ def _collect_safedir_and_other_names(
     for arg in all_args:
         if _is_annotated_safedir(arg.annotation, aliases):
             safedir_names.add(arg.arg)
-        else:
-            other_assigned_names.add(arg.arg)
-
-    # Assignments: `x = SafeDir(...)` or `x = <tracked>.open_subdir(...)`.
-    # First, collect all names assigned in this function scope (excluding nested functions)
-    assigned_names: set[str] = set()
-    for node in _walk_excluding_nested_functions(func):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    assigned_names.add(target.id)
 
     # Walk repeatedly so one level of open_subdir() propagation from a
     # newly discovered name is picked up regardless of statement order.
@@ -128,18 +160,12 @@ def _collect_safedir_and_other_names(
                     safedir_names.add(target.id)
                     changed = True
 
-    other_assigned_names.update(assigned_names - safedir_names)
+    other_assigned_names = local_binders - safedir_names
     return safedir_names, other_assigned_names
 
 
 def _walk_excluding_nested_functions(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.AST]:
-    """Like ast.walk(func), but does not descend into nested function defs.
-
-    Prevents a nested function's `try` blocks from being attributed to (and
-    checked against) the *outer* function's SafeDir-name tracking, and from
-    being visited twice (once here, once when the nested def is visited
-    directly by the NodeVisitor).
-    """
+    """Like ast.walk(func), but does not descend into nested function defs."""
     seen: list[ast.AST] = []
     stack: list[ast.AST] = list(ast.iter_child_nodes(func))
     while stack:
@@ -185,7 +211,11 @@ def _handler_reraises(handler: ast.ExceptHandler) -> bool:
 def _has_explicit_valueerror_handler(try_node: ast.Try) -> bool:
     for handler in try_node.handlers:
         names = _handler_names(handler)
-        if "ValueError" in names and "Exception" not in names and "bare" not in names:
+        catches_broadly = "Exception" in names or "bare" in names
+        if catches_broadly:
+            # Broad handler matched before explicit ValueError handler, meaning ValueError is swallowed
+            return False
+        if "ValueError" in names:
             return True
     return False
 
@@ -198,15 +228,17 @@ class _Visitor(ast.NodeVisitor):
         self.safedir_scopes: list[set[str]] = []
 
     def _visit_function(self, func: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
-        local_safedir, local_other = _collect_safedir_and_other_names(func, self.aliases)
-
         # Inherit from outer/enclosing scopes
         inherited_safedir: set[str] = set()
         for scope_set in self.safedir_scopes:
             inherited_safedir.update(scope_set)
 
-        # Subtract local shadowed variables and union with local SafeDir variables
-        active_safedir_names = (inherited_safedir - local_other) | local_safedir
+        local_binders = _collect_local_binders(func)
+        non_shadowed_inherited = inherited_safedir - local_binders
+
+        active_safedir_names, local_other = _collect_safedir_and_other_names(
+            func, self.aliases, non_shadowed_inherited
+        )
 
         for node in _walk_excluding_nested_functions(func):
             if isinstance(node, ast.Try) and _calls_safedir_method(

--- a/tests/ci/test_check_safedir_required.py
+++ b/tests/ci/test_check_safedir_required.py
@@ -206,3 +206,71 @@ def test_main_returns_one_on_violations(tmp_path: Path, monkeypatch: pytest.Monk
     (pkg / "bad.py").write_text("with open('x') as f:\n    pass\n", encoding="utf-8")
     result = checker.main()
     assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Alias imports and false validations
+# ---------------------------------------------------------------------------
+
+
+def test_flags_shutil_alias_import(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("import shutil as sh\nsh.copy2(src, dst)\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "raw shutil.copy2()" in violations[0][1]
+
+
+def test_flags_shutil_direct_import_alias(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("from shutil import copy2 as my_copy\nmy_copy(src, dst)\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "raw shutil.copy2()" in violations[0][1]
+
+
+def test_flags_open_alias_import(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text(
+        "from builtins import open as my_open\nwith my_open('x') as f:\n    pass\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "raw open()" in violations[0][1]
+
+
+def test_flags_builtins_open_call(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("import builtins\nwith builtins.open('x') as f:\n    pass\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "raw open()" in violations[0][1]
+
+
+def test_flags_path_resolve_false_validation(tmp_path: Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text(
+        "p = Path('x')\n"
+        "if p.resolve().is_relative_to('/safe') and p.exists():\n"
+        "    with p.open() as f:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "raw Path.open()" in violations[0][1]
+
+
+def test_allows_exempt_namespaces_open(tmp_path: Path) -> None:
+    src = tmp_path / "ok.py"
+    src.write_text(
+        "import cv2\n"
+        "import zipfile\n"
+        "import wave\n"
+        "cv2.open(path)\n"
+        "zipfile.open(path)\n"
+        "wave.open(path)\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []

--- a/tests/ci/test_check_safedir_valueerror.py
+++ b/tests/ci/test_check_safedir_valueerror.py
@@ -148,3 +148,97 @@ def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None
         encoding="utf-8",
     )
     assert len(checker.check_file(src)) == 1
+
+
+def test_flags_safedir_alias_import(tmp_path: Path) -> None:
+    src = tmp_path / "alias.py"
+    src.write_text(
+        "from file_organizer.utils.safedir import SafeDir as SD\n"
+        "def f(sd: SD):\n"
+        "    try:\n"
+        "        return sd.open_child('x')\n"
+        "    except Exception:\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_flags_nested_function_swallowing(tmp_path: Path) -> None:
+    src = tmp_path / "nested.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    def inner():\n"
+        "        try:\n"
+        "            return safedir.open_child('x')\n"
+        "            # swallowing ValueError in nested function\n"
+        "        except Exception:\n"
+        "            return None\n"
+        "    return inner\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_allows_nested_function_shadowing(tmp_path: Path) -> None:
+    src = tmp_path / "nested_shadow.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    def inner():\n"
+        "        safedir = 'not_a_safedir'\n"
+        "        try:\n"
+        "            # safedir is now just a string, so mkdir() is not SafeDir's\n"
+        "            return safedir.mkdir()\n"
+        "        except Exception:\n"
+        "            return None\n"
+        "    return inner\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 0
+
+
+def test_flags_tuple_with_broad_and_valueerror(tmp_path: Path) -> None:
+    src = tmp_path / "tuple_broad.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    try:\n"
+        "        return safedir.open_child('x')\n"
+        "    except (ValueError, Exception):\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+
+
+def test_allows_tuple_with_specific_exceptions(tmp_path: Path) -> None:
+    src = tmp_path / "tuple_specific.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    try:\n"
+        "        return safedir.open_child('x')\n"
+        "    except (TypeError, ValueError):\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 0
+
+
+def test_allows_explicit_and_broad_handlers(tmp_path: Path) -> None:
+    src = tmp_path / "multi_handlers.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    try:\n"
+        "        return safedir.open_child('x')\n"
+        "    except ValueError:\n"
+        "        return 'val_err'\n"
+        "    except Exception:\n"
+        "        return 'other_err'\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 0

--- a/tests/ci/test_check_safedir_valueerror.py
+++ b/tests/ci/test_check_safedir_valueerror.py
@@ -181,6 +181,22 @@ def test_flags_nested_function_swallowing(tmp_path: Path) -> None:
     violations = checker.check_file(src)
     assert len(violations) == 1
 
+    # Also test nested child propagation from inherited SafeDir
+    src2 = tmp_path / "nested_subdir.py"
+    src2.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    def inner():\n"
+        "        child = safedir.open_subdir('sub')\n"
+        "        try:\n"
+        "            return child.open_child('x')\n"
+        "        except Exception:\n"
+        "            return None\n"
+        "    return inner\n",
+        encoding="utf-8",
+    )
+    violations2 = checker.check_file(src2)
+    assert len(violations2) == 1
+
 
 def test_allows_nested_function_shadowing(tmp_path: Path) -> None:
     src = tmp_path / "nested_shadow.py"
@@ -242,3 +258,19 @@ def test_allows_explicit_and_broad_handlers(tmp_path: Path) -> None:
     )
     violations = checker.check_file(src)
     assert len(violations) == 0
+
+
+def test_flags_exception_before_valueerror(tmp_path: Path) -> None:
+    src = tmp_path / "ordering_bad.py"
+    src.write_text(
+        "def f(safedir: SafeDir):\n"
+        "    try:\n"
+        "        return safedir.open_child('x')\n"
+        "    except Exception:\n"
+        "        return None\n"
+        "    except ValueError:\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1


### PR DESCRIPTION
# Hardening SafeDir Rails Suppression and Bypass Coverage (#1412)

This pull request hardens the `safedir-required` and `safedir-valueerror` CI rails to prevent raw-path bypasses, correctly detect import aliases, and handle nested function scopes/closures.

## Changes Proposed

### 1. `safedir-required` Hardening
- **Import Aliasing Support**: Statically collects and tracks `shutil` and `open` import aliases, e.g.:
  - `import shutil as sh` -> `sh.copy2`
  - `from shutil import copy2 as my_copy` -> `my_copy`
  - `import builtins as b` -> `b.open`
  - `from builtins import open as my_open` -> `my_open`
- **Exemptions Verification**: Maintained existing `.open()` exemptions (`fitz`, `Image`, `tarfile`, `tokenize`, `aiofiles`, `os`, etc.) while adding coverage verification for others like `cv2`, `zipfile`, and `wave`.

### 2. `safedir-valueerror` Hardening
- **SafeDir Constructor Aliases**: Detects import aliases for the constructor and annotations, e.g. `from ... import SafeDir as SD`.
- **Scope-Aware Tracking (Nested Functions)**: Tracks `SafeDir` variables using a scope stack (`self.safedir_scopes`) to trace outer closure references in nested functions.
- **Variable Shadowing**: Excludes local variables of the same name defined or reassigned in nested scopes that are not `SafeDir` types (`local_other`).
- **ValueError Swallowing**: Ensures broad handlers (`except Exception:` / bare `except:`) wrapping `SafeDir` calls are flagged as violations unless a specific `ValueError` handler is present in the same try block or the handler re-raises.
- **Tuple Exception Handlers**: Flags any broad handler that catches `ValueError` *together with* `Exception` (e.g. `except (Exception, ValueError):`) without re-raising.

## Test Coverage Added

- **`test_check_safedir_required.py`**:
  - `test_flags_shutil_alias_import`
  - `test_flags_shutil_direct_import_alias`
  - `test_flags_open_alias_import`
  - `test_flags_builtins_open_call`
  - `test_flags_path_resolve_false_validation` (asserts that validation-looking calls like `resolve()` or `is_relative_to()` do not bypass raw operation checks)
  - `test_allows_exempt_namespaces_open`
- **`test_check_safedir_valueerror.py`**:
  - `test_flags_safedir_alias_import`
  - `test_flags_nested_function_swallowing` (closure references)
  - `test_allows_nested_function_shadowing`
  - `test_flags_tuple_with_broad_and_valueerror` (`(ValueError, Exception)`)
  - `test_allows_tuple_with_specific_exceptions` (`(TypeError, ValueError)`)
  - `test_allows_explicit_and_broad_handlers` (sequential except handlers)

## Verification Results

- Direct checker execution exit `0`.
- Full CI pytest suite runs successfully: `862 passed`.
- All `ruff check` and `ruff format` validations passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unsafe file access patterns when functions or modules are imported under aliases.
  * Reduced false positives in path-safety checks by better recognizing allowed library-specific `open()` usage and safer exception handling patterns.

* **Tests**
  * Added coverage for alias-based file access cases and nested scope handling.
  * Expanded validation for exception handling rules, including mixed and nested handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->