### PR TITLE
Fix benchmark contract-test JSON parsing under click < 8.2 (separate stderr in CliRunner)

### DIFF
--- a/tests/ci/test_benchmark_contracts.py
+++ b/tests/ci/test_benchmark_contracts.py
@@ -16,7 +16,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BASELINE_PATH = REPO_ROOT / "tests" / "fixtures" / "benchmark_baseline.json"
 CLI_DOC_PATH = REPO_ROOT / "docs" / "cli-reference.md"
 PERF_DOC_PATH = REPO_ROOT / "docs" / "admin" / "performance-tuning.md"
-RUNNER = CliRunner()
+# The JSON-contract tests parse ``result.stdout``, so stderr must stay out of
+# it. click >= 8.2 always captures stderr separately, but click < 8.2 defaults
+# to ``mix_stderr=True`` — suite-runner warnings (``typer.echo(..., err=True)``)
+# would land in ``result.stdout`` ahead of the JSON document and break
+# ``json.loads``. Request separated streams explicitly on old click; the
+# keyword was removed in 8.2, where separation is unconditional.
+try:
+    RUNNER = CliRunner(mix_stderr=False)  # type: ignore[call-arg]  # click < 8.2
+except TypeError:
+    RUNNER = CliRunner()
 
 
 def _build_contract_payload(


### PR DESCRIPTION
## Description
`tests/ci/test_benchmark_contracts.py::test_vision_suite_skip_is_explicit_in_json_output` fails locally (macOS, py3.12) but passes in CI (Linux, py3.11). Root cause: the tests parse `result.stdout` as JSON, but on click < 8.2 `CliRunner()` defaults to `mix_stderr=True`, so the vision suite's stderr warning ("Warning: no vision files found for vision suite; skipping benchmark.") is mixed into `result.stdout` ahead of the JSON document and `json.loads` fails. click >= 8.2 — which the lockfile pins and CI runs — removed `mix_stderr` and always captures stderr separately, hiding the problem in CI.

The CLI itself is correct and unchanged: the warning is already emitted with `typer.echo(..., err=True)` (`src/file_organizer/cli/benchmark.py:471`), and a real subprocess run of `fo benchmark run <dir> --suite vision --json` under click 8.1.8 keeps stdout as pure JSON with the warning on stderr. The fix is in the test harness only: request `CliRunner(mix_stderr=False)` where the keyword exists, falling back to the plain constructor on click >= 8.2 where separation is unconditional. This covers the whole contracts file, since every test there parses `result.stdout`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Reproduced and verified in both dependency configurations (repro steps: `uv sync --extra dev`, then swap click/typer as below):

- [x] click 8.1.8 + typer 0.15.2 (the failing local combination): `pytest tests/ci/test_benchmark_contracts.py` — the vision-suite test failed before the fix with `json.decoder.JSONDecodeError` (warning text prefixed the JSON in `result.stdout`); after the fix all 27 tests pass.
- [x] click 8.3.1 + typer 0.24.1 (lockfile/CI versions): all 27 tests in the file pass.
- [x] Real-CLI check under click 8.1.8: `fo benchmark run <dir> --suite vision --iterations 1 --warmup 0 --json` — stdout parses as pure JSON (`degradation_reasons: ["vision-no-candidates-skip"]`), warning appears only on stderr.
- [x] Adjacent benchmark CLI suites (`tests/cli/test_benchmark*.py`, `tests/cli/test_cli_benchmark_coverage.py`): 49 passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3xGAxn2Bt4FZoJ8Hq9m2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3xGAxn2Bt4FZoJ8Hq9m2f)_