### PR TITLE
Improve CLI onboarding with progressive help disclosure

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -49,6 +49,45 @@ file-organizer version
 
 ---
 
+### `start`
+
+Guided first-run setup with safe defaults (recommended beginner path).
+
+**Usage:**
+
+```bash
+file-organizer start [OPTIONS]
+```
+
+**Options:**
+
+- `--profile, -p` — Profile name (default: `default`)
+- `--dry-run` — Preview setup choices without saving configuration
+
+**Examples:**
+
+```bash
+# Run quick-start setup
+file-organizer start
+
+# Configure a named profile
+file-organizer start --profile work
+```
+
+---
+
+### `quickstart`
+
+Alias of `start` for quick-start setup.
+
+**Usage:**
+
+```bash
+file-organizer quickstart [OPTIONS]
+```
+
+---
+
 ### `organize`
 
 Organize files in a directory using AI models.
@@ -68,11 +107,25 @@ file-organizer organize INPUT_DIR OUTPUT_DIR [OPTIONS]
 
 - `--dry-run` — Preview without moving files
 - `--verbose, -v` — Verbose output
-- `--max-workers INTEGER` — Cap parallel worker count
-- `--sequential` — Force single-worker sequential processing
-- `--no-vision`, `--text-only` — Disable vision model loading and use extension fallback for images
-- `--prefetch-depth INTEGER` — Parallel task queue-ahead depth (`0` disables prefetch queueing)
-- `--no-prefetch` — Backward-compatible alias for `--prefetch-depth 0`
+- `--advanced-help` — Show advanced tuning options and exit
+
+**Advanced tuning options:**
+
+```bash
+file-organizer organize --advanced-help
+```
+
+Advanced help includes:
+
+- `--max-workers INTEGER`
+- `--sequential`
+- `--no-vision`, `--text-only`
+- `--prefetch-depth INTEGER`
+- `--no-prefetch`
+- `--transcribe-audio`
+- `--max-transcribe-seconds FLOAT`
+
+`--no-prefetch` is a backward-compatible alias for `--prefetch-depth 0`.
 
 **Examples:**
 
@@ -86,17 +139,8 @@ file-organizer organize ~/Downloads ~/Organized --dry-run
 # Verbose output
 file-organizer organize ~/Downloads ~/Organized --verbose
 
-# Limit CPU/IO pressure on constrained machines
-file-organizer organize ~/Downloads ~/Organized --max-workers 2 --prefetch-depth 1
-
-# Strict sequential mode for deterministic debugging
-file-organizer organize ~/Downloads ~/Organized --sequential
-
-# Disable AI vision processing and use extension-based image fallback
-file-organizer organize ~/Downloads ~/Organized --no-vision
-
-# Backward-compatible alias
-file-organizer organize ~/Downloads ~/Organized --no-prefetch
+# Show advanced tuning flags
+file-organizer organize --advanced-help
 ```
 
 > **Note:** To set a default methodology (PARA, Johnny Decimal, etc.) or override AI models, use `file-organizer config edit` before running organize.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,17 +259,47 @@ File Organizer also provides a command-line interface:
 ### Basic Commands
 
 ```bash
-# Configure first-run defaults
-fo setup
+# Run guided quick-start setup (recommended first CLI command)
+file-organizer start
 
-# Preview organization safely
-fo preview ~/Downloads
+# Start the web server and API
+file-organizer serve
 
 # Organize files
 fo organize ~/Downloads ~/Organized
 
-# Undo the most recent organize operation (if needed)
-fo undo
+# Preview without moving (dry run)
+file-organizer organize ./Downloads ./Organized --dry-run
+
+# Preview organisation plan
+file-organizer preview ./Downloads
+
+# Show advanced tuning flags for organize
+file-organizer organize --advanced-help
+
+# Search for files
+file-organizer search "*.pdf" ~/Documents
+file-organizer search "report" ~/Documents --type text
+
+# Analyze a file with AI
+file-organizer analyze ./report.pdf
+file-organizer analyze ./report.pdf --verbose
+
+# Auto-tag files
+file-organizer autotag suggest ./Documents
+file-organizer autotag popular
+
+# Detect duplicates
+file-organizer dedupe scan ./Documents
+
+# Analyse storage
+file-organizer analytics ./Documents
+
+# View operation history
+file-organizer history
+
+# Interactive AI assistant
+file-organizer copilot chat
 ```
 
 ### Short Alias
@@ -277,9 +307,10 @@ fo undo
 Use `fo` instead of `file-organizer`:
 
 ```bash
-fo setup
-fo preview ./Downloads
+fo start
+fo serve
 fo organize ./Downloads ./Organized
+fo preview ./Downloads
 fo undo
 ```
 

--- a/src/file_organizer/cli/lazy.py
+++ b/src/file_organizer/cli/lazy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import typing
+from collections import OrderedDict
 
 import click
 import typer
@@ -39,6 +40,48 @@ LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
         "Browse and manage marketplace plugins.",
     ),
 }
+
+COMMAND_CATEGORIES: dict[str, str] = {
+    # Core
+    "start": "Core",
+    "quickstart": "Core",
+    "setup": "Core",
+    "organize": "Core",
+    "preview": "Core",
+    "search": "Core",
+    "analyze": "Core",
+    # Interfaces
+    "serve": "Interfaces",
+    "desktop": "Interfaces",
+    "tui": "Interfaces",
+    "api": "Interfaces",
+    "api-keys": "Interfaces",
+    # Automation
+    "autotag": "Automation",
+    "dedupe": "Automation",
+    "rules": "Automation",
+    "daemon": "Automation",
+    "suggest": "Automation",
+    # Advanced
+    "analytics": "Advanced",
+    "benchmark": "Advanced",
+    "config": "Advanced",
+    "copilot": "Advanced",
+    "doctor": "Advanced",
+    "docs": "Advanced",
+    "hardware-info": "Advanced",
+    "history": "Advanced",
+    "marketplace": "Advanced",
+    "model": "Advanced",
+    "profile": "Advanced",
+    "recover": "Advanced",
+    "redo": "Advanced",
+    "undo": "Advanced",
+    "update": "Advanced",
+    "version": "Advanced",
+}
+
+HELP_CATEGORY_ORDER: tuple[str, ...] = ("Core", "Interfaces", "Automation", "Advanced")
 
 
 class LazyCommandProxy(click.Group):
@@ -182,7 +225,45 @@ class LazyTyperGroup(typer.core.TyperGroup):
         Returns:
             click.Command | None: A `LazyCommandProxy` or other `click.Command` when found, `None` if no command matches.
         """
+        command: click.Command | None
         if cmd_name in LAZY_COMMANDS:
             module_name, attr_name, help_text = LAZY_COMMANDS[cmd_name]
-            return LazyCommandProxy(cmd_name, module_name, attr_name, help_text)
-        return super().get_command(ctx, cmd_name)
+            command = LazyCommandProxy(cmd_name, module_name, attr_name, help_text)
+        else:
+            command = super().get_command(ctx, cmd_name)
+
+        if command is not None:
+            command.__dict__["rich_help_panel"] = (
+                f"{COMMAND_CATEGORIES.get(cmd_name, 'Advanced')} Commands"
+            )
+        return command
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """Render top-level commands grouped by user-facing complexity tiers."""
+        command_rows: list[tuple[str, click.Command]] = []
+        for subcommand in self.list_commands(ctx):
+            cmd = self.get_command(ctx, subcommand)
+            if cmd is None or cmd.hidden:
+                continue
+            command_rows.append((subcommand, cmd))
+
+        if not command_rows:
+            return
+
+        max_len = max(len(name) for name, _ in command_rows)
+        limit = formatter.width - 6 - max_len
+        if limit < 10:
+            limit = 10
+
+        grouped: OrderedDict[str, list[tuple[str, str]]] = OrderedDict(
+            (category, []) for category in HELP_CATEGORY_ORDER
+        )
+        for name, cmd in sorted(command_rows, key=lambda item: item[0]):
+            category = COMMAND_CATEGORIES.get(name, "Advanced")
+            grouped.setdefault(category, []).append((name, cmd.get_short_help_str(limit)))
+
+        for category, rows in grouped.items():
+            if not rows:
+                continue
+            with formatter.section(f"{category} Commands"):
+                formatter.write_dl(rows)

--- a/src/file_organizer/cli/lazy.py
+++ b/src/file_organizer/cli/lazy.py
@@ -251,7 +251,8 @@ class LazyTyperGroup(typer.core.TyperGroup):
             return
 
         max_len = max(len(name) for name, _ in command_rows)
-        limit = formatter.width - 6 - max_len
+        formatter_width = formatter.width or 80
+        limit = formatter_width - 6 - max_len
         if limit < 10:
             limit = 10
 

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -241,7 +241,7 @@ def start_command(
     ] = False,
 ) -> None:
     """Run guided first-time setup with safe defaults."""
-    _run_quick_start_setup(profile=profile, dry_run=dry_run)
+    _run_quick_start_setup(profile=profile, dry_run=_merge_flag(dry_run, _get_state().dry_run))
 
 
 @app.command()

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -56,6 +56,8 @@ def _version_callback(value: bool) -> None:
 _SETUP_GATE_ALLOWLIST: frozenset[str] = frozenset(
     {
         "setup",
+        "start",
+        "quickstart",
         "version",
         "doctor",
         "update",
@@ -220,6 +222,26 @@ app.command()(preview)
 app.command()(search)
 app.command()(analyze)
 app.command()(doctor)
+
+
+def _run_quick_start_setup(profile: str, dry_run: bool) -> None:
+    """Run the setup wizard in quick-start mode."""
+    from file_organizer.cli.setup import setup_run
+
+    setup_run(mode="quick-start", profile=profile, dry_run=dry_run)
+
+
+@app.command(name="quickstart")
+@app.command(name="start")
+def start_command(
+    profile: Annotated[str, typer.Option("--profile", "-p", help="Profile name.")] = "default",
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview setup choices without saving configuration."),
+    ] = False,
+) -> None:
+    """Run guided first-time setup with safe defaults."""
+    _run_quick_start_setup(profile=profile, dry_run=dry_run)
 
 
 @app.command()

--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
 from file_organizer.cli.path_validation import resolve_cli_path, validate_pair
 from file_organizer.cli.state import _get_state
@@ -74,6 +75,47 @@ def _resolve_parallel_settings(
     return (1 if sequential else max_workers, 0 if (sequential or no_prefetch) else prefetch_depth)
 
 
+def _print_organize_advanced_help() -> None:
+    """Print advanced tuning options for ``fo organize`` and exit."""
+    console.print(
+        Panel.fit(
+            "[bold]Advanced tuning options for `fo organize`[/bold]\n"
+            "Use these only when you need tighter control over performance, "
+            "media processing, or deterministic execution.",
+            border_style="cyan",
+        )
+    )
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Flag", style="bold")
+    table.add_column("Purpose")
+    table.add_row("`--max-workers INTEGER`", "Cap parallel worker count.")
+    table.add_row("`--sequential`", "Force single-worker sequential processing.")
+    table.add_row(
+        "`--prefetch-depth INTEGER`",
+        "Tune queue-ahead depth per worker (`0` disables prefetch).",
+    )
+    table.add_row("`--no-prefetch`", "Backward-compatible alias for `--prefetch-depth 0`.")
+    table.add_row("`--no-vision`, `--text-only`", "Disable vision model processing for images.")
+    table.add_row("`--transcribe-audio`", "Enable transcription-based audio categorization.")
+    table.add_row(
+        "`--max-transcribe-seconds FLOAT`",
+        "Skip transcription for long audio files (`0` disables cap).",
+    )
+    console.print(table)
+    console.print(
+        "\n[bold]Example:[/bold] [cyan]fo organize INPUT_DIR OUTPUT_DIR "
+        "--max-workers 2 --prefetch-depth 1[/cyan]"
+    )
+
+
+def _advanced_help_callback(value: bool) -> None:
+    """Eager callback for ``--advanced-help``."""
+    if not value:
+        return
+    _print_organize_advanced_help()
+    raise typer.Exit()
+
+
 def organize(
     input_dir: Annotated[Path, typer.Argument(help="Directory containing files to organize.")],
     output_dir: Annotated[Path, typer.Argument(help="Destination directory for organized files.")],
@@ -81,17 +123,29 @@ def organize(
         bool, typer.Option("--dry-run", help="Preview without moving files.")
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
+    advanced_help: Annotated[
+        bool,
+        typer.Option(
+            "--advanced-help",
+            callback=_advanced_help_callback,
+            is_eager=True,
+            help="Show advanced tuning options and exit.",
+        ),
+    ] = False,
     max_workers: Annotated[
         int | None,
         typer.Option(
             "--max-workers",
             min=1,
             help="Maximum number of parallel workers for file processing.",
+            hidden=True,
         ),
     ] = None,
     sequential: Annotated[
         bool,
-        typer.Option("--sequential", help="Force single-worker sequential processing."),
+        typer.Option(
+            "--sequential", help="Force single-worker sequential processing.", hidden=True
+        ),
     ] = False,
     no_vision: Annotated[
         bool,
@@ -99,6 +153,7 @@ def organize(
             "--no-vision",
             "--text-only",
             help="Disable vision model usage and organize images by extension fallback.",
+            hidden=True,
         ),
     ] = False,
     prefetch_depth: Annotated[
@@ -110,11 +165,16 @@ def organize(
                 "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
                 "uses strictly sequential submission)."
             ),
+            hidden=True,
         ),
     ] = 2,
     no_prefetch: Annotated[
         bool,
-        typer.Option("--no-prefetch", help="Backward-compatible alias for --prefetch-depth 0."),
+        typer.Option(
+            "--no-prefetch",
+            help="Backward-compatible alias for --prefetch-depth 0.",
+            hidden=True,
+        ),
     ] = False,
     transcribe_audio: Annotated[
         bool,
@@ -125,6 +185,7 @@ def organize(
                 "transcript for content-aware categorization. Off by default — "
                 "transcription is the expensive operation in the audio pipeline."
             ),
+            hidden=True,
         ),
     ] = False,
     max_transcribe_seconds: Annotated[
@@ -136,10 +197,12 @@ def organize(
                 "Skip transcription for audio files longer than this (seconds). "
                 "Default: 600 (10 min). Set to 0 to disable the cap entirely."
             ),
+            hidden=True,
         ),
     ] = 600.0,
 ) -> None:
     """Organize files in a directory using AI models."""
+    _ = advanced_help
     # First-run setup gate now lives in `cli.main.main_callback` and runs
     # for every non-allowlisted command. The previous inline call here
     # is removed (Step 3); leaving both would double-print the panel.

--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -8,7 +8,6 @@ from typing import Annotated
 import typer
 from rich.console import Console
 from rich.panel import Panel
-from rich.table import Table
 
 from file_organizer.cli.path_validation import resolve_cli_path, validate_pair
 from file_organizer.cli.state import _get_state
@@ -85,23 +84,19 @@ def _print_organize_advanced_help() -> None:
             border_style="cyan",
         )
     )
-    table = Table(show_header=True, header_style="bold cyan")
-    table.add_column("Flag", style="bold")
-    table.add_column("Purpose")
-    table.add_row("`--max-workers INTEGER`", "Cap parallel worker count.")
-    table.add_row("`--sequential`", "Force single-worker sequential processing.")
-    table.add_row(
-        "`--prefetch-depth INTEGER`",
-        "Tune queue-ahead depth per worker (`0` disables prefetch).",
+    console.print(
+        "\n".join(
+            [
+                "[bold]`--max-workers INTEGER`[/bold] — Cap parallel worker count.",
+                "[bold]`--sequential`[/bold] — Force single-worker sequential processing.",
+                "[bold]`--prefetch-depth INTEGER`[/bold] — Tune queue-ahead depth per worker (`0` disables prefetch).",
+                "[bold]`--no-prefetch`[/bold] — Backward-compatible alias for `--prefetch-depth 0`.",
+                "[bold]`--no-vision`, `--text-only`[/bold] — Disable vision model processing for images.",
+                "[bold]`--transcribe-audio`[/bold] — Enable transcription-based audio categorization.",
+                "[bold]`--max-transcribe-seconds FLOAT`[/bold] — Skip transcription for long audio files (`0` disables cap).",
+            ]
+        )
     )
-    table.add_row("`--no-prefetch`", "Backward-compatible alias for `--prefetch-depth 0`.")
-    table.add_row("`--no-vision`, `--text-only`", "Disable vision model processing for images.")
-    table.add_row("`--transcribe-audio`", "Enable transcription-based audio categorization.")
-    table.add_row(
-        "`--max-transcribe-seconds FLOAT`",
-        "Skip transcription for long audio files (`0` disables cap).",
-    )
-    console.print(table)
     console.print(
         "\n[bold]Example:[/bold] [cyan]fo organize INPUT_DIR OUTPUT_DIR "
         "--max-workers 2 --prefetch-depth 1[/cyan]"

--- a/tests/ci/test_prefetch_contracts.py
+++ b/tests/ci/test_prefetch_contracts.py
@@ -41,20 +41,25 @@ def test_no_prefetch_contract_matches_cli_runtime_and_docs() -> None:
     """Covered surfaces: CLI help, FileOrganizer runtime docs, CLI/admin docs."""
     from file_organizer.core.organizer import FileOrganizer
 
-    result = _RUNNER.invoke(app, ["organize", "--help"], terminal_width=120)
-    rendered_help = _rendered_text(result.output)
-    cli_help = _normalized(rendered_help)
+    default_help_result = _RUNNER.invoke(app, ["organize", "--help"], terminal_width=120)
+    default_help = _rendered_text(default_help_result.output)
+    advanced_help_result = _RUNNER.invoke(app, ["organize", "--advanced-help"], terminal_width=120)
+    advanced_help = _rendered_text(advanced_help_result.output)
+    normalized_advanced_help = _normalized(advanced_help)
     organizer_init_doc = _normalized(inspect.getdoc(FileOrganizer.__init__) or "")
     organizer_init_source = inspect.getsource(FileOrganizer.__init__)
     cli_reference = CLI_REFERENCE_DOC.read_text(encoding="utf-8")
     performance_doc = PERFORMANCE_TUNING_DOC.read_text(encoding="utf-8")
 
-    assert result.exit_code == 0
-    assert "--no-prefetch" in rendered_help
-    assert "--prefetch-depth" in rendered_help
-    assert "Backward-compatible" in cli_help
-    assert "alias for" in cli_help
-    assert "--prefetch-depth 0." in cli_help
+    assert default_help_result.exit_code == 0
+    assert advanced_help_result.exit_code == 0
+    assert "--no-prefetch" not in default_help
+    assert "--prefetch-depth" not in default_help
+    assert "--no-prefetch" in advanced_help
+    assert "--prefetch-depth" in advanced_help
+    assert "Backward-compatible" in normalized_advanced_help
+    assert "alias for" in normalized_advanced_help
+    assert "--prefetch-depth 0" in normalized_advanced_help
     assert "Backward-compatible alias for ``prefetch_depth=0``." in organizer_init_doc
     assert "no_prefetch=True overrides prefetch_depth" in organizer_init_source
     assert "`--no-prefetch`" in cli_reference

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -54,6 +54,8 @@ class TestHelpOutputs:
         "cmd",
         [
             ["--help"],
+            ["start", "--help"],
+            ["quickstart", "--help"],
             ["version", "--help"],
             ["organize", "--help"],
             ["preview", "--help"],
@@ -100,6 +102,18 @@ class TestHelpOutputs:
         result = runner.invoke(app, cmd)
         assert result.exit_code == 0
         assert "Usage" in result.output or "usage" in result.output.lower()
+
+    def test_top_level_help_is_grouped_and_unique(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Core Commands" in result.output
+        assert "Interfaces Commands" in result.output
+        assert "Automation Commands" in result.output
+        assert "Advanced Commands" in result.output
+
+        # Each command should appear once in grouped help rows.
+        for command in ("start", "quickstart", "organize", "serve", "dedupe", "update"):
+            assert result.output.count(f"│ {command}") == 1
 
 
 @pytest.mark.unit

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from *text* for portable string assertions."""
+    return _ANSI_RE.sub("", text)
 
 
 @pytest.mark.unit
@@ -106,14 +115,17 @@ class TestHelpOutputs:
     def test_top_level_help_is_grouped_and_unique(self) -> None:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "Core Commands" in result.output
-        assert "Interfaces Commands" in result.output
-        assert "Automation Commands" in result.output
-        assert "Advanced Commands" in result.output
+        # Typer forces terminal colors when GITHUB_ACTIONS is set — strip
+        # styling so the panel-row matching below works in CI too.
+        plain = _strip_ansi(result.output)
+        assert "Core Commands" in plain
+        assert "Interfaces Commands" in plain
+        assert "Automation Commands" in plain
+        assert "Advanced Commands" in plain
 
         # Each command should appear once in grouped help rows.
         for command in ("start", "quickstart", "organize", "serve", "dedupe", "update"):
-            assert result.output.count(f"│ {command}") == 1
+            assert plain.count(f"│ {command}") == 1
 
 
 @pytest.mark.unit

--- a/tests/cli/test_lazy.py
+++ b/tests/cli/test_lazy.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import click
 import pytest
 
-from file_organizer.cli.lazy import LazyCommandProxy
+from file_organizer.cli.lazy import LazyCommandProxy, LazyTyperGroup
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
 
@@ -41,3 +41,91 @@ def test_load_caches_result_across_calls() -> None:
 
     mock_import.assert_called_once()
     assert first is second is real_command
+
+
+class _TrackingCommand(click.Command):
+    """Track help-width limits passed by LazyTyperGroup.format_commands."""
+
+    def __init__(self, name: str, *, short_help: str, hidden: bool = False) -> None:
+        super().__init__(name=name, callback=lambda: None, short_help=short_help, hidden=hidden)
+        self.seen_limits: list[int] = []
+
+    def get_short_help_str(self, limit: int = 45) -> str:
+        self.seen_limits.append(limit)
+        return super().get_short_help_str(limit)
+
+
+class _FixedCommandGroup(LazyTyperGroup):
+    """Test helper that bypasses global lazy-command registration."""
+
+    def __init__(self, commands: dict[str, click.Command]) -> None:
+        super().__init__(name="fo")
+        self._commands = commands
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        return list(self._commands.keys())
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        return self._commands.get(cmd_name)
+
+
+class _RecordingFormatter:
+    """Minimal formatter used to inspect grouped command output."""
+
+    def __init__(self, width: int | None) -> None:
+        self.width = width
+        self._current_section: str | None = None
+        self.sections: list[tuple[str, list[tuple[str, str]]]] = []
+
+    def section(self, title: str):
+        formatter = self
+
+        class _Section:
+            def __enter__(self_nonlocal):
+                formatter._current_section = title
+
+            def __exit__(self_nonlocal, exc_type, exc, tb):
+                formatter._current_section = None
+
+        return _Section()
+
+    def write_dl(self, rows: list[tuple[str, str]]) -> None:
+        if self._current_section is None:
+            return
+        self.sections.append((self._current_section, list(rows)))
+
+
+def test_format_commands_handles_none_width_and_minimum_help_limit() -> None:
+    """format_commands should tolerate width=None and clamp help width to >= 10."""
+    long_name = "x" * 75
+    organize_command = _TrackingCommand("organize", short_help="Organize files")
+    long_command = _TrackingCommand(long_name, short_help="Long command help")
+    hidden_command = _TrackingCommand("hidden", short_help="Hidden command", hidden=True)
+
+    group = _FixedCommandGroup(
+        {"organize": organize_command, long_name: long_command, "hidden": hidden_command}
+    )
+    ctx = click.Context(group)
+    formatter = _RecordingFormatter(width=None)
+
+    group.format_commands(ctx, formatter)
+    section_titles = {title for title, _ in formatter.sections}
+    rendered_rows = [name for _, rows in formatter.sections for name, _ in rows]
+
+    assert "Core Commands" in section_titles
+    assert "Advanced Commands" in section_titles
+    assert "hidden" not in rendered_rows
+    assert organize_command.seen_limits and organize_command.seen_limits[0] == 10
+    assert long_command.seen_limits and long_command.seen_limits[0] == 10
+
+
+def test_format_commands_returns_when_no_visible_commands() -> None:
+    """format_commands should be a no-op when every command is hidden."""
+    hidden_command = _TrackingCommand("hidden", short_help="Hidden command", hidden=True)
+    group = _FixedCommandGroup({"hidden": hidden_command})
+    ctx = click.Context(group)
+    formatter = _RecordingFormatter(width=80)
+
+    group.format_commands(ctx, formatter)
+
+    assert formatter.sections == []

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,13 @@ from typer.testing import CliRunner
 from file_organizer.cli.main import app
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from *text* for portable string assertions."""
+    return _ANSI_RE.sub("", text)
 
 
 def test_version_command():
@@ -66,11 +74,14 @@ def test_organize_help_hides_advanced_flags_by_default():
     """Default organize help focuses on first-touch options."""
     result = runner.invoke(app, ["organize", "--help"], terminal_width=120)
     assert result.exit_code == 0
-    assert "--advanced-help" in result.stdout
-    assert "--max-workers" not in result.stdout
-    assert "--prefetch-depth" not in result.stdout
-    assert "--no-prefetch" not in result.stdout
-    assert "--transcribe-audio" not in result.stdout
+    # Typer forces terminal colors when GITHUB_ACTIONS is set, and rich splits
+    # option names across ANSI style segments — strip styling before matching.
+    plain = _strip_ansi(result.stdout)
+    assert "--advanced-help" in plain
+    assert "--max-workers" not in plain
+    assert "--prefetch-depth" not in plain
+    assert "--no-prefetch" not in plain
+    assert "--transcribe-audio" not in plain
 
 
 @pytest.mark.ci
@@ -79,10 +90,11 @@ def test_organize_advanced_help_lists_hidden_tuning_flags():
     """Advanced help should expose full tuning controls without args."""
     result = runner.invoke(app, ["organize", "--advanced-help"])
     assert result.exit_code == 0
-    assert "--max-workers" in result.stdout
-    assert "--prefetch-depth" in result.stdout
-    assert "--no-prefetch" in result.stdout
-    assert "--transcribe-audio" in result.stdout
+    plain = _strip_ansi(result.stdout)
+    assert "--max-workers" in plain
+    assert "--prefetch-depth" in plain
+    assert "--no-prefetch" in plain
+    assert "--transcribe-audio" in plain
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -21,6 +21,8 @@ def test_version_command():
 
 
 @patch("file_organizer.cli.setup.setup_run")
+@pytest.mark.ci
+@pytest.mark.integration
 def test_start_command_runs_quick_start(mock_setup_run):
     """start routes to setup quick-start mode."""
     result = runner.invoke(app, ["start"])
@@ -29,6 +31,8 @@ def test_start_command_runs_quick_start(mock_setup_run):
 
 
 @patch("file_organizer.cli.setup.setup_run")
+@pytest.mark.ci
+@pytest.mark.integration
 def test_quickstart_alias_runs_quick_start(mock_setup_run):
     """quickstart alias routes to setup quick-start mode."""
     result = runner.invoke(app, ["quickstart", "--profile", "work", "--dry-run"])
@@ -56,6 +60,8 @@ def test_preview_requires_setup_completed(mock_cm):
     assert "setup" in result.stdout.lower()
 
 
+@pytest.mark.ci
+@pytest.mark.integration
 def test_organize_help_hides_advanced_flags_by_default():
     """Default organize help focuses on first-touch options."""
     result = runner.invoke(app, ["organize", "--help"])
@@ -67,6 +73,8 @@ def test_organize_help_hides_advanced_flags_by_default():
     assert "--transcribe-audio" not in result.stdout
 
 
+@pytest.mark.ci
+@pytest.mark.integration
 def test_organize_advanced_help_lists_hidden_tuning_flags():
     """Advanced help should expose full tuning controls without args."""
     result = runner.invoke(app, ["organize", "--advanced-help"])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -20,6 +20,22 @@ def test_version_command():
         assert "fo 1.2.3" in result.stdout
 
 
+@patch("file_organizer.cli.setup.setup_run")
+def test_start_command_runs_quick_start(mock_setup_run):
+    """start routes to setup quick-start mode."""
+    result = runner.invoke(app, ["start"])
+    assert result.exit_code == 0
+    mock_setup_run.assert_called_once_with(mode="quick-start", profile="default", dry_run=False)
+
+
+@patch("file_organizer.cli.setup.setup_run")
+def test_quickstart_alias_runs_quick_start(mock_setup_run):
+    """quickstart alias routes to setup quick-start mode."""
+    result = runner.invoke(app, ["quickstart", "--profile", "work", "--dry-run"])
+    assert result.exit_code == 0
+    mock_setup_run.assert_called_once_with(mode="quick-start", profile="work", dry_run=True)
+
+
 @pytest.mark.uses_setup_gate
 @patch("file_organizer.config.manager.ConfigManager")
 def test_organize_requires_setup_completed(mock_cm):
@@ -38,6 +54,27 @@ def test_preview_requires_setup_completed(mock_cm):
     result = runner.invoke(app, ["preview", "in_dir"])
     assert result.exit_code == 1
     assert "setup" in result.stdout.lower()
+
+
+def test_organize_help_hides_advanced_flags_by_default():
+    """Default organize help focuses on first-touch options."""
+    result = runner.invoke(app, ["organize", "--help"])
+    assert result.exit_code == 0
+    assert "--advanced-help" in result.stdout
+    assert "--max-workers" not in result.stdout
+    assert "--prefetch-depth" not in result.stdout
+    assert "--no-prefetch" not in result.stdout
+    assert "--transcribe-audio" not in result.stdout
+
+
+def test_organize_advanced_help_lists_hidden_tuning_flags():
+    """Advanced help should expose full tuning controls without args."""
+    result = runner.invoke(app, ["organize", "--advanced-help"])
+    assert result.exit_code == 0
+    assert "--max-workers" in result.stdout
+    assert "--prefetch-depth" in result.stdout
+    assert "--no-prefetch" in result.stdout
+    assert "--transcribe-audio" in result.stdout
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -41,6 +41,16 @@ def test_start_command_runs_quick_start(mock_setup_run):
 @patch("file_organizer.cli.setup.setup_run")
 @pytest.mark.ci
 @pytest.mark.integration
+def test_start_command_merges_global_dry_run(mock_setup_run):
+    """Global --dry-run should propagate to start/quickstart setup."""
+    result = runner.invoke(app, ["--dry-run", "start"])
+    assert result.exit_code == 0
+    mock_setup_run.assert_called_once_with(mode="quick-start", profile="default", dry_run=True)
+
+
+@patch("file_organizer.cli.setup.setup_run")
+@pytest.mark.ci
+@pytest.mark.integration
 def test_quickstart_alias_runs_quick_start(mock_setup_run):
     """quickstart alias routes to setup quick-start mode."""
     result = runner.invoke(app, ["quickstart", "--profile", "work", "--dry-run"])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -64,7 +64,7 @@ def test_preview_requires_setup_completed(mock_cm):
 @pytest.mark.integration
 def test_organize_help_hides_advanced_flags_by_default():
     """Default organize help focuses on first-touch options."""
-    result = runner.invoke(app, ["organize", "--help"])
+    result = runner.invoke(app, ["organize", "--help"], terminal_width=120)
     assert result.exit_code == 0
     assert "--advanced-help" in result.stdout
     assert "--max-workers" not in result.stdout

--- a/tests/cli/test_setup_gate.py
+++ b/tests/cli/test_setup_gate.py
@@ -15,6 +15,7 @@ non-organize command crashes pre-setup with a cryptic stack trace.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -51,6 +52,20 @@ def test_allowlisted_commands_bypass_gate(cmd_args: list[str], fresh_config: Pat
     result = runner.invoke(app, cmd_args)
     assert result.exit_code == 0, result.output
     assert "First-time setup required" not in result.output
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+@pytest.mark.uses_setup_gate
+@pytest.mark.parametrize("cmd", ["start", "quickstart"])
+@patch("file_organizer.cli.setup.setup_run")
+def test_beginner_commands_bypass_gate(mock_setup_run, cmd: str, fresh_config: Path) -> None:
+    """New beginner entry commands should be reachable pre-setup."""
+    runner = CliRunner()
+    result = runner.invoke(app, [cmd, "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "First-time setup required" not in result.output
+    mock_setup_run.assert_called_once()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description
This improves first-time CLI usability by reducing top-level help density and giving new users a clear guided entrypoint, while preserving advanced capabilities for power users. It implements progressive disclosure so advanced tuning remains available but no longer dominates first-touch help.

Fixes: #1457

Key changes:
- Group `fo --help` commands into `Core`, `Interfaces`, `Automation`, and `Advanced` sections via `LazyTyperGroup` command panels.
- Add beginner entry commands: `fo start` (primary) and `fo quickstart` (alias), both routed to quick-start setup flow.
- Add `start`/`quickstart` to the pre-setup allowlist so beginners can run them before setup completion.
- Add `fo organize --advanced-help` and hide advanced tuning flags from default `organize --help`.
- Update CLI docs and getting-started docs to document the new onboarding path and advanced-help flow.
- Expand CLI/CI tests to verify grouped help behavior, beginner command routing, setup-gate bypass, and advanced option discoverability.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `pytest --no-cov -q tests/cli/test_main.py tests/cli/test_cli_main.py tests/cli/test_setup_gate.py tests/cli/test_lazy.py tests/docs/test_cli_docs_accuracy.py tests/docs/test_doc_file_paths.py`
- [x] `ruff check src/file_organizer/cli/lazy.py src/file_organizer/cli/main.py src/file_organizer/cli/organize.py tests/cli/test_main.py tests/cli/test_cli_main.py tests/cli/test_setup_gate.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `start`/`quickstart` entry command with profile selection and dry-run support.
  * Introduced grouped top-level CLI help for easier command discovery.
  * Added an `advanced help` view for `organize` to reveal extra tuning options on demand.

* **Bug Fixes**
  * Improved help output so advanced options stay hidden in standard help but appear in advanced help.
  * Clarified command alias behavior and backward-compatible option naming in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->