### PR TITLE
Fix py3.14 audio import-mock CI failures

### DIFF
--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -33,6 +33,36 @@ jobs:
           - web
           - gui
           - desktop
+          - llama  # sdist-only upstream: this is the real cmake build probe (#882)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install with extra "${{ matrix.extra }}" in isolation
+        run: bash scripts/pip_install_retry.sh -e ".[${{ matrix.extra }}]"
+      - name: Smoke-import the package
+        run: python -c "import file_organizer; print('import OK')"
+
+  # Darwin lane: validates wheel coverage that the Linux matrix cannot see —
+  # the mlx extra is Darwin-only by marker, and the media/scientific extras
+  # ship separate macOS wheels (torch, opencv, h5py, netCDF4) that must not
+  # be assumed from Linux results (#882).
+  install-extra-macos:
+    name: "Extra ${{ matrix.extra }} macOS (py${{ matrix.python-version }})"
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+        extra:
+          - mlx
+          - audio
+          - video
+          - scientific
+          - dedup
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -17,9 +17,11 @@ permissions:
 jobs:
   install-extra:
     runs-on: ubuntu-latest
+    name: "Extra ${{ matrix.extra }} (py${{ matrix.python-version }})"
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.12", "3.13", "3.14"]
         extra:
           - audio
           - video
@@ -37,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install with extra "${{ matrix.extra }}" in isolation
         run: bash scripts/pip_install_retry.sh -e ".[${{ matrix.extra }}]"
       - name: Smoke-import the package

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -34,7 +34,7 @@ jobs:
           - gui
           - desktop
           - llama  # sdist-only upstream: this is the real cmake build probe (#882)
-    steps:
+    steps: &install-extra-steps
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
@@ -63,14 +63,4 @@ jobs:
           - video
           - scientific
           - dedup
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install with extra "${{ matrix.extra }}" in isolation
-        run: bash scripts/pip_install_retry.sh -e ".[${{ matrix.extra }}]"
-      - name: Smoke-import the package
-        run: python -c "import file_organizer; print('import OK')"
+    steps: *install-extra-steps

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  # Linux full-suite (6 shards, Python 3.11 + 3.12) — same shard split as ci.yml push jobs.
+  # Linux full-suite (6 shards, Python 3.11–3.14) — same shard split as ci.yml push jobs.
   # macOS and Windows run the portable ci/smoke subset only.
 
   test-linux-full:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/python-probe.yml
+++ b/.github/workflows/python-probe.yml
@@ -1,0 +1,78 @@
+name: Deep Python Probe
+
+# Deep functional probes for the Python 3.13/3.14 migration (issue #882).
+# ci-extras.yml answers "does it install + import"; this workflow answers
+# "does the native path actually work": C extensions loading, audioop-lts
+# shimming pydub on 3.13+, imagededup's sdist-built Cython module, watchdog's
+# fsevents/inotify event round-trip, llama.cpp's cmake build, a PyInstaller
+# bundle that runs, and the numpy-2-sensitive test suites.
+#
+# Heavy by design (torch + llama.cpp build per cell) — runs weekly and on
+# demand via workflow_dispatch, not on every PR. PRs touching the probe kit
+# itself do trigger it so the probes stay honest.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1"  # Weekly Monday 08:00 UTC, after the Extras Matrix run
+  pull_request:
+    paths:
+      - "scripts/probe_python_support.py"
+      - ".github/workflows/python-probe.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deep-probe:
+    name: "Probe ${{ matrix.os }} py${{ matrix.python-version }}"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install project with all risky extras
+        # llama builds llama.cpp from source (cmake is preinstalled on
+        # GitHub runners); mlx is Darwin-only by marker.
+        run: |
+          EXTRAS="dev,audio,video,dedup,scientific,search,archive,parsers,cad,build,llama"
+          if [ "$(uname)" = "Darwin" ]; then EXTRAS="$EXTRAS,mlx"; fi
+          bash scripts/pip_install_retry.sh -e ".[$EXTRAS]"
+      - name: Deep functional probes (native paths, C extensions, stdlib shims)
+        run: python scripts/probe_python_support.py
+      - name: numpy-2-sensitive test suites
+        # The six modules that import numpy directly — NEP-50 promotion and
+        # float-output changes would surface here first.
+        run: |
+          pytest tests/services/deduplication/test_dedup_embedder.py \
+                 tests/services/deduplication/test_dedup_semantic.py \
+                 tests/services/deduplication/test_image_dedup.py \
+                 tests/services/search/test_vector_index.py \
+                 tests/services/search/test_embedding_cache.py \
+                 tests/services/video/test_scene_detector.py \
+                 tests/unit/services/video/test_scene_detector.py \
+                 --override-ini="addopts=" -p no:randomly --timeout=120 -q
+      - name: PyInstaller bundle smoke
+        # Metadata says pyinstaller supports <3.16; this proves a bundle
+        # actually builds and executes on this interpreter.
+        run: |
+          WORK="$RUNNER_TEMP/pyi-probe"
+          mkdir -p "$WORK"
+          printf 'import sys\nprint("bundle OK on", sys.version.split()[0])\n' > "$WORK/probe_hello.py"
+          pyinstaller --onefile --distpath "$WORK/dist" --workpath "$WORK/build" \
+            --specpath "$WORK" "$WORK/probe_hello.py" --log-level ERROR
+          "$WORK/dist/probe_hello"

--- a/.github/workflows/python-probe.yml
+++ b/.github/workflows/python-probe.yml
@@ -26,6 +26,7 @@ on:
   # exercised before the workflow ever reaches the default branch (where
   # workflow_dispatch would become available).
   push:
+    branches: [main, "epic/**"]
     paths:
       - "scripts/probe_python_support.py"
       - ".github/workflows/python-probe.yml"
@@ -41,7 +42,7 @@ jobs:
   deep-probe:
     name: "Probe ${{ matrix.os }} py${{ matrix.python-version }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-probe.yml
+++ b/.github/workflows/python-probe.yml
@@ -10,6 +10,9 @@ name: Deep Python Probe
 # Heavy by design (torch + llama.cpp build per cell) — runs weekly and on
 # demand via workflow_dispatch, not on every PR. PRs touching the probe kit
 # itself do trigger it so the probes stay honest.
+#
+# Windows cells double as the MSVC probes: on 3.13+ both imagededup and
+# llama-cpp-python compile from sdist there, which no other lane exercises.
 
 on:
   workflow_dispatch:
@@ -42,8 +45,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.13", "3.14"]
+    # Windows default shell is pwsh; every step here is written for bash
+    # (available on all runner images).
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Windows-only: makes the interpreter default to UTF-8, matching the
+      # test-windows job in ci-full.yml (harmless elsewhere).
+      PYTHONUTF8: "1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -53,8 +65,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install project with all risky extras
-        # llama builds llama.cpp from source (cmake is preinstalled on
-        # GitHub runners); mlx is Darwin-only by marker.
+        # llama builds llama.cpp from source (cmake + a C++ toolchain are
+        # preinstalled on all GitHub runner images, MSVC included); mlx is
+        # Darwin-only by marker. On 3.13+ imagededup also builds from sdist,
+        # which makes this step the MSVC/Cython probe on Windows.
         run: |
           EXTRAS="dev,audio,video,dedup,scientific,search,archive,parsers,cad,build,llama"
           if [ "$(uname)" = "Darwin" ]; then EXTRAS="$EXTRAS,mlx"; fi
@@ -82,4 +96,6 @@ jobs:
           printf 'import sys\nprint("bundle OK on", sys.version.split()[0])\n' > "$WORK/probe_hello.py"
           pyinstaller --onefile --distpath "$WORK/dist" --workpath "$WORK/build" \
             --specpath "$WORK" "$WORK/probe_hello.py" --log-level ERROR
-          "$WORK/dist/probe_hello"
+          BIN="$WORK/dist/probe_hello"
+          [ -f "$BIN.exe" ] && BIN="$BIN.exe"
+          "$BIN"

--- a/.github/workflows/python-probe.yml
+++ b/.github/workflows/python-probe.yml
@@ -19,6 +19,13 @@ on:
     paths:
       - "scripts/probe_python_support.py"
       - ".github/workflows/python-probe.yml"
+  # push runs from the branch's own copy of this file, so the probe can be
+  # exercised before the workflow ever reaches the default branch (where
+  # workflow_dispatch would become available).
+  push:
+    paths:
+      - "scripts/probe_python_support.py"
+      - ".github/workflows/python-probe.yml"
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Desktop Environment :: File Managers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -35,7 +37,11 @@ dependencies = [
     # NLP and data science
     # Deterministic, offline stemming (WP-4.4, #1234) — pure-Python, no corpus download.
     "snowballstemmer>=2.2",
-    "numpy~=1.24",  # Numerical computing (used in dedup, video, optimization)
+    # Deliberately NOT ~= style — a ~= rewrite (#1037) would cap this <2.0 again:
+    # numpy 1.26.4 is the last release with cp311 wheels but has none for 3.13+;
+    # numpy 2.1+ is required for Python 3.13, 2.3+ for 3.14, and opencv-python
+    # >=4.13 requires numpy>=2. Floor matches scipy>=1.17's own floor (1.26.4).
+    "numpy>=1.26.4,<3",  # Numerical computing (used in dedup, video, optimization)
     "tqdm~=4.66",  # Progress bars (used in CLI dedup)
 
     # Security: XXE/entity-expansion-safe XML parsing (dedup ODT content.xml).
@@ -62,7 +68,7 @@ dependencies = [
     "jinja2~=3.1",
     "markupsafe~=3.0",  # Direct import in web csrf_input; also a jinja2 transitive dep
     "uvicorn[standard]~=0.27",
-    "websockets~=12.0",
+    "websockets>=12.0,<17",  # 12.0 C wheels stop at cp312 (pure-py fallback on 3.13+); uvicorn[standard] needs only >=10.4
     "httpx~=0.26",
     "python-multipart>=0.0.9",  # 0.x — unstable API, keep >=
     # Pygments is transitive via rich/textual. Pin >= 2.20.0 for CVE-2026-4539.
@@ -85,10 +91,13 @@ dependencies = [
     "email-validator~=2.1",
     "python-dotenv~=1.0",
     "click~=8.1",
-    "watchdog~=3.0",  # File system event handler
+    # Upper bound <7 (not ~=3.0): watchdog 3.0 ships no macOS wheels past cp311
+    # and no py3-none-any wheel, so macOS on Python 3.12+ falls back to an
+    # fsevents sdist build. watchdog 6.0 ships cp313+ macOS wheels.
+    "watchdog>=3.0,<7",  # File system event handler
 
     # System utilities
-    "psutil~=5.9",  # System resource monitoring
+    "psutil>=5.9,<8",  # System resource monitoring; 5.9.x abi3 wheels predate Python 3.13/3.14
 
     # Logging
     "loguru>=0.7.0",  # 0.x — unstable API, keep >=
@@ -109,7 +118,7 @@ web = [
     "fastapi~=0.109",
     "jinja2~=3.1",
     "uvicorn[standard]~=0.27",
-    "websockets~=12.0",
+    "websockets>=12.0,<17",  # 12.0 C wheels stop at cp312 (pure-py fallback on 3.13+); uvicorn[standard] needs only >=10.4
     "httpx~=0.26",
     "python-multipart>=0.0.9",  # 0.x — unstable API, keep >=
     # Pygments is transitive via rich/textual. Pin >= 2.20.0 for CVE-2026-4539.
@@ -123,7 +132,7 @@ web = [
 dev = [
     "pytest~=9.0.3",
     "pytest-asyncio~=1.4",
-    "pytest-cov~=4.1",
+    "pytest-cov>=4.1,<8",  # 4.1 predates pytest 9 / Python 3.13+; allow current major
     "pytest-mock~=3.12",
     "pytest-timeout>=2.2.0,<2.5.0",  # 2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture)
     "pytest-xdist~=3.5",
@@ -136,7 +145,7 @@ dev = [
     "pre-commit~=3.6",
     "codespell~=2.2",
     "faker~=40.12",
-    "pytest-benchmark~=4.0",
+    "pytest-benchmark>=4.0,<6",  # 5.x drops benchmark_* ini keys; we pass them via CLI (see pytest note below)
     "interrogate~=1.5",  # Docstring coverage measurement
     "pymarkdownlnt>=0.9.25",  # 0.x — unstable API, keep >=; Markdown linting
     "deptry>=0.16.0",  # 0.x — unstable API, keep >=; Unused dependency detection
@@ -184,6 +193,9 @@ audio = [
     "mutagen~=1.47",  # Audio metadata extraction
     "tinytag>=1.10,<3.0",  # Lightweight audio metadata fallback
     "pydub>=0.25.0",  # 0.x — unstable API, keep >=; Audio manipulation
+    # pydub 0.25.x imports stdlib `audioop`, removed in Python 3.13 (PEP 594);
+    # audioop-lts is the PSF-blessed shim that restores it on 3.13+.
+    "audioop-lts; python_version >= '3.13'",
 ]
 
 video = [
@@ -192,7 +204,10 @@ video = [
 ]
 
 dedup = [
-    "imagededup>=0.3.0",  # 0.x — unstable API, keep >=; Image similarity and duplicate detection
+    # Gated to <3.13: imagededup 0.3.3.post2 ships wheels only up to cp312 and its
+    # sdist needs to compile a Cython extension with no upstream 3.13+ support.
+    # Image-similarity dedup degrades gracefully when absent (lazy import).
+    "imagededup>=0.3.0; python_version < '3.13'",  # 0.x — unstable API, keep >=; Image similarity and duplicate detection
     "scikit-learn~=1.4",  # ML-based text similarity for deduplication
     "pypdf>=4,<7",  # PDF text extraction fallback in dedup extractor
     "striprtf>=0.0.26",  # 0.x — unstable API, keep >=; RTF file text extraction in dedup extractor
@@ -559,6 +574,8 @@ DEP002 = [
     "Pygments",
     # pywebview: desktop GUI wrapper; import name is 'webview' (mapped above); used in desktop/app.py
     "pywebview",
+    # audioop-lts: restores stdlib `audioop` on Python 3.13+ for pydub (never imported directly)
+    "audioop-lts",
 ]
 
 [tool.coverage.floors.integration]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ dependencies = [
     # numpy 1.26.4 is the last release with cp311 wheels but has none for 3.13+;
     # numpy 2.1+ is required for Python 3.13, 2.3+ for 3.14, and opencv-python
     # >=4.13 requires numpy>=2. Floor matches scipy>=1.17's own floor (1.26.4).
-    "numpy>=1.26.4,<3",  # Numerical computing (used in dedup, video, optimization)
+    # Capped <2.5 while requires-python is >=3.11: numpy 2.5 dropped 3.11 AND
+    # its stubs use PEP 695 `type` statements, which mypy rejects under
+    # python_version = "3.11" (our floor). numpy 2.4.x ships cp311-cp314
+    # wheels, so one version still covers the whole support matrix.
+    "numpy>=1.26.4,<2.5",  # Numerical computing (used in dedup, video, optimization)
     "tqdm~=4.66",  # Progress bars (used in CLI dedup)
 
     # Security: XXE/entity-expansion-safe XML parsing (dedup ODT content.xml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,10 +204,10 @@ video = [
 ]
 
 dedup = [
-    # Gated to <3.13: imagededup 0.3.3.post2 ships wheels only up to cp312 and its
-    # sdist needs to compile a Cython extension with no upstream 3.13+ support.
-    # Image-similarity dedup degrades gracefully when absent (lazy import).
-    "imagededup>=0.3.0; python_version < '3.13'",  # 0.x — unstable API, keep >=; Image similarity and duplicate detection
+    # No wheels past cp312, so 3.13+ builds from sdist — install-probed on
+    # 3.13.2 and 3.14.6 (2026-07): the Cython extension compiles and PHash
+    # round-trips. Validated continuously by the ci-extras matrix.
+    "imagededup>=0.3.0",  # 0.x — unstable API, keep >=; Image similarity and duplicate detection
     "scikit-learn~=1.4",  # ML-based text similarity for deduplication
     "pypdf>=4,<7",  # PDF text extraction fallback in dedup extractor
     "striprtf>=0.0.26",  # 0.x — unstable API, keep >=; RTF file text extraction in dedup extractor

--- a/scripts/probe_python_support.py
+++ b/scripts/probe_python_support.py
@@ -24,13 +24,22 @@ from pathlib import Path
 IS_DARWIN = platform.system() == "Darwin"
 
 
+def require(condition: bool, message: str) -> None:
+    """Raise AssertionError for failed probe invariants, even under python -O."""
+    if not condition:
+        raise AssertionError(message)
+
+
 def probe_numpy() -> str:
     import numpy as np
 
     arr = np.asarray([0.3, 0.1, 0.2], dtype=np.float64)
-    assert list(np.argsort(arr)) == [1, 2, 0]
+    require(list(np.argsort(arr)) == [1, 2, 0], "numpy argsort result mismatch")
     # NEP 50: scalar promotion must not upcast float32 arrays (numpy 2 behavior)
-    assert (np.zeros(2, dtype=np.float32) + 1.0).dtype == np.float32
+    require(
+        (np.zeros(2, dtype=np.float32) + 1.0).dtype == np.float32,
+        "numpy scalar promotion unexpectedly upcast float32",
+    )
     return f"numpy {np.__version__}"
 
 
@@ -39,8 +48,8 @@ def probe_pydub() -> str:
     from pydub import AudioSegment
 
     seg = AudioSegment.silent(duration=50)
-    assert seg.rms == 0
-    assert seg.set_channels(2).channels == 2
+    require(seg.rms == 0, "pydub silent segment RMS expected to be 0")
+    require(seg.set_channels(2).channels == 2, "pydub channel conversion failed")
     return "pydub silent-segment RMS via audioop OK"
 
 
@@ -55,7 +64,7 @@ def probe_imagededup() -> str:
             arr = rng.integers(0, 255, (64, 64, 3), dtype=np.uint8)
             Image.fromarray(arr, "RGB").save(Path(d) / name)
         hashes = PHash().encode_images(d)
-    assert len(hashes) == 2
+    require(len(hashes) == 2, "imagededup expected hashes for both probe images")
     # Prove the compiled extension exists (sdist-built on 3.13+):
     from imagededup.handlers.search.brute_force_cython import (  # noqa: F401
         BruteForceCython,
@@ -86,7 +95,7 @@ def probe_watchdog() -> str:
         finally:
             observer.stop()
             observer.join(timeout=10)
-    assert fired, "no filesystem event received within 10s"
+    require(fired, "no filesystem event received within 10s")
     return f"watchdog {type(observer).__name__} event round-trip OK"
 
 
@@ -106,7 +115,7 @@ def probe_torch() -> str:
     import torch
 
     t = torch.ones(2, 2)
-    assert (t @ t).sum().item() == 8.0
+    require((t @ t).sum().item() == 8.0, "torch matmul probe produced unexpected result")
     return f"torch {torch.__version__} matmul OK"
 
 
@@ -115,7 +124,7 @@ def probe_opencv() -> str:
     import numpy as np
 
     gray = cv2.cvtColor(np.zeros((8, 8, 3), dtype=np.uint8), cv2.COLOR_RGB2GRAY)
-    assert gray.shape == (8, 8)
+    require(gray.shape == (8, 8), "opencv grayscale conversion produced wrong shape")
     return f"opencv {cv2.__version__} cvtColor OK"
 
 
@@ -127,7 +136,10 @@ def probe_scipy() -> str:
         path = Path(d) / "probe.mat"
         savemat(path, {"x": np.arange(4)})
         loaded = loadmat(path)
-    assert list(loaded["x"].flatten()) == [0, 1, 2, 3]
+    require(
+        list(loaded["x"].flatten()) == [0, 1, 2, 3],
+        "scipy .mat round-trip values mismatch",
+    )
     import scipy
 
     return f"scipy {scipy.__version__} .mat round-trip OK"
@@ -142,7 +154,7 @@ def probe_h5py() -> str:
         with h5py.File(path, "w") as f:
             f.create_dataset("x", data=np.arange(4))
         with h5py.File(path, "r") as f:
-            assert list(f["x"][:]) == [0, 1, 2, 3]
+            require(list(f["x"][:]) == [0, 1, 2, 3], "h5py round-trip values mismatch")
     return f"h5py {h5py.__version__} round-trip OK"
 
 
@@ -156,7 +168,7 @@ def probe_netcdf4() -> str:
             var = ds.createVariable("v", "f8", ("t",))
             var[:] = [1.0, 2.0, 3.0]
         with netCDF4.Dataset(path, "r") as ds:
-            assert float(ds["v"][1]) == 2.0
+            require(float(ds["v"][1]) == 2.0, "netCDF4 round-trip values mismatch")
     return f"netCDF4 {netCDF4.__version__} round-trip OK"
 
 
@@ -165,7 +177,7 @@ def probe_sklearn() -> str:
     from sklearn.feature_extraction.text import TfidfVectorizer
 
     matrix = TfidfVectorizer().fit_transform(["alpha beta", "beta gamma"])
-    assert matrix.shape == (2, 3)
+    require(matrix.shape == (2, 3), "scikit-learn TF-IDF matrix shape mismatch")
     return f"scikit-learn {sklearn.__version__} TF-IDF OK"
 
 
@@ -181,7 +193,10 @@ def probe_py7zr() -> str:
             z.write(src, "payload.txt")
         with py7zr.SevenZipFile(archive, "r") as z:
             z.extractall(Path(d) / "out")
-        assert (Path(d) / "out" / "payload.txt").read_text() == "probe payload"
+        require(
+            (Path(d) / "out" / "payload.txt").read_text() == "probe payload",
+            "py7zr round-trip payload mismatch",
+        )
     return f"py7zr {py7zr.__version__} round-trip OK"
 
 
@@ -190,15 +205,15 @@ def probe_pymupdf() -> str:
 
     doc = fitz.open()
     doc.new_page()
-    assert doc.page_count == 1
-    return f"PyMuPDF {fitz.__doc__.split()[1] if fitz.__doc__ else 'OK'} page create OK"
+    require(doc.page_count == 1, "PyMuPDF page creation probe expected page_count == 1")
+    return f"PyMuPDF {fitz.VersionBind} page create OK"
 
 
 def probe_lxml() -> str:
     import lxml.etree as etree
 
     root = etree.fromstring("<r><c>x</c></r>")
-    assert root.findtext("c") == "x"
+    require(root.findtext("c") == "x", "lxml XML parse probe failed")
     return f"lxml {etree.__version__} parse OK"
 
 
@@ -206,14 +221,14 @@ def probe_bcrypt() -> str:
     import bcrypt
 
     hashed = bcrypt.hashpw(b"probe", bcrypt.gensalt(rounds=4))
-    assert bcrypt.checkpw(b"probe", hashed)
+    require(bcrypt.checkpw(b"probe", hashed), "bcrypt hash/check probe failed")
     return f"bcrypt {bcrypt.__version__} hash/check OK"
 
 
 def probe_psutil() -> str:
     import psutil
 
-    assert psutil.Process().memory_info().rss > 0
+    require(psutil.Process().memory_info().rss > 0, "psutil reported non-positive RSS")
     return f"psutil {psutil.__version__} process info OK"
 
 
@@ -229,14 +244,17 @@ def probe_llama_cpp() -> str:
     import llama_cpp
 
     # Native C API call — proves the compiled library loads and answers.
-    assert isinstance(llama_cpp.llama_supports_mmap(), bool)
+    require(
+        isinstance(llama_cpp.llama_supports_mmap(), bool),
+        "llama-cpp-python native bool probe failed",
+    )
     return f"llama-cpp-python {llama_cpp.__version__} native call OK"
 
 
 def probe_mlx() -> str:
     import mlx.core as mx
 
-    assert (mx.array([1, 2]) + 1).sum().item() == 5
+    require((mx.array([1, 2]) + 1).sum().item() == 5, "mlx array operation probe failed")
     return "mlx array op OK"
 
 
@@ -245,7 +263,7 @@ def probe_ezdxf() -> str:
 
     doc = ezdxf.new()
     doc.modelspace().add_line((0, 0), (1, 1))
-    assert len(doc.modelspace()) == 1
+    require(len(doc.modelspace()) == 1, "ezdxf entity creation probe failed")
     return f"ezdxf {ezdxf.__version__} entity create OK"
 
 

--- a/scripts/probe_python_support.py
+++ b/scripts/probe_python_support.py
@@ -1,0 +1,297 @@
+"""Deep functional probes for Python-version support (issue #882).
+
+Goes beyond install + smoke-import: each probe exercises the runtime path
+that wheel metadata cannot prove — C extensions loading, removed-stdlib
+shims (audioop on 3.13+), sdist-built Cython modules (imagededup on 3.13+),
+native event backends (watchdog fsevents/inotify), and small end-to-end
+round-trips through the scientific/media stack.
+
+Run inside an environment installed with the risky extras:
+    pip install -e ".[dev,audio,video,dedup,scientific,search,archive,parsers,cad,build,llama]"
+(plus mlx on Darwin). Exits 0 when every applicable probe passes, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+import tempfile
+import threading
+import traceback
+from collections.abc import Callable
+from pathlib import Path
+
+IS_DARWIN = platform.system() == "Darwin"
+
+
+def probe_numpy() -> str:
+    import numpy as np
+
+    arr = np.asarray([0.3, 0.1, 0.2], dtype=np.float64)
+    assert list(np.argsort(arr)) == [1, 2, 0]
+    # NEP 50: scalar promotion must not upcast float32 arrays (numpy 2 behavior)
+    assert (np.zeros(2, dtype=np.float32) + 1.0).dtype == np.float32
+    return f"numpy {np.__version__}"
+
+
+def probe_pydub() -> str:
+    # Exercises stdlib `audioop` — removed in 3.13, restored by audioop-lts.
+    from pydub import AudioSegment
+
+    seg = AudioSegment.silent(duration=50)
+    assert seg.rms == 0
+    assert seg.set_channels(2).channels == 2
+    return "pydub silent-segment RMS via audioop OK"
+
+
+def probe_imagededup() -> str:
+    import numpy as np
+    from imagededup.methods import PHash
+    from PIL import Image
+
+    rng = np.random.default_rng(0)
+    with tempfile.TemporaryDirectory() as d:
+        for name in ("a.png", "b.png"):
+            arr = rng.integers(0, 255, (64, 64, 3), dtype=np.uint8)
+            Image.fromarray(arr, "RGB").save(Path(d) / name)
+        hashes = PHash().encode_images(d)
+    assert len(hashes) == 2
+    # Prove the compiled extension exists (sdist-built on 3.13+):
+    from imagededup.handlers.search.brute_force_cython import (  # noqa: F401
+        BruteForceCython,
+    )
+
+    return "imagededup PHash + Cython extension OK"
+
+
+def probe_watchdog() -> str:
+    # Proves the native observer backend (fsevents on macOS is an sdist build
+    # on Python 3.14 — no cp314 wheel exists as of watchdog 6.0).
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    seen = threading.Event()
+
+    class Handler(FileSystemEventHandler):
+        def on_any_event(self, event: object) -> None:
+            seen.set()
+
+    with tempfile.TemporaryDirectory() as d:
+        observer = Observer()
+        observer.schedule(Handler(), d)
+        observer.start()
+        try:
+            (Path(d) / "touch.txt").write_text("x")
+            fired = seen.wait(timeout=10)
+        finally:
+            observer.stop()
+            observer.join(timeout=10)
+    assert fired, "no filesystem event received within 10s"
+    return f"watchdog {type(observer).__name__} event round-trip OK"
+
+
+def probe_websockets() -> str:
+    import websockets
+
+    try:
+        import websockets.speedups
+
+        impl = "C-accelerated"
+    except ImportError:
+        impl = "pure-Python fallback"
+    return f"websockets {websockets.__version__} ({impl})"
+
+
+def probe_torch() -> str:
+    import torch
+
+    t = torch.ones(2, 2)
+    assert (t @ t).sum().item() == 8.0
+    return f"torch {torch.__version__} matmul OK"
+
+
+def probe_opencv() -> str:
+    import cv2
+    import numpy as np
+
+    gray = cv2.cvtColor(np.zeros((8, 8, 3), dtype=np.uint8), cv2.COLOR_RGB2GRAY)
+    assert gray.shape == (8, 8)
+    return f"opencv {cv2.__version__} cvtColor OK"
+
+
+def probe_scipy() -> str:
+    import numpy as np
+    from scipy.io import loadmat, savemat
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "probe.mat"
+        savemat(path, {"x": np.arange(4)})
+        loaded = loadmat(path)
+    assert list(loaded["x"].flatten()) == [0, 1, 2, 3]
+    import scipy
+
+    return f"scipy {scipy.__version__} .mat round-trip OK"
+
+
+def probe_h5py() -> str:
+    import h5py
+    import numpy as np
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "probe.h5"
+        with h5py.File(path, "w") as f:
+            f.create_dataset("x", data=np.arange(4))
+        with h5py.File(path, "r") as f:
+            assert list(f["x"][:]) == [0, 1, 2, 3]
+    return f"h5py {h5py.__version__} round-trip OK"
+
+
+def probe_netcdf4() -> str:
+    import netCDF4
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "probe.nc"
+        with netCDF4.Dataset(path, "w") as ds:
+            ds.createDimension("t", 3)
+            var = ds.createVariable("v", "f8", ("t",))
+            var[:] = [1.0, 2.0, 3.0]
+        with netCDF4.Dataset(path, "r") as ds:
+            assert float(ds["v"][1]) == 2.0
+    return f"netCDF4 {netCDF4.__version__} round-trip OK"
+
+
+def probe_sklearn() -> str:
+    import sklearn
+    from sklearn.feature_extraction.text import TfidfVectorizer
+
+    matrix = TfidfVectorizer().fit_transform(["alpha beta", "beta gamma"])
+    assert matrix.shape == (2, 3)
+    return f"scikit-learn {sklearn.__version__} TF-IDF OK"
+
+
+def probe_py7zr() -> str:
+    # Exercises the native codec stack (pyppmd/pybcj/pyzstd).
+    import py7zr
+
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "payload.txt"
+        src.write_text("probe payload")
+        archive = Path(d) / "probe.7z"
+        with py7zr.SevenZipFile(archive, "w") as z:
+            z.write(src, "payload.txt")
+        with py7zr.SevenZipFile(archive, "r") as z:
+            z.extractall(Path(d) / "out")
+        assert (Path(d) / "out" / "payload.txt").read_text() == "probe payload"
+    return f"py7zr {py7zr.__version__} round-trip OK"
+
+
+def probe_pymupdf() -> str:
+    import fitz
+
+    doc = fitz.open()
+    doc.new_page()
+    assert doc.page_count == 1
+    return f"PyMuPDF {fitz.__doc__.split()[1] if fitz.__doc__ else 'OK'} page create OK"
+
+
+def probe_lxml() -> str:
+    import lxml.etree as etree
+
+    root = etree.fromstring("<r><c>x</c></r>")
+    assert root.findtext("c") == "x"
+    return f"lxml {etree.__version__} parse OK"
+
+
+def probe_bcrypt() -> str:
+    import bcrypt
+
+    hashed = bcrypt.hashpw(b"probe", bcrypt.gensalt(rounds=4))
+    assert bcrypt.checkpw(b"probe", hashed)
+    return f"bcrypt {bcrypt.__version__} hash/check OK"
+
+
+def probe_psutil() -> str:
+    import psutil
+
+    assert psutil.Process().memory_info().rss > 0
+    return f"psutil {psutil.__version__} process info OK"
+
+
+def probe_faster_whisper() -> str:
+    # Importing loads the ctranslate2 native library.
+    import ctranslate2
+    import faster_whisper  # noqa: F401
+
+    return f"faster-whisper import OK (ctranslate2 {ctranslate2.__version__})"
+
+
+def probe_llama_cpp() -> str:
+    import llama_cpp
+
+    # Native C API call — proves the compiled library loads and answers.
+    assert isinstance(llama_cpp.llama_supports_mmap(), bool)
+    return f"llama-cpp-python {llama_cpp.__version__} native call OK"
+
+
+def probe_mlx() -> str:
+    import mlx.core as mx
+
+    assert (mx.array([1, 2]) + 1).sum().item() == 5
+    return "mlx array op OK"
+
+
+def probe_ezdxf() -> str:
+    import ezdxf
+
+    doc = ezdxf.new()
+    doc.modelspace().add_line((0, 0), (1, 1))
+    assert len(doc.modelspace()) == 1
+    return f"ezdxf {ezdxf.__version__} entity create OK"
+
+
+# (name, probe, applicable) — inapplicable probes report SKIP instead of FAIL.
+PROBES: list[tuple[str, Callable[[], str], bool]] = [
+    ("numpy", probe_numpy, True),
+    ("pydub/audioop", probe_pydub, True),
+    ("imagededup", probe_imagededup, True),
+    ("watchdog", probe_watchdog, True),
+    ("websockets", probe_websockets, True),
+    ("torch", probe_torch, True),
+    ("opencv", probe_opencv, True),
+    ("scipy", probe_scipy, True),
+    ("h5py", probe_h5py, True),
+    ("netCDF4", probe_netcdf4, True),
+    ("scikit-learn", probe_sklearn, True),
+    ("py7zr", probe_py7zr, True),
+    ("PyMuPDF", probe_pymupdf, True),
+    ("lxml", probe_lxml, True),
+    ("bcrypt", probe_bcrypt, True),
+    ("psutil", probe_psutil, True),
+    ("faster-whisper", probe_faster_whisper, True),
+    ("llama-cpp-python", probe_llama_cpp, True),
+    ("mlx", probe_mlx, IS_DARWIN),
+    ("ezdxf", probe_ezdxf, True),
+]
+
+
+def main() -> int:
+    """Run every applicable probe and print a PASS/FAIL/SKIP table."""
+    print(f"Deep probes on Python {sys.version.split()[0]} / {platform.platform()}\n")
+    failures = 0
+    for name, probe, applicable in PROBES:
+        if not applicable:
+            print(f"  SKIP  {name:<18} (not applicable on this platform)")
+            continue
+        try:
+            detail = probe()
+            print(f"  PASS  {name:<18} {detail}")
+        except Exception as exc:  # report every probe's outcome, then fail at the end
+            failures += 1
+            print(f"  FAIL  {name:<18} {type(exc).__name__}: {exc}")
+            traceback.print_exc()
+    print(f"\n{failures} failure(s) across {len(PROBES)} probes")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/file_organizer/undo/trash_gc.py
+++ b/src/file_organizer/undo/trash_gc.py
@@ -330,10 +330,14 @@ class TrashGC:
         except (OSError, RuntimeError):
             # ``OSError`` covers permissions/IO errors; ``RuntimeError``
             # is what ``Path.resolve`` raises on symlink loops (codex P2
-            # liBe). Be conservative on either: a path whose parent we
-            # can't resolve cleanly is treated as outside trash so the
-            # outcome stays inside the documented contract instead of
-            # propagating a raw exception out of safe_delete.
+            # liBe) on Python <= 3.12. On 3.13+ pathlib resolves via
+            # ``os.path.realpath`` and no longer raises for loops — the
+            # loop path then falls through to the ``lexists`` check and
+            # produces MISSING, which is equally safe (nothing deleted).
+            # Be conservative on either exception: a parent we can't
+            # resolve cleanly is treated as outside trash so the outcome
+            # stays inside the documented contract instead of propagating
+            # a raw exception out of safe_delete.
             return False
         try:
             Path(os.path.normcase(resolved_parent)).relative_to(

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -858,6 +858,10 @@ class TestDeepPythonProbeWorkflow:
         triggers = get_triggers(workflow)
         assert "schedule" in triggers, "deep-probe must keep its weekly schedule"
         assert "workflow_dispatch" in triggers, "deep-probe must stay manually dispatchable"
+        push = triggers.get("push") or {}
+        assert push.get("branches") == ["main", "epic/**"], (
+            "deep-probe push trigger must be scoped to main and epic/** branches"
+        )
         for event in ("pull_request", "push"):
             paths = (triggers.get(event) or {}).get("paths", [])
             assert "scripts/probe_python_support.py" in paths, (
@@ -865,4 +869,14 @@ class TestDeepPythonProbeWorkflow:
             )
         assert workflow.get("permissions") == {"contents": "read"}, (
             "deep-probe must run with read-only permissions"
+        )
+
+    def test_probe_timeout_accounts_for_slowest_windows_cell(
+        self, workflow: dict[str, Any]
+    ) -> None:
+        """Verify timeout budget covers the slowest cold-cache probe matrix cell."""
+        timeout = workflow["jobs"]["deep-probe"].get("timeout-minutes")
+        assert isinstance(timeout, int), "deep-probe timeout-minutes must be an integer"
+        assert timeout >= 90, (
+            "deep-probe timeout must allow the cold-cache Windows py3.14 install+probe sequence"
         )

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -748,3 +748,121 @@ class TestShardCoverage:
             f"scripts/ci_shard_paths.sh: {unassigned}. "
             f"Add them to an appropriate shard or to _EXCLUDED if intentional."
         )
+
+
+@pytest.mark.unit
+class TestExtrasMatrixWorkflow:
+    """Tests for the Extras Matrix workflow (ci-extras.yml).
+
+    ci-extras is the cheap install+import probe for every optional extra;
+    its matrix is part of the Python 3.13/3.14 migration evidence (#882).
+    """
+
+    @pytest.fixture
+    def workflow(self) -> dict[str, Any]:
+        return load_workflow("ci-extras.yml")
+
+    def test_linux_matrix_covers_migration_pythons(self, workflow: dict[str, Any]) -> None:
+        """Verify the Linux extras job installs on 3.12 through 3.14."""
+        job = workflow["jobs"]["install-extra"]
+        matrix = job["strategy"]["matrix"]
+        assert matrix["python-version"] == ["3.12", "3.13", "3.14"], (
+            f"install-extra must cover 3.12-3.14, got {matrix['python-version']}"
+        )
+        assert job["strategy"].get("fail-fast") is False, (
+            "install-extra must not fail-fast: each extra/python cell is independent evidence"
+        )
+
+    def test_linux_matrix_includes_llama_build_probe(self, workflow: dict[str, Any]) -> None:
+        """Verify the llama extra stays in the matrix.
+
+        llama-cpp-python publishes no wheels; this row is the only ongoing
+        cmake source-build probe in CI (#882).
+        """
+        matrix = workflow["jobs"]["install-extra"]["strategy"]["matrix"]
+        assert "llama" in matrix["extra"], (
+            "install-extra must include the llama extra — it is the cmake build probe"
+        )
+
+    def test_macos_lane_covers_darwin_extras(self, workflow: dict[str, Any]) -> None:
+        """Verify the Darwin lane exists and exercises what Linux cannot.
+
+        The mlx extra is Darwin-only by environment marker, so the Linux
+        matrix silently skips it; torch/opencv/h5py/netCDF4 also ship
+        separate macOS wheels that must not be assumed from Linux results.
+        """
+        job = workflow["jobs"].get("install-extra-macos")
+        assert job is not None, "ci-extras must keep the macOS lane (install-extra-macos)"
+        assert job["runs-on"] == "macos-latest"
+        matrix = job["strategy"]["matrix"]
+        assert matrix["python-version"] == ["3.12", "3.13", "3.14"], (
+            f"install-extra-macos must cover 3.12-3.14, got {matrix['python-version']}"
+        )
+        assert "mlx" in matrix["extra"], (
+            "install-extra-macos must include mlx — no other lane can exercise it"
+        )
+
+
+@pytest.mark.unit
+class TestDeepPythonProbeWorkflow:
+    """Tests for the Deep Python Probe workflow (python-probe.yml).
+
+    The deep probe is the functional (beyond install+import) evidence for
+    the 3.13/3.14 migration: native extensions, stdlib shims, sdist builds,
+    numpy-2 behavior, and PyInstaller bundles (#882).
+    """
+
+    @pytest.fixture
+    def workflow(self) -> dict[str, Any]:
+        return load_workflow("python-probe.yml")
+
+    def test_probe_script_exists(self) -> None:
+        """Verify the probe script the workflow runs is present."""
+        assert (PROJECT_ROOT / "scripts" / "probe_python_support.py").exists(), (
+            "python-probe.yml depends on scripts/probe_python_support.py"
+        )
+
+    def test_matrix_covers_all_platforms_and_pythons(self, workflow: dict[str, Any]) -> None:
+        """Verify the probe runs on all three OSes and migration Pythons."""
+        job = workflow["jobs"]["deep-probe"]
+        matrix = job["strategy"]["matrix"]
+        assert matrix["os"] == ["ubuntu-latest", "macos-latest", "windows-latest"], (
+            f"deep-probe must cover all three OSes, got {matrix['os']}"
+        )
+        assert matrix["python-version"] == ["3.11", "3.13", "3.14"], (
+            f"deep-probe must cover 3.11 (baseline), 3.13, 3.14 — got {matrix['python-version']}"
+        )
+        assert job["strategy"].get("fail-fast") is False, (
+            "deep-probe must not fail-fast: each OS/python cell is independent evidence"
+        )
+        assert job.get("timeout-minutes") is not None, (
+            "deep-probe must set timeout-minutes (llama.cpp builds can hang)"
+        )
+
+    def test_probe_stages_present(self, workflow: dict[str, Any]) -> None:
+        """Verify all three evidence stages exist: probes, numpy tests, bundle."""
+        steps = workflow["jobs"]["deep-probe"]["steps"]
+        runs = " ".join(step.get("run") or "" for step in steps)
+        assert "scripts/probe_python_support.py" in runs, (
+            "deep-probe must run the functional probe script"
+        )
+        assert "test_dedup_embedder.py" in runs, (
+            "deep-probe must run the numpy-2-sensitive test suites"
+        )
+        assert "pyinstaller --onefile" in runs, (
+            "deep-probe must build and execute a PyInstaller bundle"
+        )
+
+    def test_probe_triggers_and_permissions(self, workflow: dict[str, Any]) -> None:
+        """Verify schedule + dispatch + probe-kit path triggers, and read-only perms."""
+        triggers = get_triggers(workflow)
+        assert "schedule" in triggers, "deep-probe must keep its weekly schedule"
+        assert "workflow_dispatch" in triggers, "deep-probe must stay manually dispatchable"
+        for event in ("pull_request", "push"):
+            paths = (triggers.get(event) or {}).get("paths", [])
+            assert "scripts/probe_python_support.py" in paths, (
+                f"deep-probe {event} trigger must be scoped to the probe kit paths"
+            )
+        assert workflow.get("permissions") == {"contents": "read"}, (
+            "deep-probe must run with read-only permissions"
+        )

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -162,11 +162,12 @@ class TestCIWorkflow:
         """Verify the split PR/push test structure uses correct Python versions.
 
         ci.yml uses two separate jobs:
-        - 'test': PR-only, Python 3.11+3.12 (~2 400 tests, ci marker)
-        - 'test-full': push-only, 6 shards x Python 3.11+3.12 (~17 000 tests)
+        - 'test': PR-only, Python 3.11-3.14 (~2 400 tests, ci marker)
+        - 'test-full': push-only, 6 shards x Python 3.11-3.14 (~17 000 tests)
 
-        Both jobs cover 3.12 directly on PRs rather than waiting until after
-        merge (or the daily ci-full.yml run) to catch version-specific issues.
+        Both jobs cover every supported version directly on PRs rather than
+        waiting until after merge (or the daily ci-full.yml run) to catch
+        version-specific issues. 3.13/3.14 were added in issue #882.
         """
         jobs = workflow.get("jobs", {})
 
@@ -179,12 +180,12 @@ class TestCIWorkflow:
             "'test' job must have if: github.event_name == 'pull_request'"
         )
 
-        # Must run both Python versions so 3.12 is validated on every PR
+        # Must run all supported Python versions so each is validated on every PR
         strategy = test_job.get("strategy", {})
         matrix = strategy.get("matrix", {})
         python_versions = matrix.get("python-version", [])
-        assert set(python_versions) == {"3.11", "3.12"}, (
-            f"'test' (PR) job must include both 3.11 and 3.12, got {python_versions}"
+        assert set(python_versions) == {"3.11", "3.12", "3.13", "3.14"}, (
+            f"'test' (PR) job must include 3.11-3.14, got {python_versions}"
         )
 
         # Must have a timeout to prevent indefinite hangs
@@ -199,12 +200,12 @@ class TestCIWorkflow:
             "'test-full' job must have if: github.event_name == 'push'"
         )
 
-        # Must run both Python versions
+        # Must run all supported Python versions
         full_strategy = full_job.get("strategy", {})
         full_matrix = full_strategy.get("matrix", {})
         full_python = full_matrix.get("python-version", [])
-        assert set(full_python) == {"3.11", "3.12"}, (
-            f"'test-full' job must include both 3.11 and 3.12, got {full_python}"
+        assert set(full_python) == {"3.11", "3.12", "3.13", "3.14"}, (
+            f"'test-full' job must include 3.11-3.14, got {full_python}"
         )
 
         # Must use 6 shards so the suite stays domain-shaped instead of
@@ -429,8 +430,8 @@ class TestCIFullWorkflow:
         strategy = job.get("strategy", {})
         matrix = strategy.get("matrix", {})
         python_versions = matrix.get("python-version", [])
-        assert set(python_versions) == {"3.11", "3.12"}, (
-            f"'test-linux-full' must include both 3.11 and 3.12, got {python_versions}"
+        assert set(python_versions) == {"3.11", "3.12", "3.13", "3.14"}, (
+            f"'test-linux-full' must include 3.11-3.14, got {python_versions}"
         )
         shards = matrix.get("shard", [])
         assert shards == [1, 2, 3, 4, 5, 6], (

--- a/tests/ci/test_workflows.py
+++ b/tests/ci/test_workflows.py
@@ -158,7 +158,7 @@ class TestCIWorkflow:
         jobs = workflow.get("jobs", {})
         assert "test" in jobs, "CI workflow should have a 'test' job"
 
-    def test_ci_uses_python_312(self, workflow: dict[str, Any]) -> None:
+    def test_ci_uses_python_311_to_314(self, workflow: dict[str, Any]) -> None:
         """Verify the split PR/push test structure uses correct Python versions.
 
         ci.yml uses two separate jobs:

--- a/tests/integration/test_pipeline_stages_executor.py
+++ b/tests/integration/test_pipeline_stages_executor.py
@@ -162,16 +162,13 @@ class TestPreprocessorStageProcess:
         """An OSError from path.stat() (after exists()/is_file() pass) is reported."""
         f = tmp_path / "flaky.txt"
         f.write_text("content")
-        real_stat = Path.stat
-        calls = {"n": 0}
-
-        def flaky_stat(self: Path, *args: object, **kwargs: object) -> object:
-            calls["n"] += 1
-            if calls["n"] <= 2:
-                return real_stat(self, *args, **kwargs)
-            raise OSError("disk error")
-
-        monkeypatch.setattr(Path, "stat", flaky_stat)
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        monkeypatch.setattr(Path, "is_file", lambda self: True)
+        monkeypatch.setattr(
+            Path,
+            "stat",
+            lambda self, *args, **kwargs: (_ for _ in ()).throw(OSError("disk error")),
+        )
         stage = PreprocessorStage()
         ctx = StageContext(file_path=f)
         result = stage.process(ctx)

--- a/tests/integration/test_plugins_dedup_batch4.py
+++ b/tests/integration/test_plugins_dedup_batch4.py
@@ -1512,14 +1512,17 @@ class TestMisplacementDetector:
         sibling = tmp_path / "other.txt"
         sibling.write_text("neighbor")
         detector = MisplacementDetector()
-        real_stat = Path.stat
+        real_is_file = Path.is_file
 
-        def flaky_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+        # Patch ``is_file`` (what analyze_context actually calls per sibling),
+        # not ``Path.stat``: on Python 3.14 pathlib's ``is_file`` no longer
+        # routes through ``Path.stat``, so a stat patch never fires there.
+        def flaky_is_file(path: Path, *args: Any, **kwargs: Any) -> Any:
             if path == sibling:
                 raise OSError("permission denied")
-            return real_stat(path, *args, **kwargs)
+            return real_is_file(path, *args, **kwargs)
 
-        with patch("pathlib.Path.stat", autospec=True, side_effect=flaky_stat):
+        with patch("pathlib.Path.is_file", autospec=True, side_effect=flaky_is_file):
             context = detector.analyze_context(f)
         assert context.file_path == f
         assert context.size > 0

--- a/tests/services/audio/test_audio_utils.py
+++ b/tests/services/audio/test_audio_utils.py
@@ -7,6 +7,7 @@ All external dependencies (pydub, tinytag) are mocked.
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -453,10 +454,12 @@ class TestGetAudioPeakAmplitude:
         assert result == -3.5
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = get_audio_peak_amplitude(audio_file)

--- a/tests/services/audio/test_audio_utils.py
+++ b/tests/services/audio/test_audio_utils.py
@@ -357,10 +357,12 @@ class TestTrimAudio:
             assert result == audio_file
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = trim_audio(audio_file)

--- a/tests/services/audio/test_utils_branches.py
+++ b/tests/services/audio/test_utils_branches.py
@@ -566,12 +566,15 @@ class TestDetectSilenceSegmentsBranches:
 
     def test_no_pydub_returns_empty_list(self, audio_file: Path) -> None:
         """Lines 221-223: ImportError → warning logged, returns []."""
+        import builtins
+
+        real_import = builtins.__import__
 
         def _no_pydub(name: str, *args: object, **kwargs: object) -> object:
             """Substitute __import__ that raises ImportError for any pydub import."""
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=_no_pydub):
             result = detect_silence_segments(audio_file)

--- a/tests/services/deduplication/test_dedup_extractor.py
+++ b/tests/services/deduplication/test_dedup_extractor.py
@@ -255,10 +255,19 @@ class TestExtractDocx:
         assert "Table cell" in result
 
     def test_extract_docx_import_error(self, extractor, tmp_path):
+        import builtins
+
         p = tmp_path / "doc.docx"
         p.write_bytes(b"fake docx")
 
-        with patch("builtins.__import__", side_effect=ImportError("no docx")):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "docx":
+                raise ImportError("no docx")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
             result = extractor._extract_docx(p)
 
         assert result == ""

--- a/tests/undo/test_trash_gc.py
+++ b/tests/undo/test_trash_gc.py
@@ -628,12 +628,16 @@ class TestSafeDeleteFileFastPath:
         )
 
     def test_returns_outside_trash_for_symlink_loop_in_parent(self, tmp_path: Path) -> None:
-        """Codex P2 liBe: ``Path.resolve(strict=False)`` raises
-        ``RuntimeError`` (not ``OSError``) on symlink loops. A path
-        whose parent contains a self-referential symlink loop
-        (``loop -> loop``) MUST NOT propagate the exception out of
-        ``safe_delete``; it must return ``OUTSIDE_TRASH`` per the
-        outcome contract.
+        """Codex P2 liBe: a path whose parent contains a self-referential
+        symlink loop (``loop -> loop``) MUST NOT propagate an exception out
+        of ``safe_delete``; it must return a documented no-delete outcome.
+
+        The specific outcome is version-dependent: on Python <= 3.12,
+        ``Path.resolve(strict=False)`` raises ``RuntimeError`` on the loop,
+        which safe_delete maps to ``OUTSIDE_TRASH``. On 3.13+ pathlib was
+        reimplemented on ``os.path.realpath`` and no longer raises, so the
+        containment check passes and ``lexists`` on the loop path reports
+        the file absent — ``MISSING``. Both are safe: nothing is deleted.
         """
         if __import__("os").name == "nt":
             pytest.skip("POSIX symlinks")
@@ -653,9 +657,13 @@ class TestSafeDeleteFileFastPath:
         # MUST NOT raise; MUST return a documented outcome.
         outcome = gc.safe_delete(request)
 
-        assert outcome.result is TrashDeleteResult.OUTSIDE_TRASH, (
-            f"symlink loop in parent must produce OUTSIDE_TRASH, not "
-            f"propagate RuntimeError; got {outcome.result}"
+        assert outcome.result in (
+            TrashDeleteResult.OUTSIDE_TRASH,
+            TrashDeleteResult.MISSING,
+        ), (
+            f"symlink loop in parent must produce a documented no-delete "
+            f"outcome (OUTSIDE_TRASH on <=3.12, MISSING on 3.13+), not "
+            f"propagate an exception; got {outcome.result}"
         )
 
     def test_returns_outside_trash_for_traversal_attempt(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make `TestTrimAudio.test_no_pydub` patch `__import__` selectively (only block pydub)
- make `TestDetectSilenceSegmentsBranches.test_no_pydub_returns_empty_list` patch `__import__` selectively
- avoid breaking coverage internals (`coverage.python`) during ImportError path tests on py3.14

## Why
Main `ci.yml` failed on merge commit `d9354bd4` in `Test (shard 2, py3.14)` with:
- `TestTrimAudio::test_no_pydub`
- `TestDetectSilenceSegmentsBranches::test_no_pydub_returns_empty_list`

Both tests replaced `builtins.__import__` with a function that raised ImportError for *all* imports, which also intercepted coverage internals under Python 3.14.

## Validation
- `pytest -q tests/services/audio/test_audio_utils.py::TestTrimAudio::test_no_pydub tests/services/audio/test_utils_branches.py::TestDetectSilenceSegmentsBranches::test_no_pydub_returns_empty_list --override-ini=addopts=`
- `pytest -q tests/services/audio/test_audio_utils.py tests/services/audio/test_utils_branches.py --override-ini=addopts=`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CI coverage to include Python 3.13 and 3.14 in more test and install workflows.
  * Added a new cross-platform Python probe workflow to run deeper environment checks on a schedule and on demand.
  * Added extra validation for broader optional package combinations, including a macOS-specific lane.

* **Bug Fixes**
  * Improved test reliability around filesystem errors, import fallbacks, and version-specific path resolution behavior.
  * Updated audio and document-related fallbacks to better handle missing optional modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->