### PR TITLE
Harden xdist-loadgroup rail suppression and bypass coverage

### DIFF
--- a/scripts/ci/guardrails/check_xdist_loadgroup.py
+++ b/scripts/ci/guardrails/check_xdist_loadgroup.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution path
 
 
 def _calls_getbasetemp(node: ast.AST, wrapper_names: frozenset[str] = frozenset()) -> bool:
+    """Return True if `node` calls `.getbasetemp()` directly or via a known wrapper name."""
     for child in ast.walk(node):
         if not isinstance(child, ast.Call):
             continue
@@ -60,6 +61,8 @@ def _has_xdist_group_marker(
     mark_aliases: frozenset[str] = frozenset(),
     xdist_group_aliases: frozenset[str] = frozenset(),
 ) -> bool:
+    """Return True if any decorator expr is an `xdist_group` marker, recognizing
+    `pytest.mark.xdist_group`, aliased `mark` imports, and aliased `xdist_group` imports."""
     for dec in decorators:
         call = dec if isinstance(dec, ast.Call) else None
         func = call.func if call is not None else dec
@@ -116,6 +119,9 @@ def _pytestmark_exprs(body: list[ast.stmt]) -> list[ast.expr]:
 
 
 class _Visitor(ast.NodeVisitor):
+    """Walks a test module, flagging test functions that reach `getbasetemp()`
+    (directly or via a wrapper) without an applicable `xdist_group` marker."""
+
     def __init__(
         self,
         lines: list[str],
@@ -133,9 +139,13 @@ class _Visitor(ast.NodeVisitor):
         self._class_has_marker: list[bool] = []
 
     def _has_marker(self, exprs: list[ast.expr]) -> bool:
+        """Return True if any of `exprs` (decorators or pytestmark entries) is an
+        xdist_group marker, given this visitor's collected import aliases."""
         return _has_xdist_group_marker(exprs, self.mark_aliases, self.xdist_group_aliases)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """Track whether the enclosing class carries an xdist_group marker (via
+        decorator or class-level pytestmark) for nested test functions."""
         class_marker = self._has_marker(node.decorator_list) or self._has_marker(
             _pytestmark_exprs(node.body)
         )
@@ -144,10 +154,12 @@ class _Visitor(ast.NodeVisitor):
         self._class_has_marker.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Check this function for the violation, then recurse into nested defs."""
         self._check_function(node)
         self.generic_visit(node)
 
     def _check_function(self, node: ast.FunctionDef) -> None:
+        """Record a violation if `node` is an unmarked test reaching getbasetemp()."""
         if not node.name.startswith("test_"):
             return
         if not _calls_getbasetemp(node, self.wrapper_names):

--- a/scripts/ci/guardrails/check_xdist_loadgroup.py
+++ b/scripts/ci/guardrails/check_xdist_loadgroup.py
@@ -37,20 +37,22 @@ def _calls_getbasetemp(node: ast.AST, wrapper_names: frozenset[str] = frozenset(
 def _collect_wrapper_names(tree: ast.AST) -> frozenset[str]:
     """Find same-file functions/methods that call getbasetemp() directly,
     then expand to functions that call those wrappers, fixed-point style,
-    so chained helpers are also caught."""
-    defs: dict[str, ast.AST] = {}
+    so chained helpers are also caught. Same-named defs in different scopes
+    (e.g. two classes with a like-named method) are tracked separately so one
+    doesn't shadow and silently drop another."""
+    defs_by_name: dict[str, list[ast.AST]] = {}
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            defs[node.name] = node
+            defs_by_name.setdefault(node.name, []).append(node)
 
     wrapper_names: set[str] = set()
     changed = True
     while changed:
         changed = False
-        for name, node in defs.items():
+        for name, nodes in defs_by_name.items():
             if name in wrapper_names:
                 continue
-            if _calls_getbasetemp(node, frozenset(wrapper_names)):
+            if any(_calls_getbasetemp(node, frozenset(wrapper_names)) for node in nodes):
                 wrapper_names.add(name)
                 changed = True
     return frozenset(wrapper_names)

--- a/scripts/ci/guardrails/check_xdist_loadgroup.py
+++ b/scripts/ci/guardrails/check_xdist_loadgroup.py
@@ -20,39 +20,126 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution path
     from suppressions import has_targeted_noqa
 
 
-def _calls_getbasetemp(node: ast.AST) -> bool:
+def _calls_getbasetemp(node: ast.AST, wrapper_names: frozenset[str] = frozenset()) -> bool:
     for child in ast.walk(node):
-        if (
-            isinstance(child, ast.Call)
-            and isinstance(child.func, ast.Attribute)
-            and child.func.attr == "getbasetemp"
-        ):
+        if not isinstance(child, ast.Call):
+            continue
+        if isinstance(child.func, ast.Attribute) and child.func.attr == "getbasetemp":
+            return True
+        if isinstance(child.func, ast.Name) and child.func.id in wrapper_names:
+            return True
+        if isinstance(child.func, ast.Attribute) and child.func.attr in wrapper_names:
             return True
     return False
 
 
-def _has_xdist_group_marker(decorators: list[ast.expr]) -> bool:
+def _collect_wrapper_names(tree: ast.AST) -> frozenset[str]:
+    """Find same-file functions/methods that call getbasetemp() directly,
+    then expand to functions that call those wrappers, fixed-point style,
+    so chained helpers are also caught."""
+    defs: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            defs[node.name] = node
+
+    wrapper_names: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for name, node in defs.items():
+            if name in wrapper_names:
+                continue
+            if _calls_getbasetemp(node, frozenset(wrapper_names)):
+                wrapper_names.add(name)
+                changed = True
+    return frozenset(wrapper_names)
+
+
+def _has_xdist_group_marker(
+    decorators: list[ast.expr],
+    mark_aliases: frozenset[str] = frozenset(),
+    xdist_group_aliases: frozenset[str] = frozenset(),
+) -> bool:
     for dec in decorators:
         call = dec if isinstance(dec, ast.Call) else None
         func = call.func if call is not None else dec
         if (
             isinstance(func, ast.Attribute)
             and func.attr == "xdist_group"
-            and isinstance(func.value, ast.Attribute)
-            and func.value.attr == "mark"
+            and (
+                (isinstance(func.value, ast.Attribute) and func.value.attr == "mark")
+                or (isinstance(func.value, ast.Name) and func.value.id in mark_aliases)
+            )
         ):
+            return True
+        if isinstance(func, ast.Name) and func.id in xdist_group_aliases:
             return True
     return False
 
 
+def _collect_mark_aliases(tree: ast.AST) -> tuple[frozenset[str], frozenset[str]]:
+    """Track `from pytest import mark` and `from pytest.mark import xdist_group`
+    aliases so decorator/pytestmark detection isn't fooled by import style."""
+    mark_aliases: set[str] = set()
+    xdist_group_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module == "pytest":
+            for alias in node.names:
+                if alias.name == "mark":
+                    mark_aliases.add(alias.asname or alias.name)
+        elif node.module == "pytest.mark":
+            for alias in node.names:
+                if alias.name == "xdist_group":
+                    xdist_group_aliases.add(alias.asname or alias.name)
+    return frozenset(mark_aliases), frozenset(xdist_group_aliases)
+
+
+def _pytestmark_exprs(body: list[ast.stmt]) -> list[ast.expr]:
+    """Return marker expressions assigned via a `pytestmark = [...]` (or bare)
+    statement in a module or class body."""
+    exprs: list[ast.expr] = []
+    for stmt in body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "pytestmark" for target in stmt.targets
+        ):
+            continue
+        value = stmt.value
+        if isinstance(value, (ast.List, ast.Tuple)):
+            exprs.extend(value.elts)
+        else:
+            exprs.append(value)
+    return exprs
+
+
 class _Visitor(ast.NodeVisitor):
-    def __init__(self, lines: list[str]) -> None:
+    def __init__(
+        self,
+        lines: list[str],
+        wrapper_names: frozenset[str] = frozenset(),
+        mark_aliases: frozenset[str] = frozenset(),
+        xdist_group_aliases: frozenset[str] = frozenset(),
+        module_has_marker: bool = False,
+    ) -> None:
         self.lines = lines
+        self.wrapper_names = wrapper_names
+        self.mark_aliases = mark_aliases
+        self.xdist_group_aliases = xdist_group_aliases
+        self.module_has_marker = module_has_marker
         self.violations: list[tuple[int, str]] = []
         self._class_has_marker: list[bool] = []
 
+    def _has_marker(self, exprs: list[ast.expr]) -> bool:
+        return _has_xdist_group_marker(exprs, self.mark_aliases, self.xdist_group_aliases)
+
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        self._class_has_marker.append(_has_xdist_group_marker(node.decorator_list))
+        class_marker = self._has_marker(node.decorator_list) or self._has_marker(
+            _pytestmark_exprs(node.body)
+        )
+        self._class_has_marker.append(class_marker)
         self.generic_visit(node)
         self._class_has_marker.pop()
 
@@ -63,11 +150,11 @@ class _Visitor(ast.NodeVisitor):
     def _check_function(self, node: ast.FunctionDef) -> None:
         if not node.name.startswith("test_"):
             return
-        if not _calls_getbasetemp(node):
+        if not _calls_getbasetemp(node, self.wrapper_names):
             return
-        func_has_marker = _has_xdist_group_marker(node.decorator_list)
+        func_has_marker = self._has_marker(node.decorator_list)
         class_has_marker = any(self._class_has_marker)
-        if func_has_marker or class_has_marker:
+        if func_has_marker or class_has_marker or self.module_has_marker:
             return
 
         line_idx = node.lineno - 1
@@ -101,7 +188,18 @@ def check_file(filepath: Path) -> list[tuple[int, str]]:
         print(f"Syntax error in {filepath}: {exc}", file=sys.stderr)
         return []
 
-    visitor = _Visitor(lines)
+    wrapper_names = _collect_wrapper_names(tree)
+    mark_aliases, xdist_group_aliases = _collect_mark_aliases(tree)
+    module_has_marker = _has_xdist_group_marker(
+        _pytestmark_exprs(tree.body), mark_aliases, xdist_group_aliases
+    )
+    visitor = _Visitor(
+        lines,
+        wrapper_names,
+        mark_aliases,
+        xdist_group_aliases,
+        module_has_marker,
+    )
     visitor.visit(tree)
     return visitor.violations
 

--- a/tests/ci/test_check_xdist_loadgroup.py
+++ b/tests/ci/test_check_xdist_loadgroup.py
@@ -79,3 +79,161 @@ def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert len(checker.check_file(src)) == 1
+
+
+def test_unrelated_noqa_code_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "unrelated_noqa.py"
+    src.write_text(
+        "def test_x(tmp_path_factory):  # noqa: some-other-rail\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_marker_text_in_comment_does_not_count_as_marker(tmp_path: Path) -> None:
+    src = tmp_path / "comment_text.py"
+    src.write_text(
+        "# This test should use xdist_group but doesn't.\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_unrelated_marker_does_not_count_as_safe(tmp_path: Path) -> None:
+    src = tmp_path / "unrelated_marker.py"
+    src.write_text(
+        "import pytest\n"
+        "@pytest.mark.slow\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_marker_on_helper_function_does_not_protect_caller(tmp_path: Path) -> None:
+    src = tmp_path / "helper_marker.py"
+    src.write_text(
+        "import pytest\n"
+        "@pytest.mark.xdist_group(name='shared-temp')\n"
+        "def helper():\n"
+        "    pass\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_flags_call_to_wrapper_around_getbasetemp(tmp_path: Path) -> None:
+    src = tmp_path / "wrapper.py"
+    src.write_text(
+        "def _shared_tmp_root(tmp_path_factory):\n"
+        "    return tmp_path_factory.getbasetemp()\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = _shared_tmp_root(tmp_path_factory)\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_allows_marker_via_aliased_mark_import(tmp_path: Path) -> None:
+    src = tmp_path / "aliased_mark.py"
+    src.write_text(
+        "from pytest import mark\n"
+        "@mark.xdist_group(name='shared-temp')\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_marker_via_aliased_xdist_group_import(tmp_path: Path) -> None:
+    src = tmp_path / "aliased_xdist_group.py"
+    src.write_text(
+        "from pytest.mark import xdist_group\n"
+        "@xdist_group(name='shared-temp')\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_module_level_pytestmark_xdist_group(tmp_path: Path) -> None:
+    src = tmp_path / "module_pytestmark.py"
+    src.write_text(
+        "import pytest\n"
+        "pytestmark = [pytest.mark.xdist_group(name='shared-temp')]\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_module_level_pytestmark_single_value(tmp_path: Path) -> None:
+    src = tmp_path / "module_pytestmark_single.py"
+    src.write_text(
+        "import pytest\n"
+        "pytestmark = pytest.mark.xdist_group(name='shared-temp')\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_allows_class_level_pytestmark_attribute(tmp_path: Path) -> None:
+    src = tmp_path / "class_pytestmark.py"
+    src.write_text(
+        "import pytest\n"
+        "class TestX:\n"
+        "    pytestmark = [pytest.mark.xdist_group(name='shared-temp')]\n"
+        "    def test_x(self, tmp_path_factory):\n"
+        "        base = tmp_path_factory.getbasetemp()\n"
+        "        assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_unrelated_module_level_pytestmark_does_not_suppress(tmp_path: Path) -> None:
+    src = tmp_path / "unrelated_module_pytestmark.py"
+    src.write_text(
+        "import pytest\n"
+        "pytestmark = [pytest.mark.slow]\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = tmp_path_factory.getbasetemp()\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_allows_wrapper_call_with_xdist_group_marker(tmp_path: Path) -> None:
+    src = tmp_path / "wrapper_marked.py"
+    src.write_text(
+        "import pytest\n"
+        "def _shared_tmp_root(tmp_path_factory):\n"
+        "    return tmp_path_factory.getbasetemp()\n"
+        "@pytest.mark.xdist_group(name='shared-temp')\n"
+        "def test_x(tmp_path_factory):\n"
+        "    base = _shared_tmp_root(tmp_path_factory)\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []

--- a/tests/ci/test_check_xdist_loadgroup.py
+++ b/tests/ci/test_check_xdist_loadgroup.py
@@ -237,3 +237,21 @@ def test_allows_wrapper_call_with_xdist_group_marker(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert checker.check_file(src) == []
+
+
+def test_wrapper_name_collision_across_classes_still_detected(tmp_path: Path) -> None:
+    src = tmp_path / "collision.py"
+    src.write_text(
+        "class ClassA:\n"
+        "    def helper(self, tmp_path_factory):\n"
+        "        return tmp_path_factory.getbasetemp()\n"
+        "class ClassB:\n"
+        "    def helper(self, x):\n"
+        "        return x + 1\n"
+        "def test_x(tmp_path_factory):\n"
+        "    a = ClassA()\n"
+        "    base = a.helper(tmp_path_factory)\n"
+        "    assert base.exists()\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1


### PR DESCRIPTION
## Summary
- Closes #1416 (and its detector-hardening addendum comment).
- The `xdist-loadgroup` rail (`scripts/ci/guardrails/check_xdist_loadgroup.py`) now detects same-file wrapper functions that call `tmp_path_factory.getbasetemp()` internally — tests calling such a wrapper without an `xdist_group` marker are now flagged (previously missed entirely).
- The rail no longer false-positives on properly-marked tests that use `from pytest import mark` / `from pytest.mark import xdist_group` import aliases, or module-/class-level `pytestmark = [...]` lists, instead of the bare `@pytest.mark.xdist_group(...)` decorator shape.
- Added regression tests confirming the rail does **not** treat marker text in comments, unrelated pytest markers, or markers on unrelated helper functions as safe, and that bare/unrelated `noqa` codes don't suppress violations.

## Test plan
- [x] `pytest tests/ci/test_check_xdist_loadgroup.py -q --override-ini="addopts="` — 18 passed
- [x] `pytest tests/ci -q --override-ini="addopts="` — 931 passed
- [x] `python scripts/ci/guardrails/check_xdist_loadgroup.py` — exits 0, no violations
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` on changed file — only a pre-existing, unrelated `no-redef` warning present on `main` already
- Note: pre-commit's `diff-cover` hook (which reruns the full slow test suite) was bypassed for this commit (`--no-verify`, with explicit authorization) after three runs each failed on a different set of unrelated, flaky plugin/video/audio-integration tests under xdist worker contention — none touching the two files changed here. The directly relevant `pytest (ci guardrails)` and `ci rails` hooks passed in every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unsafe temporary-directory sharing in CI checks, including cases where the call happens through helper/wrapper functions.
  * Better recognition of existing safety markers, including alternate import styles and module/class-level marker declarations.
  * Reduced false positives by correctly ignoring unrelated markers and comments that only look like markers.

* **Tests**
  * Expanded coverage for allowed and blocked scenarios around shared temporary-directory usage and marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->