### PR TITLE
Harden test path portability rails and suppressions coverage (#1415)

### DIFF
--- a/tests/ci/test_check_test_hardcoded_paths.py
+++ b/tests/ci/test_check_test_hardcoded_paths.py
@@ -143,3 +143,75 @@ def test_check_file_returns_line_number(tmp_path: Path) -> None:
     lineno, msg, line = violations[0]
     assert lineno == 2
     assert "/tmp/foo.txt" in msg  # noqa: test-hardcoded-paths
+
+
+def test_add_violation_line_bounds() -> None:
+    import ast
+
+    visitor = checker.TestHardcodedPathVisitor(Path("dummy.py"), ["line1", "line2"])
+    # lineno=10 is out of bounds
+    node = ast.Constant(value="/tmp", lineno=10)  # noqa: test-hardcoded-paths
+    visitor.add_violation(node, "dummy error")
+    assert len(visitor.violations) == 0
+
+
+def test_check_file_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_read_text(*args, **kwargs):
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+    violations = checker.check_file(Path("dummy.py"))
+    assert violations == []
+
+
+def test_main_no_tests_directory(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    exit_code = checker.main()
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Error: tests directory not found" in captured.out
+
+
+def test_main_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    orig_path = Path
+
+    def mock_path(*args, **kwargs):
+        if args and args[0] == "tests":
+            return tmp_path
+        return orig_path(*args, **kwargs)
+
+    monkeypatch.setattr(checker, "Path", mock_path)
+
+    ok_file = tmp_path / "test_ok.py"
+    ok_file.write_text("x = 1\n", encoding="utf-8")
+
+    exit_code = checker.main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No violations found" in captured.out
+
+
+def test_main_violations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    orig_path = Path
+
+    def mock_path(*args, **kwargs):
+        if args and args[0] == "tests":
+            return tmp_path
+        return orig_path(*args, **kwargs)
+
+    monkeypatch.setattr(checker, "Path", mock_path)
+
+    bad_file = tmp_path / "test_bad.py"
+    bad_file.write_text('path = Path("/tmp/foo.txt")\n', encoding="utf-8")  # noqa: test-hardcoded-paths
+
+    exit_code = checker.main()
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Violations found" in captured.err
+    assert "test_bad.py" in captured.err

--- a/tests/ci/test_check_test_separator_paths.py
+++ b/tests/ci/test_check_test_separator_paths.py
@@ -140,3 +140,98 @@ def test_check_file_returns_line_number(tmp_path: Path) -> None:
     assert lineno == 2
     assert "docs/report.pdf" in msg  # noqa: test-separator-paths
     assert line == 'y = Path("docs/report.pdf")'
+
+
+def test_add_violation_line_bounds() -> None:
+    import ast
+
+    visitor = checker.TestSeparatorPathVisitor(Path("dummy.py"), ["line1", "line2"])
+    # lineno=10 is out of bounds
+    node = ast.Call(
+        func=ast.Name(id="Path", ctx=ast.Load()),
+        args=[ast.Constant(value="foo/bar")],
+        keywords=[],
+        lineno=10,
+    )
+    visitor.add_violation(node, "dummy error")
+    assert len(visitor.violations) == 0
+
+
+def test_check_file_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_read_text(*args, **kwargs):
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+    violations = checker.check_file(Path("dummy.py"))
+    assert violations == []
+
+
+def test_visit_call_non_path(tmp_path: Path) -> None:
+    src = tmp_path / "non_path.py"
+    src.write_text('other_func("docs/report.pdf")\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_visit_call_variable_arg(tmp_path: Path) -> None:
+    src = tmp_path / "var_path.py"
+    src.write_text('x = "docs/report.pdf"\nvalue = Path(x)\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_visit_call_fstring_no_literal(tmp_path: Path) -> None:
+    src = tmp_path / "fstring_no_lit.py"
+    src.write_text('x = "docs/report.pdf"\nvalue = Path(f"{x}")\n', encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
+def test_main_no_tests_directory(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    exit_code = checker.main()
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Error: tests directory not found" in captured.out
+
+
+def test_main_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    orig_path = Path
+
+    def mock_path(*args, **kwargs):
+        if args and args[0] == "tests":
+            return tmp_path
+        return orig_path(*args, **kwargs)
+
+    monkeypatch.setattr(checker, "Path", mock_path)
+
+    ok_file = tmp_path / "test_ok.py"
+    ok_file.write_text("x = 1\n", encoding="utf-8")
+
+    exit_code = checker.main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No violations found" in captured.out
+
+
+def test_main_violations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    orig_path = Path
+
+    def mock_path(*args, **kwargs):
+        if args and args[0] == "tests":
+            return tmp_path
+        return orig_path(*args, **kwargs)
+
+    monkeypatch.setattr(checker, "Path", mock_path)
+
+    bad_file = tmp_path / "test_bad.py"
+    bad_file.write_text('path = Path("a/b")\n', encoding="utf-8")
+
+    exit_code = checker.main()
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Violations found" in captured.err
+    assert "test_bad.py" in captured.err

--- a/tests/ci/test_guardrail_suppressions.py
+++ b/tests/ci/test_guardrail_suppressions.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from scripts.ci.guardrails.suppressions import has_comment_marker, has_targeted_noqa
+from scripts.ci.guardrails.suppressions import (
+    _manual_comment_token,
+    has_comment_marker,
+    has_targeted_noqa,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
@@ -41,3 +45,58 @@ def test_has_comment_marker_ignores_string_literals() -> None:
 
 def test_has_comment_marker_matches_real_comment() -> None:
     assert has_comment_marker("x = 1  # copilot: wontfix", "copilot: wontfix")
+
+
+def test_token_error_fallback() -> None:
+    # Open parenthesis at EOF raises TokenError in tokenize
+    assert has_targeted_noqa("x = (1  # noqa: rail", "rail")
+
+
+def test_indentation_error_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tokenize
+
+    def mock_generate_tokens(*args, **kwargs):
+        raise IndentationError("unindent does not match any outer indentation level")
+
+    monkeypatch.setattr(tokenize, "generate_tokens", mock_generate_tokens)
+    assert has_targeted_noqa("x = 1  # noqa: rail", "rail")
+
+
+def test_manual_comment_token_double_quotes() -> None:
+    assert _manual_comment_token('message = "hello"  # noqa: rail') == "# noqa: rail"
+
+
+def test_manual_comment_token_single_quotes() -> None:
+    assert _manual_comment_token("message = 'hello'  # noqa: rail") == "# noqa: rail"
+
+
+def test_manual_comment_token_escaped_quote() -> None:
+    assert _manual_comment_token('message = "hello \\" world"  # noqa: rail') == "# noqa: rail"
+
+
+def test_manual_comment_token_triple_double_quotes() -> None:
+    assert _manual_comment_token('message = """hello"""  # noqa: rail') == "# noqa: rail"
+
+
+def test_manual_comment_token_triple_single_quotes() -> None:
+    assert _manual_comment_token("message = '''hello'''  # noqa: rail") == "# noqa: rail"
+
+
+def test_manual_comment_token_unfinished_double_quote() -> None:
+    assert _manual_comment_token("message = 'hello  # noqa: rail") is None
+
+
+def test_manual_comment_token_unfinished_triple_double_quote() -> None:
+    assert _manual_comment_token('message = """hello  # noqa: rail') is None
+
+
+def test_manual_comment_token_unfinished_triple_single_quote() -> None:
+    assert _manual_comment_token("message = '''hello  # noqa: rail") is None
+
+
+def test_manual_comment_token_escaped_backslash() -> None:
+    assert _manual_comment_token('message = "hello \\\\"  # noqa: rail') == "# noqa: rail"
+
+
+def test_manual_comment_token_comment_in_string() -> None:
+    assert _manual_comment_token('message = "hello # noqa: rail"') is None


### PR DESCRIPTION
Closes #1415. Hardens unit test coverage of the test path portability guardrails and the shared suppressions parser to 100%.