### PR TITLE
Fix flaky audio/video tests: pre-warm cv2 import to avoid cold-import race

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,23 @@ try:
 except ImportError:
     collect_ignore_glob.append("playwright/**")
 
+# cv2 (opencv-python) is imported lazily inside video service functions, so the
+# first real `import cv2` in a test run can land at an arbitrary point in
+# collection/execution order. Several tests mock `sys.modules["cv2"]` (and run
+# on background threads via executor/watch-loop tests), and a first cold
+# import racing against that sys.modules mutation can abort cv2's own package
+# init partway through — leaving `cv2.dnn` cached as a real submodule while
+# the top-level `cv2` entry is evicted, so every later `import cv2` in the
+# same process repeats the same failure
+# (AttributeError: module 'cv2.dnn' has no attribute 'DictValue').
+# Importing it for real here, before any test can mock or race it, ensures
+# `sys.modules["cv2"]` is always the fully-initialized real module that
+# `unittest.mock.patch.dict` restores after each test.
+try:
+    import cv2  # noqa: F401
+except ImportError:
+    pass
+
 # ---------------------------------------------------------------------------
 # Version-aware fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the flaky `tests/core/test_audio_video_integration.py` and `tests/unit/services/video/test_scene_detector.py` (and related) failures observed intermittently in full-suite pre-commit runs while working on #1432 (now merged).

**Root cause** (found via systematic debugging — reproduced deterministically, not guessed):

`cv2` is imported lazily inside `src/file_organizer/services/video/*.py` functions, so the first real `import cv2` in a full test run lands at an arbitrary point in collection/execution order. Several tests mock `sys.modules["cv2"]` via `unittest.mock.patch.dict`, and executor/watch-loop tests run real background threads. `patch.dict` mutates `sys.modules` directly, bypassing CPython's per-module import lock — so a first cold `import cv2` racing against that mutation can abort cv2's own package `__init__` partway through. This leaves the `cv2.dnn` submodule cached as a real module (it finished importing before the abort) while the top-level `cv2` entry gets evicted from `sys.modules` (CPython removes a package from `sys.modules` if an exception escapes its `__init__`). Every later `import cv2` in the same process then repeats the exact same failure:

```
AttributeError: module 'cv2.dnn' has no attribute 'DictValue'
```

raised from cv2's own typing bootstrap (`cv2/typing/__init__.py`), cascading across every test that touches cv2 for the rest of the process — which is why a *different* set of tests appeared to fail on each full-suite run.

## Fix

Eagerly `import cv2` (best-effort, guarded by `ImportError`) at the top of `tests/conftest.py`, before any test can mock or race it. Since `unittest.mock.patch.dict` always restores `sys.modules` to whatever was present at patch-entry, pre-warming guarantees that's always the real, fully-initialized module — the dangerous cold mid-suite import never needs to happen again.

## Verification

- Reproduced deterministically: running `tests/unit/services/video/`, `tests/services/video/`, `tests/core/test_audio_video_integration.py`, `tests/integration/test_audio_video_services_batch4.py`, `tests/integration/test_coverage_ratchet_gaps.py`, and `tests/integration/test_services_coverage.py` together with `pytest-randomly` and `--randomly-seed=6` failed with this exact error every time before the fix.
- With `-p no:randomly` (deterministic order), the same files always passed — confirming order-dependence, not an application bug.
- After the fix: seed 6 passes, 8/8 auto-seeded random-order runs of the affected file set pass (vs. ~50% failure rate before).
- Full `pytest tests/ -p randomly` run (13,585 tests) passes cleanly — no AV/cv2 failures. (One pre-existing, unrelated flake remains: `tests/pipeline/test_orchestrator_watch_loop.py::TestWatchLoopExecutor::test_on_watch_future_done_logs_failed_future` — out of scope here, not cv2-related.)
- `pytest tests/ci` (932 tests) and `ruff check`/`ruff format --check` pass.
- Re-verified after rebasing onto `main` (the branch this work was originally cut from, `harden-xdist-loadgroup-rail`, was squash-merged as #1432 and its head branch auto-deleted).

## Notes for reviewers

- Opened as a draft since it's a side investigation spun out of #1432's pre-commit flakiness, not yet reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test startup reliability by initializing OpenCV earlier during test collection, reducing intermittent import-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->