### PR TITLE
docs: expand troubleshooting coverage for current user surfaces

### DIFF
--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -359,8 +359,10 @@ docker-compose ps redis
 # Restart the Redis container if it is stopped/unhealthy
 docker-compose restart redis
 
-# Test the connection from the web container
-docker-compose exec web redis-cli -u "${FO_REDIS_URL:-redis://redis:6379/0}" ping
+# Test the connection directly from the Redis container.
+# REDISCLI_AUTH is already set in the container environment (docker-compose.yml),
+# so redis-cli authenticates automatically — no password argument needed.
+docker-compose exec redis redis-cli ping
 # Expected output: PONG
 ```
 
@@ -417,27 +419,37 @@ docker-compose up -d
 
 > **Note**: This section covers rolling back the *application version* in a Docker deployment. To undo individual file organization operations, see [Operation Undo / Rollback](../troubleshooting.md#operation-undo--rollback-issues) in the User Troubleshooting Guide.
 
-### Roll Back to a Previous Docker Image Tag
+### Roll Back to a Previous Source Version
+
+The default `docker-compose.yml` builds the image from source (`build: context: .`). To roll back to a previous release, check out the target git tag and rebuild:
 
 ```bash
-# List recently used image tags (check your registry or release history)
-docker images ghcr.io/curdriceaurora/local-file-organizer --format "{{.Tag}}\t{{.CreatedAt}}"
+# Identify the release tag to roll back to
+git tag --sort=-version:refname | head -10
 
-# Pin the previous version in .env
-echo "APP_IMAGE_TAG=2.0.0-alpha.2" >> .env  # replace with the target version
+# Check out the previous release
+git checkout v2.0.0-alpha.2    # replace with the target tag
 
-# Redeploy
-docker-compose pull
+# Rebuild and redeploy
+docker-compose build
 docker-compose up -d
 ```
 
-If you do not use image tags in your compose file, pin the version explicitly:
+If your deployment uses a pre-built registry image instead of a local build, edit the `image:` field directly in `docker-compose.yml`:
 
 ```yaml
 # docker-compose.yml
 services:
-  web:
+  file-organizer:
     image: ghcr.io/curdriceaurora/local-file-organizer:2.0.0-alpha.2
+    # Remove or comment out the 'build:' block when pinning an image tag
+```
+
+Then redeploy:
+
+```bash
+docker-compose pull
+docker-compose up -d
 ```
 
 ### Database Migration Rollback
@@ -446,13 +458,13 @@ If a new version ran Alembic migrations and you need to revert:
 
 ```bash
 # Identify the previous migration revision
-docker-compose exec web alembic history --indicate-current
+docker-compose exec file-organizer alembic history --indicate-current
 
 # Downgrade one step
-docker-compose exec web alembic downgrade -1
+docker-compose exec file-organizer alembic downgrade -1
 
 # Or downgrade to a specific revision ID
-docker-compose exec web alembic downgrade <revision_id>
+docker-compose exec file-organizer alembic downgrade <revision_id>
 ```
 
 Always take a database backup before rolling back migrations in production.

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -1,5 +1,7 @@
 # Admin Troubleshooting Guide
 
+> For everyday user-facing issues (optional dependencies, AI providers, TUI/desktop, audio/video, search), see the [User Troubleshooting Guide](../troubleshooting.md).
+
 ## Common Issues
 
 ### Application Won't Start
@@ -16,11 +18,17 @@ ERROR: Failed to bind to port 8000
 # Find process using port 8000
 lsof -i :8000
 
-# Kill the process
+# Gracefully stop the process
+kill <PID>
+# If the process does not stop after a few seconds, force-kill it:
 kill -9 <PID>
 
-# Or use a different port
-PORT=8001 python app.py
+# Or start File Organizer on a different port
+file-organizer serve --port 8001
+
+# When using Docker Compose, set the port in .env instead
+echo "APP_PORT=8001" >> .env
+docker-compose up -d
 ```
 
 #### Problem: Database Connection Failed
@@ -332,6 +340,122 @@ docker stats ollama
 # Reduce concurrent requests
 # Check load on Ollama service
 ```
+
+## Redis Issues
+
+### Redis Connection Failed
+
+**Problem**: `ConnectionError: Error connecting to Redis` or session/cache features not working
+
+**Solution**:
+
+```bash
+# Check the configured Redis URL
+echo $FO_REDIS_URL
+
+# Verify the Redis container is running
+docker-compose ps redis
+
+# Restart the Redis container if it is stopped/unhealthy
+docker-compose restart redis
+
+# Test the connection from the web container
+docker-compose exec web redis-cli -u "${FO_REDIS_URL:-redis://redis:6379/0}" ping
+# Expected output: PONG
+```
+
+### Redis Memory Pressure / Eviction
+
+**Problem**: Cache misses increase, or Redis logs `maxmemory policy: allkeys-lru` evictions
+
+**Solution**:
+
+```bash
+# Check Redis memory usage
+docker-compose exec redis redis-cli info memory | grep used_memory_human
+
+# Check current eviction policy
+docker-compose exec redis redis-cli config get maxmemory-policy
+
+# If eviction is too aggressive, increase the memory limit in docker-compose.yml
+# or in your Redis configuration:
+#   maxmemory 512mb
+#   maxmemory-policy allkeys-lru
+
+docker-compose restart redis
+```
+
+### Clearing the Redis Cache (Safe)
+
+Only do this when debugging stale cache data. Flushing removes all cached sessions and data.
+
+```bash
+# Flush only the File Organizer database (default: db 0)
+docker-compose exec redis redis-cli -n 0 FLUSHDB
+
+# Restart the app after clearing
+docker-compose restart web
+```
+
+### Redis Auth / TLS Errors
+
+**Problem**: `NOAUTH Authentication required` or TLS handshake failure
+
+**Solution**:
+
+```bash
+# Set credentials in the Redis URL
+export FO_REDIS_URL=redis://:your_password@redis:6379/0
+
+# For TLS-enabled Redis (e.g., Redis Cloud, Azure Cache for Redis)
+export FO_REDIS_URL=rediss://:your_password@hostname:6380/0  # note: rediss://
+
+docker-compose up -d
+```
+
+## Deployment Rollback
+
+> **Note**: This section covers rolling back the *application version* in a Docker deployment. To undo individual file organization operations, see [Operation Undo / Rollback](../troubleshooting.md#operation-undo--rollback-issues) in the User Troubleshooting Guide.
+
+### Roll Back to a Previous Docker Image Tag
+
+```bash
+# List recently used image tags (check your registry or release history)
+docker images ghcr.io/curdriceaurora/local-file-organizer --format "{{.Tag}}\t{{.CreatedAt}}"
+
+# Pin the previous version in .env
+echo "APP_IMAGE_TAG=2.0.0-alpha.2" >> .env  # replace with the target version
+
+# Redeploy
+docker-compose pull
+docker-compose up -d
+```
+
+If you do not use image tags in your compose file, pin the version explicitly:
+
+```yaml
+# docker-compose.yml
+services:
+  web:
+    image: ghcr.io/curdriceaurora/local-file-organizer:2.0.0-alpha.2
+```
+
+### Database Migration Rollback
+
+If a new version ran Alembic migrations and you need to revert:
+
+```bash
+# Identify the previous migration revision
+docker-compose exec web alembic history --indicate-current
+
+# Downgrade one step
+docker-compose exec web alembic downgrade -1
+
+# Or downgrade to a specific revision ID
+docker-compose exec web alembic downgrade <revision_id>
+```
+
+Always take a database backup before rolling back migrations in production.
 
 ## Getting Help
 

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -26,8 +26,11 @@ kill -9 <PID>
 # Or start File Organizer on a different port
 file-organizer serve --port 8001
 
-# When using Docker Compose, set the port in .env instead
-echo "APP_PORT=8001" >> .env
+# When using Docker Compose, edit the ports mapping in docker-compose.yml:
+#   ports:
+#     - "8001:8001"   # change both sides to match your chosen port
+# Then set FO_PORT so the app binds to the same port inside the container:
+echo "FO_PORT=8001" >> .env
 docker-compose up -d
 ```
 
@@ -396,7 +399,7 @@ Only do this when debugging stale cache data. Flushing removes all cached sessio
 docker-compose exec redis redis-cli -n 0 FLUSHDB
 
 # Restart the app after clearing
-docker-compose restart web
+docker-compose restart file-organizer
 ```
 
 ### Redis Auth / TLS Errors
@@ -405,13 +408,26 @@ docker-compose restart web
 
 **Solution**:
 
+The Compose stack reads `REDIS_PASSWORD` from `.env` and injects it into both the Redis service and the app's `FO_REDIS_URL`. Exporting a shell variable will not reach the container — set it in `.env` instead:
+
 ```bash
-# Set credentials in the Redis URL
-export FO_REDIS_URL=redis://:your_password@redis:6379/0
+# Edit .env (copy from .env.example if it doesn't exist yet)
+# Set a strong password — avoid special URI characters (@ : / # %)
+echo "REDIS_PASSWORD=your_strong_password" >> .env
 
-# For TLS-enabled Redis (e.g., Redis Cloud, Azure Cache for Redis)
-export FO_REDIS_URL=rediss://:your_password@hostname:6380/0  # note: rediss://
+docker-compose up -d
+```
 
+For an external TLS-enabled Redis (e.g., Redis Cloud, Azure Cache for Redis), update `FO_REDIS_URL` in `docker-compose.yml` directly to use the `rediss://` scheme and external hostname:
+
+```yaml
+# docker-compose.yml — under the file-organizer service's environment:
+- FO_REDIS_URL=rediss://:your_password@hostname.redis.cloud:6380/0
+```
+
+Then redeploy:
+
+```bash
 docker-compose up -d
 ```
 

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -61,7 +61,33 @@ pip install "local-file-organizer[desktop]"
 
 ### Blank/slow first window
 
-The launcher waits for backend readiness, but cold starts can still feel slow. Check terminal output for server startup errors.
+The launcher waits for backend readiness, but cold starts can still feel slow. Check terminal output for server startup errors. If the window stays blank for more than 30 seconds:
+
+```bash
+# Run with verbose output to see the backend startup log
+file-organizer desktop --verbose
+```
+
+### Backend Startup Failure
+
+**Symptom**: The native window never opens and the terminal shows a traceback.
+
+**Cause**: The embedded FastAPI server failed to start — common causes are port conflict, missing dependency, or Ollama not running.
+
+**Solution**:
+
+```bash
+# Run the web server separately to see the full error
+file-organizer serve --verbose
+
+# If AI features fail to load, ensure Ollama (or your configured provider) is running
+ollama serve
+
+# For non-Ollama providers, verify environment variables are set
+file-organizer config show
+```
+
+See [AI Provider Issues](troubleshooting.md#ai-provider-issues) in the Troubleshooting Guide for provider-specific fixes.
 
 ### Linux WebKit packages
 
@@ -69,6 +95,42 @@ Install required WebKitGTK packages (distribution names can vary):
 
 ```bash
 sudo apt-get install -y libgirepository1.0-dev gir1.2-webkit2-4.1
+```
+
+### Native File Picker Dialog Not Appearing
+
+**Symptom**: Clicking a file/folder browse button in the desktop app opens a standard HTML input instead of the native OS file picker.
+
+**Cause**: The `window.pywebview.api` JavaScript bridge is only injected in full desktop mode. If pywebview is not fully initialized, the bridge falls back to a browser-safe no-op.
+
+**Solution**:
+
+- Ensure you launched with `file-organizer desktop` (not `file-organizer serve` in a browser).
+- On Linux, confirm the WebKitGTK packages above are installed and up to date.
+- Restart the desktop app; the bridge is injected during window load and may be missing if the page loaded before the backend was fully ready.
+
+### Window Appears Off-Screen or Wrong Size
+
+**Symptom**: The desktop window opens in the wrong position, off-screen, or too small to use.
+
+**Cause**: pywebview restores the last saved window position, which can be off-screen after switching monitors or changing display resolution.
+
+**Solution**:
+
+Close the app and delete the saved window state, then relaunch:
+
+```bash
+# The state file location depends on your OS and pywebview version
+# macOS
+rm -rf ~/Library/Application\ Support/file-organizer/window_state*
+
+# Linux
+rm -f ~/.local/share/file-organizer/window_state*
+
+# Windows
+del %APPDATA%\file-organizer\window_state*
+
+file-organizer desktop
 ```
 
 ### AI features unavailable

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -444,6 +444,8 @@ pip install "local-file-organizer[claude]"   # Anthropic Claude
 # Set environment variables for your provider
 export FO_PROVIDER=openai
 export FO_OPENAI_API_KEY=sk-...
+# For OpenAI-compatible endpoints (LM Studio, Groq, custom):
+# export FO_OPENAI_BASE_URL=http://localhost:1234/v1
 
 # For Claude
 export FO_PROVIDER=claude

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -430,6 +430,28 @@ ollama serve
 curl http://localhost:11434/api/version
 ```
 
+### OpenAI-Compatible API or Claude Not Connecting
+
+**Issue**: Provider fails to connect, returns 401, or "unknown provider" error.
+
+**Solutions**:
+
+```bash
+# Install the required extra
+pip install "local-file-organizer[cloud]"    # OpenAI / Groq / LM Studio
+pip install "local-file-organizer[claude]"   # Anthropic Claude
+
+# Set environment variables for your provider
+export FO_PROVIDER=openai
+export FO_OPENAI_API_KEY=sk-...
+
+# For Claude
+export FO_PROVIDER=claude
+export FO_CLAUDE_API_KEY=sk-ant-...
+```
+
+See [AI Provider Setup](setup/ai-providers.md) for full configuration details and provider-specific troubleshooting.
+
 ### Port Already in Use
 
 **Issue**: "Port 8000 is already in use"
@@ -472,7 +494,7 @@ ollama list
 - Reduce maximum file size
 - Use CPU-only mode (slower but uses less RAM)
 
-For more issues, see [Troubleshooting Guide](troubleshooting.md).
+For more issues, see the [Troubleshooting Guide](troubleshooting.md) — covers optional dependency failures, all AI providers, TUI/desktop issues, audio/video/FFmpeg, search, deduplication, and more.
 
 ## Next Steps
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -337,6 +337,132 @@ lsof -i :8000
 file-organizer serve --port 8001
 ```
 
+## AI Provider Issues
+
+### Provider Not Found / Missing Extra
+
+**Error**: `Unknown provider 'openai'. Registered providers: ['ollama']` or similar
+
+**Cause**: The required provider package is not installed.
+
+**Solution**:
+
+```bash
+# OpenAI, Groq, or LM Studio (OpenAI-compatible)
+pip install "local-file-organizer[cloud]"
+
+# Claude (Anthropic)
+pip install "local-file-organizer[claude]"
+
+# LLaMA.cpp
+pip install "local-file-organizer[llama]"
+
+# MLX (Apple Silicon)
+pip install "local-file-organizer[mlx]"
+```
+
+See [AI Provider Setup](setup/ai-providers.md) for full configuration details.
+
+### OpenAI-Compatible API: Auth Warning or 401
+
+**Error**: Warning `FO_PROVIDER=openai but neither FO_OPENAI_API_KEY nor FO_OPENAI_BASE_URL is set` or HTTP 401 from the API
+
+**Cause**: API key or base URL not set in the environment.
+
+**Solution**:
+
+```bash
+# For OpenAI
+export FO_OPENAI_API_KEY=sk-...
+export FO_OPENAI_MODEL=gpt-4o-mini
+
+# For LM Studio (no key needed, custom base URL)
+export FO_PROVIDER=openai
+export FO_OPENAI_BASE_URL=http://localhost:1234/v1
+export FO_OPENAI_MODEL=your-loaded-model
+
+# For Groq
+export FO_PROVIDER=openai
+export FO_OPENAI_API_KEY=gsk_...
+export FO_OPENAI_BASE_URL=https://api.groq.com/openai/v1
+export FO_OPENAI_MODEL=llama-3.3-70b-versatile
+```
+
+The standard `OPENAI_API_KEY` env var is also accepted as a fallback.
+
+### OpenAI-Compatible API: Model Not Found at Custom Endpoint
+
+**Error**: `404 Not Found` or `model not found` when using `FO_OPENAI_BASE_URL`
+
+**Cause**: The model name set in `FO_OPENAI_MODEL` is not available at the configured endpoint, or the endpoint URL is missing the `/v1` path.
+
+**Solution**:
+
+```bash
+# Verify your base URL ends with /v1
+export FO_OPENAI_BASE_URL=http://localhost:1234/v1   # correct
+# export FO_OPENAI_BASE_URL=http://localhost:1234    # missing /v1
+
+# List available models at the endpoint
+curl "${FO_OPENAI_BASE_URL}/models" -H "Authorization: Bearer ${FO_OPENAI_API_KEY:-none}"
+
+# Set the model to one returned by the above command
+export FO_OPENAI_MODEL=actual-model-id-from-list
+```
+
+### Claude / Anthropic: Auth Error or Missing Extra
+
+**Error**: `AuthenticationError` or `401 Unauthorized` from the Anthropic API
+
+**Cause**: `FO_CLAUDE_API_KEY` is not set, expired, or the `[claude]` extra is not installed.
+
+**Solution**:
+
+```bash
+# Install the Claude extra
+pip install "local-file-organizer[claude]"
+
+# Set your API key
+export FO_PROVIDER=claude
+export FO_CLAUDE_API_KEY=sk-ant-...
+export FO_CLAUDE_MODEL=claude-3-5-sonnet-20241022
+```
+
+The standard `ANTHROPIC_API_KEY` env var is also accepted as a fallback.
+
+### Claude / Anthropic: Rate Limit
+
+**Error**: `RateLimitError` or HTTP 429 from the Anthropic API
+
+**Cause**: API request rate or token quota exceeded on your Anthropic account.
+
+**Solution**: Wait a moment before retrying. For batch processing large directories, process files sequentially to reduce concurrent API calls:
+
+```bash
+file-organizer organize /input /output --sequential
+```
+
+Check your usage and limits in the [Anthropic console](https://console.anthropic.com/).
+
+### LM Studio: Connection Refused
+
+**Error**: `ConnectionRefusedError` or `Failed to connect to http://localhost:1234`
+
+**Cause**: LM Studio's local server is not running, or no model is loaded.
+
+**Solution**:
+
+1. Open LM Studio and navigate to **Local Server** (left sidebar).
+2. Load a model — the server only becomes active once a model is selected.
+3. Click **Start Server** and confirm the port matches `FO_OPENAI_BASE_URL`.
+4. Verify the server is responding:
+
+```bash
+curl http://localhost:1234/v1/models
+```
+
+See [AI Provider Setup — LM Studio](setup/ai-providers.md) for full configuration.
+
 ## Audio Transcription Issues
 
 ### No GPU Available Warning
@@ -648,6 +774,88 @@ unzip -l suspicious.zip  # List only, don't extract
 
 Archive bomb detection is a built-in safety feature. If you trust the archive source, extract it manually before organizing its contents.
 
+## Scientific Format Errors
+
+### HDF5 / NetCDF / MATLAB File Not Processed
+
+**Error**: `ModuleNotFoundError: No module named 'h5py'`, `No module named 'netCDF4'`, or `No module named 'scipy'` when organizing `.h5`, `.nc`, `.mat`, or `.hdf` files
+
+**Cause**: Scientific file format dependencies are not installed.
+
+**Solution**:
+
+```bash
+# Install scientific format support
+pip install "local-file-organizer[scientific]"
+
+# Verify installation
+python -c "import h5py, netCDF4, scipy; print('Scientific extras OK')"
+
+# Then retry analysis
+file-organizer analyze data.h5 --verbose
+```
+
+Supported formats after install: HDF5 (`.h5`, `.hdf`, `.hdf5`), NetCDF (`.nc`, `.nc4`), MATLAB (`.mat`).
+
+### Scientific File Metadata Unreadable
+
+**Error**: `OSError: Unable to open file` or corrupt HDF5/NetCDF error
+
+**Cause**: File is truncated, written by an incompatible library version, or on a network filesystem with locking issues.
+
+**Solution**:
+
+```bash
+# Check file integrity with h5py
+python -c "import h5py; h5py.File('data.h5', 'r').close(); print('OK')"
+
+# For NetCDF files
+python -c "import netCDF4; netCDF4.Dataset('data.nc').close(); print('OK')"
+
+# Analyze the file directly for details
+file-organizer analyze data.h5 --verbose
+```
+
+If the file is intact but on a network drive, copy it locally before processing.
+
+## CAD Format Errors
+
+### DXF / DWG File Not Processed
+
+**Error**: `ModuleNotFoundError: No module named 'ezdxf'` when organizing `.dxf` files
+
+**Cause**: CAD file format dependencies are not installed.
+
+**Solution**:
+
+```bash
+# Install CAD format support
+pip install "local-file-organizer[cad]"
+
+# Verify installation
+python -c "import ezdxf; print('CAD extras OK')"
+```
+
+Note: `.dwg` support requires `ezdxf` (read-only) and is limited to DWG versions that ezdxf can parse. If a `.dwg` file fails, try exporting it to `.dxf` from your CAD application.
+
+### DXF Parse Error
+
+**Error**: `ezdxf.lldxf.const.DXFStructureError` or "DXF version not supported"
+
+**Cause**: The DXF file uses an older version (pre-R12) or is created by software that writes non-standard DXF.
+
+**Solution**:
+
+```bash
+# Analyze the file to see the detected DXF version
+file-organizer analyze drawing.dxf --verbose
+
+# Re-export from your CAD application as DXF R2010 or later
+# Most applications: Save As → DXF → select version R2010/R2013/R2018
+```
+
+
+
 ## Video Processing Errors
 
 ### Video Scene Detection Failed
@@ -825,6 +1033,53 @@ file-organizer analyze /path/to/files --verbose
 # Try with more files or use keyword-based search
 file-organizer search "query" --type all
 ```
+
+## Operation Undo / Rollback Issues
+
+> **Note**: This section covers *file operation undo* — reversing file moves, renames, or copies performed by `file-organizer organize` and related commands. For rolling back a Docker deployment to a previous app version, see [Deployment Rollback](admin/troubleshooting.md#deployment-rollback) in the Admin Troubleshooting Guide.
+
+### History Shows No Operations
+
+**Error**: `file-organizer history` returns an empty list
+
+**Cause**: No operations have been run yet in this workspace, or the workspace path has changed since the operations were recorded.
+
+**Solution**:
+
+```bash
+# Check current workspace configuration
+file-organizer config show
+
+# List history for a specific path if needed
+file-organizer history --path /path/to/workspace
+
+# Run an organize operation first, then check history
+file-organizer organize /input /output --dry-run
+```
+
+### Undo Fails or Reports "Nothing to Undo"
+
+**Error**: `file-organizer undo` reports "No operations to undo" or similar
+
+**Cause**: The operation history is empty, the last operation was already undone, or the files have been moved or deleted since the operation was recorded.
+
+**Solution**:
+
+```bash
+# Review the full operation history first
+file-organizer history
+
+# Undo the most recent operation
+file-organizer undo
+
+# Undo a specific operation by ID (shown in history output)
+file-organizer undo --id <operation-id>
+
+# Preview what undo would do without making changes
+file-organizer undo --dry-run
+```
+
+If files were manually moved after the organize operation, undo may not be able to locate them. In that case, you can review the history to see the original file paths and restore them manually.
 
 ## Getting Help
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1042,7 +1042,7 @@ file-organizer search "query" --type all
 
 **Error**: `file-organizer history` returns an empty list
 
-**Cause**: No operations have been run yet in this workspace, or the workspace path has changed since the operations were recorded.
+**Cause**: No operations have been run yet in this workspace, or the history limit is hiding older entries.
 
 **Solution**:
 
@@ -1050,11 +1050,14 @@ file-organizer search "query" --type all
 # Check current workspace configuration
 file-organizer config show
 
-# List history for a specific path if needed
-file-organizer history --path /path/to/workspace
+# Show more history entries (default is 10)
+file-organizer history --limit 50
 
-# Run an organize operation first, then check history
-file-organizer organize /input /output --dry-run
+# Show all operation types with statistics
+file-organizer history --stats --verbose
+
+# Run an actual organize operation (not a dry run) to create history
+file-organizer organize /input /output
 ```
 
 ### Undo Fails or Reports "Nothing to Undo"
@@ -1067,16 +1070,16 @@ file-organizer organize /input /output --dry-run
 
 ```bash
 # Review the full operation history first
-file-organizer history
+file-organizer history --limit 20 --verbose
+
+# Preview what undo would do without making changes
+file-organizer undo --dry-run
 
 # Undo the most recent operation
 file-organizer undo
 
-# Undo a specific operation by ID (shown in history output)
-file-organizer undo --id <operation-id>
-
-# Preview what undo would do without making changes
-file-organizer undo --dry-run
+# Undo a specific operation by its numeric ID (shown in history output)
+file-organizer undo --operation-id <id>
 ```
 
 If files were manually moved after the organize operation, undo may not be able to locate them. In that case, you can review the history to see the original file paths and restore them manually.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -132,15 +132,28 @@ file-organizer tui
 
 **Solution**:
 
-In tmux, send a key sequence through directly with the prefix `Ctrl+b` then the key, or temporarily disable the tmux prefix for the TUI session:
+In **tmux**, use `send-keys` to inject the key directly into the foreground pane without going through tmux's binding layer:
 
 ```bash
-# In tmux: use send-prefix then the key
-# Or unbind the conflicting key just for this window
-tmux send-keys C-w   # sends Ctrl+W to the foreground pane
+# From another tmux window/pane, send Ctrl+W to the pane running the TUI
+tmux send-keys C-w
 ```
 
-For persistent conflicts, consider running the TUI in a dedicated terminal window outside of the multiplexer.
+If the shortcut conflicts with a tmux binding, unbind it for the copy-mode table (where `C-w` is most commonly bound):
+
+```bash
+# In ~/.tmux.conf
+unbind -T copy-mode C-w
+```
+
+In **GNU screen**, press `Ctrl+a` then `a` to send a literal `Ctrl+a`, or use `stuff` to inject keys programmatically. For `Ctrl+W` specifically:
+
+```bash
+# From the screen command line (Ctrl+a :)
+:stuff ^W
+```
+
+For persistent conflicts in either multiplexer, consider running the TUI in a dedicated terminal window outside the multiplexer.
 
 ## Related docs
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -59,6 +59,89 @@ Examples:
 
 If setup is not completed, the TUI opens the setup wizard first and then transitions to the main app layout.
 
+## Troubleshooting
+
+### Garbled Display or Broken Colors
+
+**Symptom**: Characters appear as raw escape codes, colors are missing, or the layout looks broken.
+
+**Cause**: The terminal's `TERM` environment variable is set to a value that Textual cannot detect color support for, or the terminal emulator itself has limited color support.
+
+**Solution**:
+
+```bash
+# Force 256-color or true-color mode
+export TERM=xterm-256color
+file-organizer tui
+
+# If colors are completely wrong, try disabling color
+export NO_COLOR=1
+file-organizer tui
+
+# Force color output on if the terminal supports it but detection fails
+export FORCE_COLOR=1
+file-organizer tui
+```
+
+If you use a multiplexer (tmux, screen), ensure it is configured to pass through true-color sequences:
+
+```bash
+# In ~/.tmux.conf
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+```
+
+### Blank Screen on Launch
+
+**Symptom**: The TUI opens but shows a blank or mostly-empty window for several seconds, then may recover or stay blank.
+
+**Cause**: Rare Textual rendering issue, typically triggered by very small terminal sizes or a terminal that mis-reports its dimensions.
+
+**Solution**:
+
+```bash
+# Resize the terminal window to at least 80x24 before launching
+file-organizer tui
+
+# If the terminal stays blank, try resetting it first
+reset
+file-organizer tui
+```
+
+### Wizard Stuck or Not Completing
+
+**Symptom**: The setup wizard does not advance, or pressing keys has no effect.
+
+**Cause**: A required field may be unfilled, or the terminal is swallowing keypresses.
+
+**Solution**:
+
+- Press `Ctrl+W` (shown in the keyboard shortcuts table above) to complete/advance the wizard.
+- Ensure the wizard panel has focus — click on it or press `Tab` to cycle focus.
+- If the wizard loop persists after completing setup, restart the TUI:
+
+```bash
+file-organizer tui
+```
+
+### Keyboard Shortcuts Swallowed by Terminal Multiplexer
+
+**Symptom**: Global shortcuts like `Ctrl+C`, `Ctrl+W`, or function keys do not reach the TUI when running inside tmux or screen.
+
+**Cause**: tmux/screen intercepts certain key sequences before they reach the application.
+
+**Solution**:
+
+In tmux, send a key sequence through directly with the prefix `Ctrl+b` then the key, or temporarily disable the tmux prefix for the TUI session:
+
+```bash
+# In tmux: use send-prefix then the key
+# Or unbind the conflicting key just for this window
+tmux send-keys C-w   # sends Ctrl+W to the foreground pane
+```
+
+For persistent conflicts, consider running the TUI in a dedicated terminal window outside of the multiplexer.
+
 ## Related docs
 
 - [CLI Reference](cli-reference.md)


### PR DESCRIPTION
Closes #1444

## Summary

Expands and corrects troubleshooting documentation across six files so that common failures on all current user-facing surfaces have accurate symptoms and fixes.

## Changes

### `docs/troubleshooting.md`
- **New: AI Provider Issues section** — OpenAI-compatible (missing `[cloud]` extra, auth warning, wrong base URL, model not found at endpoint), Claude/Anthropic (auth error, missing `[claude]` extra, rate-limit 429), LM Studio (connection refused, model not loaded). Brief entries link to `setup/ai-providers.md` for full setup.
- **New: Scientific Format Errors section** — `h5py`/`netCDF4`/`scipy` import errors for `.h5`/`.nc`/`.mat` files → `pip install "[scientific]"`.
- **New: CAD Format Errors section** — `ezdxf` import error, DXF parse/version errors → `pip install "[cad]"`.
- **New: Operation Undo / Rollback Issues section** — `history` shows empty, `undo` fails; clearly labels this as *file operation undo*, not app version rollback; cross-links admin rollback doc.
- Restored accidentally missing `## Video Processing Errors` section header.

### `docs/tui.md`
- **New: Troubleshooting section** — garbled/blank display (`TERM`, `FORCE_COLOR`, `NO_COLOR`, tmux true-color config), blank screen on launch, wizard stuck (Ctrl+W), keyboard shortcuts swallowed by tmux/screen.

### `docs/desktop-app.md`
- Expanded *Blank/slow first window* entry with `--verbose` diagnostic step.
- **New: Backend Startup Failure** — run `file-organizer serve --verbose` to see full error; links to AI Provider Issues.
- **New: Native File Picker Dialog Not Appearing** — pywebview bridge injection timing, Linux WebKit dependency check.
- **New: Window Appears Off-Screen or Wrong Size** — how to clear saved window state on macOS/Linux/Windows.

### `docs/getting-started.md`
- **New: OpenAI-Compatible API or Claude Not Connecting** entry in Troubleshooting Installation — install extras, set env vars, link to `setup/ai-providers.md`.
- Strengthened "For more issues" cross-link to `troubleshooting.md` with a summary of covered areas.

### `docs/admin/troubleshooting.md`
- Added cross-link to user `troubleshooting.md` at top of file.
- Fixed `kill -9 <PID>` → `kill <PID>` with `kill -9` noted as last resort.
- Fixed `PORT=8001 python app.py` → `file-organizer serve --port 8001` (+ Docker Compose `.env` pattern).
- **New: Redis Issues section** — connection failed (URL, container status), memory pressure/eviction, safe cache clearing (`FLUSHDB`), auth/TLS configuration.
- **New: Deployment Rollback section** — Docker image tag pinning, `docker-compose` re-deploy, Alembic migration downgrade with backup note.

## Acceptance criteria met

- ✅ Entries use current commands and dependency names (`file-organizer`, `fo`, `FO_*` env vars, `pip install "local-file-organizer[extras]"`)
- ✅ Symptoms, likely causes, and fixes are concrete
- ✅ Admin-only operational issues (Redis ops, Docker, Alembic) remain in `admin/troubleshooting.md`
- ✅ Cross-links added both ways between user and admin guides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guides for desktop, web, TUI, and getting started flows.
  * Added clearer steps for startup failures, file picker issues, window positioning, API connectivity, AI provider setup, and common terminal display problems.
  * Included updated guidance for database, cache, rollback, and recovery scenarios, with more practical checks and commands.
  * Improved troubleshooting navigation by linking related guides for faster self-service help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->