### PR TITLE
Extract apply_config_update() shared by two API routers (#1544)

### DIFF
--- a/src/file_organizer/api/routers/config.py
+++ b/src/file_organizer/api/routers/config.py
@@ -17,9 +17,9 @@ from file_organizer.api.openapi_responses import (
     success_response,
     validation_error_response,
 )
+from file_organizer.api.utils import apply_config_update
 from file_organizer.config.defaults import DEFAULT_TEXT_MODEL
 from file_organizer.config.manager import ConfigManager, UnsupportedConfigVersionError
-from file_organizer.config.methodology import normalize as normalize_methodology
 from file_organizer.config.schema import AppConfig
 
 router = APIRouter(tags=["config"], responses=INTERNAL_500_RESPONSE)
@@ -33,29 +33,6 @@ def _profile_update_lock(manager: ConfigManager, profile: str) -> RLock:
     key = (str(manager.config_dir.resolve()), profile)
     with _CONFIG_UPDATE_LOCKS_GUARD:
         return _CONFIG_UPDATE_LOCKS.setdefault(key, RLock())
-
-
-def _apply_update(config: AppConfig, request: ConfigUpdateRequest) -> None:
-    """Apply a partial API update to an AppConfig instance."""
-    if request.default_methodology is not None:
-        config.default_methodology = normalize_methodology(request.default_methodology)
-
-    models = request.models
-    if models is not None:
-        for field, value in models.model_dump(exclude_none=True).items():
-            setattr(config.models, field, value)
-
-    updates = request.updates
-    if updates is not None:
-        for field, value in updates.model_dump(exclude_none=True).items():
-            setattr(config.updates, field, value)
-
-    excluded_fields = {"profile", "default_methodology", "models", "updates"}
-    for name, value in request.model_dump(exclude_none=True).items():
-        if name in excluded_fields:
-            continue
-        if hasattr(config, name):
-            setattr(config, name, value)
 
 
 def _response(manager: ConfigManager, profile: str, config: AppConfig) -> ConfigResponse:
@@ -128,7 +105,7 @@ def update_config(
     """Apply partial updates to a persisted configuration profile."""
     with _profile_update_lock(manager, request.profile):
         config = manager.load(request.profile)
-        _apply_update(config, request)
+        apply_config_update(config, request)
 
         try:
             manager.save(config, request.profile)

--- a/src/file_organizer/api/routers/system.py
+++ b/src/file_organizer/api/routers/system.py
@@ -31,9 +31,8 @@ from file_organizer.api.openapi_responses import (
     success_response,
     validation_error_response,
 )
-from file_organizer.api.utils import file_info_from_path, resolve_path
+from file_organizer.api.utils import apply_config_update, file_info_from_path, resolve_path
 from file_organizer.config.manager import ConfigManager, UnsupportedConfigVersionError
-from file_organizer.config.methodology import normalize as normalize_methodology
 from file_organizer.services.analytics.storage_analyzer import StorageAnalyzer
 from file_organizer.version import __version__
 
@@ -140,26 +139,7 @@ def update_config(
 ) -> ConfigResponse:
     """Apply partial updates to the configuration for a named profile."""
     config = manager.load(request.profile)
-
-    if request.default_methodology is not None:
-        config.default_methodology = normalize_methodology(request.default_methodology)
-
-    if request.models is not None:
-        models = request.models
-        for field, value in models.model_dump(exclude_none=True).items():
-            setattr(config.models, field, value)
-
-    if request.updates is not None:
-        updates = request.updates
-        for field, value in updates.model_dump(exclude_none=True).items():
-            setattr(config.updates, field, value)
-
-    excluded_fields = {"profile", "default_methodology", "models", "updates"}
-    for name, value in request.model_dump(exclude_none=True).items():
-        if name in excluded_fields:
-            continue
-        if hasattr(config, name):
-            setattr(config, name, value)
+    apply_config_update(config, request)
 
     try:
         manager.save(config, request.profile)

--- a/src/file_organizer/api/utils.py
+++ b/src/file_organizer/api/utils.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import mimetypes
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from file_organizer.api.exceptions import ApiError
-from file_organizer.api.models import FileInfo
+from file_organizer.api.models import ConfigUpdateRequest, FileInfo
+from file_organizer.config.methodology import normalize as normalize_methodology
+from file_organizer.config.schema import AppConfig
 from file_organizer.utils import is_hidden as is_hidden
 from file_organizer.utils.file_times import creation_timestamp
 
@@ -84,3 +87,34 @@ def file_info_from_path(path: Path) -> FileInfo:
         file_type=path.suffix.lower() or "",
         mime_type=mime_type,
     )
+
+
+_CONFIG_UPDATE_EXCLUDED_FIELDS = frozenset({"default_methodology", "models", "updates"})
+
+
+def _merge_submodel(target: object, sub: Any) -> None:
+    """Copy every set field of a pydantic submodel onto *target* by name."""
+    if sub is not None:
+        for field, value in sub.model_dump(exclude_none=True).items():
+            setattr(target, field, value)
+
+
+def apply_config_update(config: AppConfig, request: ConfigUpdateRequest) -> None:
+    """Apply a partial API config-update request onto an AppConfig, in place.
+
+    ``models``/``updates`` are merged field-by-field; ``default_methodology``
+    goes through ``normalize_methodology``; every other set request field is
+    applied via plain ``setattr`` (fields handled above, plus ``profile``
+    which isn't an AppConfig field, are excluded from that pass).
+    """
+    if request.default_methodology is not None:
+        config.default_methodology = normalize_methodology(request.default_methodology)
+
+    _merge_submodel(config.models, request.models)
+    _merge_submodel(config.updates, request.updates)
+
+    for name, value in request.model_dump(exclude_none=True).items():
+        if name in _CONFIG_UPDATE_EXCLUDED_FIELDS:
+            continue
+        if hasattr(config, name):
+            setattr(config, name, value)

--- a/tests/api/test_config_router.py
+++ b/tests/api/test_config_router.py
@@ -18,7 +18,8 @@ from file_organizer.api.dependencies import (
     get_settings,
 )
 from file_organizer.api.exceptions import setup_exception_handlers
-from file_organizer.api.routers.config import _apply_update, router
+from file_organizer.api.routers.config import router
+from file_organizer.api.utils import apply_config_update
 from file_organizer.config.manager import ConfigManager
 from file_organizer.config.schema import AppConfig
 
@@ -235,7 +236,7 @@ class TestUpdateConfig:
             model_dump=lambda exclude_none=True: {"unknown_section": {"enabled": True}},
         )
 
-        _apply_update(config, request)
+        apply_config_update(config, request)
 
         assert not hasattr(config, "unknown_section")
 


### PR DESCRIPTION
## Description

Closes #1544 (Sprint R2 of the reusability epic, #1537 — last item).

The `excluded_fields` set + `model_dump(exclude_none=True)` + `setattr` loop for applying a config-update request onto `AppConfig` was duplicated verbatim between `api/routers/config.py`'s `_apply_update` and `api/routers/system.py`'s inline `update_config` logic. A new field needing protection from blind `setattr` had to be excluded in both places or silently diverge.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What changed

Added `apply_config_update(config: AppConfig, request: ConfigUpdateRequest) -> None` to `api/utils.py` ("Shared helpers for API routers" — matching the issue's specified location). Both routers now call it instead of their own copy:
- `api/routers/config.py::update_config` — dropped the local `_apply_update` helper.
- `api/routers/system.py::update_config` — dropped the inlined block.

A test (`tests/api/test_config_router.py`) that directly imported the deleted `_apply_update` was updated to import `apply_config_update` from `api.utils` instead.

### Code-review pass

Ran an 8-angle code review (3 correctness + 3 cleanup + altitude + conventions) before committing. No correctness bugs, no removed behavior, no cross-file breakage. Applied 3 cleanups surfaced by the review, all within the new helper itself:
- Dropped `"profile"` from the exclusion set — dead, since `AppConfig` has no `profile` attribute (only `profile_name`), so the `hasattr` guard already filtered it.
- Hoisted the exclusion set to a module-level `frozenset` instead of rebuilding it every call.
- Factored the identical `models`/`updates` merge blocks into a tiny `_merge_submodel` helper, removing a smaller duplication from inside the very function meant to eliminate duplication.

One finding was surfaced but intentionally **not** acted on (noted here rather than silently skipped): `config/manager.py` has a `_NESTED_DATACLASS_TYPES` registry (from #1542) that `apply_config_update` doesn't reuse — a future nested-dataclass `AppConfig` field could silently get a raw dict via `setattr` instead of a proper merge if this helper isn't updated in lockstep. Fully field-driving the update path the way `ConfigManager._config_to_dict`/`_dict_to_config` already are is a larger, separate change than this issue's stated scope ("extract one helper, have both routers call it") — flagging it here in case a follow-up issue is wanted.

## How Has This Been Tested?

- `tests/api/test_config_router.py`, `tests/api/test_system_router.py`, `tests/api/test_api_security.py`, `tests/integration/test_client_api_contract.py` — 43 passed.
- `tests/api/`, `tests/unit/api/` (full) — 1242 passed.
- Broader regression (`tests/api/ tests/client/ tests/unit/api/ tests/integration/`) — 7706 passed, 2 failed (both the established pre-existing root-bypasses-`chmod` permission-test environment artifact in `tests/integration/test_error_propagation.py`, unrelated to this change).
- `ruff check` / `ruff format --check`: clean on all touched files.
- `mypy`: no issues found on all touched files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9To9VprqZiGT7Mr9itnWb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration updates by centralizing how partial changes are applied.
  * Preserved support for methodology normalization, model and update settings, and other editable configuration fields.
  * Continued ignoring unsupported fields safely during configuration updates.
* **Tests**
  * Updated coverage to verify that unrecognized configuration fields do not affect saved settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->