### PR TITLE
Add Stream D guard contract and update stale invocation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ For first-wave review-regression CI parity, you can run the same audit command
 used by the standing enforcement checks:
 
 ```bash
-python3 -m file_organizer.review_regressions.audit \
+python scripts/audit.py \
   --root . \
   --detector file_organizer.review_regressions.security:SECURITY_DETECTORS \
   --detector file_organizer.review_regressions.correctness:CORRECTNESS_DETECTORS \

--- a/src/file_organizer/api/api_keys.py
+++ b/src/file_organizer/api/api_keys.py
@@ -59,7 +59,7 @@ def _write_key(path: Path, api_key: str) -> None:
 
 def _print_usage() -> None:
     """Print CLI usage instructions for the api_keys script."""
-    print("Usage: python -m file_organizer.api.api_keys --output PATH [--prefix PREFIX]")
+    print("Usage: fo api-keys generate --output PATH [--prefix PREFIX]")
 
 
 def _main(argv: list[str]) -> int:

--- a/src/file_organizer/cli/dedupe.py
+++ b/src/file_organizer/cli/dedupe.py
@@ -104,19 +104,19 @@ def dedupe_command(args: list[str] | None = None) -> int:
         epilog="""
 Examples:
   # Find duplicates in current directory (dry run)
-  python -m file_organizer.cli.dedupe . --dry-run
+  fo dedupe . --dry-run
 
   # Remove duplicates interactively
-  python -m file_organizer.cli.dedupe ~/Documents --strategy manual
+  fo dedupe ~/Documents --strategy manual
 
   # Auto-remove duplicates, keeping oldest files
-  python -m file_organizer.cli.dedupe ~/Downloads --strategy oldest
+  fo dedupe ~/Downloads --strategy oldest
 
   # Find duplicates with SHA256, non-recursive
-  python -m file_organizer.cli.dedupe . --algorithm sha256 --no-recursive
+  fo dedupe . --algorithm sha256 --no-recursive
 
   # Find large duplicate files only (>10MB)
-  python -m file_organizer.cli.dedupe ~/Videos --min-size 10485760
+  fo dedupe ~/Videos --min-size 10485760
         """,
     )
 

--- a/tests/ci/test_stream_d_main_guard_contract.py
+++ b/tests/ci/test_stream_d_main_guard_contract.py
@@ -48,3 +48,11 @@ def test_stream_d_modules_do_not_define_standalone_main_guards(module_path: Path
         f"{module_path.relative_to(REPO_ROOT)} must not define "
         'if __name__ == "__main__" after Stream D cleanup.'
     )
+
+
+def test_api_keys_help_usage_matches_cli_command(capsys: pytest.CaptureFixture[str]) -> None:
+    from file_organizer.api.api_keys import _main
+
+    assert _main(["--help"]) == 0
+    captured = capsys.readouterr()
+    assert "Usage: fo api-keys generate --output PATH [--prefix PREFIX]" in captured.out

--- a/tests/ci/test_stream_d_main_guard_contract.py
+++ b/tests/ci/test_stream_d_main_guard_contract.py
@@ -1,0 +1,50 @@
+"""Contracts for Stream D standalone __main__ cleanup targets."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET_MODULES: tuple[Path, ...] = (
+    REPO_ROOT / "src" / "file_organizer" / "cli" / "dedupe.py",
+    REPO_ROOT / "src" / "file_organizer" / "cli" / "analytics.py",
+    REPO_ROOT / "src" / "file_organizer" / "cli" / "undo_redo.py",
+    REPO_ROOT / "src" / "file_organizer" / "api" / "api_keys.py",
+    REPO_ROOT / "src" / "file_organizer" / "review_regressions" / "audit.py",
+)
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def _is_name_main_compare(node: ast.Compare) -> bool:
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq) or len(node.comparators) != 1:
+        return False
+
+    left = node.left
+    right = node.comparators[0]
+    name_main = isinstance(left, ast.Name) and left.id == "__name__"
+    const_main = isinstance(right, ast.Constant) and right.value == "__main__"
+    reverse_const = isinstance(left, ast.Constant) and left.value == "__main__"
+    reverse_name = isinstance(right, ast.Name) and right.id == "__name__"
+    return (name_main and const_main) or (reverse_const and reverse_name)
+
+
+def _has_main_guard(source: str) -> bool:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Compare):
+            if _is_name_main_compare(node.test):
+                return True
+    return False
+
+
+@pytest.mark.parametrize("module_path", TARGET_MODULES, ids=lambda path: path.name)
+def test_stream_d_modules_do_not_define_standalone_main_guards(module_path: Path) -> None:
+    source = module_path.read_text(encoding="utf-8")
+    assert not _has_main_guard(source), (
+        f"{module_path.relative_to(REPO_ROOT)} must not define "
+        'if __name__ == "__main__" after Stream D cleanup.'
+    )

--- a/tests/integration/test_api_web_coverage.py
+++ b/tests/integration/test_api_web_coverage.py
@@ -253,7 +253,7 @@ class TestAPIKeys:
         with patch("builtins.print") as mock_print:
             assert _main(["--help"]) == 0
             mock_print.assert_called_with(
-                "Usage: python -m file_organizer.api.api_keys --output PATH [--prefix PREFIX]"
+                "Usage: fo api-keys generate --output PATH [--prefix PREFIX]"
             )
 
         # 2. Missing output path


### PR DESCRIPTION
## Description
This change completes the remaining strict-scope cleanup for Stream D by locking in the already-removed standalone `__main__` guards for the issue-targeted modules and fixing stale invocation references that still pointed to removed module entry paths.

It adds a CI contract test scoped to the five Stream D modules only, updates docs/help text to supported entrypoints (`fo ...` and `python scripts/audit.py ...`), and updates the integration test that asserted the old API key usage string.

Fixes: #1188

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `pytest -q --no-cov --override-ini=addopts= tests/ci/test_stream_d_main_guard_contract.py tests/integration/test_api_web_coverage.py tests/cli/test_dedupe_coverage.py::test_dedupe_command_help`
- [x] Commit-time project hooks (pre-commit suite) passed for staged changes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples and usage text to show the current `fo` CLI commands instead of longer module-based invocations.
  * Revised pre-push checklist guidance to use the latest audit command.

* **Tests**
  * Added coverage to verify help output matches the documented CLI usage.
  * Added checks to ensure selected modules no longer rely on standalone main-entry guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->