### PR TITLE
Fix over-broad __import__ mocks in audio test "no pydub" fixtures

### DIFF
--- a/tests/services/audio/test_audio_preprocessor.py
+++ b/tests/services/audio/test_audio_preprocessor.py
@@ -7,6 +7,7 @@ External dependencies (ffmpeg, pydub) are mocked.
 
 from __future__ import annotations
 
+import builtins
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -227,10 +228,12 @@ class TestConvertWithPydub:
     def test_no_pydub(self, preprocessor, audio_file, tmp_path):
         out = tmp_path / "out.wav"
 
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             with pytest.raises(ImportError, match="Neither ffmpeg nor pydub"):
@@ -266,10 +269,12 @@ class TestNormalizeAudio:
         assert result == audio_file
 
     def test_no_pydub(self, preprocessor, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = preprocessor.normalize_audio(audio_file)
@@ -318,10 +323,12 @@ class TestRemoveSilence:
         assert result == audio_file
 
     def test_no_pydub(self, preprocessor, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = preprocessor.remove_silence(audio_file)
@@ -417,10 +424,12 @@ class TestGetAudioInfo:
         assert info["sample_rate"] == 44100
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             info = AudioPreprocessor.get_audio_info(audio_file)

--- a/tests/services/audio/test_audio_utils.py
+++ b/tests/services/audio/test_audio_utils.py
@@ -84,12 +84,14 @@ class TestGetAudioDuration:
         mock_tinytag.TinyTag.get.return_value = mock_tag
 
         # First import (pydub) fails, second (tinytag) succeeds
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if name == "pydub":
                 raise ImportError("no pydub")
             if name == "tinytag":
                 return mock_tinytag
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             duration = get_audio_duration(audio_file)
@@ -98,11 +100,12 @@ class TestGetAudioDuration:
 
     def test_no_audio_libs(self, audio_file):
         """When neither pydub nor tinytag is available."""
+        real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
             if name in ("pydub", "tinytag"):
                 raise ImportError(f"no {name}")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             duration = get_audio_duration(audio_file)
@@ -149,10 +152,12 @@ class TestNormalizeAudio:
             assert result == audio_file
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = normalize_audio(audio_file)
@@ -184,10 +189,12 @@ class TestSplitAudio:
         assert len(result) == 2
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = split_audio(audio_file)
@@ -233,10 +240,12 @@ class TestConvertAudioFormat:
             assert result == audio_file.with_suffix(".wav")
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = convert_audio_format(audio_file, "wav")
@@ -314,10 +323,12 @@ class TestDetectSilenceSegments:
         assert len(result) == 2
 
     def test_no_pydub(self, audio_file):
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = detect_silence_segments(audio_file)

--- a/tests/services/audio/test_utils_branches.py
+++ b/tests/services/audio/test_utils_branches.py
@@ -7,6 +7,7 @@ src/file_organizer/services/audio/utils.py.  Every test class carries
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -52,13 +53,15 @@ class TestGetAudioDurationBranches:
         mock_tinytag = MagicMock()
         mock_tinytag.TinyTag.get.return_value = mock_tag
 
+        real_import = builtins.__import__
+
         def fake_import(name, *args, **kwargs):
             """Substitute __import__ that raises for pydub and returns mock_tinytag for tinytag."""
             if name == "pydub":
                 raise ImportError("no pydub")
             if name == "tinytag":
                 return mock_tinytag
-            raise ImportError(f"no {name}")
+            return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             duration = get_audio_duration(audio)
@@ -566,8 +569,6 @@ class TestDetectSilenceSegmentsBranches:
 
     def test_no_pydub_returns_empty_list(self, audio_file: Path) -> None:
         """Lines 221-223: ImportError → warning logged, returns []."""
-        import builtins
-
         real_import = builtins.__import__
 
         def _no_pydub(name: str, *args: object, **kwargs: object) -> object:


### PR DESCRIPTION
## Description

Fixes a recurring main-CI flake, found while monitoring `main` after #1553 merged.

`Test (shard 2, py3.14)` failed with `ImportError: no coverage.python` in `tests/services/audio/test_audio_utils.py::TestNormalizeAudio::test_no_pydub`. This wasn't caused by #1553 — the same "CI" workflow has been failing on the last several main-branch pushes (75da43d8, 6d0863ba, 7cabcec4, 9743fbdf), always in this file.

**Root cause**: several `test_no_pydub`/`test_no_audio_libs` tests patch `builtins.__import__` with a `fake_import` that raises `ImportError` for **any** module name that isn't the one being simulated as missing:

```python
def fake_import(name, *args, **kwargs):
    if "pydub" in name:
        raise ImportError("no pydub")
    raise ImportError(f"no {name}")  # <-- breaks every other import too
```

This makes the test fragile and environment-dependent: whatever the code under test happens to lazily import next gets blocked. Locally (no coverage) it's `pathlib`'s lazy `ntpath` import; under `pytest-cov` (as CI runs) it's coverage's own internal `coverage.python` module. Reproduced locally with `pytest tests/services/audio/test_audio_utils.py::TestNormalizeAudio::test_no_pydub` (fails) vs. running with `--cov` (fails with the exact `coverage.python` error CI shows).

The correct pattern already exists in the same files (`TestTrimAudio::test_no_pydub`, `TestGetAudioPeakAmplitude::test_no_pydub`): capture the real `__import__` before patching and delegate to it for anything not being simulated as missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What changed

Applied the existing correct pattern (`real_import = builtins.__import__` captured before the patch, delegated to for any non-simulated import) to every broken instance:

- **`tests/services/audio/test_audio_utils.py`**: `TestGetAudioDuration::test_fallback_to_tinytag`, `test_no_audio_libs`; `TestNormalizeAudio::test_no_pydub`; `TestSplitAudio::test_no_pydub`; `TestConvertAudioFormat::test_no_pydub`; `TestDetectSilenceSegments::test_no_pydub` (6 tests).
- **`tests/services/audio/test_audio_preprocessor.py`**: `TestConvertWithPydub::test_no_pydub`; `TestNormalizeAudio::test_no_pydub`; `TestRemoveSilence::test_no_pydub`; `TestGetAudioInfo::test_no_pydub` (4 tests). Added the missing module-level `import builtins`.
- **`tests/services/audio/test_utils_branches.py`**: `TestGetAudioDurationBranches::test_tinytag_duration_none_returns_zero` (1 test). Promoted the existing function-local `import builtins` to module level, matching the other two files and removing a now-redundant duplicate.

Also swept the rest of the test suite for the same anti-pattern (`grep` for `raise ImportError(f"no {name}")`-style fallbacks) — the two other hits (`test_dedup_extractor.py`, `test_core_organizer_batch3.py`) were already correctly guarded with a real-import fallback, so no changes needed there.

Out of scope: `tests/services/audio/test_audio_utils.py::TestMergeAudioFiles::test_no_pydub_raises` still raises unconditionally, but that test only asserts `pytest.raises(ImportError)` without checking which import failed, so it isn't actually broken by this pattern (any `ImportError`, related or not, satisfies it) — left as-is to keep this fix minimal and focused on tests that were genuinely failing.

## How Has This Been Tested?

- `pytest tests/services/audio/` — 325 passed (was 1 failed locally with `--cov`, matching CI's coverage-instrumented run; 3 more fail intermittently depending on what a given Python/environment happens to lazily import next).
- Re-ran with `--cov=file_organizer` (reproducing CI's exact instrumentation) — 325 passed, 0 failed, confirming the root cause is resolved.
- `ruff check` / `ruff format --check`: clean on all touched files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9To9VprqZiGT7Mr9itnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved audio-related test coverage for scenarios where optional audio libraries are unavailable.
  * Refined import simulations to ensure unrelated modules continue loading normally during fallback and failure tests.
  * Strengthened validation of audio metadata and duration fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->