### PR TITLE
test: guard POSIX-only ci/smoke tests on Windows

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -95,6 +95,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          # fetch-depth: 0 so the tests/ci guardrails in the ci/smoke subset can
+          # resolve origin/main for their changed-files diff (a shallow checkout
+          # leaves it unreachable on PR branches).
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -117,6 +121,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          # fetch-depth: 0 so the tests/ci guardrails in the ci/smoke subset can
+          # resolve origin/main for their changed-files diff (a shallow checkout
+          # leaves it unreachable on PR branches).
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -456,13 +456,15 @@ class TestRulesPreview:
         assert result.exit_code == 0
         assert "5 files matched" in result.output
 
-    def test_preview_no_enabled_rules(self, runner):
+    def test_preview_no_enabled_rules(self, runner, tmp_path):
         mock_mgr = MagicMock()
         rs = RuleSet(name="empty", rules=[])
         mock_mgr.load_rule_set.return_value = rs
 
+        # Use tmp_path (not a hardcoded ``/tmp``) so the path-existence check
+        # the CLI performs passes on Windows, where ``/tmp`` does not exist.
         with patch(_RULE_MGR_PATH, return_value=mock_mgr):
-            result = runner.invoke(rules_app, ["preview", "/tmp"])  # noqa: test-hardcoded-paths
+            result = runner.invoke(rules_app, ["preview", str(tmp_path)])
         assert result.exit_code == 0
         assert "No enabled rules" in result.output
 

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -613,6 +613,10 @@ class TestClaimPidFile:
         with pytest.raises(FileExistsError):
             pid_manager2.claim_pid_file(pid_file)
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX directory-permission semantics; chmod does not block writes on Windows",
+    )
     def test_claim_oserror_on_unwritable_dir(
         self, pid_manager: PidFileManager, tmp_path: Path
     ) -> None:
@@ -631,6 +635,10 @@ class TestClaimPidFile:
         finally:
             locked_dir.chmod(stat.S_IRWXU)  # restore so tmp_path cleanup works
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="os.fchmod is POSIX-only; the source guards it with hasattr on Windows",
+    )
     def test_claim_fchmod_oserror_is_non_fatal(
         self, pid_manager: PidFileManager, pid_file: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/integration/test_optimization_core.py
+++ b/tests/integration/test_optimization_core.py
@@ -238,6 +238,9 @@ class TestMemoryProfiler:
             rss = MemoryProfiler._get_rss()
             assert rss == 1000 * 1024
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="resource module is POSIX-only (absent on Windows)"
+    )
     def test_get_rss_linux_proc_missing_vmrss(self) -> None:
         """Verify that _get_rss falls back to resource module on Linux if VmRSS is missing in proc status."""
         from unittest.mock import mock_open
@@ -255,6 +258,9 @@ class TestMemoryProfiler:
             rss = MemoryProfiler._get_rss()
             assert rss == 2000 * 1024
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="resource module is POSIX-only (absent on Windows)"
+    )
     def test_get_rss_darwin_proc_missing(self) -> None:
         """Verify that _get_rss queries resource maxrss directly on macOS/Darwin when proc status is missing."""
         from file_organizer.optimization.memory_profiler import MemoryProfiler
@@ -293,6 +299,9 @@ class TestMemoryProfiler:
             assert rss == 1000 * 1024
             assert vms == 5000 * 1024
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="resource module is POSIX-only (absent on Windows)"
+    )
     def test_get_rss_vms_darwin(self) -> None:
         """Verify that _get_rss_vms queries resource maxrss and returns 0 VMS on macOS/Darwin."""
         from file_organizer.optimization.memory_profiler import MemoryProfiler
@@ -308,6 +317,9 @@ class TestMemoryProfiler:
             assert rss == 4000
             assert vms == 0
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="resource module is POSIX-only (absent on Windows)"
+    )
     def test_get_rss_vms_linux_resource_fallback(self) -> None:
         """Verify that _get_rss_vms falls back to resource module on Linux if proc status is missing."""
         from file_organizer.optimization.memory_profiler import MemoryProfiler
@@ -323,6 +335,9 @@ class TestMemoryProfiler:
             assert rss == 5000 * 1024
             assert vms == 0
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="resource module is POSIX-only (absent on Windows)"
+    )
     def test_get_rss_vms_linux_missing_vmrss_keeps_vms(self) -> None:
         """Verify VmSize parse is preserved while RSS falls back if VmRSS is absent."""
         from unittest.mock import mock_open

--- a/tests/methodologies/johnny_decimal/test_categories.py
+++ b/tests/methodologies/johnny_decimal/test_categories.py
@@ -383,7 +383,10 @@ class TestNumberingResult:
 
         result_dict = result.to_dict()
 
-        assert result_dict["file_path"] == "/test/file.txt"
+        # ``to_dict`` serializes with ``str(path)``, which uses the native
+        # separator — compare against the same construction so the assertion
+        # holds on Windows (``\test\file.txt``) as well as POSIX.
+        assert result_dict["file_path"] == str(Path("/") / "test" / "file.txt")
         assert result_dict["number"] == "10.01"
         assert result_dict["number_name"] == "Test"
         assert result_dict["confidence"] == 0.8

--- a/tests/models/test_model_manager.py
+++ b/tests/models/test_model_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -173,6 +174,10 @@ class TestModelManager:
         assert all(m.installed is True for m in models)
         assert mock_whisper_installed.call_count == len(models)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="clears env so Path.home() raises on Windows; asserts the POSIX ~/.cache/huggingface layout",
+    )
     @patch.dict("os.environ", {}, clear=True)
     @patch("pathlib.Path.is_dir", autospec=True, return_value=True)
     @patch.dict("sys.modules", {"faster_whisper": MagicMock()})
@@ -192,8 +197,9 @@ class TestModelManager:
         with patch.dict("os.environ", {"HF_HUB_CACHE": str(hub_cache)}, clear=True):
             assert ModelManager._is_whisper_installed("small") is True
         checked_path = str(mock_is_dir.call_args.args[0])
-        assert checked_path.startswith(f"{hub_cache}/")
-        assert checked_path.endswith("models--Systran--faster-whisper-small")
+        # Build the expected path with the same ``Path`` join the source uses so
+        # the separator matches on Windows (``\``) as well as POSIX (``/``).
+        assert checked_path == str(hub_cache / "models--Systran--faster-whisper-small")
 
     def test_is_whisper_installed_returns_false_when_dependency_missing(self) -> None:
         real_import = __import__

--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -431,6 +431,10 @@ class TestWriterStage:
         result = WriterStage().process(ctx)
         assert result.error == "prior"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX fd-copy path; Windows falls back to shutil.copy2 (see test_writer_stage_windows_platform_fallback)",
+    )
     def test_special_file_error_destination(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -478,6 +482,10 @@ class TestWriterStage:
         assert dest.exists()
         assert dest.read_text() == "content"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX fd-copy path; Windows falls back to shutil.copy2 (see test_writer_stage_windows_platform_fallback)",
+    )
     def test_fdopen_os_error_closes_fd(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -531,6 +539,7 @@ class TestWriterStage:
         assert dest.exists()
         assert dest.read_text() == "fallback-content"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="xattrs are POSIX-only")
     def test_copyxattr_fd_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify that _copy_fd_xattrs successfully copies extended attributes when they are present."""
         src = tmp_path / "src.txt"
@@ -566,6 +575,7 @@ class TestWriterStage:
         assert setxattr_calls[0][1] == b"user.comment"
         assert setxattr_calls[0][2] == b"test-comment"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="xattrs are POSIX-only")
     def test_copyxattr_fd_skipped_errors(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/services/copilot/test_rules_actions.py
+++ b/tests/services/copilot/test_rules_actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -52,6 +53,9 @@ def test_conflict_skip_leaves_existing_destination(tmp_path: Path) -> None:
     assert destination.read_text(encoding="utf-8") == "old"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_conflict_rename_new_preserves_existing_destination(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     destination = tmp_path / "dest.txt"
@@ -66,6 +70,9 @@ def test_conflict_rename_new_preserves_existing_destination(tmp_path: Path) -> N
     assert result.destination.read_text(encoding="utf-8") == "new"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_copy_file_clean_success(tmp_path: Path) -> None:
     """Tests copying a file where no destination or parent directory exists yet."""
     source = tmp_path / "source.txt"
@@ -79,6 +86,9 @@ def test_copy_file_clean_success(tmp_path: Path) -> None:
     assert destination.read_text(encoding="utf-8") == "clean copy"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_conflict_overwrite_file(tmp_path: Path) -> None:
     """Tests that ConflictStrategy.OVERWRITE successfully replaces an existing file."""
     source = tmp_path / "source.txt"
@@ -104,6 +114,9 @@ def test_conflict_overwrite_directory_raises_error(tmp_path: Path) -> None:
         copy_file(source, destination, ConflictStrategy.OVERWRITE)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_conflict_rename_multiple_increments(tmp_path: Path) -> None:
     """Tests the while-loop branch where dest.txt and dest_1.txt both exist."""
     source = tmp_path / "source.txt"
@@ -117,6 +130,9 @@ def test_conflict_rename_multiple_increments(tmp_path: Path) -> None:
     assert result.destination.read_text(encoding="utf-8") == "brand new"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_copy_file_exception_unlinks_partial_file(tmp_path: Path) -> None:
     """Tests the try/except block in copy_file unlinks the target if copying fails."""
     source = tmp_path / "source.txt"
@@ -148,6 +164,9 @@ def test_link_strategies_handling_skipped_conflicts(tmp_path: Path) -> None:
     assert sl_result.reason == "exists"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_copy_file_fsync_failure_unlinks_destination(tmp_path: Path) -> None:
     """Tests that a failure in fsync_directory unlinks the created copy."""
     source = tmp_path / "source.txt"

--- a/tests/services/copilot/test_rules_executor.py
+++ b/tests/services/copilot/test_rules_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -119,6 +120,10 @@ def test_apply_move_uses_resolved_directory_destination(tmp_path: Path) -> None:
     assert (tmp_path / "archive" / "note.txt").read_text(encoding="utf-8") == "hello"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="copy apply uses SafeDir, whose Windows port is deferred (#264)",
+)
 def test_copy_to_sibling_file_destination_is_not_treated_as_destination_root(
     tmp_path: Path,
 ) -> None:
@@ -181,6 +186,10 @@ def test_link_actions_undo_and_redo_transaction(tmp_path: Path) -> None:
             assert link.resolve() == source
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="copy apply uses SafeDir, whose Windows port is deferred (#264)",
+)
 def test_watch_calls_cycle_callback(tmp_path: Path) -> None:
     source = tmp_path / "note.txt"
     source.write_text("hello", encoding="utf-8")

--- a/tests/services/copilot/test_rules_executor_coverage.py
+++ b/tests/services/copilot/test_rules_executor_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -56,6 +57,9 @@ def test_copy_file_exclusive_creation_exists(tmp_path: Path) -> None:
         assert res.reason == "exists"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy_file uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_copy_file_exception_cleanup(tmp_path: Path) -> None:
     source = tmp_path / "source.txt"
     source.write_text("hello", encoding="utf-8")
@@ -116,6 +120,9 @@ def test_post_mutation_failure_rollback_move(tmp_path: Path) -> None:
         assert not (tmp_path / "moved" / "note.txt").exists()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="copy apply uses SafeDir, whose Windows port is deferred (#264)"
+)
 def test_post_mutation_failure_rollback_copy(tmp_path: Path) -> None:
     mgr = _manager(tmp_path)
     executor = RuleExecutor(undo_manager=mgr)

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -2309,8 +2309,12 @@ class TestJournalSchemaV2Parser:
         """Equal paths are not descendants; only deeper children match."""
         from file_organizer.undo.durable_move import _is_descendant
 
-        assert _is_descendant("/trash/dir", "/trash/dir") is False
-        assert _is_descendant("/trash/dir/file.txt", "/trash/dir") is True
+        # ``_is_descendant`` compares on ``os.sep`` boundaries against inputs the
+        # caller has already normcased; build the paths with ``os.sep`` so the
+        # separator matches on Windows (``\``) as well as POSIX (``/``).
+        base = f"{os.sep}trash{os.sep}dir"
+        assert _is_descendant(base, base) is False
+        assert _is_descendant(f"{base}{os.sep}file.txt", base) is True
 
 
 # ---------------------------------------------------------------------------
@@ -2627,6 +2631,10 @@ class TestJournalLockFile:
         assert reader_done.wait(timeout=5.0)
         t.join(timeout=2)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="mocks the POSIX fcntl reader branch; Windows uses the unlocked _read_journal fallback",
+    )
     def test_read_journal_under_shared_lock_returns_empty_when_journal_vanishes(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2654,6 +2662,10 @@ class TestJournalLockFile:
 
         assert dm.read_journal_under_shared_lock(journal) == []
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="mocks the POSIX fcntl reader branch; Windows uses the unlocked _read_journal fallback",
+    )
     def test_read_journal_under_shared_lock_race_returns_list_not_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2685,6 +2697,10 @@ class TestJournalLockFile:
             "read_journal_under_shared_lock must return a list, not None or other falsy"
         )
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="mocks the POSIX fcntl reader branch; Windows uses the unlocked _read_journal fallback",
+    )
     def test_read_journal_under_shared_lock_race_with_multi_entry_journal(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2718,6 +2734,10 @@ class TestJournalLockFile:
 
         assert dm.read_journal_under_shared_lock(journal) == []
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="mocks the POSIX fcntl reader branch; Windows uses the unlocked _read_journal fallback",
+    )
     def test_read_journal_under_shared_lock_passthrough_for_non_journal_paths(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/undo/test_durable_move_1248.py
+++ b/tests/undo/test_durable_move_1248.py
@@ -46,6 +46,10 @@ def _force_exdev(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestStartedBeforeTmpOrdering:
     """#1248 #1: in-flight marker must precede the GC-visible tmp window."""
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="instruments _append_journal_line_locked, only used on the POSIX fcntl append path",
+    )
     def test_started_journaled_before_tmp_created(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## What

Fixes the **CI Full Matrix → Test Windows (Python 3.12)** job, which was failing on `main` with **31 test failures** ([example run](https://github.com/curdriceaurora/Local-File-Organizer/actions/runs/28774372296/job/85314842390)).

The `test-windows` job runs `pytest tests/ -m "ci or smoke"` — its contract is that the `ci`/`smoke` subset is portable to Windows. 31 tests violated that contract by exercising Unix-only behavior while lacking a Windows guard.

## Why the tests, not the shipping code

In every case the shipping code already handles Windows correctly — verified per failure:

| Behavior | Windows handling in source |
|---|---|
| `os.fchmod` | `hasattr(os, "fchmod")` guard (`daemon/pid.py`) |
| `resource` module | lazy/guarded import (returns 0) |
| WriterStage fd-copy / xattr | falls back to `shutil.copy2` |
| copilot copy/apply (SafeDir) | intentional `NotImplementedError` deferral (#264, `utils/safedir.py`) |
| journal shared-lock / append | non-`fcntl` `_read_journal` / `append_durable` fallback |

So only the tests needed changing.

## Changes (31 tests across 11 files)

- **27 `@pytest.mark.skipif(sys.platform == "win32", …)` guards** on genuinely POSIX-only tests (resource module ×5, `os.fchmod`/POSIX dir-perms ×2, fd-copy/xattr ×4, SafeDir copy-apply #264 ×10, journal `fcntl` reader/append branch ×5, default HF cache path ×1). Matches the existing convention in the codebase; `test_pid.py` uses its local `os.name == "nt"` idiom.
- **4 portable fixes** that *retain* Windows coverage, where only a hardcoded POSIX separator/path in an assertion was wrong (source is correct):
  - `NumberingResult.to_dict` — compare against `str(Path(...))`
  - whisper `HF_HUB_CACHE` — assert exact `str(hub_cache / model_dir)`
  - rules `preview` — use `tmp_path` instead of `/tmp` (doesn't exist on Windows)
  - `_is_descendant` — build paths with `os.sep`

## Local verification (macOS)

- 213 affected tests pass, 0 failures (no regression on POSIX).
- `ruff check` + `ruff format --check` clean on all 11 files.
- Full `pre-commit` (smoke suite, ci guardrails, diff-cover, ruff) passed.

## ⛔ Merge precondition

**Do not merge until a CI Full Matrix run against this branch is green — in particular the `Test Windows (Python 3.12)` job.** `ci-full.yml` does not trigger on `pull_request` (only `schedule` + `workflow_dispatch`), so a run has been dispatched manually against this branch; link below. macOS/Windows can't be reproduced in the local dev loop, so this run is the actual gate for the fix.

- CI Full Matrix run: https://github.com/curdriceaurora/Local-File-Organizer/actions/runs/28777677728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform reliability by making file-path handling work consistently on Windows and POSIX systems.
  * Adjusted several tests to skip platform-specific behavior where operating-system features differ, reducing false failures on Windows.
  * Updated CI checkout settings so branch comparisons work more reliably in portable smoke checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->