### PR TITLE
Docs: cumulative v2 alpha drift cleanup across guides

### DIFF
--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -433,7 +433,7 @@ docker-compose up -d
 
 ## Deployment Rollback
 
-> **Note**: This section covers rolling back the *application version* in a Docker deployment. To undo individual file organization operations, see [Operation Undo / Rollback](../troubleshooting.md#operation-undo--rollback-issues) in the User Troubleshooting Guide.
+> **Note**: This section covers rolling back the *application version* in a Docker deployment. To undo individual file organization operations, see [Operation Undo / Rollback](../troubleshooting.md#operation-undo-rollback-issues) in the User Troubleshooting Guide.
 
 ### Roll Back to a Previous Source Version
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -95,9 +95,9 @@ File Organizer v2.0
 
 **Web Server**
 
-- `web_server/main.py` - FastAPI application
-- `web_server/routes/` - API endpoints
-- `web_server/models.py` - Pydantic models
+- `src/file_organizer/api/main.py` - FastAPI application
+- `src/file_organizer/api/routers/` - API endpoints
+- `src/file_organizer/api/models.py` - Pydantic models
 
 **Core Engine**
 

--- a/docs/methodologies/johnny-decimal/faq.md
+++ b/docs/methodologies/johnny-decimal/faq.md
@@ -458,7 +458,7 @@ See [API Reference](api-reference.md) for full automation options.
 
 Start simple, add detail as needed:
 
-**Phase 1**: Areas only
+**Stage 1**: Areas only
 
 ```text
 10 Finance
@@ -466,7 +466,7 @@ Start simple, add detail as needed:
 30 Operations
 ```
 
-**Phase 2**: Add categories
+**Stage 2**: Add categories
 
 ```text
 10 Finance
@@ -474,7 +474,7 @@ Start simple, add detail as needed:
   12 Invoices
 ```
 
-**Phase 3**: Add IDs if needed
+**Stage 3**: Add IDs if needed
 
 ```text
 11 Budgets

--- a/docs/setup/ai-providers.md
+++ b/docs/setup/ai-providers.md
@@ -6,7 +6,7 @@ Complete setup guide for File Organizer's AI provider support: 5 native provider
 
 ## Overview
 
-File Organizer supports **5 native AI providers** for text analysis, plus **2 OpenAI-compatible services** (Groq, LM Studio) that use the `openai` provider with custom endpoints. Three of the native providers (Ollama, OpenAI, Claude) also support vision analysis; LLaMA.cpp and MLX are text-only for now.
+File Organizer supports **5 native AI providers** for text analysis, plus **2 OpenAI-compatible services** (Groq, LM Studio) that use the `openai` provider with custom endpoints. Three of the native providers (Ollama, OpenAI, Claude) also support vision analysis; LLaMA.cpp and MLX are text-only.
 
 **Native Providers:**
 - **Ollama** (default)
@@ -38,8 +38,8 @@ File Organizer supports **5 native AI providers** for text analysis, plus **2 Op
 | **Ollama** | `ollama` | Local | Free | Easy | No (CPU works) | ✅ Yes | Default choice, beginners, general use |
 | **OpenAI** | `openai` | Cloud | Paid (API) | Easy | No | ✅ Yes | Production quality, vision tasks, cloud OK |
 | **Claude** | `claude` | Cloud | Paid (API) | Easy | No | ✅ Yes | Strong reasoning, vision analysis, cloud OK |
-| **LLaMA.cpp** | `llama_cpp` | Local | Free | Medium | No (CPU works) | ❌ Currently unsupported | Advanced users, GGUF models, offline use |
-| **MLX** | `mlx` | Local | Free | Medium | Apple Silicon only | ❌ Currently unsupported | Mac users with M1/M2/M3 chips |
+| **LLaMA.cpp** | `llama_cpp` | Local | Free | Medium | No (CPU works) | ❌ Unsupported | Advanced users, GGUF models, offline use |
+| **MLX** | `mlx` | Local | Free | Medium | Apple Silicon only | ❌ Unsupported | Mac users with M1/M2/M3 chips |
 
 ### OpenAI-Compatible Services
 
@@ -47,7 +47,7 @@ These services use `FO_PROVIDER=openai` with a custom `FO_OPENAI_BASE_URL`:
 
 | Service | Local/Cloud | Cost | Setup Difficulty | Vision Support | Best For |
 |---------|-------------|------|------------------|----------------|----------|
-| **Groq** | Cloud | Free/Paid | Easy | ❌ Not yet | Fast inference, low latency |
+| **Groq** | Cloud | Free/Paid | Easy | ❌ Limited by model availability | Fast inference, low latency |
 | **LM Studio** | Local | Free | Medium | Varies | GUI model management, local control |
 
 ---
@@ -673,10 +673,10 @@ ollama serve
 
 ### Vision Not Supported
 
-Some providers only support text inference currently:
+Some providers support text inference only:
 
-- **LLaMA.cpp**: Vision support is currently unsupported
-- **MLX**: Vision support is currently unsupported
+- **LLaMA.cpp**: Vision support is unsupported
+- **MLX**: Vision support is unsupported
 - **Groq**: Check Groq docs for vision model availability
 
 Image files will fall back to extension-based organization.


### PR DESCRIPTION
## Description
This closes the remaining documentation drift discovered after child issues #1440-#1445 were completed, so the #1439 epic lands as a single coherent docs pass. The update keeps edits surgical while removing stale terminology and path references that could mislead users and contributors.

Fixes: #1439

Key updates:
- aligned legacy developer API path references from `web_server/*` to `src/file_organizer/api/*`
- replaced Johnny Decimal FAQ progression wording from "Phase" to "Stage" to avoid stale phase-language conflicts
- normalized AI provider support wording to present current-state behavior without roadmap-style phrasing
- corrected the admin troubleshooting anchor to the user rollback section

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `python -m mkdocs build --strict`
- [x] Commit-time pre-commit checks on staged docs changes (including stale-reference and link-integrity checks)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules