### PR TITLE
Docs: streamline terminal-first onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,47 +85,44 @@
 
 ![TUI demo](docs/assets/tui-demo.gif)
 
-## Quick Start
+## Quick Start (Essentials)
 
 ### With Ollama (local, default)
 
 ```bash
 pip install -e .
 
-# Pull models
-ollama pull qwen2.5:3b-instruct-q4_K_M
-ollama pull qwen2.5vl:7b-q4_K_M
+# 1) Configure defaults
+fo setup
 
-# Organize files (dry run first)
-file-organizer organize ./Downloads ./Organized --dry-run
+# 2) Preview a folder before changing anything
+fo preview ~/Downloads
 
-# Launch the TUI
-file-organizer tui
+# 3) Run organization
+fo organize ~/Downloads ~/Organized
 
-# Launch the native desktop window (preferred unified command)
-file-organizer desktop
-# fo desktop
-# file-organizer-desktop  # compatibility script
+# 4) Roll back the most recent organize run if needed
+fo undo
 ```
 
-### With OpenAI or compatible API
+### Prefer a browser?
 
 ```bash
-pip install -e ".[cloud]"
+file-organizer serve --reload
+```
 
+Then visit `http://localhost:8000/ui/`.
+
+### Need cloud providers instead of the default local flow?
+
+Use the [AI Provider Setup guide](docs/setup/ai-providers.md) for OpenAI-compatible endpoints and Claude.
+
+```bash
+# OpenAI-compatible providers
 export FO_PROVIDER=openai
-export FO_OPENAI_API_KEY=sk-...  # OPENAI_API_KEY is also accepted as fallback
-file-organizer organize ./Downloads ./Organized --dry-run
-```
 
-### With Anthropic Claude
-
-```bash
-pip install -e ".[claude]"
-
+# Anthropic Claude
 export FO_PROVIDER=claude
-export FO_CLAUDE_API_KEY=sk-ant-...  # ANTHROPIC_API_KEY is also accepted as fallback
-file-organizer organize ./Downloads ./Organized --dry-run
 ```
 
 ## Web UI
@@ -140,31 +137,28 @@ Then visit `http://localhost:8000/ui/` for the HTMX interface.
 
 ## Documentation
 
+### Essentials
+
 - [Documentation Home](docs/index.md)
 - [Getting Started](docs/getting-started.md)
-- [User Guide](docs/USER_GUIDE.md)
-- [Workflow Map](docs/USER_GUIDE.md#workflow-map-quick-paths)
-- [Web UI Guide](docs/web-ui/index.md)
+- [CLI Reference](docs/cli-reference.md#core-first-run-commands)
+- [User Guide Workflow Map](docs/USER_GUIDE.md#workflow-map-quick-paths)
+- [Web UI Quick Start](docs/web-ui/getting-started.md)
+- [Troubleshooting](docs/troubleshooting.md)
+
+### Advanced / Admin / Developer
+
+- [Full CLI Reference](docs/cli-reference.md)
 - [Terminal UI Guide](docs/tui.md)
-- [CLI Reference](docs/cli-reference.md)
-- [CLI Search Commands](docs/cli-reference.md#cli-search)
-- [CLI Duplicate Detection (`dedupe`)](docs/cli-reference.md#cli-dedupe)
-- [CLI Undo/Redo History (`history`)](docs/cli-reference.md#cli-history)
-- [CLI API Keys (`api-keys`)](docs/cli-reference.md)
-- [CLI Plugin Marketplace (`marketplace`)](docs/cli-reference.md#cli-marketplace)
-- [CLI Copilot Assistant (`copilot`)](docs/cli-reference.md#cli-copilot)
-- [CLI Rules Batch Review (`rules`)](docs/cli-reference.md#cli-rules)
-- [CLI Profile Behavior](docs/cli-reference.md#cli-profile)
 - [Desktop App Guide](docs/desktop-app.md)
-- [API Reference](docs/api/index.md)
-- [Johnny Decimal User Guide](docs/methodologies/johnny-decimal/user-guide.md)
-- [Johnny Decimal Migration Guide](docs/methodologies/johnny-decimal/migration.md)
 - [AI Provider Setup](docs/setup/ai-providers.md)
 - [Audio & Video Processing Guide](docs/setup/audio-video.md)
-- [File Format Reference](docs/admin/file-format-reference.md)
 - [Configuration Guide](docs/CONFIGURATION.md)
+- [API Reference](docs/api/index.md)
+- [File Format Reference](docs/admin/file-format-reference.md)
 - [Path Standardization & Migration](docs/config/path-standardization.md)
-- [Troubleshooting](docs/troubleshooting.md)
+- [Johnny Decimal User Guide](docs/methodologies/johnny-decimal/user-guide.md)
+- [Johnny Decimal Migration Guide](docs/methodologies/johnny-decimal/migration.md)
 
 ## Optional Feature Packs
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -4,6 +4,21 @@
 
 File Organizer v2 is an AI-powered local file management system built with a privacy-first architecture. It is local-first (Ollama by default) and also supports optional cloud providers when explicitly configured.
 
+## Essentials First Run (CLI)
+
+Use this workflow to get a successful first organization run before exploring advanced features:
+
+```bash
+fo setup
+fo preview ~/Downloads
+fo organize ~/Downloads ~/Organized
+fo undo
+```
+
+Use `fo undo` after at least one organize run has been recorded.
+
+Prefer a browser? Start with [Web UI Quick Start](web-ui/getting-started.md).
+
 ## Installation
 
 ### Prerequisites
@@ -50,6 +65,7 @@ Use this routing table to jump directly to a practical workflow.
 
 | Goal | Start here | Go deeper |
 |------|------------|-----------|
+| Complete your first CLI organization run safely | [Essentials first run](#essentials-first-run-cli) | [Core first run commands](cli-reference.md#core-first-run-commands) |
 | Run Copilot for a folder and get actionable output | [Copilot quick workflow](#quick-workflow-ask-verify-and-act) | [CLI `copilot` entry points](cli-reference.md#cli-copilot) |
 | Navigate TUI quickly | [Terminal UI](#terminal-ui-tui) | [TUI keyboard map](tui.md#keyboard-shortcuts) |
 | Do rules-based batch review before applying changes | [Rules batch review workflow](#rules-batch-review-workflow) | [CLI `rules` entry points](cli-reference.md#cli-rules) |
@@ -63,6 +79,8 @@ Use this routing table to jump directly to a practical workflow.
 ## CLI Commands Overview
 
 File Organizer provides two equivalent entrypoints: `file-organizer` and the short alias `fo`.
+
+If you're new, start with `setup`, `preview`, `organize`, and `undo` before exploring the full command catalog.
 
 | Command | Description |
 |---------|-------------|

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,6 +2,26 @@
 
 All commands are available via `file-organizer` or the short alias `fo`.
 
+## Core first run commands
+
+Start with this minimal workflow:
+
+```bash
+fo setup
+fo preview ~/Downloads
+fo organize ~/Downloads ~/Organized
+fo undo
+```
+
+Use `fo undo` after at least one organize run has been recorded.
+
+See the canonical command sections:
+
+- [`setup`](#setup)
+- [`preview`](#preview)
+- [`organize`](#organize)
+- [`undo`](#undo)
+
 ## Global Options
 
 These options apply to every command and may be passed before or after the command name:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,21 @@
 
 This guide will help you install and set up File Organizer quickly.
 
+## Essentials first run (CLI)
+
+If you're new, use this terminal-first path first:
+
+```bash
+fo setup
+fo preview ~/Downloads
+fo organize ~/Downloads ~/Organized
+fo undo
+```
+
+Use `fo undo` after at least one organize run has been recorded.
+
+Prefer a browser? Start with [Web UI Quick Start](web-ui/getting-started.md).
+
 ## Installation Methods
 
 Choose the installation method that best fits your needs:
@@ -174,62 +189,27 @@ When you first access File Organizer, you'll see a welcome screen with:
 
 ### 2. AI Model Configuration
 
-File Organizer supports two provider modes:
+Use this decision rule:
 
-**Option A — Ollama (default, fully local):**
+1. **Use Ollama (default)** unless you specifically need a cloud model or a custom OpenAI-compatible endpoint.
+2. If you need cloud/remote providers, use [AI Provider Setup](setup/ai-providers.md).
 
-- **Text Model**: `qwen2.5:3b-instruct-q4_K_M` (~1.9 GB)
-- **Vision Model**: `qwen2.5vl:7b-q4_K_M` (~6.0 GB)
+Default local models:
 
-These are automatically pulled on first run if Ollama is available.
+- `qwen2.5:3b-instruct-q4_K_M` (text)
+- `qwen2.5vl:7b-q4_K_M` (vision)
 
-**Manual pull** (if needed):
+Manual model pull (if needed):
 
 ```bash
 ollama pull qwen2.5:3b-instruct-q4_K_M
 ollama pull qwen2.5vl:7b-q4_K_M
 ```
 
-**Option B — OpenAI-compatible endpoint (cloud or local API server):**
+For provider-specific environment variables, see:
 
-No Ollama required. Install the `[cloud]` extra and set environment variables:
-
-```bash
-pip install "local-file-organizer[cloud]"   # from PyPI
-# pip install -e ".[cloud]"           # from source checkout
-
-# Example: OpenAI
-export FO_PROVIDER=openai
-export FO_OPENAI_API_KEY=sk-...
-export FO_OPENAI_MODEL=gpt-4o-mini
-
-# Example: LM Studio (local, no key needed)
-export FO_PROVIDER=openai
-export FO_OPENAI_BASE_URL=http://localhost:1234/v1
-export FO_OPENAI_MODEL=your-loaded-model
-```
-
-**Option C — Anthropic Claude:**
-
-No Ollama required. Install the `[claude]` extra and set environment variables:
-
-```bash
-pip install "local-file-organizer[claude]"  # from PyPI
-# pip install -e ".[claude]"          # from source checkout
-
-export FO_PROVIDER=claude
-export FO_CLAUDE_API_KEY=sk-ant-...
-export FO_CLAUDE_MODEL=claude-3-5-sonnet-20241022
-```
-
-Claude supports both text and vision tasks natively — no separate vision model configuration is required (though you can override with `FO_CLAUDE_VISION_MODEL`).
-
-SDK-native key fallbacks are also supported:
-
-- OpenAI mode: `OPENAI_API_KEY`
-- Claude mode: `ANTHROPIC_API_KEY`
-
-See [Configuration Guide](CONFIGURATION.md) for the full list of providers and options.
+- [AI Provider Setup](setup/ai-providers.md)
+- [Configuration Guide](CONFIGURATION.md)
 
 ### 3. Workspace Configuration
 
@@ -279,41 +259,17 @@ File Organizer also provides a command-line interface:
 ### Basic Commands
 
 ```bash
-# Start the web server and API
-file-organizer serve
+# Configure first-run defaults
+fo setup
+
+# Preview organization safely
+fo preview ~/Downloads
 
 # Organize files
-file-organizer organize ./Downloads ./Organized
+fo organize ~/Downloads ~/Organized
 
-# Preview without moving (dry run)
-file-organizer organize ./Downloads ./Organized --dry-run
-
-# Preview organisation plan
-file-organizer preview ./Downloads
-
-# Search for files
-file-organizer search "*.pdf" ~/Documents
-file-organizer search "report" ~/Documents --type text
-
-# Analyze a file with AI
-file-organizer analyze ./report.pdf
-file-organizer analyze ./report.pdf --verbose
-
-# Auto-tag files
-file-organizer autotag suggest ./Documents
-file-organizer autotag popular
-
-# Detect duplicates
-file-organizer dedupe scan ./Documents
-
-# Analyse storage
-file-organizer analytics ./Documents
-
-# View operation history
-file-organizer history
-
-# Interactive AI assistant
-file-organizer copilot chat
+# Undo the most recent organize operation (if needed)
+fo undo
 ```
 
 ### Short Alias
@@ -321,16 +277,13 @@ file-organizer copilot chat
 Use `fo` instead of `file-organizer`:
 
 ```bash
-fo serve
-fo organize ./Downloads ./Organized
+fo setup
 fo preview ./Downloads
-fo search "*.pdf" ~/Documents
-fo analyze ./report.pdf
-fo dedupe scan ./Documents
-fo analytics ./Documents
+fo organize ./Downloads ./Organized
+fo undo
 ```
 
-See [CLI Reference](cli-reference.md) for all commands.
+After your first run, use the full [CLI Reference](cli-reference.md) for search, analysis, dedupe, rules, marketplace, and other advanced commands.
 
 ## Choosing an Organization Methodology
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,69 +2,40 @@
 
 Welcome to the **File Organizer** documentation! A privacy-first, AI-powered local file management system that is local-first by default, with optional cloud provider integrations when explicitly configured.
 
+## Essentials (Start Here)
+
+Use this first-run terminal workflow:
+
+```bash
+fo setup
+fo preview ~/Downloads
+fo organize ~/Downloads ~/Organized
+fo undo
+```
+
+Use `fo undo` after at least one organize run has been recorded.
+
+Prefer a browser? Start with [Web UI Quick Start](web-ui/getting-started.md).
+
 ## Quick Navigation
 
-=== "🚀 Getting Started"
+=== "🚀 Essentials"
 
-    **New to File Organizer?** Start here to understand the basics.
-
-    - [Installation & Setup](getting-started.md)
-    - [Web UI Quick Start](web-ui/getting-started.md)
+    - [Getting Started](getting-started.md)
+    - [Core first run commands](cli-reference.md#core-first-run-commands)
     - [Workflow Map](USER_GUIDE.md#workflow-map-quick-paths)
+    - [Web UI Quick Start](web-ui/getting-started.md)
+    - [Troubleshooting](troubleshooting.md)
 
-=== "🖥️ Web UI & Profile"
-
-    **Using the web browser interface?** Start with implemented routes and surfaces.
-
-    - [File Management](web-ui/file-management.md)
-    - [Organization Workflows](web-ui/organization.md)
-    - [Analysis & Search](web-ui/analysis-search.md)
-    - [Settings & Profile](web-ui/settings.md)
-
-=== "🧭 Interfaces & Copilot"
-
-    **Prefer desktop or terminal workflows?** Jump directly to interface-specific guides.
+=== "🧭 Advanced / Admin / Developer"
 
     - [Terminal UI Guide](tui.md)
     - [Desktop App Guide](desktop-app.md)
-    - [Copilot workflow entry point](cli-reference.md#cli-copilot)
-    - [Rules batch review entry point](cli-reference.md#cli-rules)
-    - [Dedupe workflow entry point](cli-reference.md#cli-dedupe)
-
-=== "🗂️ Methodologies"
-
-    **Choosing PARA vs Johnny Decimal?** Use these workflow-oriented references.
-
+    - [AI Provider Setup](setup/ai-providers.md)
+    - [API Reference](api/index.md)
+    - [Admin Guide](admin/index.md)
+    - [Developer Guide](developer/index.md)
     - [Methodology selection workflow](USER_GUIDE.md#quick-workflow-choose-a-methodology)
-    - [Johnny Decimal User Guide](methodologies/johnny-decimal/user-guide.md#getting-started)
-    - [Johnny Decimal Migration Guide](methodologies/johnny-decimal/migration.md#step-by-step-migration)
-    - [Johnny Decimal + PARA Compatibility](methodologies/johnny-decimal/para-compatibility.md#integration-approaches)
-
-=== "📚 API Reference"
-
-    **Building integrations?** Use our REST API.
-
-    - [Authentication](api/authentication.md)
-    - [File Endpoints](api/file-endpoints.md)
-    - [Organization Endpoints](api/organization-endpoints.md)
-    - [Search & Analysis](api/search-endpoints.md)
-
-=== "🔧 Deployment"
-
-    **Running your own instance?** Deploy and configure File Organizer.
-
-    - [Installation](admin/installation.md)
-    - [Deployment](admin/deployment.md)
-    - [Configuration](admin/configuration.md)
-    - [Monitoring](admin/monitoring.md)
-
-=== "👨‍💻 Development"
-
-    **Extending File Organizer?** Build plugins and integrations.
-
-    - [Architecture](developer/architecture.md)
-    - [Plugin Development](developer/plugin-development.md)
-    - [API Clients](developer/api-clients.md)
 
 ## Key Features
 
@@ -98,21 +69,24 @@ File Organizer processes **48+ file formats** including:
 
 ## Documentation Sections
 
-### User Guides
+### Essentials
 
-- [Web UI Guide](web-ui/index.md) - Browser-based file management
-- [Terminal UI Guide](tui.md) - Keyboard-driven terminal interface
-- [Desktop App Guide](desktop-app.md) - Native OS desktop window
-- [Getting Started](getting-started.md) - Initial setup and overview
-- [CLI Reference](cli-reference.md) - Command-line interface guide
-- [Troubleshooting](troubleshooting.md) - Common issues and solutions
+- [Getting Started](getting-started.md) - Install and complete your first run
+- [Core first run commands](cli-reference.md#core-first-run-commands) - `setup`, `preview`, `organize`, `undo`
+- [Workflow Map](USER_GUIDE.md#workflow-map-quick-paths) - Practical jump table by goal
+- [Web UI Quick Start](web-ui/getting-started.md) - Secondary browser-first path
+- [Troubleshooting](troubleshooting.md) - Common issues and fixes
 
-### Setup
+### Advanced Setup & Interfaces
 
-- [AI Provider Setup](setup/ai-providers.md) - Configure Ollama, OpenAI, Claude, and more
+- [AI Provider Setup](setup/ai-providers.md) - OpenAI-compatible, Claude, llama.cpp, MLX
 - [Dependencies & Optional Extras](setup/dependencies.md) - Canonical extras matrix and install groups
 - [Models](setup/models.md) - AI model configuration
 - [Audio & Video Processing](setup/audio-video.md) - Media analysis prerequisites and setup
+- [Web UI Guide](web-ui/index.md) - Browser-based file management
+- [Terminal UI Guide](tui.md) - Keyboard-driven terminal interface
+- [Desktop App Guide](desktop-app.md) - Native OS desktop window
+- [CLI Reference](cli-reference.md) - Full command-line reference
 
 ### API & Integration
 

--- a/docs/setup/ai-providers.md
+++ b/docs/setup/ai-providers.md
@@ -8,6 +8,18 @@ Complete setup guide for File Organizer's AI provider support: 5 native provider
 
 File Organizer supports **5 native AI providers** for text analysis, plus **2 OpenAI-compatible services** (Groq, LM Studio) that use the `openai` provider with custom endpoints. Three of the native providers (Ollama, OpenAI, Claude) also support vision analysis; LLaMA.cpp and MLX are text-only.
 
+## Choose a provider quickly
+
+If you are unsure, use **Ollama** first. It is the local default and requires the least setup.
+
+Choose a different provider only when you specifically need:
+
+- Cloud-hosted models (OpenAI, Claude, Groq)
+- A local OpenAI-compatible endpoint you already run (LM Studio)
+- Advanced local model runtimes (LLaMA.cpp, MLX)
+
+For first-run setup guidance, see [Getting Started](../getting-started.md).
+
 **Native Providers:**
 - **Ollama** (default)
 - **OpenAI**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,24 +80,25 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Getting Started: getting-started.md
-  - User Guide: USER_GUIDE.md
-  - Interfaces:
-      - Terminal UI: tui.md
-      - Desktop App: desktop-app.md
-  - Web UI Guide:
+  - Getting Started (Essentials): getting-started.md
+  - CLI Reference (Essentials): cli-reference.md
+  - User Guide (Essentials): USER_GUIDE.md
+  - Web UI Guide (Essentials):
       - Overview: web-ui/index.md
       - Getting Started: web-ui/getting-started.md
       - File Management: web-ui/file-management.md
       - Organization Workflows: web-ui/organization.md
       - Analysis & Search: web-ui/analysis-search.md
       - Settings & Profile: web-ui/settings.md
-  - Setup & AI Providers:
+  - Interfaces:
+      - Terminal UI: tui.md
+      - Desktop App: desktop-app.md
+  - Setup & AI Providers (Advanced):
       - AI Providers: setup/ai-providers.md
       - Models: setup/models.md
       - Dependencies & Optional Extras: setup/dependencies.md
       - Audio & Video Processing: setup/audio-video.md
-  - CLI Feature Discoverability:
+  - CLI Feature Discoverability (Advanced):
       - Search commands: cli-reference.md
       - Duplicate detection (dedupe): cli-reference.md
       - Undo/Redo history: cli-reference.md
@@ -145,7 +146,6 @@ nav:
       - Configuration Guide: CONFIGURATION.md
       - Path Standardization & Migration: config/path-standardization.md
       - Deprecation Notice: config/deprecation-notice.md
-  - CLI Reference: cli-reference.md
   - Troubleshooting: troubleshooting.md
   - FAQ: faq.md
   - Blog:


### PR DESCRIPTION
## Description
This docs-only change reduces first-touch decision fatigue for non-pro terminal users by making a single happy path the default across entry docs. It keeps advanced/admin/developer content available, but no longer front-loads it before a first successful run.

Key updates:
- Added a consistent essentials CLI flow (`fo setup`, `fo preview ~/Downloads`, `fo organize ~/Downloads ~/Organized`, `fo undo`) across README, docs home, getting started, user guide, and CLI reference.
- Reframed setup guidance to default to Ollama first, with clear links to provider-specific docs when cloud or advanced runtimes are needed.
- Re-labeled and reordered MkDocs navigation to essentials-first with minimal churn.
- Added a non-duplicative core-orientation section in CLI docs that links to canonical command sections.

Fixes: #1456

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `python -m mkdocs build --strict`
- [x] Pre-commit CI guardrails during commit (including `pytest (smoke suite)`, `pytest (ci guardrails)`, `pytest (websocket validations)`, `pytest (web ui)`, and docs link-integrity)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules