### PR TITLE
[codex] Add advisory test environment leakage rail

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -98,9 +98,10 @@ Supply-chain scanning (run in `.github/workflows/security.yml`):
   ratchet baseline (see `pyproject.toml`, "WP-6.4 ratchet baseline").
   New files get full enforcement; the 41 existing ones are fixed
   incrementally — remove an entry as its file is cleaned up.
-- **One lint rail above remains advisory (`cli-file-kind-validation`).**
-  It is intentionally non-blocking while remediation and detector tuning
-  continue prior to promotion to enforced.
+- **Three lint rails above remain advisory (`cli-file-kind-validation`,
+  `subprocess-returncode`, and `test-environment-leakage`).** They are
+  intentionally non-blocking while remediation and detector tuning continue
+  prior to promotion to enforced.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,7 @@ are **enforced**; rails with pre-existing violation backlogs remain
 | `textiowrapper-detach` | An `io.TextIOWrapper` that is never `.detach()`-ed before going out of scope (use-after-close risk on the wrapped buffer/fd) | enforced |
 | `called-attribute-assertion` | Weak `assert mock.called` / bare `assert mock.call_count` test assertions | enforced |
 | `subprocess-returncode` | `subprocess.run()` call without `check=True` or `.returncode` inspection (issue #1408) | advisory |
+| `test-environment-leakage` | Tests mutating class/global state or `sys.modules` without scoped restoration (issue #1414) | advisory |
 | `xdist-loadgroup` | A test using the xdist-wide `tmp_path_factory.getbasetemp()` without an `xdist_group` marker | enforced |
 
 Per-file coverage floors (`check-integration-floors.py` for the

--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -181,7 +181,7 @@ repo-wide finding count reaches zero.
 
 | Rail | Canonical home | What it flags |
 |------|----------------|---------------|
-| `test-environment-leakage` | `scripts/ci/guardrails/check_test_environment_leakage.py` plus `tests/ci/test_check_test_environment_leakage.py` | Direct class/global state mutation, `global` writes, `globals()[...]`, or `sys.modules[...]` changes in tests without `monkeypatch`, `patch`, `patch.dict`, fixture finalizer, or `try/finally` restoration |
+| `test-environment-leakage` | `scripts/ci/guardrails/check_test_environment_leakage.py` plus `tests/ci/test_check_test_environment_leakage.py` | Direct class/global state mutation, `global` writes, dynamic `globals()` entries, or `sys.modules` entries in tests without `monkeypatch`, `patch`, `patch.dict`, fixture finalizer, or `try/finally` restoration |
 
 Safe patterns:
 - `monkeypatch.setattr` / `monkeypatch.setitem`

--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -173,6 +173,22 @@ Implementation detail:
 
 - Guardrail logic lives in `tests/ci/test_filesystem_link_copy_guardrails.py`.
 
+## Test Environment Leakage Rule Index
+
+Issue `#1414` adds an advisory rail for test process state mutations. It starts
+advisory while current findings are classified, then can be promoted once the
+repo-wide finding count reaches zero.
+
+| Rail | Canonical home | What it flags |
+|------|----------------|---------------|
+| `test-environment-leakage` | `scripts/ci/guardrails/check_test_environment_leakage.py` plus `tests/ci/test_check_test_environment_leakage.py` | Direct class/global state mutation, `global` writes, `globals()[...]`, or `sys.modules[...]` changes in tests without `monkeypatch`, `patch`, `patch.dict`, fixture finalizer, or `try/finally` restoration |
+
+Safe patterns:
+- `monkeypatch.setattr` / `monkeypatch.setitem`
+- `patch`, `patch.object`, and `patch.dict` context managers or decorators
+- fixture finalizers registered before mutation
+- `try/finally` blocks that restore the same mutated target
+
 ## Search Guardrail Rule Index
 
 Issue `#869` adds corpus-safety checks for the search service. These are

--- a/scripts/ci/guardrails/check_test_environment_leakage.py
+++ b/scripts/ci/guardrails/check_test_environment_leakage.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""CI-rail: Flag test environment mutations that can leak across tests.
+
+This advisory rail catches direct mutations of shared test process state when
+the mutation is not structurally scoped by pytest's ``monkeypatch``, unittest
+``patch`` helpers, fixture finalizers, or a ``try/finally`` restoration block.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa
+
+RAIL_ID = "test-environment-leakage"
+
+
+def _is_fixture(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for decorator in node.decorator_list:
+        call = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(call, ast.Attribute) and call.attr == "fixture":
+            return True
+        if isinstance(call, ast.Name) and call.id == "fixture":
+            return True
+    return False
+
+
+def _is_test_scope(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    return node.name.startswith("test_") or _is_fixture(node)
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _is_patch_context(expr: ast.AST) -> bool:
+    if not isinstance(expr, ast.Call):
+        return False
+    name = _call_name(expr.func)
+    return (
+        name
+        in {
+            "patch",
+            "patch.object",
+            "patch.multiple",
+            "mock.patch",
+            "mock.patch.object",
+            "mock.patch.multiple",
+            "unittest.mock.patch",
+            "unittest.mock.patch.object",
+            "unittest.mock.patch.multiple",
+        }
+        or name.endswith(".patch")
+        or name.endswith(".patch.object")
+        or name.endswith(".patch.multiple")
+    )
+
+
+def _is_patch_dict_context(expr: ast.AST) -> bool:
+    return isinstance(expr, ast.Call) and _call_name(expr.func).endswith("patch.dict")
+
+
+def _patch_object_target(expr: ast.AST) -> str | None:
+    if not isinstance(expr, ast.Call):
+        return None
+    if not _call_name(expr.func).endswith("patch.object"):
+        return None
+    if len(expr.args) < 2:
+        return None
+    obj_key = _target_key(expr.args[0])
+    attr_arg = expr.args[1]
+    if obj_key is None or not isinstance(attr_arg, ast.Constant):
+        return None
+    if not isinstance(attr_arg.value, str):
+        return None
+    return f"{obj_key}.{attr_arg.value}"
+
+
+def _is_addfinalizer_call(stmt: ast.stmt) -> bool:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return False
+    return _call_name(stmt.value.func).endswith(".addfinalizer")
+
+
+def _is_sys_modules(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "modules"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+    )
+
+
+def _target_key(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return f"name:{node.id}"
+    if isinstance(node, ast.Attribute):
+        value = _target_key(node.value)
+        if value is None:
+            return None
+        return f"{value}.{node.attr}"
+    if isinstance(node, ast.Subscript):
+        value = _target_key(node.value)
+        if value is None:
+            return None
+        try:
+            index = ast.unparse(node.slice)
+        except Exception:  # pragma: no cover - ast.unparse is best effort only
+            index = "*"
+        return f"{value}[{index}]"
+    if isinstance(node, ast.Call) and _call_name(node.func) == "globals":
+        return "globals()"
+    return None
+
+
+def _is_class_or_global_attribute(target: ast.AST, imported_names: set[str]) -> bool:
+    if not isinstance(target, ast.Attribute):
+        return False
+    if isinstance(target.value, ast.Name):
+        base = target.value.id
+        return base[:1].isupper() or base in imported_names
+    if isinstance(target.value, ast.Attribute):
+        return _attribute_root(target.value) in imported_names
+    return False
+
+
+def _attribute_root(node: ast.Attribute) -> str | None:
+    current: ast.AST = node
+    while isinstance(current, ast.Attribute):
+        current = current.value
+    return current.id if isinstance(current, ast.Name) else None
+
+
+def _is_sys_modules_target(target: ast.AST) -> bool:
+    return isinstance(target, ast.Subscript) and _is_sys_modules(target.value)
+
+
+def _is_globals_target(target: ast.AST) -> bool:
+    return (
+        isinstance(target, ast.Subscript)
+        and isinstance(target.value, ast.Call)
+        and _call_name(target.value.func) == "globals"
+    )
+
+
+def _mutation_kind(target: ast.AST, imported_names: set[str]) -> str | None:
+    if _is_sys_modules_target(target):
+        return "sys.modules mutation without patch.dict or guaranteed cleanup"
+    if _is_globals_target(target):
+        return "globals() mutation without scoped restoration"
+    if _is_class_or_global_attribute(target, imported_names):
+        return "class/global attribute mutation without scoped restoration"
+    return None
+
+
+def _stmt_targets(stmt: ast.stmt) -> list[ast.AST]:
+    if isinstance(stmt, ast.Assign):
+        return list(stmt.targets)
+    if isinstance(stmt, ast.AnnAssign):
+        return [stmt.target]
+    if isinstance(stmt, ast.AugAssign):
+        return [stmt.target]
+    if isinstance(stmt, ast.Delete):
+        return list(stmt.targets)
+    return []
+
+
+def _restores_target(finalbody: list[ast.stmt], target: ast.AST) -> bool:
+    expected = _target_key(target)
+    if expected is None:
+        return False
+    for stmt in finalbody:
+        for final_target in _stmt_targets(stmt):
+            if _target_key(final_target) == expected:
+                return True
+    return False
+
+
+class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
+    """Collect unscoped test-environment mutations."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self.lines = lines
+        self.violations: list[tuple[int, str, str]] = []
+        self._test_scope_depth = 0
+        self._patch_dict_depth = 0
+        self._safe_target_stack: list[set[str]] = []
+        self._finalizer_registered_stack: list[bool] = []
+        self._fixture_yield_mutation_lines: set[int] = set()
+        self._imported_names: set[str] = set()
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._imported_names.add(alias.asname or alias.name.split(".", maxsplit=1)[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            self._imported_names.add(alias.asname or alias.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if _is_test_scope(node):
+            patch_targets = {
+                target
+                for decorator in node.decorator_list
+                if (target := _patch_object_target(decorator)) is not None
+            }
+            patch_dict_count = sum(
+                1 for decorator in node.decorator_list if _is_patch_dict_context(decorator)
+            )
+            self._test_scope_depth += 1
+            self._patch_dict_depth += patch_dict_count
+            self._safe_target_stack.append(patch_targets)
+            self._finalizer_registered_stack.append(False)
+            try:
+                self._check_fixture_yield_cleanup(node)
+                self._visit_block(node.body)
+            finally:
+                self._finalizer_registered_stack.pop()
+                self._safe_target_stack.pop()
+                self._patch_dict_depth -= patch_dict_count
+                self._test_scope_depth -= 1
+            return
+        self.generic_visit(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Global(self, node: ast.Global) -> None:
+        if self._test_scope_depth:
+            self._add_violation(
+                node,
+                "global statement in test mutates module state without scoped restoration",
+            )
+
+    def visit_With(self, node: ast.With) -> None:
+        patch_targets = {
+            target
+            for item in node.items
+            if (target := _patch_object_target(item.context_expr)) is not None
+        }
+        patch_dict_count = sum(
+            1 for item in node.items if _is_patch_dict_context(item.context_expr)
+        )
+        self._patch_dict_depth += patch_dict_count
+        self._safe_target_stack.append(patch_targets)
+        try:
+            self._visit_block(node.body)
+        finally:
+            self._safe_target_stack.pop()
+            self._patch_dict_depth -= patch_dict_count
+
+    visit_AsyncWith = visit_With
+
+    def visit_Try(self, node: ast.Try) -> None:
+        restored = {
+            key
+            for stmt in node.body
+            for target in _stmt_targets(stmt)
+            if (key := _target_key(target)) is not None and _restores_target(node.finalbody, target)
+        }
+        self._safe_target_stack.append(restored)
+        try:
+            self._visit_block(node.body)
+        finally:
+            self._safe_target_stack.pop()
+        for handler in node.handlers:
+            self._visit_block(handler.body)
+        self._visit_block(node.orelse)
+        finalbody_restorations = {
+            key
+            for stmt in node.finalbody
+            for target in _stmt_targets(stmt)
+            if (key := _target_key(target)) is not None
+        }
+        self._safe_target_stack.append(restored | finalbody_restorations)
+        try:
+            self._visit_block(node.finalbody)
+        finally:
+            self._safe_target_stack.pop()
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        if self._test_scope_depth and _is_addfinalizer_call(node):
+            self._finalizer_registered_stack[-1] = True
+        self.generic_visit(node)
+
+    visit_TryStar = visit_Try
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self._check_assignment(node, node.targets)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._check_assignment(node, [node.target])
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._check_assignment(node, [node.target])
+        self.generic_visit(node)
+
+    def _visit_block(self, block: list[ast.stmt]) -> None:
+        for idx, stmt in enumerate(block):
+            next_stmt = block[idx + 1] if idx + 1 < len(block) else None
+            if isinstance(next_stmt, (ast.Try, ast.TryStar)):
+                restored = {
+                    key
+                    for target in _stmt_targets(stmt)
+                    if (key := _target_key(target)) is not None
+                    and _restores_target(next_stmt.finalbody, target)
+                }
+                self._safe_target_stack.append(restored)
+                try:
+                    self.visit(stmt)
+                finally:
+                    self._safe_target_stack.pop()
+                continue
+            self.visit(stmt)
+
+    def _check_fixture_yield_cleanup(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        if not _is_fixture(node):
+            return
+        for idx, stmt in enumerate(node.body):
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Yield):
+                for prior in node.body[:idx]:
+                    if _stmt_has_direct_mutation(prior, self._imported_names):
+                        self._fixture_yield_mutation_lines.update(
+                            child.lineno
+                            for child in ast.walk(prior)
+                            if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+                        )
+                        self._add_violation(
+                            prior,
+                            "fixture mutates shared state before yield without try/finally or pre-registered finalizer",
+                        )
+                for later in node.body[idx + 1 :]:
+                    self._fixture_yield_mutation_lines.update(
+                        child.lineno
+                        for child in ast.walk(later)
+                        if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+                    )
+                return
+            if _is_addfinalizer_call(stmt):
+                return
+            if isinstance(stmt, ast.Try):
+                continue
+
+    def _check_assignment(self, node: ast.AST, targets: list[ast.AST]) -> None:
+        if not self._test_scope_depth:
+            return
+        if getattr(node, "lineno", 0) in self._fixture_yield_mutation_lines:
+            return
+        if self._finalizer_registered_stack and self._finalizer_registered_stack[-1]:
+            return
+        for target in targets:
+            kind = _mutation_kind(target, self._imported_names)
+            if kind is None:
+                continue
+            if _is_sys_modules_target(target) and self._patch_dict_depth:
+                continue
+            key = _target_key(target)
+            if key is not None and any(key in safe for safe in self._safe_target_stack):
+                continue
+            self._add_violation(node, kind)
+
+    def _add_violation(self, node: ast.AST, message: str) -> None:
+        lineno = getattr(node, "lineno", 0)
+        line = self.lines[lineno - 1] if 0 < lineno <= len(self.lines) else ""
+        if has_targeted_noqa(line, RAIL_ID):
+            return
+        self.violations.append((lineno, message, line.strip()))
+
+
+def _stmt_has_direct_mutation(stmt: ast.stmt, imported_names: set[str]) -> bool:
+    if isinstance(stmt, (ast.With, ast.AsyncWith)):
+        if any(_is_patch_context(item.context_expr) for item in stmt.items):
+            return False
+        if any(_is_patch_dict_context(item.context_expr) for item in stmt.items):
+            return False
+    for child in ast.walk(stmt):
+        if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            if any(
+                _mutation_kind(target, imported_names) is not None
+                for target in _stmt_targets(child)
+            ):
+                return True
+    return False
+
+
+def check_file(filepath: Path) -> list[tuple[int, str, str]]:
+    """Parse and check a single Python test file."""
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading {filepath}: {exc}", file=sys.stderr)
+        return []
+
+    lines = content.splitlines()
+    try:
+        tree = ast.parse(content, filename=str(filepath))
+    except SyntaxError as exc:
+        print(f"Syntax error in {filepath}: {exc}", file=sys.stderr)
+        return []
+
+    visitor = TestEnvironmentLeakageVisitor(lines)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Scan test files for process-global mutation leaks."""
+    paths = [Path(arg) for arg in (argv if argv is not None else sys.argv[1:])]
+    if not paths:
+        test_dir = Path("tests")
+        if not test_dir.exists():
+            print("Error: tests directory not found. Run from the repository root.")
+            return 1
+        paths = [test_dir]
+
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.py")))
+        elif path.suffix == ".py":
+            files.append(path)
+
+    all_violations: list[tuple[str, int, str, str]] = []
+    for path in files:
+        for lineno, msg, line in check_file(path):
+            all_violations.append((path.as_posix(), lineno, msg, line))
+
+    if all_violations:
+        print(
+            f"❌ [{RAIL_ID}] Violations found (test environment mutation can leak):",
+            file=sys.stderr,
+        )
+        for file_path, lineno, msg, line in all_violations:
+            print(f"  {file_path}:{lineno}: {msg} -> `{line}`", file=sys.stderr)
+        print(
+            "\nFix: use monkeypatch, patch/patch.dict, fixture finalizers, "
+            f"try/finally restoration, or add '# noqa: {RAIL_ID}' for a documented exception.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅ [{RAIL_ID}] No violations found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/guardrails/check_test_environment_leakage.py
+++ b/scripts/ci/guardrails/check_test_environment_leakage.py
@@ -70,6 +70,48 @@ def _is_patch_dict_context(expr: ast.AST) -> bool:
     return isinstance(expr, ast.Call) and _call_name(expr.func).endswith("patch.dict")
 
 
+def _constant_key(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return repr(node.value)
+    return None
+
+
+def _mapping_item_keys(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Dict):
+        return {key for item in node.keys if (key := _constant_key(item)) is not None}
+    return set()
+
+
+def _subscript_key(base: ast.AST, key: str) -> str | None:
+    base_key = _target_key(base)
+    if base_key is None:
+        return None
+    return f"{base_key}[{key}]"
+
+
+def _patch_dict_targets(expr: ast.AST) -> set[str]:
+    if not isinstance(expr, ast.Call) or not _is_patch_dict_context(expr):
+        return set()
+    if not expr.args:
+        return set()
+
+    mapping = expr.args[0]
+    targets: set[str] = set()
+    if len(expr.args) > 1:
+        targets.update(
+            target
+            for key in _mapping_item_keys(expr.args[1])
+            if (target := _subscript_key(mapping, key)) is not None
+        )
+    for keyword in expr.keywords:
+        if keyword.arg is None:
+            continue
+        target = _subscript_key(mapping, repr(keyword.arg))
+        if target is not None:
+            targets.add(target)
+    return targets
+
+
 def _patch_object_target(expr: ast.AST) -> str | None:
     if not isinstance(expr, ast.Call):
         return None
@@ -90,6 +132,40 @@ def _is_addfinalizer_call(stmt: ast.stmt) -> bool:
     if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
         return False
     return _call_name(stmt.value.func).endswith(".addfinalizer")
+
+
+def _addfinalizer_targets(stmt: ast.stmt) -> set[str]:
+    if not _is_addfinalizer_call(stmt):
+        return set()
+    assert isinstance(stmt, ast.Expr)
+    call = stmt.value
+    assert isinstance(call, ast.Call)
+    if not call.args:
+        return set()
+
+    finalizer = call.args[0]
+    if isinstance(finalizer, ast.Lambda):
+        return _restoration_call_targets(finalizer.body)
+    return set()
+
+
+def _restoration_call_targets(node: ast.AST) -> set[str]:
+    if not isinstance(node, ast.Call):
+        return set()
+    name = _call_name(node.func)
+    if name == "setattr" and len(node.args) >= 2:
+        obj_key = _target_key(node.args[0])
+        attr_arg = node.args[1]
+        if obj_key is not None and isinstance(attr_arg, ast.Constant):
+            if isinstance(attr_arg.value, str):
+                return {f"{obj_key}.{attr_arg.value}"}
+    if name.endswith(".pop") and node.args:
+        mapping = node.func.value if isinstance(node.func, ast.Attribute) else None
+        key = _constant_key(node.args[0])
+        if mapping is not None and key is not None:
+            target = _subscript_key(mapping, key)
+            return {target} if target is not None else set()
+    return set()
 
 
 def _is_sys_modules(node: ast.AST) -> bool:
@@ -193,9 +269,8 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
         self.lines = lines
         self.violations: list[tuple[int, str, str]] = []
         self._test_scope_depth = 0
-        self._patch_dict_depth = 0
         self._safe_target_stack: list[set[str]] = []
-        self._finalizer_registered_stack: list[bool] = []
+        self._finalizer_target_stack: list[set[str]] = []
         self._fixture_yield_mutation_lines: set[int] = set()
         self._imported_names: set[str] = set()
 
@@ -214,20 +289,20 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
                 for decorator in node.decorator_list
                 if (target := _patch_object_target(decorator)) is not None
             }
-            patch_dict_count = sum(
-                1 for decorator in node.decorator_list if _is_patch_dict_context(decorator)
-            )
+            patch_dict_targets = {
+                target
+                for decorator in node.decorator_list
+                for target in _patch_dict_targets(decorator)
+            }
             self._test_scope_depth += 1
-            self._patch_dict_depth += patch_dict_count
-            self._safe_target_stack.append(patch_targets)
-            self._finalizer_registered_stack.append(False)
+            self._safe_target_stack.append(patch_targets | patch_dict_targets)
+            self._finalizer_target_stack.append(set())
             try:
                 self._check_fixture_yield_cleanup(node)
                 self._visit_block(node.body)
             finally:
-                self._finalizer_registered_stack.pop()
+                self._finalizer_target_stack.pop()
                 self._safe_target_stack.pop()
-                self._patch_dict_depth -= patch_dict_count
                 self._test_scope_depth -= 1
             return
         self.generic_visit(node)
@@ -247,16 +322,14 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
             for item in node.items
             if (target := _patch_object_target(item.context_expr)) is not None
         }
-        patch_dict_count = sum(
-            1 for item in node.items if _is_patch_dict_context(item.context_expr)
-        )
-        self._patch_dict_depth += patch_dict_count
-        self._safe_target_stack.append(patch_targets)
+        patch_dict_targets = {
+            target for item in node.items for target in _patch_dict_targets(item.context_expr)
+        }
+        self._safe_target_stack.append(patch_targets | patch_dict_targets)
         try:
             self._visit_block(node.body)
         finally:
             self._safe_target_stack.pop()
-            self._patch_dict_depth -= patch_dict_count
 
     visit_AsyncWith = visit_With
 
@@ -288,8 +361,8 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
             self._safe_target_stack.pop()
 
     def visit_Expr(self, node: ast.Expr) -> None:
-        if self._test_scope_depth and _is_addfinalizer_call(node):
-            self._finalizer_registered_stack[-1] = True
+        if self._test_scope_depth:
+            self._finalizer_target_stack[-1].update(_addfinalizer_targets(node))
         self.generic_visit(node)
 
     visit_TryStar = visit_Try
@@ -306,49 +379,63 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
         self._check_assignment(node, [node.target])
         self.generic_visit(node)
 
+    def visit_Delete(self, node: ast.Delete) -> None:
+        self._check_assignment(node, node.targets)
+        self.generic_visit(node)
+
     def _visit_block(self, block: list[ast.stmt]) -> None:
-        for idx, stmt in enumerate(block):
-            next_stmt = block[idx + 1] if idx + 1 < len(block) else None
-            if isinstance(next_stmt, (ast.Try, ast.TryStar)):
+        idx = 0
+        while idx < len(block):
+            try_index = idx
+            while try_index < len(block) and not isinstance(
+                block[try_index], (ast.Try, ast.TryStar)
+            ):
+                try_index += 1
+            if try_index < len(block) and try_index > idx:
+                try_stmt = block[try_index]
                 restored = {
                     key
+                    for stmt in block[idx:try_index]
                     for target in _stmt_targets(stmt)
                     if (key := _target_key(target)) is not None
-                    and _restores_target(next_stmt.finalbody, target)
+                    and _restores_target(try_stmt.finalbody, target)
                 }
                 self._safe_target_stack.append(restored)
                 try:
-                    self.visit(stmt)
+                    for stmt in block[idx:try_index]:
+                        self.visit(stmt)
                 finally:
                     self._safe_target_stack.pop()
+                self.visit(try_stmt)
+                idx = try_index + 1
                 continue
-            self.visit(stmt)
+            self.visit(block[idx])
+            idx += 1
 
     def _check_fixture_yield_cleanup(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         if not _is_fixture(node):
             return
+        finalizer_targets: set[str] = set()
         for idx, stmt in enumerate(node.body):
             if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Yield):
                 for prior in node.body[:idx]:
-                    if _stmt_has_direct_mutation(prior, self._imported_names):
-                        self._fixture_yield_mutation_lines.update(
-                            child.lineno
-                            for child in ast.walk(prior)
-                            if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign))
-                        )
+                    if _is_addfinalizer_call(prior):
+                        finalizer_targets.update(_addfinalizer_targets(prior))
+                        continue
+                    mutation_targets = _stmt_mutation_targets(prior, self._imported_names)
+                    unsafe_targets = mutation_targets - finalizer_targets
+                    if unsafe_targets:
+                        self._fixture_yield_mutation_lines.update(_stmt_mutation_lines(prior))
                         self._add_violation(
                             prior,
                             "fixture mutates shared state before yield without try/finally or pre-registered finalizer",
                         )
                 for later in node.body[idx + 1 :]:
-                    self._fixture_yield_mutation_lines.update(
-                        child.lineno
-                        for child in ast.walk(later)
-                        if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign))
-                    )
+                    self._fixture_yield_mutation_lines.update(_stmt_mutation_lines(later))
                 return
             if _is_addfinalizer_call(stmt):
-                return
+                finalizer_targets.update(_addfinalizer_targets(stmt))
+                continue
             if isinstance(stmt, ast.Try):
                 continue
 
@@ -357,16 +444,14 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
             return
         if getattr(node, "lineno", 0) in self._fixture_yield_mutation_lines:
             return
-        if self._finalizer_registered_stack and self._finalizer_registered_stack[-1]:
-            return
         for target in targets:
             kind = _mutation_kind(target, self._imported_names)
             if kind is None:
                 continue
-            if _is_sys_modules_target(target) and self._patch_dict_depth:
-                continue
             key = _target_key(target)
             if key is not None and any(key in safe for safe in self._safe_target_stack):
+                continue
+            if key is not None and any(key in safe for safe in self._finalizer_target_stack):
                 continue
             self._add_violation(node, kind)
 
@@ -378,20 +463,30 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
         self.violations.append((lineno, message, line.strip()))
 
 
-def _stmt_has_direct_mutation(stmt: ast.stmt, imported_names: set[str]) -> bool:
+def _stmt_mutation_targets(stmt: ast.stmt, imported_names: set[str]) -> set[str]:
     if isinstance(stmt, (ast.With, ast.AsyncWith)):
         if any(_is_patch_context(item.context_expr) for item in stmt.items):
-            return False
+            return set()
         if any(_is_patch_dict_context(item.context_expr) for item in stmt.items):
-            return False
+            return set()
+    targets: set[str] = set()
     for child in ast.walk(stmt):
-        if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
-            if any(
-                _mutation_kind(target, imported_names) is not None
+        if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete)):
+            targets.update(
+                key
                 for target in _stmt_targets(child)
-            ):
-                return True
-    return False
+                if _mutation_kind(target, imported_names) is not None
+                if (key := _target_key(target)) is not None
+            )
+    return targets
+
+
+def _stmt_mutation_lines(stmt: ast.stmt) -> set[int]:
+    return {
+        child.lineno
+        for child in ast.walk(stmt)
+        if isinstance(child, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete))
+    }
 
 
 def check_file(filepath: Path) -> list[tuple[int, str, str]]:

--- a/scripts/ci/guardrails/check_test_environment_leakage.py
+++ b/scripts/ci/guardrails/check_test_environment_leakage.py
@@ -324,9 +324,7 @@ class TestEnvironmentLeakageVisitor(ast.NodeVisitor):
                 continue
             self.visit(stmt)
 
-    def _check_fixture_yield_cleanup(
-        self, node: ast.FunctionDef | ast.AsyncFunctionDef
-    ) -> None:
+    def _check_fixture_yield_cleanup(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         if not _is_fixture(node):
             return
         for idx, stmt in enumerate(node.body):

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -89,3 +89,9 @@ name = "subprocess-returncode"
 command = ["python", "scripts/ci/guardrails/check_subprocess_returncode.py"]
 mode = "advisory"
 description = "Flags subprocess.run() calls where returncode is not checked and check=True is absent (issue #1408)."
+
+[[rail]]
+name = "test-environment-leakage"
+command = ["python", "scripts/ci/guardrails/check_test_environment_leakage.py"]
+mode = "advisory"
+description = "Flags tests that mutate class/global state or sys.modules without scoped restoration (issue #1414)."

--- a/tests/ci/test_check_test_environment_leakage.py
+++ b/tests/ci/test_check_test_environment_leakage.py
@@ -1,0 +1,267 @@
+"""Tests for the advisory test-environment-leakage CI rail."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.guardrails import check_test_environment_leakage as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def _write(tmp_path: Path, source: str) -> Path:
+    src = tmp_path / "subject.py"
+    src.write_text(source, encoding="utf-8")
+    return src
+
+
+def test_flags_direct_class_attribute_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "class Target:\n"
+        "    enabled = False\n\n"
+        "def test_leaks_class_state():\n"
+        "    Target.enabled = True\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "class/global attribute mutation" in violations[0][1]
+
+
+def test_flags_imported_module_attribute_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import package.config as config_module\n\n"
+        "def test_leaks_module_state():\n"
+        "    config_module._config = object()\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "class/global attribute mutation" in violations[0][1]
+
+
+def test_allows_instance_and_mock_attribute_setup(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "from unittest.mock import Mock\n\n"
+        "def test_plain_object_setup():\n"
+        "    user = Mock()\n"
+        "    user.is_active = False\n"
+        "    client = Mock()\n"
+        "    client.get.return_value = 'ok'\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_flags_sys_modules_assignment_without_patch_dict(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n\n"
+        "def test_leaks_import_state():\n"
+        "    sys.modules['optional_dep'] = object()\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "sys.modules" in violations[0][1]
+
+
+def test_flags_fixture_yield_cleanup_that_is_not_exception_safe(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import pytest\n\n"
+        "class Target:\n"
+        "    value = 'old'\n\n"
+        "@pytest.fixture\n"
+        "def leaky_fixture():\n"
+        "    Target.value = 'new'\n"
+        "    yield\n"
+        "    Target.value = 'old'\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert any("fixture mutates shared state before yield" in msg for _, msg, _ in violations)
+
+
+def test_allows_try_finally_restoration_around_class_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "class Target:\n"
+        "    value = 'old'\n\n"
+        "def test_scoped_mutation():\n"
+        "    try:\n"
+        "        Target.value = 'new'\n"
+        "    finally:\n"
+        "        Target.value = 'old'\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_allows_immediate_try_finally_restoration_after_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n"
+        "from io import StringIO\n\n"
+        "def test_stdout_capture():\n"
+        "    old_stdout = sys.stdout\n"
+        "    sys.stdout = StringIO()\n"
+        "    try:\n"
+        "        assert sys.stdout.getvalue() == ''\n"
+        "    finally:\n"
+        "        sys.stdout = old_stdout\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_allows_patch_dict_for_sys_modules(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n"
+        "from unittest.mock import patch\n\n"
+        "def test_scoped_import_state():\n"
+        "    with patch.dict(sys.modules, {'optional_dep': object()}):\n"
+        "        assert 'optional_dep' in sys.modules\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_allows_nested_patch_object_contexts(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "from unittest.mock import patch\n\n"
+        "class Target:\n"
+        "    left = False\n"
+        "    right = False\n\n"
+        "def test_nested_patch_contexts():\n"
+        "    with patch.object(Target, 'left', True):\n"
+        "        with patch.object(Target, 'right', True):\n"
+        "            assert Target.left and Target.right\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_allows_patch_decorators(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n"
+        "from unittest.mock import patch\n\n"
+        "class Target:\n"
+        "    enabled = False\n\n"
+        "@patch.object(Target, 'enabled', True)\n"
+        "@patch.dict(sys.modules, {'optional_dep': object()})\n"
+        "def test_patch_decorators():\n"
+        "    Target.enabled = False\n"
+        "    sys.modules['optional_dep'] = object()\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_unrelated_patch_object_does_not_hide_direct_class_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "from unittest.mock import patch\n\n"
+        "class Patched:\n"
+        "    enabled = False\n\n"
+        "class Leaky:\n"
+        "    enabled = False\n\n"
+        "def test_unrelated_patch_context():\n"
+        "    with patch.object(Patched, 'enabled', True):\n"
+        "        Leaky.enabled = True\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "Leaky.enabled" in violations[0][2]
+
+
+def test_allows_monkeypatch_setattr_and_setitem(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n\n"
+        "class Target:\n"
+        "    enabled = False\n\n"
+        "def test_monkeypatch_is_scoped(monkeypatch):\n"
+        "    monkeypatch.setattr(Target, 'enabled', True)\n"
+        "    monkeypatch.setitem(sys.modules, 'optional_dep', object())\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_allows_fixture_finalizer_registered_before_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import pytest\n\n"
+        "class Target:\n"
+        "    value = 'old'\n\n"
+        "@pytest.fixture\n"
+        "def scoped_fixture(request):\n"
+        "    request.addfinalizer(lambda: setattr(Target, 'value', 'old'))\n"
+        "    Target.value = 'new'\n"
+        "    yield\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+def test_flags_global_statement_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "STATE = False\n\n"
+        "def test_global_write():\n"
+        "    global STATE\n"
+        "    STATE = True\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "global statement" in violations[0][1]
+
+
+def test_targeted_noqa_suppresses_intentional_exception(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n\n"
+        "def test_intentional_import_cache_state():\n"
+        "    sys.modules['fixture_only'] = object()  # noqa: test-environment-leakage\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="Advisory rail: existing findings are classified before enforcement.",
+)
+def test_repo_environment_leakage_findings_are_zero() -> None:
+    root = Path(__file__).resolve().parents[2]
+    violations = [
+        (path, lineno, msg, line)
+        for path in sorted((root / "tests").rglob("*.py"))
+        for lineno, msg, line in checker.check_file(path)
+    ]
+
+    assert not violations, (
+        "test-environment-leakage findings remain:\n"
+        + "\n".join(
+            f"{path.relative_to(root)}:{lineno}: {msg} -> `{line}`"
+            for path, lineno, msg, line in violations
+        )
+    )

--- a/tests/ci/test_check_test_environment_leakage.py
+++ b/tests/ci/test_check_test_environment_leakage.py
@@ -125,6 +125,26 @@ def test_allows_immediate_try_finally_restoration_after_mutation(tmp_path: Path)
     assert checker.check_file(src) == []
 
 
+def test_allows_multiple_setup_mutations_restored_by_following_finally(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "class First:\n"
+        "    value = 'old'\n\n"
+        "class Second:\n"
+        "    value = 'old'\n\n"
+        "def test_multi_setup_restore():\n"
+        "    First.value = 'new'\n"
+        "    Second.value = 'new'\n"
+        "    try:\n"
+        "        assert First.value == 'new'\n"
+        "    finally:\n"
+        "        First.value = 'old'\n"
+        "        Second.value = 'old'\n",
+    )
+
+    assert checker.check_file(src) == []
+
+
 def test_allows_patch_dict_for_sys_modules(tmp_path: Path) -> None:
     src = _write(
         tmp_path,
@@ -136,6 +156,23 @@ def test_allows_patch_dict_for_sys_modules(tmp_path: Path) -> None:
     )
 
     assert checker.check_file(src) == []
+
+
+def test_unrelated_patch_dict_does_not_hide_sys_modules_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import os\n"
+        "import sys\n"
+        "from unittest.mock import patch\n\n"
+        "def test_unrelated_patch_dict():\n"
+        "    with patch.dict(os.environ, {'FLAG': '1'}):\n"
+        "        sys.modules['optional_dep'] = object()\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "sys.modules" in violations[0][1]
 
 
 def test_allows_nested_patch_object_contexts(tmp_path: Path) -> None:
@@ -220,6 +257,27 @@ def test_allows_fixture_finalizer_registered_before_mutation(tmp_path: Path) -> 
     assert checker.check_file(src) == []
 
 
+def test_unrelated_fixture_finalizer_does_not_hide_later_mutation(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "import pytest\n\n"
+        "class Target:\n"
+        "    value = 'old'\n\n"
+        "class Other:\n"
+        "    value = 'old'\n\n"
+        "@pytest.fixture\n"
+        "def leaky_fixture(request):\n"
+        "    request.addfinalizer(lambda: setattr(Other, 'value', 'old'))\n"
+        "    Target.value = 'new'\n"
+        "    yield\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert "fixture mutates shared state before yield" in violations[0][1]
+
+
 def test_flags_global_statement_mutation(tmp_path: Path) -> None:
     src = _write(
         tmp_path,
@@ -230,6 +288,31 @@ def test_flags_global_statement_mutation(tmp_path: Path) -> None:
 
     assert len(violations) == 1
     assert "global statement" in violations[0][1]
+
+
+@pytest.mark.parametrize(
+    ("statement", "expected_message"),
+    [
+        ("del sys.modules['optional_dep']", "sys.modules"),
+        ("del globals()['STATE']", "globals()"),
+        ("del imported_mod.flag", "class/global attribute"),
+    ],
+)
+def test_flags_delete_based_state_mutation(
+    tmp_path: Path, statement: str, expected_message: str
+) -> None:
+    src = _write(
+        tmp_path,
+        "import sys\n"
+        "import package.config as imported_mod\n\n"
+        "def test_delete_leaks_state():\n"
+        f"    {statement}\n",
+    )
+
+    violations = checker.check_file(src)
+
+    assert len(violations) == 1
+    assert expected_message in violations[0][1]
 
 
 def test_targeted_noqa_suppresses_intentional_exception(tmp_path: Path) -> None:

--- a/tests/ci/test_check_test_environment_leakage.py
+++ b/tests/ci/test_check_test_environment_leakage.py
@@ -223,10 +223,7 @@ def test_allows_fixture_finalizer_registered_before_mutation(tmp_path: Path) -> 
 def test_flags_global_statement_mutation(tmp_path: Path) -> None:
     src = _write(
         tmp_path,
-        "STATE = False\n\n"
-        "def test_global_write():\n"
-        "    global STATE\n"
-        "    STATE = True\n",
+        "STATE = False\n\ndef test_global_write():\n    global STATE\n    STATE = True\n",
     )
 
     violations = checker.check_file(src)
@@ -258,10 +255,7 @@ def test_repo_environment_leakage_findings_are_zero() -> None:
         for lineno, msg, line in checker.check_file(path)
     ]
 
-    assert not violations, (
-        "test-environment-leakage findings remain:\n"
-        + "\n".join(
-            f"{path.relative_to(root)}:{lineno}: {msg} -> `{line}`"
-            for path, lineno, msg, line in violations
-        )
+    assert not violations, "test-environment-leakage findings remain:\n" + "\n".join(
+        f"{path.relative_to(root)}:{lineno}: {msg} -> `{line}`"
+        for path, lineno, msg, line in violations
     )

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -144,5 +144,6 @@ def test_repo_registry_loads_registered_rails() -> None:
         "called-attribute-assertion": "enforce",
         "xdist-loadgroup": "enforce",
         "subprocess-returncode": "advisory",
+        "test-environment-leakage": "advisory",
     }
     assert {rail.name: rail.mode for rail in rails} == expected_modes


### PR DESCRIPTION
## Summary

Adds an advisory CI rail for issue #1414 that detects test environment leakage from unscoped shared-state mutations.

## User-visible behavior

- Adds the `test-environment-leakage` advisory rail to the CI rail registry.
- Documents the new advisory rail in `SECURITY.md` and the guardrail developer docs.

## Implementation details

- Adds an AST-based checker for direct class/imported-module/global mutations, `global` writes, `globals()[...]`, and `sys.modules[...]` changes in tests.
- Recognizes scoped patterns including `monkeypatch`, `patch.object`, `patch.dict`, fixture finalizers registered before mutation, and `try/finally` restoration.
- Keeps repo-wide zero-finding enforcement as an expected xfail while existing findings are classified.

## Validation

- `pytest tests/ci -q --override-ini="addopts="`
- `ruff check scripts/ci/guardrails/check_test_environment_leakage.py tests/ci/test_check_test_environment_leakage.py tests/ci/test_ci_rails_framework.py`
- `git diff --staged --check`

## Risk

Low. The rail is registered as advisory, so existing findings report without blocking CI until the backlog is cleaned up and the rail is promoted.

Fixes #1414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new advisory CI check to catch test cases that leak shared state across runs.
  * Expanded documentation with guidance on safe patterns for isolating test state.

* **Bug Fixes**
  * Improved detection of unsafe global, class, and module state changes in tests.
  * Added coverage for approved restoration and scoping patterns, including fixture cleanup and scoped patching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->