### PR TITLE
Unify the organization-methodology vocabulary (#1538)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -676,6 +676,7 @@ DEP002 = [
 "src/file_organizer/client/sync_client.py" = 70
 "src/file_organizer/config/__init__.py" = 100
 "src/file_organizer/config/manager.py" = 80
+"src/file_organizer/config/methodology.py" = 100
 "src/file_organizer/config/migrations.py" = 20
 "src/file_organizer/config/path_manager.py" = 100
 "src/file_organizer/config/path_migration.py" = 90

--- a/src/file_organizer/api/routers/config.py
+++ b/src/file_organizer/api/routers/config.py
@@ -18,6 +18,7 @@ from file_organizer.api.openapi_responses import (
     validation_error_response,
 )
 from file_organizer.config.manager import ConfigManager, UnsupportedConfigVersionError
+from file_organizer.config.methodology import normalize as normalize_methodology
 from file_organizer.config.schema import AppConfig
 
 router = APIRouter(tags=["config"], responses=INTERNAL_500_RESPONSE)
@@ -36,7 +37,7 @@ def _profile_update_lock(manager: ConfigManager, profile: str) -> RLock:
 def _apply_update(config: AppConfig, request: ConfigUpdateRequest) -> None:
     """Apply a partial API update to an AppConfig instance."""
     if request.default_methodology is not None:
-        config.default_methodology = request.default_methodology
+        config.default_methodology = normalize_methodology(request.default_methodology)
 
     models = request.models
     if models is not None:

--- a/src/file_organizer/api/routers/system.py
+++ b/src/file_organizer/api/routers/system.py
@@ -33,6 +33,7 @@ from file_organizer.api.openapi_responses import (
 )
 from file_organizer.api.utils import file_info_from_path, resolve_path
 from file_organizer.config.manager import ConfigManager, UnsupportedConfigVersionError
+from file_organizer.config.methodology import normalize as normalize_methodology
 from file_organizer.services.analytics.storage_analyzer import StorageAnalyzer
 from file_organizer.version import __version__
 
@@ -94,7 +95,7 @@ def system_status(
             "Returned configuration profile.",
             {
                 "profile": "default",
-                "config": {"default_methodology": "PARA"},
+                "config": {"default_methodology": "para"},
                 "profiles": ["default"],
             },
         ),
@@ -119,7 +120,7 @@ def get_config(
             "Updated configuration profile.",
             {
                 "profile": "default",
-                "config": {"default_methodology": "PARA"},
+                "config": {"default_methodology": "para"},
                 "profiles": ["default"],
             },
         ),
@@ -141,7 +142,7 @@ def update_config(
     config = manager.load(request.profile)
 
     if request.default_methodology is not None:
-        config.default_methodology = request.default_methodology
+        config.default_methodology = normalize_methodology(request.default_methodology)
 
     if request.models is not None:
         models = request.models

--- a/src/file_organizer/config/manager.py
+++ b/src/file_organizer/config/manager.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
+from file_organizer.config.methodology import normalize as normalize_methodology
 from file_organizer.config.migrations import compare_versions, migrate_to_current
 from file_organizer.config.path_manager import get_config_dir
 from file_organizer.config.schema import (
@@ -512,7 +513,7 @@ class ConfigManager:
             # Normalize to str so a YAML-parsed float (``version: 1.0``) does not
             # leak through as a float despite the ``str`` annotation.
             version=str(data.get("version", CURRENT_SCHEMA_VERSION)),
-            default_methodology=data.get("default_methodology", "none"),
+            default_methodology=normalize_methodology(data.get("default_methodology")),
             default_input_dir=data.get("default_input_dir", ""),
             default_output_dir=data.get("default_output_dir", ""),
             setup_completed=data.get("setup_completed", False),

--- a/src/file_organizer/config/methodology.py
+++ b/src/file_organizer/config/methodology.py
@@ -1,0 +1,56 @@
+"""Canonical organization-methodology vocabulary.
+
+Single source of truth for the three organization methodologies (flat/none,
+PARA, Johnny Decimal) shared across ``AppConfig``, the TUI, the web UI, and
+the API. Previously the web layer defined its own, partially incompatible
+vocabulary (``content_based`` / ``date_based`` instead of ``none``), with no
+implementation ever backing ``date_based`` — see #1538.
+"""
+
+from __future__ import annotations
+
+NONE = "none"
+PARA = "para"
+JOHNNY_DECIMAL = "jd"
+
+DEFAULT = NONE
+
+ORDER: tuple[str, ...] = (NONE, PARA, JOHNNY_DECIMAL)
+
+LABELS: dict[str, str] = {
+    NONE: "None (flat / content-based)",
+    PARA: "PARA",
+    JOHNNY_DECIMAL: "Johnny Decimal",
+}
+
+# Legacy string values from before the vocabulary was unified (old
+# web-settings.json files, in-memory web job metadata, hand-typed API
+# requests). Mapped to their canonical equivalent by normalize(); never
+# written back out. ``date_based`` is deliberately absent: it was a web-only
+# dropdown option with no organizer implementation behind it anywhere in the
+# codebase, so there is no canonical value to alias it to.
+_ALIASES: dict[str, str] = {
+    "content_based": NONE,
+    "johnny_decimal": JOHNNY_DECIMAL,
+}
+
+
+def normalize(value: object, *, default: str = DEFAULT) -> str:
+    """Return a canonical methodology value, mapping known legacy aliases.
+
+    Args:
+        value: Candidate methodology value from any surface (form field,
+            API request, persisted config/settings).
+        default: Value to return when *value* is unrecognized.
+
+    Returns:
+        One of :data:`ORDER`, or *default* if *value* is not a canonical
+        value or a known legacy alias.
+    """
+    if isinstance(value, str):
+        candidate = value.strip().lower()
+        if candidate in ORDER:
+            return candidate
+        if candidate in _ALIASES:
+            return _ALIASES[candidate]
+    return default

--- a/src/file_organizer/config/schema.py
+++ b/src/file_organizer/config/schema.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
+
 # Schema-version constants. ``CURRENT_SCHEMA_VERSION`` is what new configs are
 # written as; ``SUPPORTED_SCHEMA_VERSIONS`` is the set ConfigManager will load
 # without falling back to defaults. It is derived from CURRENT_SCHEMA_VERSION so
@@ -74,7 +76,8 @@ class AppConfig:
     Args:
         profile_name: Name of this configuration profile.
         version: Configuration schema version.
-        default_methodology: Default organization methodology (none, para, jd).
+        default_methodology: Default organization methodology — one of
+            ``config.methodology.ORDER`` (currently none, para, jd).
         default_input_dir: Default source directory pre-filled for organize runs
             (empty string means "unset — prompt each run").
         default_output_dir: Default destination directory pre-filled for organize
@@ -95,7 +98,7 @@ class AppConfig:
 
     profile_name: str = "default"
     version: str = CURRENT_SCHEMA_VERSION
-    default_methodology: str = "none"
+    default_methodology: str = _DEFAULT_METHODOLOGY
     default_input_dir: str = ""
     default_output_dir: str = ""
     setup_completed: bool = False

--- a/src/file_organizer/core/setup_wizard.py
+++ b/src/file_organizer/core/setup_wizard.py
@@ -14,6 +14,7 @@ from typing import Any
 from loguru import logger
 
 from file_organizer.config.manager import ConfigManager
+from file_organizer.config.methodology import normalize as normalize_methodology
 from file_organizer.config.schema import AppConfig, ModelPreset
 from file_organizer.core.backend_detector import (
     InstalledModel,
@@ -261,7 +262,9 @@ class SetupWizard:
             if custom_settings
             else "default",
             version="1.0",
-            default_methodology="none",
+            default_methodology=normalize_methodology(
+                custom_settings.get("methodology") if custom_settings else None
+            ),
             models=models,
         )
 

--- a/src/file_organizer/tui/settings_view.py
+++ b/src/file_organizer/tui/settings_view.py
@@ -29,19 +29,13 @@ from textual.containers import Vertical
 from textual.widgets import Input, Static
 
 from file_organizer.config.manager import ConfigManager
+from file_organizer.config.methodology import LABELS as _METHODOLOGY_LABELS
+from file_organizer.config.methodology import ORDER as _METHODOLOGY_ORDER
+from file_organizer.config.methodology import normalize as _normalize_methodology
 
 _DEFAULT_PREFETCH_DEPTH = 2
 _MAX_WORKERS_CAP = max(1, os.cpu_count() or 1)
 logger = logging.getLogger(__name__)
-
-# Organization methodologies, in cycle order. Values match
-# ``AppConfig.default_methodology`` and the TUI MethodologyView vocabulary.
-_METHODOLOGY_ORDER = ("none", "para", "jd")
-_METHODOLOGY_LABELS = {
-    "none": "None (flat / content-based)",
-    "para": "PARA",
-    "jd": "Johnny Decimal",
-}
 
 # Curated text-model presets cycled through with the "t" binding. A value
 # persisted outside this list is preserved and prepended so cycling never
@@ -106,13 +100,6 @@ def _coerce_non_negative_int(value: Any, *, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= 0 else default
-
-
-def _normalize_methodology(value: Any) -> str:
-    """Return a known methodology identifier, defaulting to ``"none"``."""
-    if isinstance(value, str) and value in _METHODOLOGY_ORDER:
-        return value
-    return "none"
 
 
 def load_parallel_runtime_settings(

--- a/src/file_organizer/web/organize_routes.py
+++ b/src/file_organizer/web/organize_routes.py
@@ -23,6 +23,9 @@ from file_organizer.api.exceptions import ApiError
 from file_organizer.api.jobs import create_job, get_job, list_jobs, update_job
 from file_organizer.api.models import OrganizationError, OrganizationResultResponse, OrganizeRequest
 from file_organizer.api.utils import is_hidden, resolve_path
+from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
+from file_organizer.config.methodology import LABELS as ORGANIZE_METHODOLOGIES
+from file_organizer.config.methodology import normalize as _normalize_methodology
 from file_organizer.core.organizer import FileOrganizer, OrganizationResult
 from file_organizer.web._helpers import (
     allowed_roots,
@@ -42,13 +45,6 @@ ORGANIZE_PLAN_LIMIT = 200
 ORGANIZE_JOB_TYPE = "organize_web"
 JOB_METADATA_PRUNE_THRESHOLD = 256
 JOB_METADATA_PRUNE_INTERVAL_SECONDS = 60.0
-
-ORGANIZE_METHODOLOGIES = {
-    "johnny_decimal": "Johnny Decimal",
-    "para": "PARA",
-    "content_based": "Content-Based",
-    "date_based": "Date-Based",
-}
 
 _ORGANIZE_PLAN_STORE: dict[str, dict[str, Any]] = {}
 _ORGANIZE_PLAN_LOCK = Lock()
@@ -93,14 +89,6 @@ def _parse_delay_minutes(value: str | None) -> int:
             message=f"Schedule delay must be between 0 and {ORGANIZE_MAX_DELAY_MIN} minutes.",
         )
     return minutes
-
-
-def _normalize_methodology(value: str | None) -> str:
-    """Normalize a methodology string, defaulting to ``content_based``."""
-    token = (value or "").strip().lower()
-    if token in ORGANIZE_METHODOLOGIES:
-        return token
-    return "content_based"
 
 
 def _scan_directory(path: Path, recursive: bool, include_hidden: bool) -> list[Path]:
@@ -313,6 +301,8 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
     elif total_files > 0 and job.status == "running":
         progress = max(progress, int((processed_files / max(total_files, 1)) * 100))
 
+    methodology = _normalize_methodology(metadata.get("methodology"))
+
     return {
         "job_id": job.job_id,
         "status": job.status,
@@ -325,11 +315,8 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
         "failed_files": failed_files,
         "skipped_files": skipped_files,
         "result": result,
-        "methodology": metadata.get("methodology", "content_based"),
-        "methodology_label": ORGANIZE_METHODOLOGIES.get(
-            metadata.get("methodology", "content_based"),
-            "Content-Based",
-        ),
+        "methodology": methodology,
+        "methodology_label": ORGANIZE_METHODOLOGIES[methodology],
         "input_dir": metadata.get("input_dir", ""),
         "output_dir": metadata.get("output_dir", ""),
         "dry_run": bool(metadata.get("dry_run", False)),
@@ -380,7 +367,7 @@ def _build_organize_stats() -> dict[str, Any]:
 
     methodology_counts: dict[str, int] = {}
     for job in jobs:
-        label = job.get("methodology_label", "Content-Based")
+        label = job.get("methodology_label", ORGANIZE_METHODOLOGIES[_DEFAULT_METHODOLOGY])
         methodology_counts[label] = methodology_counts.get(label, 0) + 1
 
     return {
@@ -514,7 +501,7 @@ def organize_scan(
     settings: ApiSettings = Depends(get_settings),
     input_dir: str = Form(""),
     output_dir: str = Form(""),
-    methodology: str = Form("content_based"),
+    methodology: str = Form(_DEFAULT_METHODOLOGY),
     recursive: str = Form("1"),
     include_hidden: str = Form("0"),
     skip_existing: str = Form("1"),
@@ -685,7 +672,7 @@ def organize_execute(
                 "plan_id": plan_id,
                 "input_dir": organize_request.input_dir,
                 "output_dir": organize_request.output_dir,
-                "methodology": str(plan.get("methodology", "content_based")),
+                "methodology": _normalize_methodology(plan.get("methodology")),
                 "dry_run": organize_request.dry_run,
                 "schedule_delay_minutes": delay_minutes,
                 "scheduled_for": scheduled_for,

--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -22,6 +22,9 @@ from loguru import logger
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_settings
 from file_organizer.api.utils import resolve_path
+from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
+from file_organizer.config.methodology import LABELS as METHODOLOGY_OPTIONS
+from file_organizer.config.methodology import normalize as _normalize_methodology
 from file_organizer.config.path_manager import get_config_dir
 from file_organizer.utils.atomic_write import atomic_write_text
 from file_organizer.web._helpers import base_context, templates
@@ -31,12 +34,6 @@ settings_router = APIRouter(tags=["web"])
 _SETTINGS_DIR = get_config_dir()
 _SETTINGS_FILE = _SETTINGS_DIR / "web-settings.json"
 
-METHODOLOGY_OPTIONS = {
-    "content_based": "Content-Based",
-    "johnny_decimal": "Johnny Decimal",
-    "para": "PARA",
-    "date_based": "Date-Based",
-}
 LOG_LEVEL_OPTIONS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 THEME_OPTIONS = ["light", "dark", "auto", "custom"]
 LANGUAGE_OPTIONS = ["en", "es", "fr", "de", "ja"]
@@ -102,7 +99,7 @@ class WebSettings:
     ollama_url: str = "http://localhost:11434"
 
     # Organization
-    default_methodology: str = "content_based"
+    default_methodology: str = _DEFAULT_METHODOLOGY
     auto_organize: bool = False
     notifications_enabled: bool = True
     file_filter_glob: str = "*"
@@ -139,12 +136,6 @@ def _validate_choice(value: str, allowed: list[str], fallback: str) -> str:
     """Return *value* if it is in *allowed*, otherwise return *fallback*."""
     candidate = value.strip()
     return candidate if candidate in allowed else fallback
-
-
-def _validate_methodology(value: str) -> str:
-    """Validate and normalize a methodology identifier."""
-    candidate = value.strip().lower()
-    return candidate if candidate in METHODOLOGY_OPTIONS else "content_based"
 
 
 def _validate_rules(rules: str) -> tuple[bool, str]:
@@ -190,7 +181,7 @@ def _load_web_settings() -> WebSettings:
                 continue
             if isinstance(value, str):
                 setattr(ws, key, value)
-        ws.default_methodology = _validate_methodology(ws.default_methodology)
+        ws.default_methodology = _normalize_methodology(ws.default_methodology)
         ws.theme = _validate_choice(ws.theme, THEME_OPTIONS, "light")
         ws.log_level = _validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
         ws.performance_mode = _validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
@@ -405,7 +396,7 @@ async def settings_import(
             elif isinstance(value, str):
                 setattr(ws, key, value)
 
-        ws.default_methodology = _validate_methodology(ws.default_methodology)
+        ws.default_methodology = _normalize_methodology(ws.default_methodology)
         ws.theme = _validate_choice(ws.theme, THEME_OPTIONS, "light")
         ws.log_level = _validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
         ws.performance_mode = _validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
@@ -586,7 +577,7 @@ def settings_organization_validate(
 @settings_router.post("/settings/organization", response_class=HTMLResponse)
 def settings_organization_post(
     request: Request,
-    default_methodology: str = Form("content_based"),
+    default_methodology: str = Form(_DEFAULT_METHODOLOGY),
     auto_organize: str | None = Form(None),
     notifications_enabled: str | None = Form(None),
     file_filter_glob: str = Form("*"),
@@ -607,7 +598,7 @@ def settings_organization_post(
 
     try:
         ws = _update_web_settings(
-            default_methodology=_validate_methodology(default_methodology),
+            default_methodology=_normalize_methodology(default_methodology),
             auto_organize=_as_form_bool(auto_organize),
             notifications_enabled=_as_form_bool(notifications_enabled),
             file_filter_glob=file_filter_glob.strip() or "*",

--- a/src/file_organizer/web/static/js/setup_wizard.js
+++ b/src/file_organizer/web/static/js/setup_wizard.js
@@ -259,7 +259,7 @@ window.browseDirectory = async (inputId) => {
       models: {
         text_model: textModel,
       },
-      methodology: methodology || "content_based",
+      methodology: methodology || "none",
     };
 
     if (visionModel) {

--- a/src/file_organizer/web/templates/organize/_plan.html
+++ b/src/file_organizer/web/templates/organize/_plan.html
@@ -10,7 +10,7 @@
 <div class="plan-summary-grid" data-plan-id="{{ plan.plan_id }}">
     <article>
         <h3>Plan summary</h3>
-        <p><strong>Method:</strong> {{ methodology_options.get(plan.methodology, 'Content-Based') }}</p>
+        <p><strong>Method:</strong> {{ methodology_options.get(plan.methodology, 'None (flat / content-based)') }}</p>
         <p><strong>Input:</strong> {{ plan.input_dir }}</p>
         <p><strong>Output:</strong> {{ plan.output_dir }}</p>
     </article>

--- a/src/file_organizer/web/templates/setup_wizard.html
+++ b/src/file_organizer/web/templates/setup_wizard.html
@@ -162,10 +162,9 @@
                         <div class="form-group">
                             <label for="methodology">Methodology</label>
                             <select id="methodology" name="methodology" class="form-select">
-                                <option value="content_based">Content-Based (Recommended)</option>
-                                <option value="johnny_decimal">Johnny Decimal</option>
+                                <option value="none">None (flat / content-based) (Recommended)</option>
+                                <option value="jd">Johnny Decimal</option>
                                 <option value="para">PARA</option>
-                                <option value="date_based">Date-Based</option>
                             </select>
                         </div>
                     </div>

--- a/tests/api/test_api_system.py
+++ b/tests/api/test_api_system.py
@@ -56,6 +56,32 @@ def test_system_config_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert update.json()["config"]["default_methodology"] == "para"
 
 
+def test_system_config_update_normalizes_legacy_methodology_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-unification/legacy methodology value is normalized on write.
+
+    Regression test: this endpoint previously wrote request.default_methodology
+    straight onto AppConfig with no validation at all, so an unrecognized or
+    legacy-web value (e.g. "content_based") would corrupt the persisted config
+    with a value the TUI/core vocabulary doesn't recognize.
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("FO_CONFIG_DIR", str(config_dir))
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    client, headers = _client(tmp_path, [str(data_dir)], admin=True)
+
+    update = client.patch(
+        "/api/v1/system/config",
+        json={"profile": "default", "default_methodology": "content_based"},
+        headers=headers,
+    )
+    assert update.status_code == 200
+    assert update.json()["config"]["default_methodology"] == "none"
+
+
 def test_system_config_update_refuses_unsupported_version(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/api/test_config_router.py
+++ b/tests/api/test_config_router.py
@@ -183,6 +183,24 @@ class TestUpdateConfig:
         assert config["models"]["temperature"] == 0.5
         assert config["updates"]["check_on_startup"] is True
 
+    def test_update_config_normalizes_legacy_methodology_value(self, tmp_path: Path) -> None:
+        """A pre-unification/legacy methodology value is normalized on write.
+
+        Regression test: this endpoint previously wrote request.default_methodology
+        straight onto AppConfig with no validation at all, so an unrecognized or
+        legacy-web value (e.g. "content_based") would corrupt the persisted config
+        with a value the TUI/core vocabulary doesn't recognize.
+        """
+        _, client = _build_app(tmp_path, admin_user=_admin_user())
+
+        resp = client.put(
+            "/api/v1/config",
+            json={"default_methodology": "content_based"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["config"]["default_methodology"] == "none"
+
     def test_update_config_multiple_sections(self, tmp_path: Path) -> None:
         """PUT can update top-level, model, update, and module override fields."""
         _, client = _build_app(tmp_path, admin_user=_admin_user())

--- a/tests/core/test_setup_wizard.py
+++ b/tests/core/test_setup_wizard.py
@@ -156,6 +156,57 @@ class TestGenerateConfig:
         assert config.models.temperature == 0.8
         assert config.models.max_tokens == 4096
 
+    def test_generate_config_default_methodology_is_none(self):
+        """Absent custom_settings, default_methodology should be canonical 'none'."""
+        wizard = SetupWizard(mode=WizardMode.QUICK_START)
+        mock_hw = Mock(spec=HardwareProfile)
+        mock_hw.recommended_text_model.return_value = "qwen2.5:3b-instruct-q4_K_M"
+        wizard.capabilities = SystemCapabilities(
+            hardware=mock_hw,
+            ollama_status=OllamaStatus(installed=True, running=True),
+            installed_models=[],
+        )
+
+        config = wizard.generate_config()
+
+        assert config.default_methodology == "none"
+
+    def test_generate_config_applies_custom_methodology(self):
+        """custom_settings["methodology"] must reach AppConfig.default_methodology.
+
+        Regression test: the setup wizard's methodology selector previously sent
+        this value but generate_config() silently discarded it, always writing
+        "none" regardless of what the user picked. Also verifies this isn't
+        gated to POWER_USER mode, matching profile_name's existing treatment.
+        """
+        wizard = SetupWizard(mode=WizardMode.QUICK_START)
+        mock_hw = Mock(spec=HardwareProfile)
+        mock_hw.recommended_text_model.return_value = "qwen2.5:3b-instruct-q4_K_M"
+        wizard.capabilities = SystemCapabilities(
+            hardware=mock_hw,
+            ollama_status=OllamaStatus(installed=True, running=True),
+            installed_models=[],
+        )
+
+        config = wizard.generate_config(custom_settings={"methodology": "para"})
+
+        assert config.default_methodology == "para"
+
+    def test_generate_config_normalizes_legacy_methodology_alias(self):
+        """An unrecognized/legacy methodology value should normalize, not pass through."""
+        wizard = SetupWizard(mode=WizardMode.POWER_USER)
+        mock_hw = Mock(spec=HardwareProfile)
+        mock_hw.recommended_text_model.return_value = "qwen2.5:3b-instruct-q4_K_M"
+        wizard.capabilities = SystemCapabilities(
+            hardware=mock_hw,
+            ollama_status=OllamaStatus(installed=True, running=True),
+            installed_models=[],
+        )
+
+        config = wizard.generate_config(custom_settings={"methodology": "content_based"})
+
+        assert config.default_methodology == "none"
+
     def test_generate_config_uses_first_available_model(self):
         wizard = SetupWizard(mode=WizardMode.QUICK_START)
 

--- a/tests/integration/test_api_auth_system_routes.py
+++ b/tests/integration/test_api_auth_system_routes.py
@@ -429,8 +429,9 @@ class TestSystemConfigPatch:
             },
         )
         assert resp.status_code == 200
-        # Top-level scalar update applied.
-        assert config.default_methodology == "PARA"
+        # Top-level scalar update applied, normalized to the canonical
+        # lowercase vocabulary (see file_organizer.config.methodology).
+        assert config.default_methodology == "para"
         # Nested models update applied via setattr loop.
         assert config.models.text_model == "x-text"
         # Nested updates update applied via setattr loop.

--- a/tests/integration/test_web_organize_routes_extended.py
+++ b/tests/integration/test_web_organize_routes_extended.py
@@ -2,7 +2,7 @@
 
 Covers uncovered lines including:
 - _parse_delay_minutes: None/empty → 0, non-int raises, negative raises, over-max raises
-- _normalize_methodology: known key, unknown key → content_based
+- _normalize_methodology: known key, unknown key → none (canonical default)
 - _scan_directory: single file input (hidden/not hidden), non-recursive glob
 - _counts_by_type: image, video, audio, cad, other categories
 - _store_organize_plan / _get_organize_plan / _delete_organize_plan
@@ -146,11 +146,17 @@ class TestNormalizeMethodology:
     def test_known_key_returns_key(self) -> None:
         assert _normalize_methodology("para") == "para"
 
-    def test_unknown_key_returns_content_based(self) -> None:
-        assert _normalize_methodology("nonsense") == "content_based"
+    def test_unknown_key_returns_none(self) -> None:
+        """``date_based`` and other unrecognized values fall back to canonical "none"."""
+        assert _normalize_methodology("nonsense") == "none"
+        assert _normalize_methodology("date_based") == "none"
 
-    def test_none_returns_content_based(self) -> None:
-        assert _normalize_methodology(None) == "content_based"
+    def test_none_returns_none(self) -> None:
+        assert _normalize_methodology(None) == "none"
+
+    def test_legacy_alias_maps_to_canonical(self) -> None:
+        assert _normalize_methodology("content_based") == "none"
+        assert _normalize_methodology("johnny_decimal") == "jd"
 
     def test_uppercase_known_key_is_case_insensitive(self) -> None:
         assert _normalize_methodology("PARA") == "para"

--- a/tests/integration/test_web_settings_extended.py
+++ b/tests/integration/test_web_settings_extended.py
@@ -4,7 +4,7 @@ Covers: settings_page, settings_search, settings_export, settings_import,
 settings_reset, all section GET/POST routes (general, models, organization,
 appearance, advanced), settings_organization_validate, settings_models_test,
 and the pure helpers (_as_form_bool, _coerce_bool, _validate_choice,
-_validate_methodology, _validate_rules, WebSettings defaults).
+_normalize_methodology, _validate_rules, WebSettings defaults).
 """
 
 from __future__ import annotations
@@ -121,17 +121,17 @@ class TestValidateChoice:
         assert result == "dark"
 
 
-class TestValidateMethodology:
+class TestNormalizeMethodology:
     def test_valid_methodology(self) -> None:
-        from file_organizer.web.settings_routes import _validate_methodology
+        from file_organizer.web.settings_routes import _normalize_methodology
 
-        assert _validate_methodology("para") == "para"
-        assert _validate_methodology("PARA") == "para"
+        assert _normalize_methodology("para") == "para"
+        assert _normalize_methodology("PARA") == "para"
 
     def test_invalid_methodology_returns_default(self) -> None:
-        from file_organizer.web.settings_routes import _validate_methodology
+        from file_organizer.web.settings_routes import _normalize_methodology
 
-        assert _validate_methodology("unknown_meth") == "content_based"
+        assert _normalize_methodology("unknown_meth") == "none"
 
 
 class TestValidateRules:

--- a/tests/tui/test_tui_coverage_gaps.py
+++ b/tests/tui/test_tui_coverage_gaps.py
@@ -347,12 +347,17 @@ class TestSettingsViewActions:
 
     # --- compose / on_mount ---
 
-    def test_compose_yields_static(self):
+    def test_compose_yields_static_and_directory_inputs(self):
+        from textual.widgets import Input, Static
+
         from file_organizer.tui.settings_view import SettingsView
 
         view = SettingsView()
         result = list(view.compose())
-        assert len(result) == 1
+        assert len(result) == 3
+        assert isinstance(result[0], Static)
+        assert isinstance(result[1], Input)
+        assert isinstance(result[2], Input)
 
     def test_on_mount_calls_reload(self):
         from file_organizer.tui.settings_view import SettingsView

--- a/tests/web/test_organize_routes.py
+++ b/tests/web/test_organize_routes.py
@@ -98,22 +98,33 @@ class TestNormalizeMethodology:
     """Test the _normalize_methodology helper."""
 
     def test_known_methodology(self):
-        """Verifies known methodology names are returned unchanged."""
+        """Verifies canonical methodology names are returned unchanged."""
         assert _normalize_methodology("para") == "para"
-        assert _normalize_methodology("johnny_decimal") == "johnny_decimal"
-        assert _normalize_methodology("date_based") == "date_based"
+        assert _normalize_methodology("jd") == "jd"
+        assert _normalize_methodology("none") == "none"
+
+    def test_legacy_aliases_map_to_canonical(self):
+        """Pre-unification web values should map to their canonical equivalent."""
+        assert _normalize_methodology("johnny_decimal") == "jd"
+        assert _normalize_methodology("content_based") == "none"
 
     def test_none_returns_default(self):
-        """Verifies None input falls back to the default 'content_based' methodology."""
-        assert _normalize_methodology(None) == "content_based"
+        """Verifies None input falls back to the default 'none' methodology."""
+        assert _normalize_methodology(None) == "none"
 
     def test_empty_string_returns_default(self):
         """Verifies an empty string falls back to the default methodology."""
-        assert _normalize_methodology("") == "content_based"
+        assert _normalize_methodology("") == "none"
 
     def test_unknown_returns_default(self):
-        """Verifies an unrecognised methodology name falls back to the default."""
-        assert _normalize_methodology("unknown_method") == "content_based"
+        """Verifies an unrecognised methodology name falls back to the default.
+
+        ``date_based`` was a web-only dropdown option with no organizer
+        implementation behind it anywhere in the codebase, so it is not a
+        recognized alias either — it falls back like any other unknown value.
+        """
+        assert _normalize_methodology("unknown_method") == "none"
+        assert _normalize_methodology("date_based") == "none"
 
     def test_case_insensitive(self):
         """Verifies methodology names are matched case-insensitively."""
@@ -733,10 +744,12 @@ class TestModuleConstants:
     """Verify module-level constants are sensible."""
 
     def test_methodologies_dict(self):
-        """Verifies the methodologies dict contains all expected methodology keys."""
-        assert "johnny_decimal" in ORGANIZE_METHODOLOGIES
-        assert "para" in ORGANIZE_METHODOLOGIES
-        assert "content_based" in ORGANIZE_METHODOLOGIES
+        """Verifies the methodologies dict is exactly the canonical vocabulary.
+
+        ``date_based`` was removed: it was a web-only dropdown option with no
+        organizer implementation behind it anywhere in the codebase (#1538).
+        """
+        assert set(ORGANIZE_METHODOLOGIES) == {"none", "para", "jd"}
 
     def test_max_delay(self):
         """Verifies ORGANIZE_MAX_DELAY_MIN is positive and equals 7 days in minutes."""

--- a/tests/web/test_settings_routes.py
+++ b/tests/web/test_settings_routes.py
@@ -34,12 +34,12 @@ from file_organizer.web.settings_routes import (
     _as_form_bool,
     _coerce_bool,
     _load_web_settings,
+    _normalize_methodology,
     _render_section,
     _save_web_settings,
     _section_context,
     _update_web_settings,
     _validate_choice,
-    _validate_methodology,
     _validate_rules,
     settings_router,
 )
@@ -165,30 +165,41 @@ class TestValidateChoice:
 
 
 # ---------------------------------------------------------------------------
-# _validate_methodology
+# _normalize_methodology (canonical vocabulary — see file_organizer.config.methodology)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestValidateMethodology:
-    """Test methodology validation."""
+class TestNormalizeMethodology:
+    """Test methodology normalization against the canonical vocabulary."""
 
-    def test_valid_methodologies(self):
-        """Should accept valid methodologies."""
-        assert _validate_methodology("content_based") == "content_based"
-        assert _validate_methodology("johnny_decimal") == "johnny_decimal"
-        assert _validate_methodology("para") == "para"
-        assert _validate_methodology("date_based") == "date_based"
+    def test_canonical_values_pass_through(self):
+        """Should accept the canonical none/para/jd values unchanged."""
+        assert _normalize_methodology("none") == "none"
+        assert _normalize_methodology("para") == "para"
+        assert _normalize_methodology("jd") == "jd"
+
+    def test_legacy_aliases_map_to_canonical(self):
+        """Pre-unification web values should map to their canonical equivalent."""
+        assert _normalize_methodology("content_based") == "none"
+        assert _normalize_methodology("johnny_decimal") == "jd"
 
     def test_case_insensitive(self):
         """Should be case insensitive."""
-        assert _validate_methodology("CONTENT_BASED") == "content_based"
-        assert _validate_methodology("PARA") == "para"
+        assert _normalize_methodology("CONTENT_BASED") == "none"
+        assert _normalize_methodology("PARA") == "para"
 
-    def test_invalid_defaults_to_content_based(self):
-        """Should default to content_based for invalid."""
-        assert _validate_methodology("invalid") == "content_based"
-        assert _validate_methodology("") == "content_based"
+    def test_invalid_defaults_to_none(self):
+        """Should default to none for invalid or unimplemented values.
+
+        ``date_based`` was a web-only dropdown option with no organizer
+        implementation behind it anywhere in the codebase, so it is not a
+        recognized alias — it falls back to the default like any other
+        unrecognized value.
+        """
+        assert _normalize_methodology("invalid") == "none"
+        assert _normalize_methodology("") == "none"
+        assert _normalize_methodology("date_based") == "none"
 
 
 # ---------------------------------------------------------------------------
@@ -550,11 +561,12 @@ class TestConstants:
     """Test that option constants are properly defined."""
 
     def test_methodology_options(self):
-        """Should have methodology options."""
-        assert "content_based" in METHODOLOGY_OPTIONS
-        assert "johnny_decimal" in METHODOLOGY_OPTIONS
-        assert "para" in METHODOLOGY_OPTIONS
-        assert "date_based" in METHODOLOGY_OPTIONS
+        """Should have the canonical methodology options and nothing else.
+
+        ``date_based`` was removed: it was a web-only dropdown option with no
+        organizer implementation behind it anywhere in the codebase (#1538).
+        """
+        assert set(METHODOLOGY_OPTIONS) == {"none", "para", "jd"}
 
     def test_theme_options(self):
         """Should have theme options."""

--- a/tests/web/test_web_settings.py
+++ b/tests/web/test_web_settings.py
@@ -114,7 +114,7 @@ class TestSettingsSectionPartials:
         client = _build_client(tmp_path)
         response = client.get("/ui/settings/organization")
         assert response.status_code == 200
-        assert "Content-Based" in response.text
+        assert "None (flat / content-based)" in response.text
         assert "Johnny Decimal" in response.text
         assert "PARA" in response.text
 
@@ -245,7 +245,7 @@ class TestSettingsValidation:
     """Test handling of invalid inputs and edge cases."""
 
     @pytest.mark.usefixtures("_patch_settings_file")
-    def test_invalid_methodology_defaults_to_content_based(
+    def test_invalid_methodology_defaults_to_none(
         self, tmp_path: Path, _patch_settings_file: Path
     ) -> None:
         client = _build_client(tmp_path)
@@ -258,7 +258,7 @@ class TestSettingsValidation:
         assert "Organization settings saved" in response.text
 
         data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["default_methodology"] == "content_based"
+        assert data["default_methodology"] == "none"
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_invalid_theme_defaults_to_light(


### PR DESCRIPTION
## Description

Sprint R1 item #1538 from the reusability epic (#1537). Adds `file_organizer.config.methodology` as the single source of truth for the three organization methodologies (`none`/`para`/`jd`), replacing three independent, partially-incompatible vocabularies:

- TUI/`AppConfig` used `none`/`para`/`jd`.
- `web/settings_routes.py` used `content_based`/`johnny_decimal`/`para`/`date_based`, with its own default (`"content_based"`) and validator.
- `web/organize_routes.py` duplicated that same vocabulary independently, with its own normalizer and three separate `"content_based"` fallback literals.

**`date_based` is dropped entirely** — it was a web-only dropdown option with no organizer implementation behind it anywhere in the codebase. I traced every date-based lead before removing it: `services/video/organizer.py` is per-filetype dispatch unrelated to the top-level methodology selector; `template_manager.py`'s `"date_based"` folder_structure label is inert (never read by any code); `para/folder_mapper.py`'s date-based subfolder helper is PARA-internal. `content_based`/`johnny_decimal` are kept as `normalize()`-only legacy *input* aliases so old `web-settings.json` files and in-memory job metadata still read back correctly — they're never written out again. The DB-persisted `job_repo.py`/`db_models.py` `"content_based"` default is deliberately left untouched (separate persistence layer, explicitly out of scope).

**Also fixes a real bug** found while tracing the vocabulary: the setup wizard's methodology dropdown was wired to nothing. The frontend sends `methodology` as a top-level key in `custom_settings`, but `SetupWizard.generate_config()` hardcoded `default_methodology="none"` and never read it — silently discarding the user's selection in both Quick Start and Power User mode. Now normalized and applied.

Two of `api/routers/{config,system}.py`'s `ConfigUpdateRequest` handlers wrote `request.default_methodology` straight onto `AppConfig` with **no validation at all**; both now normalize on write, closing a path that could otherwise persist a value the TUI/core vocabulary doesn't recognize.

Fixes #1538

## Type of change

- [x] Bug fix (setup wizard methodology wiring; unvalidated API write path)
- [x] New feature (n/a — refactor/consolidation)
- [x] This change requires a documentation update (docstrings on the new canonical module)

## How Has This Been Tested?

- [x] Full targeted regression run across every consumer of the changed symbols: `tests/config/`, `tests/tui/`, `tests/web/`, `tests/api/`, `tests/core/test_setup_wizard.py`, `tests/integration/`, `tests/methodologies/`, `tests/history/` — **10212 passed**. The only 7 failures are pre-existing environment artifacts unrelated to this diff (confirmed in isolation): 2 `chmod(0o000)` permission tests that don't trigger under root, and 5 tests requiring `scikit-learn`, which isn't installed in my dev venv (CI's full-extras install covers both).
- [x] Added regression tests for the setup-wizard wiring fix (`tests/core/test_setup_wizard.py`) and the two API normalize-on-write fixes (`tests/api/test_config_router.py`, `tests/api/test_api_system.py`).
- [x] Renamed stale `*_content_based`-named tests to their new canonical-default names across `tests/web/` and `tests/integration/` (same rename pattern as #1488).
- [x] Fixed one unrelated pre-existing stale assertion in `test_tui_coverage_gaps.py` (`compose()` asserted `len==1`, dangling since #1495 added two `Input` widgets — surfaced by this PR's full-suite run, unrelated to this diff's logic).
- [x] `ruff check` + `ruff format --check` clean; `mypy src/file_organizer/` clean (435 files).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9To9VprqZiGT7Mr9itnWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9To9VprqZiGT7Mr9itnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized organization methodologies to **None**, **PARA**, and **Johnny Decimal**.
  * Added consistent handling of legacy, invalid, and case-variant methodology values.
  * Updated setup and settings screens with the revised methodology options and labels.

* **Bug Fixes**
  * Configuration updates now normalize methodology values before saving.
  * Unknown or unsupported values now safely default to **None**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->