### PR TITLE
Fix docs extras heading compatibility in pyproject sync test

### DIFF
--- a/tests/docs/test_pyproject_sync.py
+++ b/tests/docs/test_pyproject_sync.py
@@ -59,13 +59,27 @@ def _extract_section(content: str, heading: str) -> str:
     return content[start:]
 
 
+def _extract_section_with_fallbacks(content: str, headings: tuple[str, ...]) -> str:
+    """Extract section content by trying an ordered list of accepted headings."""
+    for heading in headings:
+        try:
+            return _extract_section(content, heading)
+        except ValueError:
+            continue
+    accepted = ", ".join(f"'{heading}'" for heading in headings)
+    raise ValueError(f"None of the accepted headings were found: {accepted}")
+
+
 @pytest.mark.parametrize("extra", _get_extras())
 def test_extra_documented(extra: str) -> None:
     """Each pyproject.toml optional-dependency group must appear in dependencies.md."""
     content = DEPS_DOC.read_text(encoding="utf-8")
-    section = _extract_section(content, "Optional Dependencies")
+    section_headings = ("Optional extras matrix", "Optional Dependencies")
+    section = _extract_section_with_fallbacks(content, section_headings)
+    accepted_headings = ", ".join(f"'{heading}'" for heading in section_headings)
     assert re.search(rf"\b{re.escape(extra)}\b", section), (
-        f"Optional extra '{extra}' not found in 'Optional Dependencies' section "
+        f"Optional extra '{extra}' not found in accepted extras section headings "
+        f"({accepted_headings}) "
         f"of {DEPS_DOC.relative_to(REPO_ROOT)}"
     )
 
@@ -114,3 +128,47 @@ class TestExtractSection:
         content = "### Optional Dependencies\n\nContent\n"
         result = _extract_section(content, "Optional Dependencies")
         assert "Content" in result
+
+
+class TestExtractSectionWithFallbacks:
+    """Tests for _extract_section_with_fallbacks helper."""
+
+    def test_uses_first_heading_when_present(self) -> None:
+        content = "## Optional extras matrix\n\nCanonical content\n"
+        result = _extract_section_with_fallbacks(
+            content, ("Optional extras matrix", "Optional Dependencies")
+        )
+        assert "Canonical content" in result
+
+    def test_uses_second_heading_as_fallback(self) -> None:
+        content = "## Optional Dependencies\n\nLegacy content\n"
+        result = _extract_section_with_fallbacks(
+            content, ("Optional extras matrix", "Optional Dependencies")
+        )
+        assert "Legacy content" in result
+
+    def test_raises_when_no_fallback_heading_exists(self) -> None:
+        content = "# Title\n\nNo matching section\n"
+        with pytest.raises(
+            ValueError,
+            match=(
+                "None of the accepted headings were found: "
+                "'Optional extras matrix', 'Optional Dependencies'"
+            ),
+        ):
+            _extract_section_with_fallbacks(
+                content, ("Optional extras matrix", "Optional Dependencies")
+            )
+
+    def test_extraction_stops_at_next_same_or_higher_level_heading(self) -> None:
+        content = (
+            "## Optional Dependencies\n\nTop content\n\n"
+            "### Nested\n\nNested content\n\n"
+            "## Common install combinations\n\nSibling content\n"
+        )
+        result = _extract_section_with_fallbacks(
+            content, ("Optional extras matrix", "Optional Dependencies")
+        )
+        assert "Top content" in result
+        assert "Nested content" in result
+        assert "Sibling content" not in result


### PR DESCRIPTION
## Description
This fixes a brittle docs-sync test that failed after the dependencies doc heading was renamed from `Optional Dependencies` to `Optional extras matrix`. The test now accepts the canonical heading while preserving strict section extraction behavior.

Fixes: #1458

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `pytest -q tests/docs/test_pyproject_sync.py --override-ini="addopts="`
- [x] `ruff check tests/docs/test_pyproject_sync.py && pytest -q tests/docs --override-ini="addopts="`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation to accept either of two documentation section headings for optional dependencies.
  * Added coverage for heading fallback behavior, including missing sections and boundary cases.
  * Improved test failure messages to show the accepted section headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->