### PR TITLE
Version stamping: single source + drift contract test (#1540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,4 @@ This project is licensed under the [MIT License](LICENSE).
 
 ---
 
-**Status**: Stable | **Version**: 2.0.0 | **Last Updated**: 2026-07-05
+**Status**: Stable | **Version**: 2.0.2 | **Last Updated**: 2026-07-05

--- a/desktop/build/app.manifest
+++ b/desktop/build/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="2.0.0.0"
+    version="2.0.2.0"
     processorArchitecture="*"
     name="com.fileorganizer.app"
     type="win32"

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,10 +179,10 @@ See the [Installation Guide](admin/installation.md) for detailed instructions.
 
 ## Documentation Updates
 
-This documentation is maintained for File Organizer `2.0.0`. For older versions, check the [GitHub releases](https://github.com/curdriceaurora/Local-File-Organizer/releases).
+This documentation is maintained for File Organizer `2.0.2`. For older versions, check the [GitHub releases](https://github.com/curdriceaurora/Local-File-Organizer/releases).
 
 **Last Updated**: 2026-07-09
-**Version**: 2.0.1
+**Version**: 2.0.2
 
 ______________________________________________________________________
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,6 +1,6 @@
 # Terminal User Interface (TUI)
 
-> **Version**: 2.0.1
+> **Version**: 2.0.2
 
 The TUI is built with Textual and launched from the unified CLI.
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Sync hardcoded version stamps (docs, README, Windows manifest) to ``__version__``.
+
+The package version is single-sourced in ``src/file_organizer/version.py``
+(``__version__``), but a handful of other files also carry their own copy of
+it for humans or platform tooling to read: doc "**Version**: X.Y.Z" stamps
+and the Windows desktop manifest's assembly version. Nothing kept those in
+sync, so they drifted independently across release cycles (see #1540 — at
+time of filing, version.py said 2.0.2 while README.md and docs/index.md
+still said 2.0.0 and 2.0.1). This script is *not* the semantic-version
+bumper (that's ``release.py``'s ``bump_version()``, which bumps
+major/minor/patch); it only rewrites these stamps to match whatever
+``__version__`` already is.
+
+``tests/ci/test_version_drift.py`` fails CI if a stamp disagrees with
+``__version__``, using the same ``TOUCHPOINTS`` list as this script so the
+two can't drift apart from each other.
+
+Usage:
+    python scripts/bump_version.py          # rewrite every stale touchpoint
+    python scripts/bump_version.py --check  # exit 1 if any touchpoint is stale; write nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from file_organizer.version import __version__  # noqa: E402
+
+
+def _same_as_version(version: str) -> str:
+    """Default touchpoint formatter: the stamp should read exactly ``__version__``."""
+    return version
+
+
+def _windows_assembly_version(version: str) -> str:
+    """Windows assembly versions are 4-part (major.minor.build.revision)."""
+    return f"{version}.0"
+
+
+# Matches the "**Version**: X.Y.Z" stamp used verbatim (optionally inside a
+# blockquote, as in docs/tui.md's "> **Version**: X.Y.Z").
+_DOC_VERSION_STAMP = re.compile(r"\*\*Version\*\*:\s*(?P<version>\S+)")
+
+# Matches only File Organizer's own <assemblyIdentity> in the Windows
+# manifest (not the nested Microsoft.Windows.Common-Controls dependency,
+# which is a fixed OS component version and must never be touched).
+_WINDOWS_MANIFEST_STAMP = re.compile(
+    r'<assemblyIdentity\s+version="(?P<version>[\d.]+)"\s+'
+    r'processorArchitecture="\*"\s+name="com\.fileorganizer\.app"'
+)
+
+
+@dataclass(frozen=True)
+class Touchpoint:
+    """A single hardcoded version stamp somewhere in the repo."""
+
+    path: Path
+    pattern: re.Pattern[str] = _DOC_VERSION_STAMP
+    expected: Callable[[str], str] = _same_as_version
+
+
+TOUCHPOINTS: list[Touchpoint] = [
+    Touchpoint(REPO_ROOT / "README.md"),
+    Touchpoint(REPO_ROOT / "docs" / "index.md"),
+    Touchpoint(REPO_ROOT / "docs" / "tui.md"),
+    Touchpoint(
+        REPO_ROOT / "desktop" / "build" / "app.manifest",
+        _WINDOWS_MANIFEST_STAMP,
+        _windows_assembly_version,
+    ),
+]
+
+
+def find_drift(*, fix: bool, touchpoints: list[Touchpoint] | None = None) -> list[str]:
+    """Check every touchpoint against ``__version__``, optionally rewriting stale ones.
+
+    Args:
+        fix: If True, rewrite stale touchpoints in place. If False, only report.
+        touchpoints: Touchpoints to check. Defaults to ``TOUCHPOINTS``; overridable
+            for testing against synthetic files.
+
+    Returns:
+        Human-readable description of each stale touchpoint found (before any
+        fix was applied). Empty list means everything already matched.
+
+    Raises:
+        SystemExit: If a touchpoint file has no recognizable version stamp.
+    """
+    stale: list[str] = []
+    for touchpoint in touchpoints if touchpoints is not None else TOUCHPOINTS:
+        text = touchpoint.path.read_text(encoding="utf-8")
+        match = touchpoint.pattern.search(text)
+        if match is None:
+            raise SystemExit(f"error: no version stamp found in {touchpoint.path}")
+
+        current = match.group("version")
+        expected = touchpoint.expected(__version__)
+        if current == expected:
+            continue
+
+        try:
+            display_path = touchpoint.path.relative_to(REPO_ROOT)
+        except ValueError:
+            display_path = touchpoint.path
+        stale.append(f"{display_path}: {current} (expected {expected})")
+
+        if fix:
+            start, end = match.span("version")
+            touchpoint.path.write_text(text[:start] + expected + text[end:], encoding="utf-8")
+
+    return stale
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if any touchpoint is stale, without writing changes.",
+    )
+    args = parser.parse_args(argv)
+
+    stale = find_drift(fix=not args.check)
+
+    if not stale:
+        print(f"All version touchpoints already match {__version__}.")
+        return 0
+
+    if args.check:
+        print("Version drift detected:", file=sys.stderr)
+        for line in stale:
+            print(f"  {line}", file=sys.stderr)
+        print("Run `python scripts/bump_version.py` to fix.", file=sys.stderr)
+        return 1
+
+    print(f"Updated {len(stale)} version touchpoint(s) to {__version__}:")
+    for line in stale:
+        print(f"  {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_bump_version.py
+++ b/tests/ci/test_bump_version.py
@@ -1,0 +1,128 @@
+"""Tests for scripts/bump_version.py (doc version-stamp sync, see #1540)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts dir to path so we can import bump_version.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+
+from bump_version import _DOC_VERSION_STAMP, Touchpoint, find_drift, main
+
+from file_organizer.version import __version__
+
+pytestmark = pytest.mark.ci
+
+
+def _make_touchpoint(tmp_path: Path, name: str, stamp_line: str) -> Touchpoint:
+    doc = tmp_path / name
+    doc.write_text(f"# Some doc\n\n{stamp_line}\n", encoding="utf-8")
+    return Touchpoint(doc, _DOC_VERSION_STAMP)
+
+
+class TestFindDrift:
+    """Tests for find_drift()."""
+
+    def test_reports_nothing_when_up_to_date(self, tmp_path: Path) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", f"**Version**: {__version__}")
+        assert find_drift(fix=False, touchpoints=[tp]) == []
+
+    def test_reports_stale_touchpoint_without_writing(self, tmp_path: Path) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", "**Version**: 0.0.1")
+        stale = find_drift(fix=False, touchpoints=[tp])
+        assert len(stale) == 1
+        assert "0.0.1" in stale[0]
+        assert __version__ in stale[0]
+        # Check mode must not have touched the file.
+        assert "0.0.1" in tp.path.read_text(encoding="utf-8")
+
+    def test_fix_rewrites_stale_touchpoint_in_place(self, tmp_path: Path) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", "**Version**: 0.0.1")
+        stale = find_drift(fix=True, touchpoints=[tp])
+        assert len(stale) == 1
+        assert f"**Version**: {__version__}" in tp.path.read_text(encoding="utf-8")
+
+    def test_fix_preserves_surrounding_text(self, tmp_path: Path) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", "> **Version**: 0.0.1")
+        find_drift(fix=True, touchpoints=[tp])
+        assert f"> **Version**: {__version__}" in tp.path.read_text(encoding="utf-8")
+
+    def test_missing_stamp_raises(self, tmp_path: Path) -> None:
+        doc = tmp_path / "a.md"
+        doc.write_text("# No stamp here\n", encoding="utf-8")
+        tp = Touchpoint(doc, _DOC_VERSION_STAMP)
+        with pytest.raises(SystemExit):
+            find_drift(fix=False, touchpoints=[tp])
+
+    def test_multiple_touchpoints_all_checked(self, tmp_path: Path) -> None:
+        stale_tp = _make_touchpoint(tmp_path, "a.md", "**Version**: 0.0.1")
+        fresh_tp = _make_touchpoint(tmp_path, "b.md", f"**Version**: {__version__}")
+        stale = find_drift(fix=False, touchpoints=[stale_tp, fresh_tp])
+        assert len(stale) == 1
+        assert "a.md" in stale[0]
+
+    def test_custom_expected_formatter_is_used_for_comparison_and_rewrite(
+        self, tmp_path: Path
+    ) -> None:
+        """A touchpoint with a non-identity `expected()` (e.g. a 4-part Windows
+        version) should compare and rewrite against the formatted value, not
+        the raw __version__."""
+        doc = tmp_path / "app.manifest"
+        doc.write_text('version="0.0.0.0"\n', encoding="utf-8")
+        tp = Touchpoint(
+            doc,
+            re.compile(r'version="(?P<version>[\d.]+)"'),
+            lambda v: f"{v}.0",
+        )
+        stale = find_drift(fix=True, touchpoints=[tp])
+        assert len(stale) == 1
+        assert f"expected {__version__}.0" in stale[0]
+        assert f'version="{__version__}.0"' in doc.read_text(encoding="utf-8")
+
+    def test_custom_expected_formatter_reports_no_drift_when_matching(self, tmp_path: Path) -> None:
+        doc = tmp_path / "app.manifest"
+        doc.write_text(f'version="{__version__}.0"\n', encoding="utf-8")
+        tp = Touchpoint(
+            doc,
+            re.compile(r'version="(?P<version>[\d.]+)"'),
+            lambda v: f"{v}.0",
+        )
+        assert find_drift(fix=False, touchpoints=[tp]) == []
+
+
+class TestMain:
+    """Tests for the CLI entry point."""
+
+    def test_check_mode_exits_1_on_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", "**Version**: 0.0.1")
+        monkeypatch.setattr("bump_version.TOUCHPOINTS", [tp])
+        assert main(["--check"]) == 1
+
+    def test_check_mode_exits_0_when_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", f"**Version**: {__version__}")
+        monkeypatch.setattr("bump_version.TOUCHPOINTS", [tp])
+        assert main(["--check"]) == 0
+
+    def test_default_mode_fixes_and_exits_0(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", "**Version**: 0.0.1")
+        monkeypatch.setattr("bump_version.TOUCHPOINTS", [tp])
+        assert main([]) == 0
+        assert f"**Version**: {__version__}" in tp.path.read_text(encoding="utf-8")
+
+    def test_default_mode_is_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tp = _make_touchpoint(tmp_path, "a.md", f"**Version**: {__version__}")
+        monkeypatch.setattr("bump_version.TOUCHPOINTS", [tp])
+        assert main([]) == 0
+        assert f"**Version**: {__version__}" in tp.path.read_text(encoding="utf-8")

--- a/tests/ci/test_version_drift.py
+++ b/tests/ci/test_version_drift.py
@@ -1,0 +1,47 @@
+"""CI guardrail: hardcoded version stamps must match file_organizer.version.__version__.
+
+version.py is the single source of truth for the package version, but a
+handful of other files also carry their own copy of it (doc "**Version**:
+X.Y.Z" stamps, the Windows desktop manifest's assembly version). Nothing
+enforced agreement between them, so they drifted independently across past
+release cycles (see #1540). This test fails CI the moment a stamp
+disagrees, instead of relying on someone noticing in review.
+
+Reuses ``scripts/bump_version.py``'s ``TOUCHPOINTS`` list (and each
+touchpoint's ``expected()`` formatter) so the set of tracked files and their
+expected values can't drift between the script and this test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from bump_version import TOUCHPOINTS, Touchpoint  # noqa: E402
+
+from file_organizer.version import __version__  # noqa: E402
+
+pytestmark = pytest.mark.ci
+
+
+@pytest.mark.parametrize(
+    "touchpoint", TOUCHPOINTS, ids=[str(tp.path.relative_to(REPO_ROOT)) for tp in TOUCHPOINTS]
+)
+def test_version_stamp_matches_source_of_truth(touchpoint: Touchpoint) -> None:
+    """Every tracked version stamp must equal __version__ (via its formatter)."""
+    text = touchpoint.path.read_text(encoding="utf-8")
+    match = touchpoint.pattern.search(text)
+    assert match is not None, f"{touchpoint.path}: no version stamp found"
+
+    stamped = match.group("version")
+    expected = touchpoint.expected(__version__)
+    assert stamped == expected, (
+        f"{touchpoint.path.relative_to(REPO_ROOT)} stamps version {stamped!r}, but "
+        f"file_organizer.version.__version__ is {__version__!r} (expected {expected!r}). "
+        "Run `python scripts/bump_version.py` to fix."
+    )

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -8,6 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
+from file_organizer.version import __version__
 
 runner = CliRunner()
 
@@ -27,7 +28,7 @@ class TestVersionCommand:
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert "fo" in result.output
-        assert "2.0.0" in result.output
+        assert __version__ in result.output
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description

Closes #1540 (Sprint R1 of the reusability epic, #1537).

`version.py`'s `__version__` is the single source of truth for the package version, but a handful of other files carried their own copy: doc "**Version**: X.Y.Z" stamps (`README.md`, `docs/index.md`, `docs/tui.md`) and the Windows desktop manifest's assembly version. Nothing kept them in sync, so they drifted independently across release cycles — at time of filing, `version.py` said `2.0.2` while `README.md` and `docs/index.md` still said `2.0.0` and `2.0.1`. This happened during the very release cycle meant to fix version-labeling bugs (#1490/2.0.0 GA), so it's a recurring failure mode, not a one-off typo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What changed

- **`scripts/bump_version.py`** — syncs every tracked version touchpoint to `__version__` in one step. `--check` mode reports drift and exits 1 without writing (usable in CI or locally). Each touchpoint carries its own `pattern` (regex with a `version` named group) and `expected()` formatter, so non-identity cases are handled without special-casing — e.g. the Windows manifest's 4-part `major.minor.build.revision` format (`{__version__}.0`) versus the docs' plain `**Version**: X.Y.Z` stamp. This is deliberately a different script from `release.py`'s `bump_version()`, which bumps the semantic version itself (major/minor/patch); this one only propagates an already-bumped `__version__` to the doc/manifest stamps.
- **`tests/ci/test_version_drift.py`** — new CI contract test, parametrized over the same `TOUCHPOINTS` list the script uses (imported directly, so the two can't drift apart from each other), failing the moment any tracked stamp disagrees with `__version__`.
- **`tests/ci/test_bump_version.py`** — unit tests for the script's `find_drift()`/`main()` against synthetic `tmp_path` files, covering: no-op when already in sync, report-without-writing in `--check` mode, in-place rewrite preserving surrounding text, missing-stamp error, multiple touchpoints, and the custom `expected()` formatter path (Windows-manifest-style).
- **Fixed the current drift**: `README.md` (2.0.0 → 2.0.2), `docs/index.md` (2.0.1 → 2.0.2, plus a self-contradictory inline "maintained for File Organizer `2.0.0`" sentence on the same page), `docs/tui.md` (2.0.1 → 2.0.2), `desktop/build/app.manifest` (2.0.0.0 → 2.0.2.0 — found by broadening the search beyond the issue's explicit doc-header list; this file isn't referenced by any build script, so it was silently going stale with no automation touching it at all).
- **Also fixed `tests/cli/test_cli_main.py::TestVersionCommand::test_version_output`**, which hardcoded `assert "2.0.0" in result.output` against the real CLI's `fo version` output — same root-cause class of bug (a hardcoded version string that drifted from `__version__`), surfaced by a full regression run rather than the new contract test (which only tracks doc/manifest stamps, not CLI output). Now asserts against `file_organizer.version.__version__` directly so it can't drift again.

## How Has This Been Tested?

- `tests/ci/test_bump_version.py`, `tests/ci/test_version_drift.py`, `tests/ci/test_windows_manifest.py`, `tests/cli/test_cli_main.py`, `tests/ci/test_docs_contracts.py` — 91 passed.
- Full regression run (`tests/`) — 21048 passed, 191 skipped, 1 xfailed, 23 failed, 51 errors. All 23 failures and 51 errors are pre-existing environment artifacts unrelated to this change: root-bypasses-`chmod` permission tests, missing `sklearn`/`pydub` optional dependencies, home-directory-dependent defaults, and Playwright browser-launch failures in this sandboxed session (confirmed by inspecting each failure's traceback — none touch any file this PR modifies).
- `ruff check` / `ruff format --check`: clean on all touched files.
- `mypy scripts/bump_version.py`: no issues found.
- Manually ran `python scripts/bump_version.py --check` (exit 1, reports drift) then `python scripts/bump_version.py` (fixes it, exit 0) then `--check` again (exit 0, confirms idempotent) against the real repo files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9To9VprqZiGT7Mr9itnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented application and TUI version to 2.0.2.
  * Updated the Windows application release metadata to version 2.0.2.

* **Chores**
  * Added tooling to synchronize release versions across application metadata and documentation.
  * Added automated checks to detect outdated version references and verify CLI version reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->