### PR TITLE
test(ci): harden guardrail docs drift checks (#1418)

### DIFF
--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -142,6 +142,24 @@ def _parse_rail_status_table(source: str) -> dict[str, str]:
     return {name: ("enforce" if status == "enforced" else status) for name, status in rows}
 
 
+def _parse_known_limitations_advisory_rails(source: str) -> set[str]:
+    section_match = re.search(
+        r"## Known Limitations\n(?P<section>.*?)(?:\n## |\Z)",
+        source,
+        flags=re.DOTALL,
+    )
+    assert section_match, "Doc must define a Known Limitations section"
+
+    remain_advisory_match = re.search(
+        r"remains? advisory \((?P<names>.*?)\)",
+        section_match.group("section"),
+        flags=re.DOTALL,
+    )
+    assert remain_advisory_match, "Known Limitations must name the rails that remain advisory"
+
+    return set(re.findall(r"`([^`]+)`", remain_advisory_match.group("names")))
+
+
 def test_security_rail_status_table_matches_registry() -> None:
     assert RAILS_REGISTRY.exists(), f"Rail registry not found: {RAILS_REGISTRY}"
     assert SECURITY_DOC.exists(), f"Security doc not found: {SECURITY_DOC}"
@@ -203,3 +221,30 @@ def test_rail_status_table_detects_missing_row() -> None:
     assert "rail-b" not in table_modes
     registry_modes = {"rail-a": "enforce", "rail-b": "advisory"}
     assert table_modes != registry_modes
+
+
+def test_known_limitations_advisory_rails_match_registry() -> None:
+    assert RAILS_REGISTRY.exists(), f"Rail registry not found: {RAILS_REGISTRY}"
+    assert SECURITY_DOC.exists(), f"Security doc not found: {SECURITY_DOC}"
+
+    registry = tomllib.loads(RAILS_REGISTRY.read_text(encoding="utf-8"))
+    expected_advisory = {rail["name"] for rail in registry["rail"] if rail["mode"] == "advisory"}
+
+    source = SECURITY_DOC.read_text(encoding="utf-8")
+    assert _parse_known_limitations_advisory_rails(source) == expected_advisory
+
+
+def test_known_limitations_detects_newly_added_advisory_rail() -> None:
+    source = (
+        "## Known Limitations\n\n- Two lint rails above remain advisory (`rail-a` and `rail-b`).\n"
+    )
+    doc_advisory = _parse_known_limitations_advisory_rails(source)
+    registry_advisory = {"rail-a", "rail-b", "rail-c"}
+    assert doc_advisory != registry_advisory
+
+
+def test_known_limitations_detects_newly_promoted_enforced_rail() -> None:
+    source = "## Known Limitations\n\n- One lint rail above remains advisory (`rail-a`).\n"
+    doc_advisory = _parse_known_limitations_advisory_rails(source)
+    registry_advisory: set[str] = set()
+    assert doc_advisory != registry_advisory

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -150,6 +150,8 @@ def _parse_known_limitations_advisory_rails(source: str) -> set[str]:
     )
     assert section_match, "Doc must define a Known Limitations section"
 
+    # "remains?" tolerates both "remain advisory" (2+ rails) and "remains advisory"
+    # (exactly 1 rail) — the count-dependent verb shouldn't need a prose rewrite.
     remain_advisory_match = re.search(
         r"remains? advisory \((?P<names>.*?)\)",
         section_match.group("section"),
@@ -239,6 +241,7 @@ def test_known_limitations_detects_newly_added_advisory_rail() -> None:
         "## Known Limitations\n\n- Two lint rails above remain advisory (`rail-a` and `rail-b`).\n"
     )
     doc_advisory = _parse_known_limitations_advisory_rails(source)
+    assert doc_advisory == {"rail-a", "rail-b"}
     registry_advisory = {"rail-a", "rail-b", "rail-c"}
     assert doc_advisory != registry_advisory
 
@@ -246,5 +249,6 @@ def test_known_limitations_detects_newly_added_advisory_rail() -> None:
 def test_known_limitations_detects_newly_promoted_enforced_rail() -> None:
     source = "## Known Limitations\n\n- One lint rail above remains advisory (`rail-a`).\n"
     doc_advisory = _parse_known_limitations_advisory_rails(source)
+    assert doc_advisory == {"rail-a"}
     registry_advisory: set[str] = set()
     assert doc_advisory != registry_advisory

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -6,6 +6,7 @@ import re
 import shlex
 import tomllib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -162,14 +163,21 @@ def _parse_known_limitations_advisory_rails(source: str) -> set[str]:
     return set(re.findall(r"`([^`]+)`", remain_advisory_match.group("names")))
 
 
-def test_security_rail_status_table_matches_registry() -> None:
+@pytest.fixture
+def registry_and_doc_source() -> tuple[dict[str, Any], str]:
     assert RAILS_REGISTRY.exists(), f"Rail registry not found: {RAILS_REGISTRY}"
     assert SECURITY_DOC.exists(), f"Security doc not found: {SECURITY_DOC}"
 
     registry = tomllib.loads(RAILS_REGISTRY.read_text(encoding="utf-8"))
-    expected_modes = {rail["name"]: rail["mode"] for rail in registry["rail"]}
-
     source = SECURITY_DOC.read_text(encoding="utf-8")
+    return registry, source
+
+
+def test_security_rail_status_table_matches_registry(
+    registry_and_doc_source: tuple[dict[str, Any], str],
+) -> None:
+    registry, source = registry_and_doc_source
+    expected_modes = {rail["name"]: rail["mode"] for rail in registry["rail"]}
     table_modes = _parse_rail_status_table(source)
     assert table_modes == expected_modes
 
@@ -225,14 +233,11 @@ def test_rail_status_table_detects_missing_row() -> None:
     assert table_modes != registry_modes
 
 
-def test_known_limitations_advisory_rails_match_registry() -> None:
-    assert RAILS_REGISTRY.exists(), f"Rail registry not found: {RAILS_REGISTRY}"
-    assert SECURITY_DOC.exists(), f"Security doc not found: {SECURITY_DOC}"
-
-    registry = tomllib.loads(RAILS_REGISTRY.read_text(encoding="utf-8"))
+def test_known_limitations_advisory_rails_match_registry(
+    registry_and_doc_source: tuple[dict[str, Any], str],
+) -> None:
+    registry, source = registry_and_doc_source
     expected_advisory = {rail["name"] for rail in registry["rail"] if rail["mode"] == "advisory"}
-
-    source = SECURITY_DOC.read_text(encoding="utf-8")
     assert _parse_known_limitations_advisory_rails(source) == expected_advisory
 
 

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -122,6 +122,26 @@ def test_contributing_points_to_guardrail_workflow() -> None:
     assert "canonical pre-PR guardrail orchestrator" in source
 
 
+def _parse_rail_status_table(source: str) -> dict[str, str]:
+    section_match = re.search(
+        r"## CI-Enforced Lint Rails\n(?P<section>.*?)(?:\n\n[A-Z#]|\Z)",
+        source,
+        flags=re.DOTALL,
+    )
+    assert section_match, "Doc must define a CI-Enforced Lint Rails section"
+
+    rows = re.findall(
+        r"^\| `([^`]+)` \| [^|]+ \| (advisory|enforced) \|$",
+        section_match.group("section"),
+        flags=re.MULTILINE,
+    )
+    names = [name for name, _ in rows]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    assert not duplicates, f"Rail status table has duplicate rows for: {duplicates}"
+
+    return {name: ("enforce" if status == "enforced" else status) for name, status in rows}
+
+
 def test_security_rail_status_table_matches_registry() -> None:
     assert RAILS_REGISTRY.exists(), f"Rail registry not found: {RAILS_REGISTRY}"
     assert SECURITY_DOC.exists(), f"Security doc not found: {SECURITY_DOC}"
@@ -130,21 +150,7 @@ def test_security_rail_status_table_matches_registry() -> None:
     expected_modes = {rail["name"]: rail["mode"] for rail in registry["rail"]}
 
     source = SECURITY_DOC.read_text(encoding="utf-8")
-    section_match = re.search(
-        r"## CI-Enforced Lint Rails\n(?P<section>.*?)(?:\n\n[A-Z#]|\Z)",
-        source,
-        flags=re.DOTALL,
-    )
-    assert section_match, "SECURITY.md must define a CI-Enforced Lint Rails section"
-
-    table_modes = {
-        name: ("enforce" if status == "enforced" else status)
-        for name, status in re.findall(
-            r"^\| `([^`]+)` \| [^|]+ \| (advisory|enforced) \|$",
-            section_match.group("section"),
-            flags=re.MULTILINE,
-        )
-    }
+    table_modes = _parse_rail_status_table(source)
     assert table_modes == expected_modes
 
 
@@ -161,3 +167,38 @@ def test_api_compat_rules_are_not_duplicated_in_shell_orchestrator() -> None:
             "API-compat semantic policy must stay in tests/ci, not in the shell orchestrator. "
             f"Found rule id in script: {rule_id}"
         )
+
+
+def test_rail_status_table_rejects_duplicate_rows_for_same_rail() -> None:
+    source = (
+        "## CI-Enforced Lint Rails\n\n"
+        "| Rail | What it flags | Status |\n"
+        "|---|---|---|\n"
+        "| `rail-a` | thing | enforced |\n"
+        "| `rail-a` | thing again | advisory |\n"
+    )
+    with pytest.raises(AssertionError, match="duplicate"):
+        _parse_rail_status_table(source)
+
+
+def test_rail_status_table_ignores_prose_mentions_outside_table_rows() -> None:
+    source = (
+        "## CI-Enforced Lint Rails\n\n"
+        "| Rail | What it flags | Status |\n"
+        "|---|---|---|\n"
+        "| `rail-a` | thing | enforced |\n\n"
+        "Note: `rail-b` is advisory but has no table row yet.\n"
+    )
+    assert _parse_rail_status_table(source) == {"rail-a": "enforce"}
+
+
+def test_rail_status_table_detects_missing_row() -> None:
+    source = (
+        "## CI-Enforced Lint Rails\n\n"
+        "| Rail | What it flags | Status |\n"
+        "|---|---|---|\n"
+        "| `rail-a` | thing | enforced |\n"
+    )
+    table_modes = _parse_rail_status_table(source)
+    registry_modes = {"rail-a": "enforce", "rail-b": "advisory"}
+    assert table_modes != registry_modes

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -186,8 +186,8 @@ def test_rail_status_table_ignores_prose_mentions_outside_table_rows() -> None:
         "## CI-Enforced Lint Rails\n\n"
         "| Rail | What it flags | Status |\n"
         "|---|---|---|\n"
-        "| `rail-a` | thing | enforced |\n\n"
-        "Note: `rail-b` is advisory but has no table row yet.\n"
+        "| `rail-a` | thing | enforced |\n"
+        "see also `rail-b`, which has no table row yet.\n"
     )
     assert _parse_rail_status_table(source) == {"rail-a": "enforce"}
 
@@ -200,5 +200,6 @@ def test_rail_status_table_detects_missing_row() -> None:
         "| `rail-a` | thing | enforced |\n"
     )
     table_modes = _parse_rail_status_table(source)
+    assert "rail-b" not in table_modes
     registry_modes = {"rail-a": "enforce", "rail-b": "advisory"}
     assert table_modes != registry_modes


### PR DESCRIPTION
## Summary

Closes #1418. Hardens `tests/ci/test_guardrail_governance.py` so it treats `scripts/ci/rails.toml` as the sole source of truth for rail enforcement status, per the issue's addendum comment on detector gaps.

- Extracted the inline `SECURITY.md` rail-status-table regex into a reusable `_parse_rail_status_table` helper and added duplicate-row rejection, so two conflicting doc rows for the same rail can no longer silently resolve to whichever is parsed last.
- Added regression tests proving the parser ignores prose mentions of a rail outside a table row, and detects a missing row via diff against the registry.
- Added a new `_parse_known_limitations_advisory_rails` helper + `test_known_limitations_advisory_rails_match_registry`, closing the previously-unguarded gap where `SECURITY.md`'s "## Known Limitations" prose (which separately names the advisory rails) could drift from `rails.toml` without any test catching it.
- Added synthetic regression tests locking in detection of a newly-added-but-undocumented advisory rail, and a rail promoted to enforced whose doc text is stale.

Test-only change — no production code touched. Full task-by-task history (implementer + spec-compliance review + code-quality review per task) is in the commit log below.

## Test plan

- [x] `pytest tests/ci/test_guardrail_governance.py -q --override-ini="addopts="` — 12 passed (5 pre-existing + 7 new)
- [x] `pytest tests/ci -q --override-ini="addopts="` — 962 passed, 1 skipped, 1 xfailed, no regressions
- [x] `ruff check .` / `ruff format --check` / `mypy tests/ci/test_guardrail_governance.py` — clean
- [ ] Full `pre-commit run --all-files` (including the `diff-cover` full-repo-coverage gate) was not run in this environment — it exceeded a 10-minute tool timeout and a subsequent OOM-kill on retry. The equivalent fast hooks (ruff, format, mypy, and the `pytest-ci-lint` hook's own test suite) were verified directly above; recommend CI confirms the coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added stronger checks for governance documentation so status tables are parsed more reliably.
  * Improved detection of duplicate, missing, or malformed entries in status listings.
  * Added coverage to ensure advisory items stay in sync with the expected registry, including newly added or updated statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->