### PR TITLE
Fix hidden FilterInput stealing TUI focus and crashing on Enter

### DIFF
--- a/scripts/capture_tui_assets.py
+++ b/scripts/capture_tui_assets.py
@@ -336,11 +336,6 @@ async def capture_tui(out_dir: Path) -> list[tuple[str, int]]:
     async with app.run_test(size=TERM_SIZE) as pilot:
         await settle(pilot, 0.5)
 
-        # The hidden FilterInput takes initial focus and swallows keys;
-        # focus the tree so navigation and the 1-8 bindings work.
-        app.set_focus(app.query_one("#file-tree"))
-        await pilot.pause(0.2)
-
         # Files view: highlight the markdown report so the preview panel
         # shows real text content (13th entry in sorted order).
         for _ in range(13):

--- a/src/file_organizer/tui/file_browser.py
+++ b/src/file_organizer/tui/file_browser.py
@@ -147,11 +147,16 @@ class FileMetadataPanel(Static):
             self.update(f"[dim]Cannot read metadata for {path.name}[/dim]")
 
 
-class FilterInput(Input):
+class FilterInput(Input, can_focus=False):
     """Hidden filter input toggled with ``/``.
 
-    When the user presses Enter, posts a ``FilterInput.Submitted``
+    When the user presses Enter, posts a ``FilterInput.FilterApplied``
     message with the filter value, then hides itself.
+
+    Declared ``can_focus=False`` because the widget starts hidden: if it
+    could take the screen's initial auto-focus it would invisibly swallow
+    every keystroke, leaving the app-level ``1``-``8`` view bindings dead.
+    ``toggle_visibility`` grants focusability only while it is shown.
     """
 
     DEFAULT_CSS = """
@@ -165,11 +170,17 @@ class FilterInput(Input):
     }
     """
 
-    class Submitted(Message):
-        """Posted when the user submits a filter value."""
+    class FilterApplied(Message):
+        """Posted when the user submits a filter value.
+
+        This intentionally does NOT shadow ``Input.Submitted``:
+        ``Input.action_submit`` constructs ``self.Submitted(self, value,
+        validation_result)``, so overriding ``Submitted`` with a
+        different signature made pressing Enter raise ``TypeError``.
+        """
 
         def __init__(self, value: str) -> None:
-            """Create a submitted message carrying the input value."""
+            """Create a message carrying the submitted filter value."""
             super().__init__()
             self.value = value
 
@@ -177,15 +188,22 @@ class FilterInput(Input):
         """Show or hide the filter input."""
         self.toggle_class("-visible")
         if self.has_class("-visible"):
+            self.can_focus = True
             self.focus()
         else:
-            self.value = ""
+            self._hide()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Handle Enter key — post filter and hide."""
-        self.post_message(self.Submitted(event.value))
+        """Handle Enter key — post the filter value and hide."""
+        event.stop()
+        self.post_message(self.FilterApplied(event.value))
         self.remove_class("-visible")
+        self._hide()
+
+    def _hide(self) -> None:
+        """Clear and drop focusability so hidden state swallows no keys."""
         self.value = ""
+        self.can_focus = False
 
 
 class FileBrowserView(Vertical):
@@ -242,16 +260,21 @@ class FileBrowserView(Vertical):
             self.query_one(FileMetadataPanel).show_metadata(path)
             self.post_message(self.FileHighlighted(path))
 
-    @on(FilterInput.Submitted)
-    def _on_filter_submitted(self, event: FilterInput.Submitted) -> None:
-        """Apply the extension filter from the filter input."""
+    @on(FilterInput.FilterApplied)
+    def _on_filter_applied(self, event: FilterInput.FilterApplied) -> None:
+        """Apply the extension filter and return focus to the tree."""
         raw = event.value.strip()
         if raw:
             extensions = {tok.strip() for tok in raw.replace(",", " ").split() if tok.strip()}
         else:
             extensions = set()
-        self.query_one(FileBrowserTree).set_extension_filter(extensions)
+        tree = self.query_one(FileBrowserTree)
+        tree.set_extension_filter(extensions)
+        tree.focus()
 
     def action_toggle_filter(self) -> None:
-        """Show/hide the filter input."""
-        self.query_one(FilterInput).toggle_visibility()
+        """Show/hide the filter input, restoring tree focus on hide."""
+        filter_input = self.query_one(FilterInput)
+        filter_input.toggle_visibility()
+        if not filter_input.has_class("-visible"):
+            self.query_one(FileBrowserTree).focus()

--- a/tests/tui/test_file_browser_coverage.py
+++ b/tests/tui/test_file_browser_coverage.py
@@ -19,7 +19,8 @@ from file_organizer.tui.file_browser import (
     _format_size,
 )
 
-pytestmark = pytest.mark.unit
+# ci: these tests carry the diff-coverage for file_browser.py in the PR suite.
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui/test_file_browser_coverage.py
+++ b/tests/tui/test_file_browser_coverage.py
@@ -226,6 +226,10 @@ class TestFileMetadataPanel:
 class TestFilterInput:
     """Test FilterInput toggle and submit behavior."""
 
+    def test_not_focusable_while_hidden(self) -> None:
+        fi = FilterInput()
+        assert fi.can_focus is False
+
     def test_toggle_visibility_shows_and_focuses(self) -> None:
         fi = FilterInput()
         fi.toggle_class = MagicMock()
@@ -234,17 +238,36 @@ class TestFilterInput:
         fi.toggle_visibility()
         fi.toggle_class.assert_called_with("-visible")
         fi.focus.assert_called_once()
+        assert fi.can_focus is True
 
-    def test_toggle_visibility_hides_and_clears(self) -> None:
+    def test_toggle_visibility_hides_clears_and_drops_focusability(self) -> None:
         fi = FilterInput()
         fi.toggle_class = MagicMock()
         fi.has_class = MagicMock(return_value=False)
+        fi.can_focus = True
         fi.toggle_visibility()
         assert fi.value == ""
+        assert fi.can_focus is False
 
-    def test_submitted_message_has_value(self) -> None:
-        msg = FilterInput.Submitted("test value")
+    def test_filter_applied_message_has_value(self) -> None:
+        msg = FilterInput.FilterApplied("test value")
         assert msg.value == "test value"
+
+    def test_on_input_submitted_posts_filter_and_hides(self) -> None:
+        fi = FilterInput()
+        fi.post_message = MagicMock()
+        fi.remove_class = MagicMock()
+        fi.can_focus = True
+        event = MagicMock()
+        event.value = ".py"
+        fi.on_input_submitted(event)
+        event.stop.assert_called_once()
+        posted = fi.post_message.call_args[0][0]
+        assert isinstance(posted, FilterInput.FilterApplied)
+        assert posted.value == ".py"
+        fi.remove_class.assert_called_with("-visible")
+        assert fi.value == ""
+        assert fi.can_focus is False
 
 
 # ---------------------------------------------------------------------------
@@ -271,9 +294,37 @@ class TestFileBrowserView:
         keys = [b.key for b in FileBrowserView.BINDINGS]
         assert "slash" in keys
 
-    def test_action_toggle_filter(self) -> None:
+    def test_action_toggle_filter_shown_keeps_input_focus(self) -> None:
         view = FileBrowserView()
         mock_fi = MagicMock()
+        mock_fi.has_class.return_value = True
         view.query_one = MagicMock(return_value=mock_fi)
         view.action_toggle_filter()
         mock_fi.toggle_visibility.assert_called_once()
+        view.query_one.assert_called_once()  # tree not queried while visible
+
+    def test_action_toggle_filter_hidden_refocuses_tree(self) -> None:
+        view = FileBrowserView()
+        mock_fi = MagicMock()
+        mock_fi.has_class.return_value = False
+        mock_tree = MagicMock()
+        view.query_one = MagicMock(side_effect=[mock_fi, mock_tree])
+        view.action_toggle_filter()
+        mock_fi.toggle_visibility.assert_called_once()
+        mock_tree.focus.assert_called_once()
+
+    def test_on_filter_applied_sets_filter_and_refocuses_tree(self) -> None:
+        view = FileBrowserView()
+        mock_tree = MagicMock()
+        view.query_one = MagicMock(return_value=mock_tree)
+        view._on_filter_applied(FilterInput.FilterApplied(" .py, txt "))
+        mock_tree.set_extension_filter.assert_called_once_with({".py", "txt"})
+        mock_tree.focus.assert_called_once()
+
+    def test_on_filter_applied_empty_clears_filter(self) -> None:
+        view = FileBrowserView()
+        mock_tree = MagicMock()
+        view.query_one = MagicMock(return_value=mock_tree)
+        view._on_filter_applied(FilterInput.FilterApplied("   "))
+        mock_tree.set_extension_filter.assert_called_once_with(set())
+        mock_tree.focus.assert_called_once()

--- a/tests/tui/test_tui_file_browser.py
+++ b/tests/tui/test_tui_file_browser.py
@@ -161,11 +161,23 @@ class TestFilterInput:
 
         assert FilterInput is not None
 
-    def test_submitted_message(self) -> None:
+    def test_filter_applied_message(self) -> None:
         from file_organizer.tui.file_browser import FilterInput
 
-        msg = FilterInput.Submitted(".py .txt")
+        msg = FilterInput.FilterApplied(".py .txt")
         assert msg.value == ".py .txt"
+
+    def test_submitted_is_not_shadowed(self) -> None:
+        """FilterInput must keep textual's Input.Submitted intact.
+
+        Overriding ``Submitted`` with a custom signature broke
+        ``Input.action_submit`` (TypeError on Enter).
+        """
+        from textual.widgets import Input
+
+        from file_organizer.tui.file_browser import FilterInput
+
+        assert FilterInput.Submitted is Input.Submitted
 
 
 @pytest.mark.unit
@@ -212,3 +224,61 @@ class TestTuiExports:
             cls is not None
             for cls in (FileBrowserTree, FileBrowserView, FileMetadataPanel, FilterInput)
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: hidden FilterInput must not steal focus or crash on Enter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_startup_focus_not_stolen_by_hidden_filter() -> None:
+    """The hidden FilterInput must not take the screen's initial auto-focus.
+
+    Regression: it previously did, so every keystroke went into the
+    invisible input and the app-level ``1``-``8`` view bindings were
+    dead on launch.
+    """
+    from file_organizer.tui.app import FileOrganizerApp
+    from file_organizer.tui.file_browser import FileBrowserTree, FilterInput
+
+    app = FileOrganizerApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert not isinstance(app.focused, FilterInput)
+        assert isinstance(app.focused, FileBrowserTree)
+        await pilot.press("7")
+        await pilot.pause()
+        assert app._current_view == "settings"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_filter_submit_applies_and_refocuses_tree() -> None:
+    """Enter in the filter applies it, hides the input, and refocuses the tree.
+
+    Regression: ``FilterInput.Submitted`` shadowed textual's
+    ``Input.Submitted`` with an incompatible signature, so
+    ``Input.action_submit`` raised ``TypeError`` on Enter.
+    """
+    from file_organizer.tui.app import FileOrganizerApp
+    from file_organizer.tui.file_browser import FileBrowserTree, FilterInput
+
+    app = FileOrganizerApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("slash")
+        await pilot.pause()
+        filter_input = app.query_one(FilterInput)
+        assert filter_input.has_class("-visible")
+        assert app.focused is filter_input
+
+        await pilot.press("p", "y", "enter")
+        await pilot.pause()
+
+        tree = app.query_one(FileBrowserTree)
+        assert tree._extension_filter == {".py"}
+        assert not filter_input.has_class("-visible")
+        assert filter_input.value == ""
+        assert app.focused is tree

--- a/tests/tui/test_tui_file_browser.py
+++ b/tests/tui/test_tui_file_browser.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# ci: run in the PR suite so the FilterInput focus/Submitted regressions
+# are exercised on every pull request.
+pytestmark = pytest.mark.ci
+
 
 @pytest.mark.unit
 class TestFormatSize:


### PR DESCRIPTION
## Description

Fixes the TUI keyboard bug discovered (and empirically verified) while capturing the real screenshots for #1467: on launch, the file browser's *hidden* `FilterInput` received the screen's initial auto-focus, so every keystroke went into an invisible input — the app-level `1`–`8` view bindings, arrow-key tree navigation, and `/` were all dead until focus moved. Worse, pressing Enter in that state crashed with `TypeError: FilterInput.Submitted.__init__() takes 2 positional arguments but 4 were given`.

Two root causes, two fixes in `src/file_organizer/tui/file_browser.py`:

- **Focus theft:** `FilterInput` is now declared `can_focus=False` (it starts hidden via `display: none`). `toggle_visibility` grants focusability only while shown; hiding it — via `/` toggle or Enter submit — drops focusability again and returns focus to the directory tree, so the hidden input can never swallow keys. Initial auto-focus now lands on the `FileBrowserTree`.
- **Enter crash:** the custom `FilterInput.Submitted` message class shadowed textual's `Input.Submitted`, whose `action_submit` constructs `self.Submitted(self, value, validation_result)` — incompatible with the override's one-argument `__init__`. The custom message is renamed to `FilterInput.FilterApplied`, leaving `Input.Submitted` intact (asserted by a regression test: `FilterInput.Submitted is Input.Submitted`).

Also removes the now-unnecessary `set_focus` workaround for this bug from `scripts/capture_tui_assets.py` (added in #1467).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] New end-to-end regression tests (`tests/tui/test_tui_file_browser.py`): startup focus lands on the tree, not the FilterInput; pressing `7` switches views; `/` opens and focuses the filter; typing `py` + Enter applies `{".py"}` without raising, hides the input, and refocuses the tree
- [x] New unit tests (`tests/tui/test_file_browser_coverage.py`) for `can_focus` lifecycle, `on_input_submitted`, `_on_filter_applied` (populated and empty filters), and both `action_toggle_filter` branches
- [x] Full TUI suite: `pytest tests/tui/` — 670 passed
- [x] Diff coverage on changed `src/` lines: 100% under the repo gate's own selection (`-m "not benchmark and not e2e and not integration"`, `--fail-under=80`)
- [x] `ruff check` / `ruff format --check`, `mypy` (via `scripts/run-mypy-changed.sh`), and `interrogate --fail-under 95` all pass on the changed files
- [x] Smoke suite run locally: only pre-existing environmental failure (`tests/daemon/test_pid.py` unwritable-dir test fails as root; fails identically without this diff)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AetGP7Zigfm7yfUoJsCWW9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AetGP7Zigfm7yfUoJsCWW9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter handling in the file browser so Enter applies the filter cleanly, hides the input, clears its text, and returns focus to the file tree.
  * Prevented the hidden filter field from taking focus on startup or after closing it.
  * Kept tree navigation working smoothly after toggling the filter panel.
* **Tests**
  * Expanded automated coverage for filter visibility, focus behavior, and Enter-key interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->