### PR TITLE
Collapse dual settings stores: web Settings now shares AppConfig (#1539)

### DIFF
--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -20,14 +20,22 @@ from fastapi.responses import HTMLResponse, Response
 from loguru import logger
 
 from file_organizer.api.config import ApiSettings
-from file_organizer.api.dependencies import get_settings
+from file_organizer.api.dependencies import get_config_manager, get_settings
 from file_organizer.api.utils import resolve_path
+from file_organizer.config.manager import ConfigManager
 from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.config.methodology import LABELS as METHODOLOGY_OPTIONS
 from file_organizer.config.methodology import normalize as _normalize_methodology
 from file_organizer.config.path_manager import get_config_dir
+from file_organizer.config.schema import AppConfig
 from file_organizer.utils.atomic_write import atomic_write_text
 from file_organizer.web._helpers import base_context, templates
+
+# Profile used for the AppConfig-backed fields shown on this page (default
+# input/output dirs, methodology, text/vision model). The web UI does not
+# yet expose profile switching, so it always reads/writes "default" — same
+# as every other AppConfig consumer (TUI, CLI, API routers).
+_PROFILE = "default"
 
 settings_router = APIRouter(tags=["web"])
 
@@ -85,21 +93,24 @@ _SECTION_INDEX = {
 
 @dataclass
 class WebSettings:
-    """Persistent settings for the web UI."""
+    """Persistent settings for the web UI.
+
+    Holds only fields with no canonical home elsewhere. The workflow fields
+    shown alongside these on the settings page — default input/output dirs,
+    methodology, text/vision model — live on the shared ``AppConfig``
+    (``config.manager.ConfigManager``) instead, so a value set here is
+    visible to the TUI, CLI, and API too (see #1539). Loaded/saved via
+    ``_load_app_config``/``_save_app_config`` in the route handlers below.
+    """
 
     # General
     language: str = "en"
     timezone: str = "UTC"
-    default_input_dir: str = ""
-    default_output_dir: str = ""
 
     # Models
-    text_model: str = "qwen2.5:3b-instruct-q4_K_M"
-    vision_model: str = "qwen2.5vl:7b-q4_K_M"
     ollama_url: str = "http://localhost:11434"
 
     # Organization
-    default_methodology: str = _DEFAULT_METHODOLOGY
     auto_organize: bool = False
     notifications_enabled: bool = True
     file_filter_glob: str = "*"
@@ -181,7 +192,6 @@ def _load_web_settings() -> WebSettings:
                 continue
             if isinstance(value, str):
                 setattr(ws, key, value)
-        ws.default_methodology = _normalize_methodology(ws.default_methodology)
         ws.theme = _validate_choice(ws.theme, THEME_OPTIONS, "light")
         ws.log_level = _validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
         ws.performance_mode = _validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
@@ -213,9 +223,20 @@ def _update_web_settings(**kwargs: object) -> WebSettings:
     return ws
 
 
+def _load_app_config(manager: ConfigManager) -> AppConfig:
+    """Load the canonical ``AppConfig`` backing this page's workflow fields."""
+    return manager.load(profile=_PROFILE)
+
+
+def _save_app_config(manager: ConfigManager, config: AppConfig) -> None:
+    """Persist *config*, the canonical ``AppConfig`` backing this page."""
+    manager.save(config, profile=_PROFILE)
+
+
 def _section_context(
     request: Request,
     ws: WebSettings,
+    app_config: AppConfig,
     *,
     section: str,
     success_message: str = "",
@@ -225,6 +246,7 @@ def _section_context(
     return {
         "request": request,
         "ws": ws,
+        "app_config": app_config,
         "section": section,
         "success_message": success_message,
         "error_message": error_message,
@@ -240,6 +262,7 @@ def _section_context(
 def _render_section(
     request: Request,
     ws: WebSettings,
+    app_config: AppConfig,
     *,
     section: str,
     success_message: str = "",
@@ -249,7 +272,8 @@ def _render_section(
 
     Args:
         request: Incoming FastAPI request.
-        ws: Current persisted web settings.
+        ws: Current persisted web-only settings.
+        app_config: Current shared AppConfig (dirs, methodology, model).
         section: Section name (e.g. ``"general"``, ``"models"``).
         success_message: Optional success flash.
         error_message: Optional error flash.
@@ -260,6 +284,7 @@ def _render_section(
     context = _section_context(
         request,
         ws,
+        app_config,
         section=section,
         success_message=success_message,
         error_message=error_message,
@@ -269,7 +294,9 @@ def _render_section(
 
 @settings_router.get("/settings", response_class=HTMLResponse)
 def settings_page(
-    request: Request, settings_obj: ApiSettings = Depends(get_settings)
+    request: Request,
+    settings_obj: ApiSettings = Depends(get_settings),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Render the full settings page with all sections.
 
@@ -277,6 +304,7 @@ def settings_page(
         Full HTML page for settings.
     """
     ws = _load_web_settings()
+    app_config = _load_app_config(manager)
     context = base_context(
         request,
         settings_obj,
@@ -284,6 +312,7 @@ def settings_page(
         title="Settings",
         extras={
             "ws": ws,
+            "app_config": app_config,
             "methodology_options": METHODOLOGY_OPTIONS,
             "log_level_options": LOG_LEVEL_OPTIONS,
             "theme_options": THEME_OPTIONS,
@@ -326,10 +355,23 @@ def settings_search(query: str = Query("", alias="q")) -> HTMLResponse:
 
 
 @settings_router.get("/settings/export")
-def settings_export() -> Response:
-    """Export current web settings as a downloadable JSON file."""
+def settings_export(manager: ConfigManager = Depends(get_config_manager)) -> Response:
+    """Export current web settings, plus the shared AppConfig fields shown on this page.
+
+    Returns:
+        A single downloadable JSON file.
+    """
     ws = _load_web_settings()
-    payload = json.dumps(asdict(ws), indent=2) + "\n"
+    app_config = _load_app_config(manager)
+    payload_dict = asdict(ws)
+    payload_dict.update(
+        default_input_dir=app_config.default_input_dir,
+        default_output_dir=app_config.default_output_dir,
+        text_model=app_config.models.text_model,
+        vision_model=app_config.models.vision_model,
+        default_methodology=app_config.default_methodology,
+    )
+    payload = json.dumps(payload_dict, indent=2) + "\n"
     return Response(
         content=payload,
         media_type="application/json",
@@ -344,6 +386,7 @@ async def settings_import(
     settings_file: UploadFile | None = File(None),
     settings_path: str | None = Form(None),
     settings: ApiSettings = Depends(get_settings),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Import web settings from an uploaded JSON file or a desktop file path.
 
@@ -366,6 +409,7 @@ async def settings_import(
                 return _render_section(
                     request,
                     ws,
+                    _load_app_config(manager),
                     section=target_section,
                     error_message="Import failed: uploaded file is empty.",
                 )
@@ -379,6 +423,7 @@ async def settings_import(
             return _render_section(
                 request,
                 ws,
+                _load_app_config(manager),
                 section=target_section,
                 error_message="Import failed: provide either a settings file or a valid path.",
             )
@@ -396,7 +441,6 @@ async def settings_import(
             elif isinstance(value, str):
                 setattr(ws, key, value)
 
-        ws.default_methodology = _normalize_methodology(ws.default_methodology)
         ws.theme = _validate_choice(ws.theme, THEME_OPTIONS, "light")
         ws.log_level = _validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
         ws.performance_mode = _validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
@@ -404,9 +448,27 @@ async def settings_import(
         ws.timezone = _validate_choice(ws.timezone, TIMEZONE_OPTIONS, "UTC")
         _save_web_settings(ws)
 
+        # Shared AppConfig fields (dirs, methodology, model) are imported
+        # separately since #1539 — WebSettings no longer carries them.
+        app_config = _load_app_config(manager)
+        if isinstance(payload.get("default_input_dir"), str):
+            app_config.default_input_dir = payload["default_input_dir"].strip()
+        if isinstance(payload.get("default_output_dir"), str):
+            app_config.default_output_dir = payload["default_output_dir"].strip()
+        if isinstance(payload.get("text_model"), str) and payload["text_model"].strip():
+            app_config.models.text_model = payload["text_model"].strip()
+        if isinstance(payload.get("vision_model"), str) and payload["vision_model"].strip():
+            app_config.models.vision_model = payload["vision_model"].strip()
+        if "default_methodology" in payload:
+            app_config.default_methodology = _normalize_methodology(
+                payload.get("default_methodology")
+            )
+        _save_app_config(manager, app_config)
+
         return _render_section(
             request,
             ws,
+            app_config,
             section=target_section,
             success_message="Settings imported successfully.",
         )
@@ -415,14 +477,23 @@ async def settings_import(
         return _render_section(
             request,
             ws,
+            _load_app_config(manager),
             section=target_section,
             error_message=f"Import failed: {exc}",
         )
 
 
 @settings_router.post("/settings/reset", response_class=HTMLResponse)
-def settings_reset(request: Request, section: str = Form("general")) -> HTMLResponse:
-    """Reset all web settings to their defaults.
+def settings_reset(
+    request: Request,
+    section: str = Form("general"),
+    manager: ConfigManager = Depends(get_config_manager),
+) -> HTMLResponse:
+    """Reset all web settings, and the shared AppConfig fields shown on this page.
+
+    Only the fields this page owns (default dirs, methodology, text/vision
+    model) are reset on AppConfig — other AppConfig state (setup_completed,
+    updates, module overrides, ...) is left untouched.
 
     Returns:
         Re-rendered section partial confirming the reset.
@@ -431,18 +502,33 @@ def settings_reset(request: Request, section: str = Form("general")) -> HTMLResp
     target_section = section if section in valid_sections else "general"
     ws = WebSettings()
     _save_web_settings(ws)
+
+    defaults = AppConfig()
+    app_config = _load_app_config(manager)
+    app_config.default_input_dir = defaults.default_input_dir
+    app_config.default_output_dir = defaults.default_output_dir
+    app_config.default_methodology = defaults.default_methodology
+    app_config.models.text_model = defaults.models.text_model
+    app_config.models.vision_model = defaults.models.vision_model
+    _save_app_config(manager, app_config)
+
     return _render_section(
         request,
         ws,
+        app_config,
         section=target_section,
         success_message="Settings reset to defaults.",
     )
 
 
 @settings_router.get("/settings/general", response_class=HTMLResponse)
-def settings_general_get(request: Request) -> HTMLResponse:
+def settings_general_get(
+    request: Request, manager: ConfigManager = Depends(get_config_manager)
+) -> HTMLResponse:
     """Render the General settings section partial."""
-    return _render_section(request, _load_web_settings(), section="general")
+    return _render_section(
+        request, _load_web_settings(), _load_app_config(manager), section="general"
+    )
 
 
 @settings_router.post("/settings/general", response_class=HTMLResponse)
@@ -452,18 +538,22 @@ def settings_general_post(
     timezone: str = Form("UTC"),
     default_input_dir: str = Form(""),
     default_output_dir: str = Form(""),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save General settings and re-render the section partial."""
     try:
         ws = _update_web_settings(
             language=_validate_choice(language, LANGUAGE_OPTIONS, "en"),
             timezone=_validate_choice(timezone, TIMEZONE_OPTIONS, "UTC"),
-            default_input_dir=default_input_dir.strip(),
-            default_output_dir=default_output_dir.strip(),
         )
+        app_config = _load_app_config(manager)
+        app_config.default_input_dir = default_input_dir.strip()
+        app_config.default_output_dir = default_output_dir.strip()
+        _save_app_config(manager, app_config)
         return _render_section(
             request,
             ws,
+            app_config,
             section="general",
             success_message="General settings saved.",
         )
@@ -472,15 +562,20 @@ def settings_general_post(
         return _render_section(
             request,
             _load_web_settings(),
+            _load_app_config(manager),
             section="general",
             error_message=f"Failed to save settings: {exc}",
         )
 
 
 @settings_router.get("/settings/models", response_class=HTMLResponse)
-def settings_models_get(request: Request) -> HTMLResponse:
+def settings_models_get(
+    request: Request, manager: ConfigManager = Depends(get_config_manager)
+) -> HTMLResponse:
     """Render the Models settings section partial."""
-    return _render_section(request, _load_web_settings(), section="models")
+    return _render_section(
+        request, _load_web_settings(), _load_app_config(manager), section="models"
+    )
 
 
 @settings_router.post("/settings/models", response_class=HTMLResponse)
@@ -489,17 +584,21 @@ def settings_models_post(
     text_model: str = Form(""),
     vision_model: str = Form(""),
     ollama_url: str = Form(""),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Models settings and re-render the section partial."""
     try:
         ws = _update_web_settings(
-            text_model=text_model.strip() or "qwen2.5:3b-instruct-q4_K_M",
-            vision_model=vision_model.strip() or "qwen2.5vl:7b-q4_K_M",
             ollama_url=ollama_url.strip() or "http://localhost:11434",
         )
+        app_config = _load_app_config(manager)
+        app_config.models.text_model = text_model.strip() or "qwen2.5:3b-instruct-q4_K_M"
+        app_config.models.vision_model = vision_model.strip() or "qwen2.5vl:7b-q4_K_M"
+        _save_app_config(manager, app_config)
         return _render_section(
             request,
             ws,
+            app_config,
             section="models",
             success_message="Model settings saved.",
         )
@@ -508,6 +607,7 @@ def settings_models_post(
         return _render_section(
             request,
             _load_web_settings(),
+            _load_app_config(manager),
             section="models",
             error_message=f"Failed to save settings: {exc}",
         )
@@ -517,9 +617,11 @@ def settings_models_post(
 def settings_models_test(
     request: Request,
     ollama_url: str = Form(""),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Test Ollama connectivity and re-render the Models section partial."""
     ws = _load_web_settings()
+    app_config = _load_app_config(manager)
     target = ollama_url.strip() or ws.ollama_url
     try:
         with httpx.Client(timeout=3.0) as client:
@@ -529,6 +631,7 @@ def settings_models_test(
         return _render_section(
             request,
             ws,
+            app_config,
             section="models",
             success_message="Ollama connection successful.",
         )
@@ -536,24 +639,31 @@ def settings_models_test(
         return _render_section(
             request,
             ws,
+            app_config,
             section="models",
             error_message=f"Ollama connection failed: {exc}",
         )
 
 
 @settings_router.get("/settings/organization", response_class=HTMLResponse)
-def settings_organization_get(request: Request) -> HTMLResponse:
+def settings_organization_get(
+    request: Request, manager: ConfigManager = Depends(get_config_manager)
+) -> HTMLResponse:
     """Render the Organization settings section partial."""
-    return _render_section(request, _load_web_settings(), section="organization")
+    return _render_section(
+        request, _load_web_settings(), _load_app_config(manager), section="organization"
+    )
 
 
 @settings_router.post("/settings/organization/validate", response_class=HTMLResponse)
 def settings_organization_validate(
     request: Request,
     organization_rules: str = Form(""),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Validate organization rules and re-render the section partial."""
     ws = _load_web_settings()
+    app_config = _load_app_config(manager)
     candidate_rules = organization_rules or ws.organization_rules
     valid, message = _validate_rules(candidate_rules)
     if valid:
@@ -562,6 +672,7 @@ def settings_organization_validate(
         return _render_section(
             request,
             ws,
+            app_config,
             section="organization",
             success_message=message,
         )
@@ -569,6 +680,7 @@ def settings_organization_validate(
     return _render_section(
         request,
         ws,
+        app_config,
         section="organization",
         error_message=message,
     )
@@ -582,6 +694,7 @@ def settings_organization_post(
     notifications_enabled: str | None = Form(None),
     file_filter_glob: str = Form("*"),
     organization_rules: str = Form(""),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Organization settings and re-render the section partial."""
     existing = _load_web_settings()
@@ -592,21 +705,25 @@ def settings_organization_post(
         return _render_section(
             request,
             existing,
+            _load_app_config(manager),
             section="organization",
             error_message=message,
         )
 
     try:
         ws = _update_web_settings(
-            default_methodology=_normalize_methodology(default_methodology),
             auto_organize=_as_form_bool(auto_organize),
             notifications_enabled=_as_form_bool(notifications_enabled),
             file_filter_glob=file_filter_glob.strip() or "*",
             organization_rules=candidate_rules,
         )
+        app_config = _load_app_config(manager)
+        app_config.default_methodology = _normalize_methodology(default_methodology)
+        _save_app_config(manager, app_config)
         return _render_section(
             request,
             ws,
+            app_config,
             section="organization",
             success_message="Organization settings saved.",
         )
@@ -615,15 +732,20 @@ def settings_organization_post(
         return _render_section(
             request,
             _load_web_settings(),
+            _load_app_config(manager),
             section="organization",
             error_message=f"Failed to save settings: {exc}",
         )
 
 
 @settings_router.get("/settings/appearance", response_class=HTMLResponse)
-def settings_appearance_get(request: Request) -> HTMLResponse:
+def settings_appearance_get(
+    request: Request, manager: ConfigManager = Depends(get_config_manager)
+) -> HTMLResponse:
     """Render the Appearance settings section partial."""
-    return _render_section(request, _load_web_settings(), section="appearance")
+    return _render_section(
+        request, _load_web_settings(), _load_app_config(manager), section="appearance"
+    )
 
 
 @settings_router.post("/settings/appearance", response_class=HTMLResponse)
@@ -631,6 +753,7 @@ def settings_appearance_post(
     request: Request,
     theme: str = Form("light"),
     custom_theme_name: str = Form(""),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Appearance settings and re-render the section partial."""
     try:
@@ -641,6 +764,7 @@ def settings_appearance_post(
         return _render_section(
             request,
             ws,
+            _load_app_config(manager),
             section="appearance",
             success_message="Appearance settings saved.",
         )
@@ -649,15 +773,20 @@ def settings_appearance_post(
         return _render_section(
             request,
             _load_web_settings(),
+            _load_app_config(manager),
             section="appearance",
             error_message=f"Failed to save settings: {exc}",
         )
 
 
 @settings_router.get("/settings/advanced", response_class=HTMLResponse)
-def settings_advanced_get(request: Request) -> HTMLResponse:
+def settings_advanced_get(
+    request: Request, manager: ConfigManager = Depends(get_config_manager)
+) -> HTMLResponse:
     """Render the Advanced settings section partial."""
-    return _render_section(request, _load_web_settings(), section="advanced")
+    return _render_section(
+        request, _load_web_settings(), _load_app_config(manager), section="advanced"
+    )
 
 
 @settings_router.post("/settings/advanced", response_class=HTMLResponse)
@@ -667,6 +796,7 @@ def settings_advanced_post(
     cache_enabled: str | None = Form(None),
     debug_mode: str | None = Form(None),
     performance_mode: str = Form("balanced"),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Advanced settings and re-render the section partial."""
     try:
@@ -683,6 +813,7 @@ def settings_advanced_post(
         return _render_section(
             request,
             ws,
+            _load_app_config(manager),
             section="advanced",
             success_message="Advanced settings saved.",
         )
@@ -691,6 +822,7 @@ def settings_advanced_post(
         return _render_section(
             request,
             _load_web_settings(),
+            _load_app_config(manager),
             section="advanced",
             error_message=f"Failed to save settings: {exc}",
         )

--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -500,25 +500,35 @@ def settings_reset(
     """
     valid_sections = {"general", "models", "organization", "appearance", "advanced"}
     target_section = section if section in valid_sections else "general"
-    ws = WebSettings()
-    _save_web_settings(ws)
+    try:
+        ws = WebSettings()
+        _save_web_settings(ws)
 
-    defaults = AppConfig()
-    app_config = _load_app_config(manager)
-    app_config.default_input_dir = defaults.default_input_dir
-    app_config.default_output_dir = defaults.default_output_dir
-    app_config.default_methodology = defaults.default_methodology
-    app_config.models.text_model = defaults.models.text_model
-    app_config.models.vision_model = defaults.models.vision_model
-    _save_app_config(manager, app_config)
+        defaults = AppConfig()
+        app_config = _load_app_config(manager)
+        app_config.default_input_dir = defaults.default_input_dir
+        app_config.default_output_dir = defaults.default_output_dir
+        app_config.default_methodology = defaults.default_methodology
+        app_config.models.text_model = defaults.models.text_model
+        app_config.models.vision_model = defaults.models.vision_model
+        _save_app_config(manager, app_config)
 
-    return _render_section(
-        request,
-        ws,
-        app_config,
-        section=target_section,
-        success_message="Settings reset to defaults.",
-    )
+        return _render_section(
+            request,
+            ws,
+            app_config,
+            section=target_section,
+            success_message="Settings reset to defaults.",
+        )
+    except Exception as exc:
+        logger.exception("Failed to reset settings")
+        return _render_section(
+            request,
+            _load_web_settings(),
+            _load_app_config(manager),
+            section=target_section,
+            error_message=f"Failed to reset settings: {exc}",
+        )
 
 
 @settings_router.get("/settings/general", response_class=HTMLResponse)
@@ -592,8 +602,9 @@ def settings_models_post(
             ollama_url=ollama_url.strip() or "http://localhost:11434",
         )
         app_config = _load_app_config(manager)
-        app_config.models.text_model = text_model.strip() or "qwen2.5:3b-instruct-q4_K_M"
-        app_config.models.vision_model = vision_model.strip() or "qwen2.5vl:7b-q4_K_M"
+        defaults = AppConfig()
+        app_config.models.text_model = text_model.strip() or defaults.models.text_model
+        app_config.models.vision_model = vision_model.strip() or defaults.models.vision_model
         _save_app_config(manager, app_config)
         return _render_section(
             request,

--- a/src/file_organizer/web/templates/settings/_general.html
+++ b/src/file_organizer/web/templates/settings/_general.html
@@ -43,7 +43,7 @@
                 id="settings-input-dir"
                 name="default_input_dir"
                 type="text"
-                value="{{ ws.default_input_dir }}"
+                value="{{ app_config.default_input_dir }}"
                 placeholder="e.g. ~/Downloads"
             >
             <p class="form-hint">The default source directory for file organization.</p>
@@ -55,7 +55,7 @@
                 id="settings-output-dir"
                 name="default_output_dir"
                 type="text"
-                value="{{ ws.default_output_dir }}"
+                value="{{ app_config.default_output_dir }}"
                 placeholder="e.g. ~/Organized"
             >
             <p class="form-hint">The default destination directory for organized files.</p>

--- a/src/file_organizer/web/templates/settings/_models.html
+++ b/src/file_organizer/web/templates/settings/_models.html
@@ -33,7 +33,7 @@
                 id="settings-text-model"
                 name="text_model"
                 type="text"
-                value="{{ ws.text_model }}"
+                value="{{ app_config.models.text_model }}"
                 placeholder="qwen2.5:3b-instruct-q4_K_M"
             >
             <p class="form-hint">Ollama model identifier for text analysis and generation.</p>
@@ -45,7 +45,7 @@
                 id="settings-vision-model"
                 name="vision_model"
                 type="text"
-                value="{{ ws.vision_model }}"
+                value="{{ app_config.models.vision_model }}"
                 placeholder="qwen2.5vl:7b-q4_K_M"
             >
             <p class="form-hint">Ollama model identifier for image and video analysis.</p>

--- a/src/file_organizer/web/templates/settings/_organization.html
+++ b/src/file_organizer/web/templates/settings/_organization.html
@@ -19,7 +19,7 @@
             <label for="settings-methodology">Default methodology</label>
             <select id="settings-methodology" name="default_methodology">
                 {% for key, label in methodology_options.items() %}
-                <option value="{{ key }}" {% if ws.default_methodology == key %}selected{% endif %}>{{ label }}</option>
+                <option value="{{ key }}" {% if app_config.default_methodology == key %}selected{% endif %}>{{ label }}</option>
                 {% endfor %}
             </select>
             <p class="form-hint">The default file organization methodology used for new jobs.</p>

--- a/tests/integration/test_web_settings_extended.py
+++ b/tests/integration/test_web_settings_extended.py
@@ -390,6 +390,7 @@ class TestSettingsModelsPost:
         assert r.status_code == 200
         app_config = ConfigManager(config_dir=tmp_path / "app-config").load()
         assert app_config.models.text_model == "qwen2.5:3b-instruct-q4_K_M"
+        assert app_config.models.vision_model == "qwen2.5vl:7b-q4_K_M"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_web_settings_extended.py
+++ b/tests/integration/test_web_settings_extended.py
@@ -19,9 +19,10 @@ from fastapi.responses import HTMLResponse
 from starlette.testclient import TestClient
 
 from file_organizer.api.config import ApiSettings
-from file_organizer.api.dependencies import get_settings
+from file_organizer.api.dependencies import get_config_manager, get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
 from file_organizer.api.test_utils import csrf_headers, seed_csrf_token
+from file_organizer.config.manager import ConfigManager
 from file_organizer.web.settings_routes import settings_router
 
 pytestmark = pytest.mark.integration
@@ -47,6 +48,9 @@ def settings_settings(tmp_path: Path) -> ApiSettings:
 def settings_client(settings_settings: ApiSettings, tmp_path: Path) -> TestClient:
     app = FastAPI()
     app.dependency_overrides[get_settings] = lambda: settings_settings
+    app.dependency_overrides[get_config_manager] = lambda: ConfigManager(
+        config_dir=tmp_path / "app-config"
+    )
     setup_exception_handlers(app)
     app.include_router(settings_router, prefix="/ui")
     client = TestClient(app, raise_server_exceptions=False)
@@ -384,9 +388,8 @@ class TestSettingsModelsPost:
                         headers=csrf_headers(settings_client),
                     )
         assert r.status_code == 200
-        if ws_file.exists():
-            data = json.loads(ws_file.read_text())
-            assert data["text_model"] == "qwen2.5:3b-instruct-q4_K_M"
+        app_config = ConfigManager(config_dir=tmp_path / "app-config").load()
+        assert app_config.models.text_model == "qwen2.5:3b-instruct-q4_K_M"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/test_settings_routes.py
+++ b/tests/web/test_settings_routes.py
@@ -22,7 +22,9 @@ from fastapi.responses import HTMLResponse
 from starlette.testclient import TestClient
 
 from file_organizer.api.config import ApiSettings
-from file_organizer.api.dependencies import get_settings
+from file_organizer.api.dependencies import get_config_manager, get_settings
+from file_organizer.config.manager import ConfigManager
+from file_organizer.config.schema import AppConfig
 from file_organizer.web.settings_routes import (
     LANGUAGE_OPTIONS,
     LOG_LEVEL_OPTIONS,
@@ -80,6 +82,12 @@ def use_temp_settings_dir(monkeypatch, tmp_path):
             tmp_path / "web-settings.json",
         ):
             yield tmp_path
+
+
+@pytest.fixture()
+def app_config():
+    """Return a default ``AppConfig`` for tests that render sections directly."""
+    return AppConfig()
 
 
 # ---------------------------------------------------------------------------
@@ -401,18 +409,19 @@ class TestUpdateWebSettings:
 class TestSectionContext:
     """Test section context building."""
 
-    def test_section_context_has_required_keys(self, mock_request):
+    def test_section_context_has_required_keys(self, mock_request, app_config):
         """Should include required keys."""
         ws = WebSettings()
-        ctx = _section_context(mock_request, ws, section="general")
+        ctx = _section_context(mock_request, ws, app_config, section="general")
         assert ctx["request"] == mock_request
         assert ctx["ws"] == ws
+        assert ctx["app_config"] == app_config
         assert ctx["section"] == "general"
 
-    def test_section_context_includes_options(self, mock_request):
+    def test_section_context_includes_options(self, mock_request, app_config):
         """Should include all option lists."""
         ws = WebSettings()
-        ctx = _section_context(mock_request, ws, section="general")
+        ctx = _section_context(mock_request, ws, app_config, section="general")
         assert "methodology_options" in ctx
         assert "log_level_options" in ctx
         assert "theme_options" in ctx
@@ -420,23 +429,25 @@ class TestSectionContext:
         assert "timezone_options" in ctx
         assert "performance_modes" in ctx
 
-    def test_success_message(self, mock_request):
+    def test_success_message(self, mock_request, app_config):
         """Should include success message."""
         ws = WebSettings()
         ctx = _section_context(
             mock_request,
             ws,
+            app_config,
             section="general",
             success_message="Settings saved!",
         )
         assert ctx["success_message"] == "Settings saved!"
 
-    def test_error_message(self, mock_request):
+    def test_error_message(self, mock_request, app_config):
         """Should include error message."""
         ws = WebSettings()
         ctx = _section_context(
             mock_request,
             ws,
+            app_config,
             section="general",
             error_message="Save failed!",
         )
@@ -453,7 +464,7 @@ class TestRenderSection:
     """Test section rendering."""
 
     @patch("file_organizer.web.settings_routes.templates")
-    def test_render_section_calls_template(self, mock_templates, mock_request):
+    def test_render_section_calls_template(self, mock_templates, mock_request, app_config):
         """Should call template renderer."""
         ws = WebSettings()
         mock_response = MagicMock()
@@ -462,6 +473,7 @@ class TestRenderSection:
         result = _render_section(
             mock_request,
             ws,
+            app_config,
             section="general",
             success_message="Saved!",
         )
@@ -470,7 +482,7 @@ class TestRenderSection:
         mock_templates.TemplateResponse.assert_called_once()
 
     @patch("file_organizer.web.settings_routes.templates")
-    def test_render_section_with_error(self, mock_templates, mock_request):
+    def test_render_section_with_error(self, mock_templates, mock_request, app_config):
         """Should render with error message."""
         ws = WebSettings()
         mock_response = MagicMock()
@@ -479,6 +491,7 @@ class TestRenderSection:
         result = _render_section(
             mock_request,
             ws,
+            app_config,
             section="general",
             error_message="Save failed!",
         )
@@ -533,12 +546,7 @@ class TestWebSettings:
         ws = WebSettings()
         assert hasattr(ws, "language")
         assert hasattr(ws, "timezone")
-        assert hasattr(ws, "default_input_dir")
-        assert hasattr(ws, "default_output_dir")
-        assert hasattr(ws, "text_model")
-        assert hasattr(ws, "vision_model")
         assert hasattr(ws, "ollama_url")
-        assert hasattr(ws, "default_methodology")
         assert hasattr(ws, "auto_organize")
         assert hasattr(ws, "notifications_enabled")
         assert hasattr(ws, "file_filter_glob")
@@ -549,6 +557,15 @@ class TestWebSettings:
         assert hasattr(ws, "cache_enabled")
         assert hasattr(ws, "debug_mode")
         assert hasattr(ws, "performance_mode")
+
+    def test_shared_fields_moved_to_app_config(self):
+        """Workflow fields now live on AppConfig, not WebSettings (see #1539)."""
+        ws = WebSettings()
+        assert not hasattr(ws, "default_input_dir")
+        assert not hasattr(ws, "default_output_dir")
+        assert not hasattr(ws, "text_model")
+        assert not hasattr(ws, "vision_model")
+        assert not hasattr(ws, "default_methodology")
 
 
 # ---------------------------------------------------------------------------
@@ -696,6 +713,9 @@ class TestSettingsImportPathBased:
         )
         app = FastAPI()
         app.dependency_overrides[get_settings] = lambda: api_settings
+        app.dependency_overrides[get_config_manager] = lambda: ConfigManager(
+            config_dir=tmp_path / "app-config"
+        )
         app.include_router(settings_router)
         return TestClient(app, raise_server_exceptions=False), tmp_path
 
@@ -736,6 +756,9 @@ class TestSettingsImportPathBased:
 
             app = FastAPI()
             app.dependency_overrides[get_settings] = lambda: api_settings
+            app.dependency_overrides[get_config_manager] = lambda: ConfigManager(
+                config_dir=tmp_path / "app-config"
+            )
             app.include_router(settings_router)
             client = TestClient(app, raise_server_exceptions=False)
 

--- a/tests/web/test_settings_routes.py
+++ b/tests/web/test_settings_routes.py
@@ -480,6 +480,8 @@ class TestRenderSection:
 
         assert result == mock_response
         mock_templates.TemplateResponse.assert_called_once()
+        rendered_context = mock_templates.TemplateResponse.call_args[0][2]
+        assert rendered_context["app_config"] is app_config
 
     @patch("file_organizer.web.settings_routes.templates")
     def test_render_section_with_error(self, mock_templates, mock_request, app_config):
@@ -497,6 +499,8 @@ class TestRenderSection:
         )
 
         assert result == mock_response
+        rendered_context = mock_templates.TemplateResponse.call_args[0][2]
+        assert rendered_context["app_config"] is app_config
 
 
 # ---------------------------------------------------------------------------
@@ -724,7 +728,19 @@ class TestSettingsImportPathBased:
         """A valid JSON file under allowed_paths should be imported with status 200."""
         client, tmp_path = _client
         cfg_file = tmp_path / "cfg.json"
-        cfg_file.write_text(json.dumps({"theme": "dark", "language": "en"}))
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "theme": "dark",
+                    "language": "en",
+                    "default_input_dir": "/import/input",
+                    "default_output_dir": "/import/output",
+                    "text_model": "imported-text-model",
+                    "vision_model": "imported-vision-model",
+                    "default_methodology": "para",
+                }
+            )
+        )
 
         with patch("file_organizer.web.settings_routes.templates") as mock_tpl:
             mock_tpl.TemplateResponse.side_effect = _make_tpl_side_effect()
@@ -739,6 +755,13 @@ class TestSettingsImportPathBased:
         ws = _load_web_settings()
         assert ws.theme == "dark"
         assert ws.language == "en"
+        # Shared workflow fields persist to AppConfig, not web-settings.json.
+        app_config = ConfigManager(config_dir=tmp_path / "app-config").load()
+        assert app_config.default_input_dir == "/import/input"
+        assert app_config.default_output_dir == "/import/output"
+        assert app_config.models.text_model == "imported-text-model"
+        assert app_config.models.vision_model == "imported-vision-model"
+        assert app_config.default_methodology == "para"
 
     def test_import_via_path_outside_allowed_root_returns_error(self, tmp_path):
         """A path outside allowed_paths must trigger an error flash (not a 403 raise)."""

--- a/tests/web/test_settings_routes_coverage.py
+++ b/tests/web/test_settings_routes_coverage.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from file_organizer.config.schema import AppConfig
+
 pytestmark = pytest.mark.unit
 
 
@@ -34,6 +36,14 @@ def mock_templates():
 
 
 @pytest.fixture()
+def mock_manager():
+    """Return a mock ConfigManager backed by a fresh default AppConfig."""
+    manager = MagicMock()
+    manager.load.return_value = AppConfig()
+    return manager
+
+
+@pytest.fixture()
 def mock_base_context():
     """Patch base_context to return a minimal dict."""
     with patch(
@@ -46,12 +56,12 @@ def mock_base_context():
 class TestSettingsPageRoute:
     """Covers settings_page handler."""
 
-    def test_settings_page(self, mock_templates, mock_base_context) -> None:
+    def test_settings_page(self, mock_templates, mock_base_context, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_page
 
         request = MagicMock()
         settings_obj = MagicMock()
-        settings_page(request, settings_obj)
+        settings_page(request, settings_obj, manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
 
@@ -80,107 +90,118 @@ class TestSettingsSearchRoute:
 class TestSettingsExportRoute:
     """Covers settings_export handler."""
 
-    def test_export_returns_json(self) -> None:
+    def test_export_returns_json(self, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_export
 
-        response = settings_export()
+        response = settings_export(manager=mock_manager)
         assert response.media_type == "application/json"
         payload = json.loads(response.body)
         assert "language" in payload
+        assert "default_input_dir" in payload
+        assert "default_methodology" in payload
 
 
 class TestSettingsImportRoute:
     """Covers settings_import handler."""
 
     @pytest.mark.asyncio
-    async def test_import_valid(self, mock_templates) -> None:
+    async def test_import_valid(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_import
 
         upload = MagicMock()
         upload.read.return_value = json.dumps({"language": "fr", "theme": "dark"}).encode()
         request = MagicMock()
-        await settings_import(request, section="general", settings_file=upload)
+        await settings_import(
+            request, section="general", settings_file=upload, manager=mock_manager
+        )
         mock_templates.TemplateResponse.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_import_invalid_json(self, mock_templates) -> None:
+    async def test_import_invalid_json(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_import
 
         upload = MagicMock()
         upload.read.return_value = b"not json"
         request = MagicMock()
-        await settings_import(request, section="general", settings_file=upload)
+        await settings_import(
+            request, section="general", settings_file=upload, manager=mock_manager
+        )
         # Should render with error message
         mock_templates.TemplateResponse.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_import_non_dict(self, mock_templates) -> None:
+    async def test_import_non_dict(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_import
 
         upload = MagicMock()
         upload.read.return_value = b'"just a string"'
         request = MagicMock()
-        await settings_import(request, section="models", settings_file=upload)
+        await settings_import(request, section="models", settings_file=upload, manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
 
 class TestSettingsResetRoute:
     """Covers settings_reset handler."""
 
-    def test_reset(self, mock_templates) -> None:
+    def test_reset(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_reset
 
         request = MagicMock()
-        settings_reset(request, section="advanced")
+        settings_reset(request, section="advanced", manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
 
 class TestSettingsSectionGetRoutes:
     """Covers GET section routes."""
 
-    def test_general_get(self, mock_templates) -> None:
+    def test_general_get(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_general_get
 
-        settings_general_get(MagicMock())
+        settings_general_get(MagicMock(), manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_models_get(self, mock_templates) -> None:
+    def test_models_get(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_models_get
 
-        settings_models_get(MagicMock())
+        settings_models_get(MagicMock(), manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_organization_get(self, mock_templates) -> None:
+    def test_organization_get(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_organization_get
 
-        settings_organization_get(MagicMock())
+        settings_organization_get(MagicMock(), manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_appearance_get(self, mock_templates) -> None:
+    def test_appearance_get(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_appearance_get
 
-        settings_appearance_get(MagicMock())
+        settings_appearance_get(MagicMock(), manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_advanced_get(self, mock_templates) -> None:
+    def test_advanced_get(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_advanced_get
 
-        settings_advanced_get(MagicMock())
+        settings_advanced_get(MagicMock(), manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
 
 class TestSettingsSectionPostRoutes:
     """Covers POST section routes."""
 
-    def test_general_post(self, mock_templates) -> None:
+    def test_general_post(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_general_post
 
         settings_general_post(
-            MagicMock(), language="fr", timezone="UTC", default_input_dir="", default_output_dir=""
+            MagicMock(),
+            language="fr",
+            timezone="UTC",
+            default_input_dir="",
+            default_output_dir="",
+            manager=mock_manager,
         )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_general_post_exception(self, mock_templates) -> None:
+    def test_general_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_general_post
 
         with patch(
@@ -193,28 +214,39 @@ class TestSettingsSectionPostRoutes:
                 timezone="UTC",
                 default_input_dir="",
                 default_output_dir="",
+                manager=mock_manager,
             )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_models_post(self, mock_templates) -> None:
+    def test_models_post(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_models_post
 
         settings_models_post(
-            MagicMock(), text_model="m1", vision_model="m2", ollama_url="http://localhost:11434"
+            MagicMock(),
+            text_model="m1",
+            vision_model="m2",
+            ollama_url="http://localhost:11434",
+            manager=mock_manager,
         )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_models_post_exception(self, mock_templates) -> None:
+    def test_models_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_models_post
 
         with patch(
             "file_organizer.web.settings_routes._update_web_settings",
             side_effect=RuntimeError("boom"),
         ):
-            settings_models_post(MagicMock(), text_model="", vision_model="", ollama_url="")
+            settings_models_post(
+                MagicMock(),
+                text_model="",
+                vision_model="",
+                ollama_url="",
+                manager=mock_manager,
+            )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_models_test_success(self, mock_templates) -> None:
+    def test_models_test_success(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_models_test
 
         mock_response = MagicMock()
@@ -225,10 +257,12 @@ class TestSettingsSectionPostRoutes:
         mock_client.get.return_value = mock_response
 
         with patch("file_organizer.web.settings_routes.httpx.Client", return_value=mock_client):
-            settings_models_test(MagicMock(), ollama_url="http://localhost:11434")
+            settings_models_test(
+                MagicMock(), ollama_url="http://localhost:11434", manager=mock_manager
+            )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_models_test_failure(self, mock_templates) -> None:
+    def test_models_test_failure(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_models_test
 
         mock_client = MagicMock()
@@ -237,10 +271,10 @@ class TestSettingsSectionPostRoutes:
         mock_client.get.side_effect = ConnectionError("refused")
 
         with patch("file_organizer.web.settings_routes.httpx.Client", return_value=mock_client):
-            settings_models_test(MagicMock(), ollama_url="http://bad:1234")
+            settings_models_test(MagicMock(), ollama_url="http://bad:1234", manager=mock_manager)
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_organization_post(self, mock_templates) -> None:
+    def test_organization_post(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_organization_post
 
         settings_organization_post(
@@ -250,10 +284,11 @@ class TestSettingsSectionPostRoutes:
             notifications_enabled="1",
             file_filter_glob="*",
             organization_rules="docs/* -> Documents",
+            manager=mock_manager,
         )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_organization_post_invalid_rules(self, mock_templates) -> None:
+    def test_organization_post_invalid_rules(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_organization_post
 
         settings_organization_post(
@@ -263,10 +298,11 @@ class TestSettingsSectionPostRoutes:
             notifications_enabled=None,
             file_filter_glob="*",
             organization_rules="bad line without arrow",
+            manager=mock_manager,
         )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_organization_post_exception(self, mock_templates) -> None:
+    def test_organization_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_organization_post
 
         with patch(
@@ -280,38 +316,47 @@ class TestSettingsSectionPostRoutes:
                 notifications_enabled=None,
                 file_filter_glob="*",
                 organization_rules="docs/* -> Documents",
+                manager=mock_manager,
             )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_organization_validate_valid(self, mock_templates) -> None:
+    def test_organization_validate_valid(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_organization_validate
 
-        settings_organization_validate(MagicMock(), organization_rules="docs/* -> Documents")
+        settings_organization_validate(
+            MagicMock(), organization_rules="docs/* -> Documents", manager=mock_manager
+        )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_organization_validate_invalid(self, mock_templates) -> None:
+    def test_organization_validate_invalid(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_organization_validate
 
-        settings_organization_validate(MagicMock(), organization_rules="no arrow")
+        settings_organization_validate(
+            MagicMock(), organization_rules="no arrow", manager=mock_manager
+        )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_appearance_post(self, mock_templates) -> None:
+    def test_appearance_post(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_appearance_post
 
-        settings_appearance_post(MagicMock(), theme="dark", custom_theme_name="mytheme")
+        settings_appearance_post(
+            MagicMock(), theme="dark", custom_theme_name="mytheme", manager=mock_manager
+        )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_appearance_post_exception(self, mock_templates) -> None:
+    def test_appearance_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_appearance_post
 
         with patch(
             "file_organizer.web.settings_routes._update_web_settings",
             side_effect=RuntimeError("boom"),
         ):
-            settings_appearance_post(MagicMock(), theme="dark", custom_theme_name="")
+            settings_appearance_post(
+                MagicMock(), theme="dark", custom_theme_name="", manager=mock_manager
+            )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_advanced_post(self, mock_templates) -> None:
+    def test_advanced_post(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_advanced_post
 
         settings_advanced_post(
@@ -320,10 +365,11 @@ class TestSettingsSectionPostRoutes:
             cache_enabled="1",
             debug_mode="1",
             performance_mode="performance",
+            manager=mock_manager,
         )
         mock_templates.TemplateResponse.assert_called_once()
 
-    def test_advanced_post_exception(self, mock_templates) -> None:
+    def test_advanced_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_advanced_post
 
         with patch(
@@ -336,6 +382,7 @@ class TestSettingsSectionPostRoutes:
                 cache_enabled=None,
                 debug_mode=None,
                 performance_mode="balanced",
+                manager=mock_manager,
             )
         mock_templates.TemplateResponse.assert_called_once()
 

--- a/tests/web/test_settings_routes_coverage.py
+++ b/tests/web/test_settings_routes_coverage.py
@@ -9,7 +9,7 @@ import pytest
 
 from file_organizer.config.schema import AppConfig
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/web/test_web_settings.py
+++ b/tests/web/test_web_settings.py
@@ -408,6 +408,10 @@ class TestSettingsUtilities:
         stored = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
         assert stored["language"] == "fr"
         assert stored["timezone"] == "Europe/London"
+        # Shared workflow fields persist to AppConfig, not web-settings.json.
+        app_config = _load_app_config(tmp_path)
+        assert app_config.default_input_dir == "/import/input"
+        assert app_config.default_output_dir == "/import/output"
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_settings_reset(self, tmp_path: Path, _patch_settings_file: Path) -> None:

--- a/tests/web/test_web_settings.py
+++ b/tests/web/test_web_settings.py
@@ -9,8 +9,11 @@ from pathlib import Path
 import pytest
 from starlette.testclient import TestClient
 
+from file_organizer.api.dependencies import get_config_manager
 from file_organizer.api.main import create_app
 from file_organizer.api.test_utils import build_test_settings, csrf_headers, seed_csrf_token
+from file_organizer.config.manager import ConfigManager
+from file_organizer.config.schema import AppConfig
 
 
 def _build_client(tmp_path: Path) -> TestClient:
@@ -20,9 +23,17 @@ def _build_client(tmp_path: Path) -> TestClient:
         auth_overrides={"auth_enabled": False},
     )
     app = create_app(settings)
+    app.dependency_overrides[get_config_manager] = lambda: ConfigManager(
+        config_dir=tmp_path / "app-config"
+    )
     client = TestClient(app)
     seed_csrf_token(client)
     return client
+
+
+def _load_app_config(tmp_path: Path) -> AppConfig:
+    """Load the AppConfig backing a test client built by ``_build_client``."""
+    return ConfigManager(config_dir=tmp_path / "app-config").load()
 
 
 @pytest.fixture()
@@ -159,10 +170,10 @@ class TestSettingsSectionSaves:
         assert response.status_code == 200
         assert "General settings saved" in response.text
 
-        # Verify persisted
-        data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["default_input_dir"] == "/tmp/input"  # noqa: test-hardcoded-paths
-        assert data["default_output_dir"] == "/tmp/output"  # noqa: test-hardcoded-paths
+        # Verify persisted to the shared AppConfig, not web-settings.json.
+        app_config = _load_app_config(tmp_path)
+        assert app_config.default_input_dir == "/tmp/input"  # noqa: test-hardcoded-paths
+        assert app_config.default_output_dir == "/tmp/output"  # noqa: test-hardcoded-paths
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_save_model_settings(self, tmp_path: Path, _patch_settings_file: Path) -> None:
@@ -178,9 +189,9 @@ class TestSettingsSectionSaves:
         assert response.status_code == 200
         assert "Model settings saved" in response.text
 
-        data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["text_model"] == "llama3:8b"
-        assert data["vision_model"] == "llava:7b"
+        app_config = _load_app_config(tmp_path)
+        assert app_config.models.text_model == "llama3:8b"
+        assert app_config.models.vision_model == "llava:7b"
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_save_organization_settings(self, tmp_path: Path, _patch_settings_file: Path) -> None:
@@ -196,8 +207,9 @@ class TestSettingsSectionSaves:
         assert response.status_code == 200
         assert "Organization settings saved" in response.text
 
+        app_config = _load_app_config(tmp_path)
+        assert app_config.default_methodology == "para"
         data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["default_methodology"] == "para"
         assert data["auto_organize"] is True
 
     @pytest.mark.usefixtures("_patch_settings_file")
@@ -257,8 +269,8 @@ class TestSettingsValidation:
         assert response.status_code == 200
         assert "Organization settings saved" in response.text
 
-        data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["default_methodology"] == "none"
+        app_config = _load_app_config(tmp_path)
+        assert app_config.default_methodology == "none"
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_invalid_theme_defaults_to_light(
@@ -302,9 +314,9 @@ class TestSettingsValidation:
         )
         assert response.status_code == 200
 
-        data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["text_model"] == "qwen2.5:3b-instruct-q4_K_M"
-        assert data["vision_model"] == "qwen2.5vl:7b-q4_K_M"
+        app_config = _load_app_config(tmp_path)
+        assert app_config.models.text_model == "qwen2.5:3b-instruct-q4_K_M"
+        assert app_config.models.vision_model == "qwen2.5vl:7b-q4_K_M"
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_unchecked_checkboxes_save_as_false(
@@ -412,9 +424,9 @@ class TestSettingsUtilities:
         )
         assert response.status_code == 200
         assert "Settings reset to defaults" in response.text
-        data = json.loads(_patch_settings_file.read_text(encoding="utf-8"))
-        assert data["default_input_dir"] == ""
-        assert data["default_output_dir"] == ""
+        app_config = _load_app_config(tmp_path)
+        assert app_config.default_input_dir == ""
+        assert app_config.default_output_dir == ""
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_rules_validation_endpoint(self, tmp_path: Path) -> None:

--- a/tests/web/test_web_settings.py
+++ b/tests/web/test_web_settings.py
@@ -159,11 +159,13 @@ class TestSettingsSectionSaves:
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_save_general_settings(self, tmp_path: Path, _patch_settings_file: Path) -> None:
         client = _build_client(tmp_path)
+        input_dir = str(tmp_path / "input")
+        output_dir = str(tmp_path / "output")
         response = client.post(
             "/ui/settings/general",
             data={
-                "default_input_dir": "/tmp/input",  # noqa: test-hardcoded-paths
-                "default_output_dir": "/tmp/output",  # noqa: test-hardcoded-paths
+                "default_input_dir": input_dir,
+                "default_output_dir": output_dir,
             },
             headers=csrf_headers(client),
         )
@@ -172,8 +174,8 @@ class TestSettingsSectionSaves:
 
         # Verify persisted to the shared AppConfig, not web-settings.json.
         app_config = _load_app_config(tmp_path)
-        assert app_config.default_input_dir == "/tmp/input"  # noqa: test-hardcoded-paths
-        assert app_config.default_output_dir == "/tmp/output"  # noqa: test-hardcoded-paths
+        assert app_config.default_input_dir == input_dir
+        assert app_config.default_output_dir == output_dir
 
     @pytest.mark.usefixtures("_patch_settings_file")
     def test_save_model_settings(self, tmp_path: Path, _patch_settings_file: Path) -> None:


### PR DESCRIPTION
## Description

Closes #1539 (Sprint R1 of the reusability epic, #1537).

The web Settings page persisted its own copy of `default_input_dir`, `default_output_dir`, `text_model`, `vision_model`, and `default_methodology` in `web-settings.json` — the same 5 fields #1495 added to the canonical `AppConfig`. A directory or model set via the TUI Settings view was invisible to the web Settings page, and vice versa; the methodology defaults could also disagree between the two stores.

This depended on #1538 (methodology vocabulary unification) landing first so both surfaces agree on values before merging storage — #1538 merged via #1550.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What changed

- `WebSettings` no longer declares `default_input_dir`, `default_output_dir`, `text_model`, `vision_model`, or `default_methodology`. It now holds only fields with no `AppConfig` equivalent (language, timezone, ollama_url, auto_organize, notifications_enabled, file_filter_glob, organization_rules, theme, custom_theme_name, log_level, cache_enabled, debug_mode, performance_mode).
- All 5 route handlers/sections that touch the moved fields (General, Models, Organization GET/POST, plus the shared `settings_page`, export, import, and reset flows) now load/save those fields on the shared `AppConfig` via `ConfigManager` (`Depends(get_config_manager)`), using the `"default"` profile — the same profile every other `AppConfig` consumer (TUI, CLI, API routers) uses.
- Export/import/reset continue to present a single coherent set of fields on the page despite the storage split:
  - **Export** merges both stores into one JSON payload.
  - **Import** writes each field back to its owning store.
  - **Reset** is scoped to only the 5 fields this page owns on `AppConfig` (not the entire `AppConfig`), so `setup_completed`, `updates`, and module overrides are left untouched.
- Updated the 3 templates (`_general.html`, `_models.html`, `_organization.html`) that render these fields to read from `app_config` instead of `ws`.

## Scope note

The original issue text mentioned "update/privacy" toggles as fields to migrate — investigation found no such fields exist on `WebSettings` today (that phrase referred to fields that already live only on `AppConfig.updates` with no web equivalent). Adding new web UI for those is a separate feature enhancement, out of scope for this dedup fix.

## How Has This Been Tested?

- `tests/web/test_settings_routes.py`, `tests/web/test_settings_routes_coverage.py`, `tests/web/test_web_settings.py`, `tests/integration/test_web_settings_extended.py` updated for the new `AppConfig`-backed fields and the `_render_section`/`_section_context` signature change (added required `app_config` param).
- Full regression run: `tests/web/`, `tests/config/`, `tests/tui/`, `tests/api/` — 2661 passed, 5 skipped (pre-existing), 0 new failures.
- `tests/integration/` — 6149 passed, 90 skipped, 7 failed; all 7 failures are pre-existing environment artifacts unrelated to this change (missing `sklearn` module, and a `chmod`-as-root permission test that doesn't actually restrict reads in this container) — confirmed by inspecting each failure's traceback.
- `ruff check` / `ruff format --check`: clean on all touched files.
- `mypy src/file_organizer/`: no issues found.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9To9VprqZiGT7Mr9itnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Settings for directories, models, and methodology now use a shared configuration, keeping values consistent across the application.
  - Updated settings pages display the correct saved values for general, model, and organization options.
  - Settings import and export now include shared workflow preferences.
  - Resetting settings restores both web preferences and workflow defaults.
  - Settings sections now render consistently after saving, importing, or encountering validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->