### PR TITLE
[codex] Harden defusedxml fallback rail coverage

### DIFF
--- a/scripts/ci/guardrails/ast_helpers.py
+++ b/scripts/ci/guardrails/ast_helpers.py
@@ -1,0 +1,18 @@
+"""Shared AST helpers for CI guardrails."""
+
+from __future__ import annotations
+
+import ast
+
+
+def extract_name_targets(node: ast.AST) -> set[str]:
+    """Recursively extract all Name ID targets from a binding pattern."""
+    names: set[str] = set()
+    if isinstance(node, ast.Name):
+        names.add(node.id)
+    elif isinstance(node, ast.Starred):
+        names.update(extract_name_targets(node.value))
+    elif isinstance(node, (ast.Tuple, ast.List)):
+        for elt in node.elts:
+            names.update(extract_name_targets(elt))
+    return names

--- a/scripts/ci/guardrails/check_defusedxml_fallback.py
+++ b/scripts/ci/guardrails/check_defusedxml_fallback.py
@@ -67,20 +67,22 @@ class DefusedXmlVisitor(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         string_value = self._literal_string_value(node.value)
-        if string_value is not None:
-            for target in node.targets:
+        xml_module = self._stdlib_xml_dynamic_import(node.value)
+        uses_xml_alias = self._expr_uses_stdlib_xml_alias(node.value)
+        returns_xml_alias = self._returns_stdlib_xml_alias(node.value)
+
+        for target in node.targets:
+            self._clear_target_state(target)
+            if string_value is not None:
                 for name in extract_name_targets(target):
                     self.scope.string_bindings[name] = string_value
 
-        xml_module = self._stdlib_xml_dynamic_import(node.value)
         if xml_module is not None:
             for target in node.targets:
                 self.scope.stdlib_xml_aliases.update(self._target_keys(target))
             self._reported_dynamic_imports.add(id(node.value))
             self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
-        elif self._expr_uses_stdlib_xml_alias(node.value) or self._returns_stdlib_xml_alias(
-            node.value
-        ):
+        elif uses_xml_alias or returns_xml_alias:
             for target in node.targets:
                 self.scope.stdlib_xml_aliases.update(self._target_keys(target))
         self.generic_visit(node)
@@ -88,37 +90,41 @@ class DefusedXmlVisitor(ast.NodeVisitor):
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if node.value is not None:
             string_value = self._literal_string_value(node.value)
+            xml_module = self._stdlib_xml_dynamic_import(node.value)
+            uses_xml_alias = self._expr_uses_stdlib_xml_alias(node.value)
+            returns_xml_alias = self._returns_stdlib_xml_alias(node.value)
+
+            self._clear_target_state(node.target)
             if string_value is not None:
                 for name in extract_name_targets(node.target):
                     self.scope.string_bindings[name] = string_value
 
-            xml_module = self._stdlib_xml_dynamic_import(node.value)
             if xml_module is not None:
                 self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
                 self._reported_dynamic_imports.add(id(node.value))
                 self.add_violation(
                     node, f"dynamic standard library import '{xml_module}' is unsafe"
                 )
-            elif self._expr_uses_stdlib_xml_alias(node.value) or self._returns_stdlib_xml_alias(
-                node.value
-            ):
+            elif uses_xml_alias or returns_xml_alias:
                 self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
         self.generic_visit(node)
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         string_value = self._literal_string_value(node.value)
+        xml_module = self._stdlib_xml_dynamic_import(node.value)
+        uses_xml_alias = self._expr_uses_stdlib_xml_alias(node.value)
+        returns_xml_alias = self._returns_stdlib_xml_alias(node.value)
+
+        self._clear_target_state(node.target)
         if string_value is not None:
             for name in extract_name_targets(node.target):
                 self.scope.string_bindings[name] = string_value
 
-        xml_module = self._stdlib_xml_dynamic_import(node.value)
         if xml_module is not None:
             self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
             self._reported_dynamic_imports.add(id(node.value))
             self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
-        elif self._expr_uses_stdlib_xml_alias(node.value) or self._returns_stdlib_xml_alias(
-            node.value
-        ):
+        elif uses_xml_alias or returns_xml_alias:
             self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
         self.generic_visit(node)
 
@@ -208,10 +214,7 @@ class DefusedXmlVisitor(ast.NodeVisitor):
     def _function_returns_stdlib_xml_alias(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef
     ) -> bool:
-        for child in ast.walk(node):
-            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-                if child is not node:
-                    continue
+        for child in self._walk_current_scope(node.body):
             if isinstance(child, ast.Return) and child.value is not None:
                 if self._expr_uses_stdlib_xml_alias(child.value):
                     return True
@@ -268,24 +271,52 @@ class DefusedXmlVisitor(ast.NodeVisitor):
             + ([node.args.kwarg] if node.args.kwarg else [])
         )
         binders.update(arg.arg for arg in args)
-        for child in node.body:
-            for nested in ast.walk(child):
-                if isinstance(nested, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-                    continue
-                if isinstance(nested, ast.Assign):
-                    for target in nested.targets:
-                        binders.update(extract_name_targets(target))
-                elif isinstance(nested, ast.AnnAssign):
-                    binders.update(extract_name_targets(nested.target))
-                elif isinstance(nested, ast.NamedExpr):
-                    binders.update(extract_name_targets(nested.target))
-                elif isinstance(nested, (ast.For, ast.AsyncFor)):
-                    binders.update(extract_name_targets(nested.target))
-                elif isinstance(nested, (ast.With, ast.AsyncWith)):
-                    for item in nested.items:
-                        if item.optional_vars is not None:
-                            binders.update(extract_name_targets(item.optional_vars))
+        for nested in self._walk_current_scope(node.body):
+            if isinstance(nested, ast.Assign):
+                for target in nested.targets:
+                    binders.update(extract_name_targets(target))
+            elif isinstance(nested, ast.AnnAssign):
+                binders.update(extract_name_targets(nested.target))
+            elif isinstance(nested, ast.NamedExpr):
+                binders.update(extract_name_targets(nested.target))
+            elif isinstance(nested, (ast.For, ast.AsyncFor)):
+                binders.update(extract_name_targets(nested.target))
+            elif isinstance(nested, (ast.With, ast.AsyncWith)):
+                for item in nested.items:
+                    if item.optional_vars is not None:
+                        binders.update(extract_name_targets(item.optional_vars))
         return binders
+
+    def _walk_current_scope(self, body: list[ast.stmt]) -> list[ast.AST]:
+        nodes: list[ast.AST] = []
+        stack: list[ast.AST] = list(reversed(body))
+        while stack:
+            node = stack.pop()
+            nodes.append(node)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+                continue
+            stack.extend(reversed(list(ast.iter_child_nodes(node))))
+        return nodes
+
+    def _clear_target_state(self, target: ast.AST) -> None:
+        target_keys = self._target_keys(target)
+        target_names = extract_name_targets(target)
+
+        for name in target_names:
+            self.scope.string_bindings.pop(name, None)
+            self.scope.import_module_aliases.discard(name)
+            self.scope.xml_alias_factories.discard(name)
+
+        self.scope.stdlib_xml_aliases = {
+            alias
+            for alias in self.scope.stdlib_xml_aliases
+            if not self._matches_target(alias, target_keys)
+        }
+        self.scope.importlib_aliases = {
+            alias
+            for alias in self.scope.importlib_aliases
+            if not self._matches_target(alias, target_keys)
+        }
 
     def _target_keys(self, target: ast.AST) -> set[str]:
         if isinstance(target, (ast.Name, ast.Attribute)):
@@ -320,6 +351,9 @@ class DefusedXmlVisitor(ast.NodeVisitor):
 
     def _root_name(self, key: str) -> str:
         return key.split(".", maxsplit=1)[0]
+
+    def _matches_target(self, alias: str, target_keys: set[str]) -> bool:
+        return any(alias == key or alias.startswith(f"{key}.") for key in target_keys)
 
     def add_violation(self, node: ast.AST, message: str) -> None:
         lineno = node.lineno

--- a/scripts/ci/guardrails/check_defusedxml_fallback.py
+++ b/scripts/ci/guardrails/check_defusedxml_fallback.py
@@ -24,17 +24,99 @@ class DefusedXmlVisitor(ast.NodeVisitor):
         self.filepath = filepath
         self.lines = lines
         self.violations: list[tuple[int, str, str]] = []
+        self.stdlib_xml_aliases: set[str] = set()
+        self.importlib_aliases: set[str] = {"importlib"}
+        self.import_module_aliases: set[str] = set()
+        self._reported_dynamic_imports: set[int] = set()
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             if alias.name == "xml" or alias.name.startswith("xml."):
+                self.stdlib_xml_aliases.add(alias.asname or alias.name.split(".", maxsplit=1)[0])
                 self.add_violation(node, f"standard library import '{alias.name}' is unsafe")
+            elif alias.name == "importlib":
+                self.importlib_aliases.add(alias.asname or alias.name)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if node.module == "xml" or (node.module and node.module.startswith("xml.")):
+            for alias in node.names:
+                self.stdlib_xml_aliases.add(alias.asname or alias.name)
             self.add_violation(node, f"standard library import from '{node.module}' is unsafe")
+        elif node.module == "importlib":
+            for alias in node.names:
+                if alias.name == "import_module":
+                    self.import_module_aliases.add(alias.asname or alias.name)
         self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        xml_module = self._stdlib_xml_dynamic_import(node.value)
+        if xml_module is not None:
+            for target in node.targets:
+                for name in self._target_names(target):
+                    self.stdlib_xml_aliases.add(name)
+            self._reported_dynamic_imports.add(id(node.value))
+            self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            xml_module = self._stdlib_xml_dynamic_import(node.value)
+            if xml_module is not None:
+                for name in self._target_names(node.target):
+                    self.stdlib_xml_aliases.add(name)
+                self._reported_dynamic_imports.add(id(node.value))
+                self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        xml_module = self._stdlib_xml_dynamic_import(node)
+        if xml_module is not None and id(node) not in self._reported_dynamic_imports:
+            self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
+        elif self._uses_stdlib_xml_parser_alias(node):
+            self.add_violation(node, "standard library XML parser constructed through alias is unsafe")
+        self.generic_visit(node)
+
+    def _stdlib_xml_dynamic_import(self, node: ast.AST) -> str | None:
+        if not isinstance(node, ast.Call):
+            return None
+
+        module_arg: ast.AST | None = None
+        if isinstance(node.func, ast.Name) and node.func.id == "__import__":
+            module_arg = node.args[0] if node.args else None
+        elif isinstance(node.func, ast.Name) and node.func.id in self.import_module_aliases:
+            module_arg = node.args[0] if node.args else None
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "import_module"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in self.importlib_aliases
+        ):
+            module_arg = node.args[0] if node.args else None
+
+        if not isinstance(module_arg, ast.Constant) or not isinstance(module_arg.value, str):
+            return None
+        module_name = module_arg.value
+        if module_name == "xml" or module_name.startswith("xml."):
+            return module_name
+        return None
+
+    def _uses_stdlib_xml_parser_alias(self, node: ast.Call) -> bool:
+        if not isinstance(node.func, ast.Attribute):
+            return False
+        if node.func.attr not in {"XMLParser", "XML", "fromstring", "parse", "iterparse"}:
+            return False
+        return isinstance(node.func.value, ast.Name) and node.func.value.id in self.stdlib_xml_aliases
+
+    def _target_names(self, target: ast.AST) -> set[str]:
+        if isinstance(target, ast.Name):
+            return {target.id}
+        if isinstance(target, (ast.Tuple, ast.List)):
+            names: set[str] = set()
+            for element in target.elts:
+                names.update(self._target_names(element))
+            return names
+        return set()
 
     def add_violation(self, node: ast.AST, message: str) -> None:
         lineno = node.lineno

--- a/scripts/ci/guardrails/check_defusedxml_fallback.py
+++ b/scripts/ci/guardrails/check_defusedxml_fallback.py
@@ -9,12 +9,24 @@ from __future__ import annotations
 
 import ast
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 try:
+    from scripts.ci.guardrails.ast_helpers import extract_name_targets
     from scripts.ci.guardrails.suppressions import has_targeted_noqa
 except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from ast_helpers import extract_name_targets
     from suppressions import has_targeted_noqa
+
+
+@dataclass
+class _Scope:
+    stdlib_xml_aliases: set[str] = field(default_factory=set)
+    string_bindings: dict[str, str] = field(default_factory=dict)
+    importlib_aliases: set[str] = field(default_factory=lambda: {"importlib"})
+    import_module_aliases: set[str] = field(default_factory=set)
+    xml_alias_factories: set[str] = field(default_factory=set)
 
 
 class DefusedXmlVisitor(ast.NodeVisitor):
@@ -24,52 +36,101 @@ class DefusedXmlVisitor(ast.NodeVisitor):
         self.filepath = filepath
         self.lines = lines
         self.violations: list[tuple[int, str, str]] = []
-        self.stdlib_xml_aliases: set[str] = set()
-        self.importlib_aliases: set[str] = {"importlib"}
-        self.import_module_aliases: set[str] = set()
+        self.scopes: list[_Scope] = [_Scope()]
         self._reported_dynamic_imports: set[int] = set()
+
+    @property
+    def scope(self) -> _Scope:
+        return self.scopes[-1]
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             if alias.name == "xml" or alias.name.startswith("xml."):
-                self.stdlib_xml_aliases.add(alias.asname or alias.name.split(".", maxsplit=1)[0])
+                self.scope.stdlib_xml_aliases.add(
+                    alias.asname or alias.name.split(".", maxsplit=1)[0]
+                )
                 self.add_violation(node, f"standard library import '{alias.name}' is unsafe")
-            elif alias.name == "importlib":
-                self.importlib_aliases.add(alias.asname or alias.name)
+            elif alias.name == "importlib" or alias.name.startswith("importlib."):
+                self.scope.importlib_aliases.add(alias.asname or alias.name)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if node.module == "xml" or (node.module and node.module.startswith("xml.")):
             for alias in node.names:
-                self.stdlib_xml_aliases.add(alias.asname or alias.name)
+                self.scope.stdlib_xml_aliases.add(alias.asname or alias.name)
             self.add_violation(node, f"standard library import from '{node.module}' is unsafe")
         elif node.module == "importlib":
             for alias in node.names:
                 if alias.name == "import_module":
-                    self.import_module_aliases.add(alias.asname or alias.name)
+                    self.scope.import_module_aliases.add(alias.asname or alias.name)
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:
+        string_value = self._literal_string_value(node.value)
+        if string_value is not None:
+            for target in node.targets:
+                for name in extract_name_targets(target):
+                    self.scope.string_bindings[name] = string_value
+
         xml_module = self._stdlib_xml_dynamic_import(node.value)
         if xml_module is not None:
             for target in node.targets:
-                for name in self._target_names(target):
-                    self.stdlib_xml_aliases.add(name)
+                self.scope.stdlib_xml_aliases.update(self._target_keys(target))
             self._reported_dynamic_imports.add(id(node.value))
             self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
+        elif self._expr_uses_stdlib_xml_alias(node.value) or self._returns_stdlib_xml_alias(
+            node.value
+        ):
+            for target in node.targets:
+                self.scope.stdlib_xml_aliases.update(self._target_keys(target))
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if node.value is not None:
+            string_value = self._literal_string_value(node.value)
+            if string_value is not None:
+                for name in extract_name_targets(node.target):
+                    self.scope.string_bindings[name] = string_value
+
             xml_module = self._stdlib_xml_dynamic_import(node.value)
             if xml_module is not None:
-                for name in self._target_names(node.target):
-                    self.stdlib_xml_aliases.add(name)
+                self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
                 self._reported_dynamic_imports.add(id(node.value))
                 self.add_violation(
                     node, f"dynamic standard library import '{xml_module}' is unsafe"
                 )
+            elif self._expr_uses_stdlib_xml_alias(node.value) or self._returns_stdlib_xml_alias(
+                node.value
+            ):
+                self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
         self.generic_visit(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        string_value = self._literal_string_value(node.value)
+        if string_value is not None:
+            for name in extract_name_targets(node.target):
+                self.scope.string_bindings[name] = string_value
+
+        xml_module = self._stdlib_xml_dynamic_import(node.value)
+        if xml_module is not None:
+            self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
+            self._reported_dynamic_imports.add(id(node.value))
+            self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
+        elif self._expr_uses_stdlib_xml_alias(node.value) or self._returns_stdlib_xml_alias(
+            node.value
+        ):
+            self.scope.stdlib_xml_aliases.update(self._target_keys(node.target))
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self._function_returns_stdlib_xml_alias(node):
+            self.scope.xml_alias_factories.add(node.name)
+        self._visit_function_scope(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if self._function_returns_stdlib_xml_alias(node):
+            self.scope.xml_alias_factories.add(node.name)
+        self._visit_function_scope(node)
 
     def visit_Call(self, node: ast.Call) -> None:
         xml_module = self._stdlib_xml_dynamic_import(node)
@@ -87,22 +148,54 @@ class DefusedXmlVisitor(ast.NodeVisitor):
 
         module_arg: ast.AST | None = None
         if isinstance(node.func, ast.Name) and node.func.id == "__import__":
-            module_arg = node.args[0] if node.args else None
-        elif isinstance(node.func, ast.Name) and node.func.id in self.import_module_aliases:
-            module_arg = node.args[0] if node.args else None
+            module_arg = self._module_argument(node)
+        elif isinstance(node.func, ast.Name) and node.func.id in self.scope.import_module_aliases:
+            module_arg = self._module_argument(node)
         elif (
             isinstance(node.func, ast.Attribute)
             and node.func.attr == "import_module"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id in self.importlib_aliases
+            and self._expr_key(node.func.value) in self.scope.importlib_aliases
         ):
-            module_arg = node.args[0] if node.args else None
+            module_arg = self._module_argument(node)
 
-        if not isinstance(module_arg, ast.Constant) or not isinstance(module_arg.value, str):
+        module_name = self._literal_string_value(module_arg)
+        if module_name is None:
             return None
-        module_name = module_arg.value
         if module_name == "xml" or module_name.startswith("xml."):
             return module_name
+        return None
+
+    def _module_argument(self, node: ast.Call) -> ast.AST | None:
+        if node.args:
+            return node.args[0]
+        for keyword in node.keywords:
+            if keyword.arg == "name":
+                return keyword.value
+        return None
+
+    def _literal_string_value(self, node: ast.AST | None) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            return self.scope.string_bindings.get(node.id)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left = self._literal_string_value(node.left)
+            right = self._literal_string_value(node.right)
+            if left is not None and right is not None:
+                return left + right
+        if isinstance(node, ast.JoinedStr):
+            parts: list[str] = []
+            for value in node.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    parts.append(value.value)
+                elif isinstance(value, ast.FormattedValue):
+                    formatted = self._literal_string_value(value.value)
+                    if formatted is None:
+                        return None
+                    parts.append(formatted)
+                else:
+                    return None
+            return "".join(parts)
         return None
 
     def _uses_stdlib_xml_parser_alias(self, node: ast.Call) -> bool:
@@ -110,19 +203,123 @@ class DefusedXmlVisitor(ast.NodeVisitor):
             return False
         if node.func.attr not in {"XMLParser", "XML", "fromstring", "parse", "iterparse"}:
             return False
+        return self._expr_uses_stdlib_xml_alias(node.func.value)
+
+    def _function_returns_stdlib_xml_alias(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> bool:
+        for child in ast.walk(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                if child is not node:
+                    continue
+            if isinstance(child, ast.Return) and child.value is not None:
+                if self._expr_uses_stdlib_xml_alias(child.value):
+                    return True
+        return False
+
+    def _returns_stdlib_xml_alias(self, node: ast.AST) -> bool:
         return (
-            isinstance(node.func.value, ast.Name) and node.func.value.id in self.stdlib_xml_aliases
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in self.scope.xml_alias_factories
         )
 
-    def _target_names(self, target: ast.AST) -> set[str]:
-        if isinstance(target, ast.Name):
-            return {target.id}
+    def _expr_uses_stdlib_xml_alias(self, node: ast.AST) -> bool:
+        keys = self._expr_key_prefixes(node)
+        return any(key in self.scope.stdlib_xml_aliases for key in keys)
+
+    def _visit_function_scope(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        inherited = self.scope
+        local_binders = self._function_local_binders(node)
+        self.scopes.append(
+            _Scope(
+                stdlib_xml_aliases={
+                    alias
+                    for alias in inherited.stdlib_xml_aliases
+                    if self._root_name(alias) not in local_binders
+                },
+                string_bindings={
+                    name: value
+                    for name, value in inherited.string_bindings.items()
+                    if name not in local_binders
+                },
+                importlib_aliases={
+                    alias
+                    for alias in inherited.importlib_aliases
+                    if self._root_name(alias) not in local_binders
+                },
+                import_module_aliases=inherited.import_module_aliases - local_binders,
+                xml_alias_factories=inherited.xml_alias_factories - local_binders,
+            )
+        )
+        try:
+            for child in node.body:
+                self.visit(child)
+        finally:
+            self.scopes.pop()
+
+    def _function_local_binders(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+        binders: set[str] = set()
+        args = (
+            node.args.posonlyargs
+            + node.args.args
+            + node.args.kwonlyargs
+            + ([node.args.vararg] if node.args.vararg else [])
+            + ([node.args.kwarg] if node.args.kwarg else [])
+        )
+        binders.update(arg.arg for arg in args)
+        for child in node.body:
+            for nested in ast.walk(child):
+                if isinstance(nested, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                    continue
+                if isinstance(nested, ast.Assign):
+                    for target in nested.targets:
+                        binders.update(extract_name_targets(target))
+                elif isinstance(nested, ast.AnnAssign):
+                    binders.update(extract_name_targets(nested.target))
+                elif isinstance(nested, ast.NamedExpr):
+                    binders.update(extract_name_targets(nested.target))
+                elif isinstance(nested, (ast.For, ast.AsyncFor)):
+                    binders.update(extract_name_targets(nested.target))
+                elif isinstance(nested, (ast.With, ast.AsyncWith)):
+                    for item in nested.items:
+                        if item.optional_vars is not None:
+                            binders.update(extract_name_targets(item.optional_vars))
+        return binders
+
+    def _target_keys(self, target: ast.AST) -> set[str]:
+        if isinstance(target, (ast.Name, ast.Attribute)):
+            key = self._expr_key(target)
+            return {key} if key is not None else set()
+        if isinstance(target, ast.NamedExpr):
+            return self._target_keys(target.target)
+        if isinstance(target, ast.Starred):
+            return self._target_keys(target.value)
         if isinstance(target, (ast.Tuple, ast.List)):
-            names: set[str] = set()
+            keys: set[str] = set()
             for element in target.elts:
-                names.update(self._target_names(element))
-            return names
+                keys.update(self._target_keys(element))
+            return keys
         return set()
+
+    def _expr_key_prefixes(self, node: ast.AST) -> list[str]:
+        key = self._expr_key(node)
+        if key is None:
+            return []
+        parts = key.split(".")
+        return [".".join(parts[:idx]) for idx in range(1, len(parts) + 1)]
+
+    def _expr_key(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            parent = self._expr_key(node.value)
+            if parent is not None:
+                return f"{parent}.{node.attr}"
+        return None
+
+    def _root_name(self, key: str) -> str:
+        return key.split(".", maxsplit=1)[0]
 
     def add_violation(self, node: ast.AST, message: str) -> None:
         lineno = node.lineno

--- a/scripts/ci/guardrails/check_defusedxml_fallback.py
+++ b/scripts/ci/guardrails/check_defusedxml_fallback.py
@@ -66,7 +66,9 @@ class DefusedXmlVisitor(ast.NodeVisitor):
                 for name in self._target_names(node.target):
                     self.stdlib_xml_aliases.add(name)
                 self._reported_dynamic_imports.add(id(node.value))
-                self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
+                self.add_violation(
+                    node, f"dynamic standard library import '{xml_module}' is unsafe"
+                )
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -74,7 +76,9 @@ class DefusedXmlVisitor(ast.NodeVisitor):
         if xml_module is not None and id(node) not in self._reported_dynamic_imports:
             self.add_violation(node, f"dynamic standard library import '{xml_module}' is unsafe")
         elif self._uses_stdlib_xml_parser_alias(node):
-            self.add_violation(node, "standard library XML parser constructed through alias is unsafe")
+            self.add_violation(
+                node, "standard library XML parser constructed through alias is unsafe"
+            )
         self.generic_visit(node)
 
     def _stdlib_xml_dynamic_import(self, node: ast.AST) -> str | None:
@@ -106,7 +110,9 @@ class DefusedXmlVisitor(ast.NodeVisitor):
             return False
         if node.func.attr not in {"XMLParser", "XML", "fromstring", "parse", "iterparse"}:
             return False
-        return isinstance(node.func.value, ast.Name) and node.func.value.id in self.stdlib_xml_aliases
+        return (
+            isinstance(node.func.value, ast.Name) and node.func.value.id in self.stdlib_xml_aliases
+        )
 
     def _target_names(self, target: ast.AST) -> set[str]:
         if isinstance(target, ast.Name):

--- a/scripts/ci/guardrails/check_safedir_valueerror.py
+++ b/scripts/ci/guardrails/check_safedir_valueerror.py
@@ -32,8 +32,10 @@ import sys
 from pathlib import Path
 
 try:
+    from scripts.ci.guardrails.ast_helpers import extract_name_targets
     from scripts.ci.guardrails.suppressions import has_targeted_noqa
 except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from ast_helpers import extract_name_targets
     from suppressions import has_targeted_noqa
 
 _SAFEDIR_METHODS = {
@@ -71,17 +73,6 @@ def _collect_safedir_aliases(tree: ast.AST) -> set[str]:
     return aliases
 
 
-def _extract_names(node: ast.AST) -> set[str]:
-    """Recursively extract all Name ID targets from a binding pattern."""
-    names: set[str] = set()
-    if isinstance(node, ast.Name):
-        names.add(node.id)
-    elif isinstance(node, (ast.Tuple, ast.List)):
-        for elt in node.elts:
-            names.update(_extract_names(elt))
-    return names
-
-
 def _collect_local_binders(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     """Collect all local binder names in the function scope (excluding nested functions)."""
     binders: set[str] = set()
@@ -100,15 +91,15 @@ def _collect_local_binders(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[
     for node in _walk_excluding_nested_functions(func):
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                binders.update(_extract_names(target))
+                binders.update(extract_name_targets(target))
         elif isinstance(node, ast.AnnAssign):
-            binders.update(_extract_names(node.target))
+            binders.update(extract_name_targets(node.target))
         elif isinstance(node, (ast.For, ast.AsyncFor)):
-            binders.update(_extract_names(node.target))
+            binders.update(extract_name_targets(node.target))
         elif isinstance(node, (ast.With, ast.AsyncWith)):
             for item in node.items:
                 if item.optional_vars:
-                    binders.update(_extract_names(item.optional_vars))
+                    binders.update(extract_name_targets(item.optional_vars))
     return binders
 
 

--- a/tests/ci/test_check_defusedxml_fallback.py
+++ b/tests/ci/test_check_defusedxml_fallback.py
@@ -66,6 +66,55 @@ def test_flags_dynamic_importlib_stdlib_xml_import(tmp_path: Path) -> None:
     assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
 
 
+def test_flags_dynamic_importlib_variable_module_name(tmp_path: Path) -> None:
+    src = tmp_path / "dynamic_import_variable.py"
+    src.write_text(
+        "import importlib\n"
+        "mod_name = 'xml.etree.ElementTree'\n"
+        "ET = importlib.import_module(mod_name)\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
+
+
+def test_flags_dynamic_importlib_composed_module_name(tmp_path: Path) -> None:
+    src = tmp_path / "dynamic_import_composed.py"
+    src.write_text(
+        "import importlib\n"
+        "root = 'xml.etree'\n"
+        "ET = importlib.import_module(f'{root}.ElementTree')\n"
+        "DOM = importlib.import_module('xml.' + 'dom.minidom')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 2
+    assert all("dynamic standard library import" in violation[1] for violation in violations)
+
+
+def test_flags_dynamic_importlib_keyword_module_name(tmp_path: Path) -> None:
+    src = tmp_path / "dynamic_import_keyword.py"
+    src.write_text(
+        "import importlib\nET = importlib.import_module(name='xml.etree.ElementTree')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
+
+
+def test_flags_importlib_submodule_alias(tmp_path: Path) -> None:
+    src = tmp_path / "dynamic_import_submodule_alias.py"
+    src.write_text(
+        "import importlib.util as iu\nET = iu.import_module('xml.etree.ElementTree')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
+
+
 def test_flags_aliased_import_module_stdlib_xml_import(tmp_path: Path) -> None:
     src = tmp_path / "dynamic_import_alias.py"
     src.write_text(
@@ -97,6 +146,75 @@ def test_flags_parser_construction_through_resolved_alias(tmp_path: Path) -> Non
     violations = checker.check_file(src)
     assert len(violations) == 2
     assert "XML parser constructed through alias" in violations[1][1]
+
+
+def test_flags_multi_level_parser_call_through_suppressed_alias(tmp_path: Path) -> None:
+    src = tmp_path / "multi_level_parser_alias.py"
+    src.write_text(
+        "from xml import etree  # noqa: defusedxml-fallback\n"
+        "etree.ElementTree.parse('untrusted.xml')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "XML parser constructed through alias" in violations[0][1]
+
+
+def test_flags_attribute_target_parser_alias(tmp_path: Path) -> None:
+    src = tmp_path / "attribute_target.py"
+    src.write_text(
+        "import importlib\n"
+        "class Parser:\n"
+        "    def parse(self):\n"
+        "        self.mod = importlib.import_module('xml.etree.ElementTree')\n"
+        "        return self.mod.parse('untrusted.xml')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 2
+    assert "XML parser constructed through alias" in violations[1][1]
+
+
+def test_flags_walrus_target_parser_alias(tmp_path: Path) -> None:
+    src = tmp_path / "walrus_target.py"
+    src.write_text(
+        "import importlib\n"
+        "if ET := importlib.import_module('xml.etree.ElementTree'):\n"
+        "    ET.parse('untrusted.xml')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 2
+    assert "XML parser constructed through alias" in violations[1][1]
+
+
+def test_flags_wrapper_reexported_parser_alias(tmp_path: Path) -> None:
+    src = tmp_path / "wrapper_reexport.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n"
+        "def get_parser():\n"
+        "    return ET\n"
+        "mod = get_parser()\n"
+        "mod.parse('untrusted.xml')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "XML parser constructed through alias" in violations[0][1]
+
+
+def test_alias_tracking_does_not_cross_function_scope(tmp_path: Path) -> None:
+    src = tmp_path / "scoped_aliases.py"
+    src.write_text(
+        "def unsafe():\n"
+        "    import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n"
+        "\n"
+        "def safe(json_parser):\n"
+        "    ET = json_parser\n"
+        "    return ET.parse('{}')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
 
 
 def test_allows_defusedxml_import(tmp_path: Path) -> None:

--- a/tests/ci/test_check_defusedxml_fallback.py
+++ b/tests/ci/test_check_defusedxml_fallback.py
@@ -58,8 +58,7 @@ def test_flags_defusedxml_importerror_fallback_to_stdlib_xml(tmp_path: Path) -> 
 def test_flags_dynamic_importlib_stdlib_xml_import(tmp_path: Path) -> None:
     src = tmp_path / "dynamic_import.py"
     src.write_text(
-        "import importlib as imports\n"
-        "ET = imports.import_module('xml.etree.ElementTree')\n",
+        "import importlib as imports\nET = imports.import_module('xml.etree.ElementTree')\n",
         encoding="utf-8",
     )
     violations = checker.check_file(src)

--- a/tests/ci/test_check_defusedxml_fallback.py
+++ b/tests/ci/test_check_defusedxml_fallback.py
@@ -36,8 +36,18 @@ def test_flags_local_stdlib_xml_import(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     violations = checker.check_file(src)
-    assert len(violations) >= 1
-    assert "xml.etree.ElementTree" in violations[0][1]
+    assert violations == [
+        (
+            2,
+            "standard library import 'xml.etree.ElementTree' is unsafe",
+            "import xml.etree.ElementTree as ET",
+        ),
+        (
+            3,
+            "standard library XML parser constructed through alias is unsafe",
+            "return ET.fromstring(data)",
+        ),
+    ]
 
 
 def test_flags_defusedxml_importerror_fallback_to_stdlib_xml(tmp_path: Path) -> None:
@@ -212,6 +222,68 @@ def test_alias_tracking_does_not_cross_function_scope(tmp_path: Path) -> None:
         "def safe(json_parser):\n"
         "    ET = json_parser\n"
         "    return ET.parse('{}')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_nested_return_does_not_mark_outer_function_as_xml_factory(tmp_path: Path) -> None:
+    src = tmp_path / "nested_return.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n"
+        "def outer():\n"
+        "    def inner():\n"
+        "        return ET\n"
+        "mod = outer()\n"
+        "mod.parse('safe.json')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_nested_binder_does_not_shadow_outer_xml_alias(tmp_path: Path) -> None:
+    src = tmp_path / "nested_binder.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n"
+        "def outer():\n"
+        "    def inner():\n"
+        "        ET = object()\n"
+        "    return ET.fromstring('<x/>')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "XML parser constructed through alias" in violations[0][1]
+
+
+def test_reassignment_clears_stale_xml_alias(tmp_path: Path) -> None:
+    src = tmp_path / "reassigned_alias.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n"
+        "ET = object()\n"
+        "ET.parse('safe.json')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_reassignment_clears_stale_dynamic_import_state(tmp_path: Path) -> None:
+    src = tmp_path / "reassigned_importlib.py"
+    src.write_text(
+        "import importlib\n"
+        "importlib = object()\n"
+        "importlib.import_module('xml.etree.ElementTree')\n",
+        encoding="utf-8",
+    )
+    assert checker.check_file(src) == []
+
+
+def test_walrus_reassignment_clears_stale_parser_alias(tmp_path: Path) -> None:
+    src = tmp_path / "walrus_reassigned_alias.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: defusedxml-fallback\n"
+        "if ET := object():\n"
+        "    ET.parse('safe.json')\n",
         encoding="utf-8",
     )
     assert checker.check_file(src) == []

--- a/tests/ci/test_check_defusedxml_fallback.py
+++ b/tests/ci/test_check_defusedxml_fallback.py
@@ -19,6 +19,93 @@ def test_flags_stdlib_xml_import(tmp_path: Path) -> None:
     assert "xml.etree" in violations[0][1]
 
 
+def test_flags_alias_import(tmp_path: Path) -> None:
+    src = tmp_path / "alias.py"
+    src.write_text("import xml.etree.ElementTree as apparently_safe\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "xml.etree.ElementTree" in violations[0][1]
+
+
+def test_flags_local_stdlib_xml_import(tmp_path: Path) -> None:
+    src = tmp_path / "local_import.py"
+    src.write_text(
+        "def parse(data):\n"
+        "    import xml.etree.ElementTree as ET\n"
+        "    return ET.fromstring(data)\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) >= 1
+    assert "xml.etree.ElementTree" in violations[0][1]
+
+
+def test_flags_defusedxml_importerror_fallback_to_stdlib_xml(tmp_path: Path) -> None:
+    src = tmp_path / "fallback.py"
+    src.write_text(
+        "try:\n"
+        "    from defusedxml import ElementTree as ET\n"
+        "except ImportError:\n"
+        "    import xml.etree.ElementTree as ET\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert violations[0][0] == 4
+    assert "xml.etree.ElementTree" in violations[0][1]
+
+
+def test_flags_dynamic_importlib_stdlib_xml_import(tmp_path: Path) -> None:
+    src = tmp_path / "dynamic_import.py"
+    src.write_text(
+        "import importlib as imports\n"
+        "ET = imports.import_module('xml.etree.ElementTree')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
+
+
+def test_flags_aliased_import_module_stdlib_xml_import(tmp_path: Path) -> None:
+    src = tmp_path / "dynamic_import_alias.py"
+    src.write_text(
+        "from importlib import import_module as load_module\n"
+        "ET = load_module('xml.etree.ElementTree')\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
+
+
+def test_flags_dunder_import_stdlib_xml_import(tmp_path: Path) -> None:
+    src = tmp_path / "dunder_import.py"
+    src.write_text("ET = __import__('xml.etree.ElementTree')\n", encoding="utf-8")
+    violations = checker.check_file(src)
+    assert len(violations) == 1
+    assert "dynamic standard library import 'xml.etree.ElementTree'" in violations[0][1]
+
+
+def test_flags_parser_construction_through_resolved_alias(tmp_path: Path) -> None:
+    src = tmp_path / "parser_alias.py"
+    src.write_text(
+        "import importlib\n"
+        "ET = importlib.import_module('xml.etree.ElementTree')\n"
+        "parser = ET.XMLParser()\n",
+        encoding="utf-8",
+    )
+    violations = checker.check_file(src)
+    assert len(violations) == 2
+    assert "XML parser constructed through alias" in violations[1][1]
+
+
+def test_allows_defusedxml_import(tmp_path: Path) -> None:
+    src = tmp_path / "safe.py"
+    src.write_text("from defusedxml import ElementTree as ET\n", encoding="utf-8")
+    assert checker.check_file(src) == []
+
+
 def test_targeted_noqa_suppresses_violation(tmp_path: Path) -> None:
     src = tmp_path / "exempt.py"
     src.write_text(
@@ -34,10 +121,30 @@ def test_bare_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
     assert len(checker.check_file(src)) == 1
 
 
+def test_unrelated_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "unrelated.py"
+    src.write_text(
+        "import xml.etree.ElementTree as ET  # noqa: some-other-rail\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
 def test_string_literal_noqa_does_not_suppress_violation(tmp_path: Path) -> None:
     src = tmp_path / "string_literal.py"
     src.write_text(
         "msg = 'noqa: defusedxml-fallback'\nimport xml.etree.ElementTree as ET\n",
+        encoding="utf-8",
+    )
+    assert len(checker.check_file(src)) == 1
+
+
+def test_broad_suppression_text_in_string_does_not_suppress_violation(tmp_path: Path) -> None:
+    src = tmp_path / "broad_string.py"
+    src.write_text(
+        "def reason():\n"
+        "    return '# noqa: defusedxml-fallback'\n"
+        "import xml.etree.ElementTree as ET\n",
         encoding="utf-8",
     )
     assert len(checker.check_file(src)) == 1

--- a/tests/services/deduplication/test_dedup_extractor_xxe.py
+++ b/tests/services/deduplication/test_dedup_extractor_xxe.py
@@ -92,14 +92,14 @@ def test_extract_odt_fails_closed_when_defusedxml_is_missing(
 
     def fail_defusedxml_import(
         name: str,
-        globals: dict[str, object] | None = None,
-        locals: dict[str, object] | None = None,
+        globalns: dict[str, object] | None = None,
+        localns: dict[str, object] | None = None,
         fromlist: tuple[str, ...] = (),
         level: int = 0,
     ) -> object:
         if name.startswith("defusedxml"):
             raise ImportError("defusedxml intentionally unavailable")
-        return original_import(name, globals, locals, fromlist, level)
+        return original_import(name, globalns, localns, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fail_defusedxml_import)
 

--- a/tests/services/deduplication/test_dedup_extractor_xxe.py
+++ b/tests/services/deduplication/test_dedup_extractor_xxe.py
@@ -11,6 +11,7 @@ on defusedxml (a core dependency), not the heavier dedup extras.
 
 from __future__ import annotations
 
+import builtins
 import zipfile
 from pathlib import Path
 
@@ -71,4 +72,35 @@ def test_extract_odt_handles_malformed_xml(tmp_path: Path) -> None:
     """
     odt = tmp_path / "malformed.odt"
     _write_odt(odt, f"<office:document-content {_NS}><office:body><text:p>oops")
+    assert DocumentExtractor()._extract_odt(odt) == ""
+
+
+def test_extract_odt_fails_closed_when_defusedxml_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing ``defusedxml`` must not silently downgrade to stdlib XML."""
+    odt = tmp_path / "clean.odt"
+    _write_odt(
+        odt,
+        f'<?xml version="1.0"?><office:document-content {_NS}>'
+        "<office:body><office:text>"
+        "<text:p>Hello without defusedxml</text:p>"
+        "</office:text></office:body></office:document-content>",
+    )
+
+    original_import = builtins.__import__
+
+    def fail_defusedxml_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name.startswith("defusedxml"):
+            raise ImportError("defusedxml intentionally unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_defusedxml_import)
+
     assert DocumentExtractor()._extract_odt(odt) == ""


### PR DESCRIPTION
## Summary

- Harden the enforced `defusedxml-fallback` rail so it catches additional resolvable stdlib XML import forms: literal and simple string-composed `importlib` loads, aliased `import_module`, `__import__`, keyword `name=` module arguments, and `importlib.*` aliases.
- Track parser calls through simple resolved aliases, including multi-level attribute chains, attribute/walrus targets in the same lexical scope, and straightforward helper functions that re-export a tracked XML alias.
- Add regression tests for the issue #1417 cases and follow-up review gaps: alias imports, local imports, fallback imports, broad or unrelated suppressions, suppression text in strings, valid `defusedxml` imports, parser alias construction, string-bound dynamic imports, keyword module args, and same-name aliases across unrelated scopes.
- Add an ODT extractor regression proving missing `defusedxml` fails closed instead of silently downgrading to stdlib XML.

## Context

Issue #1417 notes that the rail was already enforced, but needed stronger coverage for fallback behavior and suppression handling. The follow-up comment specifically asked the detector to reject indirect or fallback-shaped stdlib XML usage, including aliases, local imports, `try defusedxml / except ImportError: xml` fallbacks, broad suppressions, string-only suppression text, and parser construction through aliases where reasonable.

This remains an AST guardrail for resolvable source patterns, not a complete dynamic import sandbox. It intentionally does not claim to catch arbitrary indirection such as `sys.modules`, `getattr(importlib, ...)`, `eval`/`exec`, or values that cannot be resolved from simple string literals/bindings. The runtime fail-closed ODT behavior remains the hard safety net for this code path.

## Validation

- `ruff format --check scripts/ci/guardrails/check_defusedxml_fallback.py scripts/ci/guardrails/check_safedir_valueerror.py scripts/ci/guardrails/ast_helpers.py tests/ci/test_check_defusedxml_fallback.py`
- `python scripts/ci/guardrails/check_defusedxml_fallback.py`
- `pytest tests/ci/test_check_defusedxml_fallback.py tests/services/deduplication/test_dedup_extractor_xxe.py -q --override-ini="addopts="`
- `pytest tests/ci -q --override-ini="addopts="`

Fixes #1417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML safety checks to catch more unsafe import and parser usage patterns, including aliased and dynamic imports.
  * Ensured ODT extraction fails closed when secure XML support is unavailable, instead of falling back silently.
  * Fixed local name handling in guardrail checks for more accurate detection across assignments and loops.

* **Tests**
  * Added broader coverage for XML guardrail violations, scope handling, and `noqa` behavior.
  * Added a test covering secure fallback behavior during document extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->