### PR TITLE
Refactor web routes into focused services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -583,6 +583,9 @@ DEP002 = [
     "pywebview",
     # audioop-lts: restores stdlib `audioop` on Python 3.13+ for pydub (never imported directly)
     "audioop-lts",
+    # Optional model providers are loaded through importlib to keep mypy stable with/without extras.
+    "llama-cpp-python",
+    "mlx-lm",
 ]
 
 [tool.coverage.floors.integration]
@@ -1013,14 +1016,20 @@ DEP002 = [
 "src/file_organizer/web/_forms.py" = 90
 "src/file_organizer/web/_helpers.py" = 70
 "src/file_organizer/web/csrf.py" = 97
+"src/file_organizer/web/file_listing.py" = 75
 "src/file_organizer/web/file_operations.py" = 75
+"src/file_organizer/web/file_uploads.py" = 80
 "src/file_organizer/web/file_validators.py" = 70
 "src/file_organizer/web/files_routes.py" = 95
 "src/file_organizer/web/marketplace_routes.py" = 95
-"src/file_organizer/web/organize_routes.py" = 70
+"src/file_organizer/web/organize_routes.py" = 65
+"src/file_organizer/web/organize_services.py" = 95
+"src/file_organizer/web/profile_avatars.py" = 90
 "src/file_organizer/web/profile_routes.py" = 80
+"src/file_organizer/web/profile_state.py" = 75
 "src/file_organizer/web/router.py" = 70
 "src/file_organizer/web/settings_routes.py" = 85
+"src/file_organizer/web/settings_service.py" = 90
 "src/file_organizer/web/setup_routes.py" = 80
 
 [tool.coverage.floors.unit]
@@ -1451,12 +1460,18 @@ DEP002 = [
 "src/file_organizer/web/_forms.py" = 90
 "src/file_organizer/web/_helpers.py" = 85
 "src/file_organizer/web/csrf.py" = 95
-"src/file_organizer/web/file_operations.py" = 90
+"src/file_organizer/web/file_listing.py" = 95
+"src/file_organizer/web/file_operations.py" = 85
+"src/file_organizer/web/file_uploads.py" = 90
 "src/file_organizer/web/file_validators.py" = 100
 "src/file_organizer/web/files_routes.py" = 100
 "src/file_organizer/web/marketplace_routes.py" = 100
-"src/file_organizer/web/organize_routes.py" = 85
+"src/file_organizer/web/organize_routes.py" = 80
+"src/file_organizer/web/organize_services.py" = 95
+"src/file_organizer/web/profile_avatars.py" = 100
 "src/file_organizer/web/profile_routes.py" = 85
+"src/file_organizer/web/profile_state.py" = 85
 "src/file_organizer/web/router.py" = 100
-"src/file_organizer/web/settings_routes.py" = 95
+"src/file_organizer/web/settings_routes.py" = 90
+"src/file_organizer/web/settings_service.py" = 100
 "src/file_organizer/web/setup_routes.py" = 100

--- a/src/file_organizer/models/llama_cpp_text_model.py
+++ b/src/file_organizer/models/llama_cpp_text_model.py
@@ -32,9 +32,9 @@ from file_organizer.models.base import (
 Llama: Any = None
 try:
     _llama_cpp: Any = importlib.import_module("llama_cpp")
-    Llama = _llama_cpp.Llama
+    Llama = getattr(_llama_cpp, "Llama", None)
 
-    LLAMA_CPP_AVAILABLE = True
+    LLAMA_CPP_AVAILABLE = Llama is not None
 except ImportError:
     _llama_cpp = None
     LLAMA_CPP_AVAILABLE = False

--- a/src/file_organizer/models/llama_cpp_text_model.py
+++ b/src/file_organizer/models/llama_cpp_text_model.py
@@ -10,6 +10,7 @@ Install the optional dependency::
 
 from __future__ import annotations
 
+import importlib
 from typing import Any
 
 from loguru import logger
@@ -28,13 +29,14 @@ from file_organizer.models.base import (
     TokenExhaustionError,
 )
 
-Llama: Any
+Llama: Any = None
 try:
-    from llama_cpp import Llama
+    _llama_cpp: Any = importlib.import_module("llama_cpp")
+    Llama = _llama_cpp.Llama
 
     LLAMA_CPP_AVAILABLE = True
 except ImportError:
-    Llama = None
+    _llama_cpp = None
     LLAMA_CPP_AVAILABLE = False
 
 
@@ -97,6 +99,8 @@ class LlamaCppTextModel(BaseModel):
             raise RuntimeError("model_path is required before initializing LlamaCppTextModel")
 
         n_gpu_layers = self._device_to_gpu_layers()
+        if Llama is None:  # guarded by LLAMA_CPP_AVAILABLE in __init__
+            raise RuntimeError("llama_cpp.Llama is required before initializing LlamaCppTextModel")
         try:
             self.client = Llama(
                 model_path=model_path,

--- a/src/file_organizer/models/llama_cpp_text_model.py
+++ b/src/file_organizer/models/llama_cpp_text_model.py
@@ -28,6 +28,7 @@ from file_organizer.models.base import (
     TokenExhaustionError,
 )
 
+Llama: Any
 try:
     from llama_cpp import Llama
 
@@ -91,10 +92,14 @@ class LlamaCppTextModel(BaseModel):
             logger.debug("LlamaCpp text model {} already initialized", self.config.name)
             return
 
+        model_path = self.config.model_path
+        if model_path is None:
+            raise RuntimeError("model_path is required before initializing LlamaCppTextModel")
+
         n_gpu_layers = self._device_to_gpu_layers()
         try:
             self.client = Llama(
-                model_path=self.config.model_path,
+                model_path=model_path,
                 n_ctx=self.config.context_window,
                 n_gpu_layers=n_gpu_layers,
                 verbose=False,

--- a/src/file_organizer/models/mlx_text_model.py
+++ b/src/file_organizer/models/mlx_text_model.py
@@ -23,10 +23,10 @@ mlx_generate: Any = None
 mlx_load: Any = None
 try:
     _mlx_lm: Any = importlib.import_module("mlx_lm")
-    mlx_generate = _mlx_lm.generate
-    mlx_load = _mlx_lm.load
+    mlx_generate = getattr(_mlx_lm, "generate", None)
+    mlx_load = getattr(_mlx_lm, "load", None)
 
-    MLX_LM_AVAILABLE = True
+    MLX_LM_AVAILABLE = mlx_generate is not None and mlx_load is not None
 except ImportError:
     _mlx_lm = None
     MLX_LM_AVAILABLE = False

--- a/src/file_organizer/models/mlx_text_model.py
+++ b/src/file_organizer/models/mlx_text_model.py
@@ -18,6 +18,8 @@ from loguru import logger
 
 from file_organizer.models.base import BaseModel, ModelConfig, ModelType
 
+mlx_generate: Any
+mlx_load: Any
 try:
     from mlx_lm import generate as mlx_generate
     from mlx_lm import load as mlx_load
@@ -87,8 +89,11 @@ class MLXTextModel(BaseModel):
 
             if mlx_load is None:  # guarded by MLX_LM_AVAILABLE in __init__; belt-and-suspenders
                 raise RuntimeError("mlx_load is None — mlx-lm is required; should not be reachable")
+            model_path = self.config.model_path
+            if model_path is None:
+                raise RuntimeError("model_path is required before initializing MLXTextModel")
             try:
-                loaded = mlx_load(self.config.model_path)
+                loaded = mlx_load(model_path)
             except (RuntimeError, OSError, ValueError, ImportError) as exc:
                 raise RuntimeError(
                     f"Could not load MLX model from '{self.config.model_path}': {exc}"

--- a/src/file_organizer/models/mlx_text_model.py
+++ b/src/file_organizer/models/mlx_text_model.py
@@ -11,6 +11,7 @@ Install the optional dependency::
 
 from __future__ import annotations
 
+import importlib
 import threading
 from typing import Any
 
@@ -18,16 +19,16 @@ from loguru import logger
 
 from file_organizer.models.base import BaseModel, ModelConfig, ModelType
 
-mlx_generate: Any
-mlx_load: Any
+mlx_generate: Any = None
+mlx_load: Any = None
 try:
-    from mlx_lm import generate as mlx_generate
-    from mlx_lm import load as mlx_load
+    _mlx_lm: Any = importlib.import_module("mlx_lm")
+    mlx_generate = _mlx_lm.generate
+    mlx_load = _mlx_lm.load
 
     MLX_LM_AVAILABLE = True
 except ImportError:
-    mlx_generate = None
-    mlx_load = None
+    _mlx_lm = None
     MLX_LM_AVAILABLE = False
 
 
@@ -88,7 +89,7 @@ class MLXTextModel(BaseModel):
                 return
 
             if mlx_load is None:  # guarded by MLX_LM_AVAILABLE in __init__; belt-and-suspenders
-                raise RuntimeError("mlx_load is None — mlx-lm is required; should not be reachable")
+                raise RuntimeError("mlx_lm.load is required before initializing MLXTextModel")
             model_path = self.config.model_path
             if model_path is None:
                 raise RuntimeError("model_path is required before initializing MLXTextModel")
@@ -136,7 +137,7 @@ class MLXTextModel(BaseModel):
         top_k = int(kwargs.get("top_k", self.config.top_k))
 
         if mlx_generate is None:  # guarded by MLX_LM_AVAILABLE in __init__; belt-and-suspenders
-            raise RuntimeError("mlx_generate is None — mlx-lm is required; should not be reachable")
+            raise RuntimeError("mlx_lm.generate is required before generating with MLXTextModel")
         try:
             response = self._call_generate(
                 prompt=prompt,
@@ -169,7 +170,7 @@ class MLXTextModel(BaseModel):
         skip the probe loop entirely.
         """
         if mlx_generate is None:  # guarded by MLX_LM_AVAILABLE in __init__; belt-and-suspenders
-            raise RuntimeError("mlx_generate is None — mlx-lm is required; should not be reachable")
+            raise RuntimeError("mlx_lm.generate is required before generating with MLXTextModel")
         call_variants: tuple[dict[str, Any], ...] = (
             {"max_tokens": max_tokens, "temp": temperature, "top_p": top_p, "top_k": top_k},
             {"max_tokens": max_tokens, "temperature": temperature, "top_p": top_p, "top_k": top_k},

--- a/src/file_organizer/web/_helpers.py
+++ b/src/file_organizer/web/_helpers.py
@@ -55,6 +55,7 @@ TEXT_SAMPLE_BYTES = 8192
 TEXT_PREVIEW_CHARS = 4000
 INVALID_FILENAME_CHARS = set('<>:"/\\|?*')
 SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._()-]*$")
+SAFE_HIDDEN_FILENAME_RE = re.compile(r"^\.[A-Za-z0-9][A-Za-z0-9 ._()-]*$")
 ALLOWED_VIEWS = {"grid", "list"}
 ALLOWED_SORT_BY = {"name", "size", "created", "modified", "type"}
 ALLOWED_SORT_ORDER = {"asc", "desc"}
@@ -230,18 +231,19 @@ def is_probably_text(path: Path) -> bool:
     return True
 
 
-def sanitize_upload_name(name: str) -> str | None:
+def sanitize_upload_name(name: str, *, allow_hidden: bool = False) -> str | None:
     """Sanitize an upload filename, returning None when unsafe."""
     safe_name = Path(name).name.strip()
     if not safe_name or safe_name in {".", ".."}:
         return None
-    if safe_name.startswith("."):
+    if safe_name.startswith(".") and not allow_hidden:
         return None
     if len(safe_name) > 255:
         return None
     if any(char in INVALID_FILENAME_CHARS for char in safe_name):
         return None
-    if not SAFE_FILENAME_RE.match(safe_name):
+    safe_pattern = SAFE_HIDDEN_FILENAME_RE if safe_name.startswith(".") else SAFE_FILENAME_RE
+    if not safe_pattern.match(safe_name):
         return None
     return safe_name
 

--- a/src/file_organizer/web/file_listing.py
+++ b/src/file_organizer/web/file_listing.py
@@ -1,0 +1,208 @@
+"""Directory listing helpers for the web file browser."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from file_organizer.api.utils import file_info_from_path, is_hidden
+from file_organizer.utils.file_times import creation_timestamp
+from file_organizer.web._helpers import (
+    detect_kind,
+    format_bytes,
+    format_timestamp,
+    has_children,
+    parse_file_type_filter,
+    path_id,
+)
+
+
+def normalized_extension(path: Path) -> str:
+    """Return a normalized extension, preserving supported compound archives."""
+    suffixes = [suffix.lower() for suffix in path.suffixes]
+    if len(suffixes) >= 2:
+        compound = "".join(suffixes[-2:])
+        if compound in {".tar.gz", ".tar.bz2"}:
+            return compound
+    return suffixes[-1] if suffixes else ""
+
+
+def list_tree_nodes(path: Path, include_hidden: bool) -> list[dict[str, Any]]:
+    """List immediate child directories of *path* as sidebar tree nodes."""
+    nodes: list[dict[str, Any]] = []
+    try:
+        entries = sorted(
+            [p for p in path.iterdir() if p.is_dir()],
+            key=lambda p: p.name.lower(),
+        )
+    except OSError:
+        return nodes
+    for entry in entries:
+        if not include_hidden and is_hidden(entry):
+            continue
+        nodes.append(
+            {
+                "id": path_id(entry),
+                "name": entry.name,
+                "path": str(entry),
+                "path_param": quote(str(entry)),
+                "has_children": has_children(entry),
+            }
+        )
+    return nodes
+
+
+def collect_entries(
+    path: Path,
+    *,
+    query: str | None,
+    file_type: str | None,
+    sort_by: str,
+    sort_order: str,
+    include_hidden: bool,
+    limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Collect, filter, and sort directory entries for the file browser."""
+    try:
+        children = list(path.iterdir())
+    except OSError:
+        return [], 0
+
+    query_token = query.lower() if query else None
+    allowed_types = parse_file_type_filter(file_type)
+
+    directories, files = _filter_children(
+        children,
+        query_token=query_token,
+        include_hidden=include_hidden,
+        allowed_types=allowed_types,
+    )
+    directories.sort(key=lambda p: p.name.lower())
+
+    file_stats: dict[Path, os.stat_result | None] = {}
+    if sort_by in {"size", "created", "modified"}:
+        for entry in files:
+            try:
+                file_stats[entry] = entry.stat()
+            except OSError:
+                file_stats[entry] = None
+
+    _sort_files(files, sort_by, sort_order, file_stats)
+
+    total = len(directories) + len(files)
+    if limit <= 0:
+        return [], total
+
+    dir_limit = min(limit, len(directories))
+    remaining = max(limit - dir_limit, 0)
+
+    entries: list[dict[str, Any]] = [_dir_entry(d) for d in directories[:dir_limit]]
+    entries.extend(_file_entry(f) for f in files[:remaining])
+
+    return entries, total
+
+
+def _filter_children(
+    children: list[Path],
+    *,
+    query_token: str | None,
+    include_hidden: bool,
+    allowed_types: set[str] | None,
+) -> tuple[list[Path], list[Path]]:
+    """Split and filter children into directories and files."""
+    directories = [p for p in children if p.is_dir()]
+    files = [p for p in children if p.is_file()]
+
+    if not include_hidden:
+        directories = [p for p in directories if not is_hidden(p)]
+        files = [p for p in files if not is_hidden(p)]
+
+    if query_token:
+        directories = [p for p in directories if query_token in p.name.lower()]
+        files = [p for p in files if query_token in p.name.lower()]
+
+    if allowed_types is not None:
+        files = [p for p in files if normalized_extension(p) in allowed_types]
+
+    return directories, files
+
+
+def _sort_files(
+    files: list[Path],
+    sort_by: str,
+    sort_order: str,
+    file_stats: dict[Path, os.stat_result | None],
+) -> None:
+    """Sort files in-place according to the requested column and order."""
+    reverse = sort_order == "desc"
+
+    if sort_by == "name":
+        files.sort(key=lambda p: p.name.lower(), reverse=reverse)
+    elif sort_by == "size":
+        files.sort(key=lambda p: _file_size_sort_key(file_stats.get(p)), reverse=reverse)
+    elif sort_by == "created":
+        files.sort(key=lambda p: _creation_sort_key(file_stats.get(p)), reverse=reverse)
+    elif sort_by == "type":
+        files.sort(key=lambda p: normalized_extension(p), reverse=reverse)
+    else:
+        files.sort(key=lambda p: _modified_sort_key(file_stats.get(p)), reverse=reverse)
+
+
+def _file_size_sort_key(stat: os.stat_result | None) -> int:
+    """Return file size for sorting, defaulting missing stats to 0."""
+    return stat.st_size if stat is not None else 0
+
+
+def _modified_sort_key(stat: os.stat_result | None) -> float:
+    """Return modified timestamp for sorting, defaulting missing stats to 0."""
+    return stat.st_mtime if stat is not None else 0.0
+
+
+def _creation_sort_key(s: os.stat_result | None) -> float:
+    """Return a file creation timestamp for sorting, with platform fallbacks."""
+    if s is None:
+        return 0.0
+    return creation_timestamp(s)
+
+
+def _dir_entry(entry: Path) -> dict[str, Any]:
+    """Build a directory entry dict for the file browser."""
+    try:
+        stat = entry.stat()
+        modified = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+    except OSError:
+        modified = datetime.now(UTC)
+    return {
+        "name": entry.name,
+        "path": str(entry),
+        "path_param": quote(str(entry)),
+        "is_dir": True,
+        "kind": "folder",
+        "size_display": "-",
+        "modified_display": format_timestamp(modified),
+        "thumbnail_url": None,
+        "meta": "Folder",
+    }
+
+
+def _file_entry(entry: Path) -> dict[str, Any]:
+    """Build a file entry dict for the file browser."""
+    info = file_info_from_path(entry)
+    kind = detect_kind(entry)
+    thumbnail_url = None
+    if kind in {"image", "pdf", "video"}:
+        thumbnail_url = f"/ui/files/thumbnail?path={quote(info.path)}&kind={kind}"
+    return {
+        "name": info.name,
+        "path": info.path,
+        "path_param": quote(info.path),
+        "is_dir": False,
+        "kind": kind,
+        "size_display": format_bytes(info.size),
+        "modified_display": format_timestamp(info.modified),
+        "thumbnail_url": thumbnail_url,
+        "meta": f"{info.file_type or 'file'}",
+    }

--- a/src/file_organizer/web/file_listing.py
+++ b/src/file_organizer/web/file_listing.py
@@ -80,7 +80,7 @@ def collect_entries(
         include_hidden=include_hidden,
         allowed_types=allowed_types,
     )
-    directories.sort(key=lambda p: p.name.lower())
+    directories.sort(key=lambda p: p.name.lower(), reverse=sort_order == "desc")
 
     file_stats: dict[Path, os.stat_result | None] = {}
     if sort_by in {"size", "created", "modified"}:

--- a/src/file_organizer/web/file_operations.py
+++ b/src/file_organizer/web/file_operations.py
@@ -7,25 +7,20 @@ from route handling.
 
 from __future__ import annotations
 
-import os
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote
 
-from fastapi import Request, UploadFile
+from fastapi import Request
 from PIL import Image, UnidentifiedImageError
 
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
-from file_organizer.api.utils import file_info_from_path, is_hidden, resolve_path
-from file_organizer.utils.file_times import creation_timestamp
+from file_organizer.api.utils import file_info_from_path, resolve_path
 from file_organizer.web._helpers import (
     MAX_THUMBNAIL_BYTES,
-    MAX_UPLOAD_BYTES,
     TEXT_PREVIEW_CHARS,
     THUMBNAIL_SIZE,
-    UPLOAD_CHUNK_SIZE,
     allowed_roots,
     clamp_limit,
     detect_kind,
@@ -33,25 +28,53 @@ from file_organizer.web._helpers import (
     format_timestamp,
     has_children,
     is_probably_text,
-    parse_file_type_filter,
     path_id,
     render_image_thumbnail,
     render_placeholder_thumbnail,
     resolve_selected_path,
-    sanitize_upload_name,
     select_root_for_path,
     validate_depth,
 )
+from file_organizer.web.file_listing import (
+    _creation_sort_key,
+    _dir_entry,
+    _file_entry,
+    _filter_children,
+    _sort_files,
+    collect_entries,
+    list_tree_nodes,
+)
+from file_organizer.web.file_listing import (
+    normalized_extension as _normalized_extension,
+)
+from file_organizer.web.file_uploads import (
+    process_file_uploads,
+)
+from file_organizer.web.file_uploads import (
+    save_upload as _save_upload,
+)
+from file_organizer.web.file_uploads import (
+    write_upload_chunks as _write_upload_chunks,
+)
 
-
-def _normalized_extension(path: Path) -> str:
-    """Return a normalized extension, preserving supported compound archives."""
-    suffixes = [suffix.lower() for suffix in path.suffixes]
-    if len(suffixes) >= 2:
-        compound = "".join(suffixes[-2:])
-        if compound in {".tar.gz", ".tar.bz2"}:
-            return compound
-    return suffixes[-1] if suffixes else ""
+__all__ = [
+    "_creation_sort_key",
+    "_dir_entry",
+    "_file_entry",
+    "_filter_children",
+    "_normalized_extension",
+    "_save_upload",
+    "_sort_files",
+    "_write_upload_chunks",
+    "build_breadcrumbs",
+    "build_file_results_context",
+    "build_preview_context",
+    "build_tree_context",
+    "collect_entries",
+    "generate_thumbnail",
+    "list_tree_nodes",
+    "process_file_uploads",
+]
 
 
 def build_breadcrumbs(path: Path, roots: list[Path]) -> list[dict[str, str]]:
@@ -89,205 +112,6 @@ def build_breadcrumbs(path: Path, roots: list[Path]) -> list[dict[str, str]]:
             }
         )
     return crumbs
-
-
-def list_tree_nodes(path: Path, include_hidden: bool) -> list[dict[str, Any]]:
-    """List immediate child directories of *path* as sidebar tree nodes.
-
-    Args:
-        path: Directory to list children of.
-        include_hidden: Whether to include hidden directories.
-
-    Returns:
-        List of node dicts suitable for the sidebar tree template.
-    """
-    nodes: list[dict[str, Any]] = []
-    try:
-        entries = sorted(
-            [p for p in path.iterdir() if p.is_dir()],
-            key=lambda p: p.name.lower(),
-        )
-    except OSError:
-        return nodes
-    for entry in entries:
-        if not include_hidden and is_hidden(entry):
-            continue
-        nodes.append(
-            {
-                "id": path_id(entry),
-                "name": entry.name,
-                "path": str(entry),
-                "path_param": quote(str(entry)),
-                "has_children": has_children(entry),
-            }
-        )
-    return nodes
-
-
-def _filter_children(
-    children: list[Path],
-    *,
-    query_token: str | None,
-    include_hidden: bool,
-    allowed_types: set[str] | None,
-) -> tuple[list[Path], list[Path]]:
-    """Split and filter children into directories and files."""
-    directories = [p for p in children if p.is_dir()]
-    files = [p for p in children if p.is_file()]
-
-    if not include_hidden:
-        directories = [p for p in directories if not is_hidden(p)]
-        files = [p for p in files if not is_hidden(p)]
-
-    if query_token:
-        directories = [p for p in directories if query_token in p.name.lower()]
-        files = [p for p in files if query_token in p.name.lower()]
-
-    if allowed_types is not None:
-        files = [p for p in files if _normalized_extension(p) in allowed_types]
-
-    return directories, files
-
-
-def _sort_files(
-    files: list[Path],
-    sort_by: str,
-    sort_order: str,
-    file_stats: dict[Path, os.stat_result | None],
-) -> None:
-    """Sort files in-place according to the requested column and order."""
-    reverse = sort_order == "desc"
-
-    if sort_by == "name":
-        files.sort(key=lambda p: p.name.lower(), reverse=reverse)
-    elif sort_by == "size":
-        files.sort(key=lambda p: _file_size_sort_key(file_stats.get(p)), reverse=reverse)
-    elif sort_by == "created":
-        files.sort(key=lambda p: _creation_sort_key(file_stats.get(p)), reverse=reverse)
-    elif sort_by == "type":
-        files.sort(key=lambda p: _normalized_extension(p), reverse=reverse)
-    else:
-        files.sort(key=lambda p: _modified_sort_key(file_stats.get(p)), reverse=reverse)
-
-
-def _file_size_sort_key(stat: os.stat_result | None) -> int:
-    """Return file size for sorting, defaulting missing stats to 0."""
-    return stat.st_size if stat is not None else 0
-
-
-def _modified_sort_key(stat: os.stat_result | None) -> float:
-    """Return modified timestamp for sorting, defaulting missing stats to 0."""
-    return stat.st_mtime if stat is not None else 0.0
-
-
-def _creation_sort_key(s: os.stat_result | None) -> float:
-    """Return a file creation timestamp for sorting, with platform fallbacks."""
-    if s is None:
-        return 0.0
-    return creation_timestamp(s)
-
-
-def _dir_entry(entry: Path) -> dict[str, Any]:
-    """Build a directory entry dict for the file browser."""
-    try:
-        stat = entry.stat()
-        modified = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
-    except OSError:
-        modified = datetime.now(UTC)
-    return {
-        "name": entry.name,
-        "path": str(entry),
-        "path_param": quote(str(entry)),
-        "is_dir": True,
-        "kind": "folder",
-        "size_display": "-",
-        "modified_display": format_timestamp(modified),
-        "thumbnail_url": None,
-        "meta": "Folder",
-    }
-
-
-def _file_entry(entry: Path) -> dict[str, Any]:
-    """Build a file entry dict for the file browser."""
-    info = file_info_from_path(entry)
-    kind = detect_kind(entry)
-    thumbnail_url = None
-    if kind in {"image", "pdf", "video"}:
-        thumbnail_url = f"/ui/files/thumbnail?path={quote(info.path)}&kind={kind}"
-    return {
-        "name": info.name,
-        "path": info.path,
-        "path_param": quote(info.path),
-        "is_dir": False,
-        "kind": kind,
-        "size_display": format_bytes(info.size),
-        "modified_display": format_timestamp(info.modified),
-        "thumbnail_url": thumbnail_url,
-        "meta": f"{info.file_type or 'file'}",
-    }
-
-
-def collect_entries(
-    path: Path,
-    *,
-    query: str | None,
-    file_type: str | None,
-    sort_by: str,
-    sort_order: str,
-    include_hidden: bool,
-    limit: int,
-) -> tuple[list[dict[str, Any]], int]:
-    """Collect, filter, and sort directory entries for the file browser.
-
-    Args:
-        path: Directory to scan.
-        query: Optional name substring filter.
-        file_type: Optional file-type filter (e.g. ``"image"``).
-        sort_by: Column to sort by (``name``, ``size``, ``created``, etc.).
-        sort_order: ``"asc"`` or ``"desc"``.
-        include_hidden: Whether to include hidden entries.
-        limit: Maximum number of entries to return.
-
-    Returns:
-        Tuple of ``(entries, total)`` where *entries* is the page slice.
-    """
-    try:
-        children = list(path.iterdir())
-    except OSError:
-        return [], 0
-
-    query_token = query.lower() if query else None
-    allowed_types = parse_file_type_filter(file_type)
-
-    directories, files = _filter_children(
-        children,
-        query_token=query_token,
-        include_hidden=include_hidden,
-        allowed_types=allowed_types,
-    )
-    directories.sort(key=lambda p: p.name.lower())
-
-    file_stats: dict[Path, os.stat_result | None] = {}
-    if sort_by in {"size", "created", "modified"}:
-        for entry in files:
-            try:
-                file_stats[entry] = entry.stat()
-            except OSError:
-                file_stats[entry] = None
-
-    _sort_files(files, sort_by, sort_order, file_stats)
-
-    total = len(directories) + len(files)
-    if limit <= 0:
-        return [], total
-
-    dir_limit = min(limit, len(directories))
-    remaining = max(limit - dir_limit, 0)
-
-    entries: list[dict[str, Any]] = [_dir_entry(d) for d in directories[:dir_limit]]
-    entries.extend(_file_entry(f) for f in files[:remaining])
-
-    return entries, total
 
 
 def build_file_results_context(
@@ -530,107 +354,3 @@ def build_preview_context(path: str, settings: ApiSettings) -> dict[str, Any]:
         "modified_display": modified_display,
         "error_message": error_message,
     }
-
-
-def _save_upload(upload: UploadFile, target_dir: Path, allow_hidden: bool) -> str | None:
-    """Validate and save a single upload file.
-
-    Args:
-        upload: The uploaded file.
-        target_dir: Destination directory.
-        allow_hidden: Whether hidden files are allowed.
-
-    Returns:
-        An error message string if the upload failed, empty string if skipped
-        (no filename), or ``None`` on success.
-    """
-    from file_organizer.web.file_validators import (
-        validate_file_not_exists,
-        validate_upload_filename,
-    )
-
-    if not upload.filename:
-        return ""  # skipped — no filename, not an error but not saved
-
-    try:
-        validate_upload_filename(upload.filename, allow_hidden=allow_hidden)
-    except ApiError as exc:
-        return exc.message
-
-    filename = upload.filename
-    assert filename is not None
-    safe_name = sanitize_upload_name(filename)
-    if safe_name is None:
-        return f"Rejected {filename}: invalid filename."
-
-    destination = target_dir / safe_name
-    try:
-        validate_file_not_exists(destination, safe_name)
-    except ApiError as exc:
-        return exc.message
-
-    try:
-        _write_upload_chunks(upload, destination, safe_name)
-    except ApiError as exc:
-        destination.unlink(missing_ok=True)
-        return exc.message
-    except OSError:
-        destination.unlink(missing_ok=True)
-        return f"Failed to save {safe_name}."
-
-    return None
-
-
-def _write_upload_chunks(upload: UploadFile, destination: Path, safe_name: str) -> None:
-    """Stream upload chunks to disk, enforcing size limit."""
-    from file_organizer.web.file_validators import validate_file_size
-
-    total_bytes = 0
-    with destination.open("wb") as handle:  # noqa: safedir-required, atomic-write  # web file op — destination path validated by the web-layer access control
-        while True:
-            chunk = upload.file.read(UPLOAD_CHUNK_SIZE)
-            if not chunk:
-                break
-            total_bytes += len(chunk)
-            try:
-                validate_file_size(total_bytes, MAX_UPLOAD_BYTES)
-            except ApiError:
-                raise ApiError(
-                    status_code=400,
-                    error="file_too_large",
-                    message=f"{safe_name} exceeds upload size limit.",
-                ) from None
-            handle.write(chunk)
-
-
-def process_file_uploads(
-    files: list[UploadFile],
-    target_dir: Path,
-    allow_hidden: bool = False,
-) -> tuple[int, list[str]]:
-    """Process multiple file uploads to a target directory.
-
-    Args:
-        files: List of uploaded files to process.
-        target_dir: Directory to save files to.
-        allow_hidden: Whether to allow hidden files.
-
-    Returns:
-        Tuple of (saved_count, error_messages).
-    """
-    saved = 0
-    errors: list[str] = []
-
-    for upload in files:
-        try:
-            error = _save_upload(upload, target_dir, allow_hidden)
-        finally:
-            if upload.file:
-                upload.file.close()
-
-        if error is None:
-            saved += 1
-        elif upload.filename:
-            errors.append(error)
-
-    return saved, errors

--- a/src/file_organizer/web/file_uploads.py
+++ b/src/file_organizer/web/file_uploads.py
@@ -1,0 +1,105 @@
+"""Upload persistence helpers for web file operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import UploadFile
+
+from file_organizer.api.exceptions import ApiError
+from file_organizer.utils.atomic_write import atomic_write_with
+from file_organizer.web._helpers import (
+    MAX_UPLOAD_BYTES,
+    UPLOAD_CHUNK_SIZE,
+    sanitize_upload_name,
+)
+from file_organizer.web.file_validators import (
+    validate_file_not_exists,
+    validate_file_size,
+    validate_upload_filename,
+)
+
+
+def process_file_uploads(
+    files: list[UploadFile],
+    target_dir: Path,
+    allow_hidden: bool = False,
+) -> tuple[int, list[str]]:
+    """Process multiple file uploads to a target directory."""
+    saved = 0
+    errors: list[str] = []
+
+    for upload in files:
+        try:
+            error = save_upload(upload, target_dir, allow_hidden)
+        finally:
+            if upload.file:
+                upload.file.close()
+
+        if error is None:
+            saved += 1
+        elif upload.filename:
+            errors.append(error)
+
+    return saved, errors
+
+
+def save_upload(upload: UploadFile, target_dir: Path, allow_hidden: bool) -> str | None:
+    """Validate and save a single upload file.
+
+    Returns an error message string if the upload failed, an empty string if it
+    was skipped because no filename was provided, or ``None`` on success.
+    """
+    if not upload.filename:
+        return ""
+
+    try:
+        validate_upload_filename(upload.filename, allow_hidden=allow_hidden)
+    except ApiError as exc:
+        return exc.message
+
+    filename = upload.filename
+    assert filename is not None
+    safe_name = sanitize_upload_name(filename)
+    if safe_name is None:
+        return f"Rejected {filename}: invalid filename."
+
+    destination = target_dir / safe_name
+    try:
+        validate_file_not_exists(destination, safe_name)
+    except ApiError as exc:
+        return exc.message
+
+    try:
+        write_upload_chunks(upload, destination, safe_name)
+    except ApiError as exc:
+        return exc.message
+    except OSError:
+        return f"Failed to save {safe_name}."
+
+    return None
+
+
+def write_upload_chunks(upload: UploadFile, destination: Path, safe_name: str) -> None:
+    """Stream upload chunks to disk, enforcing size limit."""
+    total_bytes = 0
+
+    def _writer(handle: Any) -> None:
+        nonlocal total_bytes
+        while True:
+            chunk = upload.file.read(UPLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            total_bytes += len(chunk)
+            try:
+                validate_file_size(total_bytes, MAX_UPLOAD_BYTES)
+            except ApiError:
+                raise ApiError(
+                    status_code=400,
+                    error="file_too_large",
+                    message=f"{safe_name} exceeds upload size limit.",
+                ) from None
+            handle.write(chunk)
+
+    atomic_write_with(destination, _writer, mode="wb")

--- a/src/file_organizer/web/file_uploads.py
+++ b/src/file_organizer/web/file_uploads.py
@@ -61,7 +61,7 @@ def save_upload(upload: UploadFile, target_dir: Path, allow_hidden: bool) -> str
 
     filename = upload.filename
     assert filename is not None
-    safe_name = sanitize_upload_name(filename)
+    safe_name = sanitize_upload_name(filename, allow_hidden=allow_hidden)
     if safe_name is None:
         return f"Rejected {filename}: invalid filename."
 
@@ -86,6 +86,7 @@ def write_upload_chunks(upload: UploadFile, destination: Path, safe_name: str) -
     total_bytes = 0
 
     def _writer(handle: Any) -> None:
+        """Copy upload chunks into the atomic write handle."""
         nonlocal total_bytes
         while True:
             chunk = upload.file.read(UPLOAD_CHUNK_SIZE)

--- a/src/file_organizer/web/organize_routes.py
+++ b/src/file_organizer/web/organize_routes.py
@@ -7,11 +7,9 @@ import csv
 import io
 import json
 from datetime import UTC, datetime
-from pathlib import Path
 from threading import Lock, Timer
 from time import monotonic
 from typing import Any
-from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
@@ -21,12 +19,12 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_settings
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.jobs import create_job, get_job, list_jobs, update_job
-from file_organizer.api.models import OrganizationError, OrganizationResultResponse, OrganizeRequest
-from file_organizer.api.utils import is_hidden, resolve_path
+from file_organizer.api.models import OrganizeRequest
+from file_organizer.api.utils import resolve_path
 from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.config.methodology import LABELS as ORGANIZE_METHODOLOGIES
 from file_organizer.config.methodology import normalize as _normalize_methodology
-from file_organizer.core.organizer import FileOrganizer, OrganizationResult
+from file_organizer.core.organizer import FileOrganizer
 from file_organizer.web._helpers import (
     allowed_roots,
     as_bool,
@@ -34,201 +32,68 @@ from file_organizer.web._helpers import (
     format_timestamp,
     templates,
 )
+from file_organizer.web.organize_services import (
+    _ORGANIZE_PLAN_STORE,
+    ORGANIZE_DEFAULT_DELAY_MIN,
+    ORGANIZE_MAX_DELAY_MIN,
+    ORGANIZE_PLAN_LIMIT,
+    _build_plan_movements,
+    _counts_by_type,
+    _delete_organize_plan,
+    _get_organize_plan,
+    _job_report_payload,
+    _parse_delay_minutes,
+    _result_to_response,
+    _scan_directory,
+    _store_organize_plan,
+    build_organize_plan,
+)
 
 organize_router = APIRouter(tags=["web"])
 
-ORGANIZE_DEFAULT_DELAY_MIN = 0
-ORGANIZE_MAX_DELAY_MIN = 7 * 24 * 60
+__all__ = [
+    "ORGANIZE_DEFAULT_DELAY_MIN",
+    "ORGANIZE_EVENT_POLL_SECONDS",
+    "ORGANIZE_HISTORY_LIMIT",
+    "ORGANIZE_JOB_TYPE",
+    "ORGANIZE_MAX_DELAY_MIN",
+    "ORGANIZE_METHODOLOGIES",
+    "ORGANIZE_PLAN_LIMIT",
+    "_ORGANIZE_PLAN_STORE",
+    "_build_job_view",
+    "_build_organize_stats",
+    "_build_plan_movements",
+    "_cancel_scheduled_job",
+    "_counts_by_type",
+    "_delete_organize_plan",
+    "_get_job_metadata",
+    "_get_organize_plan",
+    "_job_report_payload",
+    "_list_organize_jobs",
+    "_normalize_methodology",
+    "_parse_delay_minutes",
+    "_prune_job_metadata",
+    "_result_to_response",
+    "_run_organize_job",
+    "_scan_directory",
+    "_schedule_job",
+    "_set_job_metadata",
+    "_status_progress",
+    "_store_organize_plan",
+    "organize_router",
+]
+
 ORGANIZE_EVENT_POLL_SECONDS = 1
 ORGANIZE_HISTORY_LIMIT = 50
-ORGANIZE_PLAN_LIMIT = 200
 ORGANIZE_JOB_TYPE = "organize_web"
 JOB_METADATA_PRUNE_THRESHOLD = 256
 JOB_METADATA_PRUNE_INTERVAL_SECONDS = 60.0
 
-_ORGANIZE_PLAN_STORE: dict[str, dict[str, Any]] = {}
-_ORGANIZE_PLAN_LOCK = Lock()
 _SCHEDULED_TIMERS: dict[str, Timer] = {}
 _SCHEDULED_TIMERS_LOCK = Lock()
 _JOB_METADATA: dict[str, dict[str, Any]] = {}
 _JOB_METADATA_LOCK = Lock()
 _LAST_JOB_METADATA_PRUNE_MONOTONIC = 0.0
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _parse_delay_minutes(value: str | None) -> int:
-    """Parse and validate a schedule delay value in minutes.
-
-    Args:
-        value: Raw string from the form field.
-
-    Returns:
-        Validated delay in minutes.
-
-    Raises:
-        ApiError: If the value is not a valid non-negative integer within bounds.
-    """
-    if value is None or value.strip() == "":
-        return ORGANIZE_DEFAULT_DELAY_MIN
-    try:
-        minutes = int(value)
-    except ValueError as exc:
-        raise ApiError(
-            status_code=400,
-            error="invalid_schedule_delay",
-            message="Schedule delay must be a whole number of minutes.",
-        ) from exc
-    if minutes < 0 or minutes > ORGANIZE_MAX_DELAY_MIN:
-        raise ApiError(
-            status_code=400,
-            error="invalid_schedule_delay",
-            message=f"Schedule delay must be between 0 and {ORGANIZE_MAX_DELAY_MIN} minutes.",
-        )
-    return minutes
-
-
-def _scan_directory(path: Path, recursive: bool, include_hidden: bool) -> list[Path]:
-    """Collect files from *path*, optionally recursing and including hidden items.
-
-    Returns:
-        List of file ``Path`` objects found under *path*.
-    """
-    files: list[Path] = []
-    if path.is_file():
-        if include_hidden or not is_hidden(path):
-            files.append(path)
-        return files
-
-    iterator = path.rglob("*") if recursive else path.glob("*")
-    for entry in iterator:
-        if not entry.is_file():
-            continue
-        if not include_hidden and is_hidden(entry):
-            continue
-        files.append(entry)
-    return files
-
-
-def _counts_by_type(files: list[Path]) -> dict[str, int]:
-    """Tally files by broad type category (text, image, video, etc.).
-
-    Returns:
-        Dict mapping category names to counts.
-    """
-    counts = {
-        "text": 0,
-        "image": 0,
-        "video": 0,
-        "audio": 0,
-        "cad": 0,
-        "other": 0,
-    }
-    for path in files:
-        suffix = path.suffix.lower()
-        if suffix in FileOrganizer.TEXT_EXTENSIONS:
-            counts["text"] += 1
-        elif suffix in FileOrganizer.IMAGE_EXTENSIONS:
-            counts["image"] += 1
-        elif suffix in FileOrganizer.VIDEO_EXTENSIONS:
-            counts["video"] += 1
-        elif suffix in FileOrganizer.AUDIO_EXTENSIONS:
-            counts["audio"] += 1
-        elif suffix in FileOrganizer.CAD_EXTENSIONS:
-            counts["cad"] += 1
-        else:
-            counts["other"] += 1
-    return counts
-
-
-def _result_to_response(result: OrganizationResult) -> OrganizationResultResponse:
-    """Convert an ``OrganizationResult`` to the API response model."""
-    return OrganizationResultResponse(
-        total_files=result.total_files,
-        processed_files=result.processed_files,
-        skipped_files=result.skipped_files,
-        failed_files=result.failed_files,
-        processing_time=result.processing_time,
-        organized_structure=result.organized_structure,
-        errors=[
-            OrganizationError(file=file_name, error=error) for file_name, error in result.errors
-        ],
-    )
-
-
-def _build_plan_movements(
-    files: list[Path],
-    output_dir: Path,
-    preview: OrganizationResultResponse,
-) -> list[dict[str, str]]:
-    """Build a list of planned source-to-destination movements from a dry-run preview.
-
-    Returns:
-        List of dicts with *file_name*, *source*, *destination*, and *reason*.
-    """
-    source_lookup: dict[str, list[str]] = {}
-    for file_path in sorted(files, key=lambda item: item.as_posix().lower()):
-        source_lookup.setdefault(file_path.name, []).append(str(file_path))
-
-    movements: list[dict[str, str]] = []
-    for bucket, names in sorted(
-        preview.organized_structure.items(), key=lambda item: item[0].lower()
-    ):
-        for name in sorted(names, key=str.lower):
-            sources = source_lookup.get(name, [])
-            source_path = sources.pop(0) if sources else name
-            destination = output_dir / bucket / name
-            movements.append(
-                {
-                    "file_name": name,
-                    "source": source_path,
-                    "destination": str(destination),
-                    "reason": f"Categorized into {bucket}",
-                }
-            )
-    return movements
-
-
-def _prune_plan_store() -> None:
-    """Evict the oldest plans when the in-memory store exceeds its limit."""
-    while len(_ORGANIZE_PLAN_STORE) > ORGANIZE_PLAN_LIMIT:
-        oldest_plan_id = next(iter(_ORGANIZE_PLAN_STORE))
-        _ORGANIZE_PLAN_STORE.pop(oldest_plan_id, None)
-
-
-def _store_organize_plan(plan_data: dict[str, Any]) -> dict[str, Any]:
-    """Persist *plan_data* in the in-memory plan store and return the stored record."""
-    plan_id = uuid4().hex
-    created_at = datetime.now(UTC)
-    record = {
-        "plan_id": plan_id,
-        "created_at": created_at,
-        "updated_at": created_at,
-        **plan_data,
-    }
-    with _ORGANIZE_PLAN_LOCK:
-        _ORGANIZE_PLAN_STORE[plan_id] = record
-        _prune_plan_store()
-    return record
-
-
-def _get_organize_plan(plan_id: str) -> dict[str, Any] | None:
-    """Retrieve a stored plan by *plan_id*, or ``None`` if expired/missing."""
-    with _ORGANIZE_PLAN_LOCK:
-        plan = _ORGANIZE_PLAN_STORE.get(plan_id)
-        if plan is None:
-            return None
-        plan["updated_at"] = datetime.now(UTC)
-        return dict(plan)
-
-
-def _delete_organize_plan(plan_id: str) -> None:
-    """Remove a plan from the in-memory store."""
-    with _ORGANIZE_PLAN_LOCK:
-        _ORGANIZE_PLAN_STORE.pop(plan_id, None)
 
 
 def _prune_job_metadata(*, force: bool = False) -> None:
@@ -439,26 +304,6 @@ def _cancel_scheduled_job(job_id: str) -> bool:
     return True
 
 
-def _job_report_payload(job: dict[str, Any]) -> dict[str, Any]:
-    """Extract a serializable report payload from a job view dict."""
-    return {
-        "job_id": job["job_id"],
-        "status": job["status"],
-        "created_at": job["created_at"],
-        "updated_at": job["updated_at"],
-        "methodology": job["methodology"],
-        "input_dir": job["input_dir"],
-        "output_dir": job["output_dir"],
-        "dry_run": job["dry_run"],
-        "processed_files": job["processed_files"],
-        "total_files": job["total_files"],
-        "failed_files": job["failed_files"],
-        "skipped_files": job["skipped_files"],
-        "error": job["error"],
-        "result": job["result"],
-    }
-
-
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
@@ -517,64 +362,16 @@ def organize_scan(
     plan: dict[str, Any] | None = None
 
     try:
-        if not input_dir.strip():
-            raise ApiError(
-                status_code=400,
-                error="missing_input_dir",
-                message="Input directory is required.",
-            )
-        if not output_dir.strip():
-            raise ApiError(
-                status_code=400,
-                error="missing_output_dir",
-                message="Output directory is required.",
-            )
-
-        safe_input = resolve_path(input_dir, settings.allowed_paths)
-        safe_output = resolve_path(output_dir, settings.allowed_paths)
-        if not safe_input.exists():
-            raise ApiError(status_code=404, error="not_found", message="Input directory not found.")
-
-        normalized_methodology = _normalize_methodology(methodology)
-        recursive_enabled = as_bool(recursive)
-        include_hidden_enabled = as_bool(include_hidden)
-        if include_hidden_enabled:
-            raise ApiError(
-                status_code=400,
-                error="include_hidden_not_supported",
-                message="Including hidden files is not supported in this dashboard flow yet.",
-            )
-        skip_existing_enabled = as_bool(skip_existing)
-        use_hardlinks_enabled = as_bool(use_hardlinks)
-
-        scan_files = _scan_directory(
-            safe_input,
-            recursive=recursive_enabled,
-            include_hidden=include_hidden_enabled,
-        )
-        counts = _counts_by_type(scan_files)
-
-        organizer = FileOrganizer(dry_run=True, use_hardlinks=use_hardlinks_enabled)
-        preview_result = organizer.organize(
-            input_path=safe_input,
-            output_path=safe_output,
-            skip_existing=skip_existing_enabled,
-        )
-        preview = _result_to_response(preview_result)
-        plan = _store_organize_plan(
-            {
-                "input_dir": str(safe_input),
-                "output_dir": str(safe_output),
-                "methodology": normalized_methodology,
-                "recursive": recursive_enabled,
-                "include_hidden": include_hidden_enabled,
-                "skip_existing": skip_existing_enabled,
-                "use_hardlinks": use_hardlinks_enabled,
-                "scan_counts": counts,
-                "scan_total_files": len(scan_files),
-                "preview": preview.model_dump(),
-                "movements": _build_plan_movements(scan_files, safe_output, preview),
-            }
+        plan = build_organize_plan(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            methodology=methodology,
+            recursive=recursive,
+            include_hidden=include_hidden,
+            skip_existing=skip_existing,
+            use_hardlinks=use_hardlinks,
+            allowed_paths=settings.allowed_paths,
+            organizer_factory=FileOrganizer,
         )
         info_message = "Plan generated. Review movements and execute when ready."
     except ApiError as exc:

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -1,0 +1,267 @@
+"""Service helpers for the web organization dashboard."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Lock
+from typing import Any
+from uuid import uuid4
+
+from file_organizer.api.exceptions import ApiError
+from file_organizer.api.models import OrganizationError, OrganizationResultResponse
+from file_organizer.api.utils import is_hidden, resolve_path
+from file_organizer.config.methodology import normalize as _normalize_methodology
+from file_organizer.core.organizer import FileOrganizer, OrganizationResult
+from file_organizer.web._helpers import as_bool
+
+ORGANIZE_DEFAULT_DELAY_MIN = 0
+ORGANIZE_MAX_DELAY_MIN = 7 * 24 * 60
+ORGANIZE_PLAN_LIMIT = 200
+
+_ORGANIZE_PLAN_STORE: dict[str, dict[str, Any]] = {}
+_ORGANIZE_PLAN_LOCK = Lock()
+
+
+def _parse_delay_minutes(value: str | None) -> int:
+    """Parse and validate a schedule delay value in minutes."""
+    if value is None or value.strip() == "":
+        return ORGANIZE_DEFAULT_DELAY_MIN
+    try:
+        minutes = int(value)
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            error="invalid_schedule_delay",
+            message="Schedule delay must be a whole number of minutes.",
+        ) from exc
+    if minutes < 0 or minutes > ORGANIZE_MAX_DELAY_MIN:
+        raise ApiError(
+            status_code=400,
+            error="invalid_schedule_delay",
+            message=f"Schedule delay must be between 0 and {ORGANIZE_MAX_DELAY_MIN} minutes.",
+        )
+    return minutes
+
+
+def _scan_directory(path: Path, recursive: bool, include_hidden: bool) -> list[Path]:
+    """Collect files from *path*, optionally recursing and including hidden items."""
+    files: list[Path] = []
+    if path.is_file():
+        if include_hidden or not is_hidden(path):
+            files.append(path)
+        return files
+
+    iterator = path.rglob("*") if recursive else path.glob("*")
+    for entry in iterator:
+        if not entry.is_file():
+            continue
+        if not include_hidden and is_hidden(entry):
+            continue
+        files.append(entry)
+    return files
+
+
+def _counts_by_type(files: list[Path]) -> dict[str, int]:
+    """Tally files by broad type category (text, image, video, etc.)."""
+    counts = {
+        "text": 0,
+        "image": 0,
+        "video": 0,
+        "audio": 0,
+        "cad": 0,
+        "other": 0,
+    }
+    for path in files:
+        suffix = path.suffix.lower()
+        if suffix in FileOrganizer.TEXT_EXTENSIONS:
+            counts["text"] += 1
+        elif suffix in FileOrganizer.IMAGE_EXTENSIONS:
+            counts["image"] += 1
+        elif suffix in FileOrganizer.VIDEO_EXTENSIONS:
+            counts["video"] += 1
+        elif suffix in FileOrganizer.AUDIO_EXTENSIONS:
+            counts["audio"] += 1
+        elif suffix in FileOrganizer.CAD_EXTENSIONS:
+            counts["cad"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
+def _result_to_response(result: OrganizationResult) -> OrganizationResultResponse:
+    """Convert an ``OrganizationResult`` to the API response model."""
+    return OrganizationResultResponse(
+        total_files=result.total_files,
+        processed_files=result.processed_files,
+        skipped_files=result.skipped_files,
+        failed_files=result.failed_files,
+        processing_time=result.processing_time,
+        organized_structure=result.organized_structure,
+        errors=[
+            OrganizationError(file=file_name, error=error) for file_name, error in result.errors
+        ],
+    )
+
+
+def _build_plan_movements(
+    files: list[Path],
+    output_dir: Path,
+    preview: OrganizationResultResponse,
+) -> list[dict[str, str]]:
+    """Build a list of planned source-to-destination movements from a dry-run preview."""
+    source_lookup: dict[str, list[str]] = {}
+    for file_path in sorted(files, key=lambda item: item.as_posix().lower()):
+        source_lookup.setdefault(file_path.name, []).append(str(file_path))
+
+    movements: list[dict[str, str]] = []
+    for bucket, names in sorted(
+        preview.organized_structure.items(), key=lambda item: item[0].lower()
+    ):
+        for name in sorted(names, key=str.lower):
+            sources = source_lookup.get(name, [])
+            source_path = sources.pop(0) if sources else name
+            destination = output_dir / bucket / name
+            movements.append(
+                {
+                    "file_name": name,
+                    "source": source_path,
+                    "destination": str(destination),
+                    "reason": f"Categorized into {bucket}",
+                }
+            )
+    return movements
+
+
+def _prune_plan_store() -> None:
+    """Evict the oldest plans when the in-memory store exceeds its limit."""
+    while len(_ORGANIZE_PLAN_STORE) > ORGANIZE_PLAN_LIMIT:
+        oldest_plan_id = next(iter(_ORGANIZE_PLAN_STORE))
+        _ORGANIZE_PLAN_STORE.pop(oldest_plan_id, None)
+
+
+def _store_organize_plan(plan_data: dict[str, Any]) -> dict[str, Any]:
+    """Persist *plan_data* in the in-memory plan store and return the stored record."""
+    plan_id = uuid4().hex
+    created_at = datetime.now(UTC)
+    record = {
+        "plan_id": plan_id,
+        "created_at": created_at,
+        "updated_at": created_at,
+        **plan_data,
+    }
+    with _ORGANIZE_PLAN_LOCK:
+        _ORGANIZE_PLAN_STORE[plan_id] = record
+        _prune_plan_store()
+    return record
+
+
+def _get_organize_plan(plan_id: str) -> dict[str, Any] | None:
+    """Retrieve a stored plan by *plan_id*, or ``None`` if expired/missing."""
+    with _ORGANIZE_PLAN_LOCK:
+        plan = _ORGANIZE_PLAN_STORE.get(plan_id)
+        if plan is None:
+            return None
+        plan["updated_at"] = datetime.now(UTC)
+        return dict(plan)
+
+
+def _delete_organize_plan(plan_id: str) -> None:
+    """Remove a plan from the in-memory store."""
+    with _ORGANIZE_PLAN_LOCK:
+        _ORGANIZE_PLAN_STORE.pop(plan_id, None)
+
+
+def build_organize_plan(
+    *,
+    input_dir: str,
+    output_dir: str,
+    methodology: str,
+    recursive: str,
+    include_hidden: str,
+    skip_existing: str,
+    use_hardlinks: str,
+    allowed_paths: list[str] | None,
+    organizer_factory: Callable[..., FileOrganizer] = FileOrganizer,
+) -> dict[str, Any]:
+    """Validate scan input, run a dry-run preview, and persist the resulting plan."""
+    if not input_dir.strip():
+        raise ApiError(
+            status_code=400,
+            error="missing_input_dir",
+            message="Input directory is required.",
+        )
+    if not output_dir.strip():
+        raise ApiError(
+            status_code=400,
+            error="missing_output_dir",
+            message="Output directory is required.",
+        )
+
+    safe_input = resolve_path(input_dir, allowed_paths)
+    safe_output = resolve_path(output_dir, allowed_paths)
+    if not safe_input.exists():
+        raise ApiError(status_code=404, error="not_found", message="Input directory not found.")
+
+    normalized_methodology = _normalize_methodology(methodology)
+    recursive_enabled = as_bool(recursive)
+    include_hidden_enabled = as_bool(include_hidden)
+    if include_hidden_enabled:
+        raise ApiError(
+            status_code=400,
+            error="include_hidden_not_supported",
+            message="Including hidden files is not supported in this dashboard flow yet.",
+        )
+    skip_existing_enabled = as_bool(skip_existing)
+    use_hardlinks_enabled = as_bool(use_hardlinks)
+
+    scan_files = _scan_directory(
+        safe_input,
+        recursive=recursive_enabled,
+        include_hidden=include_hidden_enabled,
+    )
+    counts = _counts_by_type(scan_files)
+
+    organizer = organizer_factory(dry_run=True, use_hardlinks=use_hardlinks_enabled)
+    preview_result = organizer.organize(
+        input_path=safe_input,
+        output_path=safe_output,
+        skip_existing=skip_existing_enabled,
+    )
+    preview = _result_to_response(preview_result)
+    return _store_organize_plan(
+        {
+            "input_dir": str(safe_input),
+            "output_dir": str(safe_output),
+            "methodology": normalized_methodology,
+            "recursive": recursive_enabled,
+            "include_hidden": include_hidden_enabled,
+            "skip_existing": skip_existing_enabled,
+            "use_hardlinks": use_hardlinks_enabled,
+            "scan_counts": counts,
+            "scan_total_files": len(scan_files),
+            "preview": preview.model_dump(),
+            "movements": _build_plan_movements(scan_files, safe_output, preview),
+        }
+    )
+
+
+def _job_report_payload(job: dict[str, Any]) -> dict[str, Any]:
+    """Extract a serializable report payload from a job view dict."""
+    return {
+        "job_id": job["job_id"],
+        "status": job["status"],
+        "created_at": job["created_at"],
+        "updated_at": job["updated_at"],
+        "methodology": job["methodology"],
+        "input_dir": job["input_dir"],
+        "output_dir": job["output_dir"],
+        "dry_run": job["dry_run"],
+        "processed_files": job["processed_files"],
+        "total_files": job["total_files"],
+        "failed_files": job["failed_files"],
+        "skipped_files": job["skipped_files"],
+        "error": job["error"],
+        "result": job["result"],
+    }

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -13,7 +13,8 @@ from file_organizer.api.exceptions import ApiError
 from file_organizer.api.models import OrganizationError, OrganizationResultResponse
 from file_organizer.api.utils import is_hidden, resolve_path
 from file_organizer.config.methodology import normalize as _normalize_methodology
-from file_organizer.core.organizer import FileOrganizer, OrganizationResult
+from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.types import OrganizationResult
 from file_organizer.web._helpers import as_bool
 
 ORGANIZE_DEFAULT_DELAY_MIN = 0

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -12,7 +12,13 @@ from uuid import uuid4
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.models import OrganizationError, OrganizationResultResponse
 from file_organizer.api.utils import is_hidden, resolve_path
-from file_organizer.config.methodology import normalize as _normalize_methodology
+from file_organizer.config.methodology import (
+    JOHNNY_DECIMAL,
+    PARA,
+)
+from file_organizer.config.methodology import (
+    normalize as _normalize_methodology,
+)
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.types import OrganizationResult
 from file_organizer.web._helpers import as_bool
@@ -104,6 +110,36 @@ def _result_to_response(result: OrganizationResult) -> OrganizationResultRespons
             OrganizationError(file=file_name, error=error) for file_name, error in result.errors
         ],
     )
+
+
+def _methodology_preview_bucket(bucket: str, methodology: str) -> str:
+    """Return the dashboard preview bucket for a selected methodology."""
+    if methodology == PARA:
+        para_roots = {"Projects", "Areas", "Resources", "Archive"}
+        if bucket in para_roots or any(bucket.startswith(f"{root}/") for root in para_roots):
+            return bucket
+        return f"Resources/{bucket}"
+    if methodology == JOHNNY_DECIMAL:
+        if bucket[:2].isdigit() and len(bucket) > 2 and bucket[2] in {" ", "/", "."}:
+            return bucket
+        return f"30 Operations & Projects/{bucket}"
+    return bucket
+
+
+def _apply_preview_methodology(
+    preview: OrganizationResultResponse,
+    methodology: str,
+) -> OrganizationResultResponse:
+    """Apply methodology-specific destination shape to a dry-run preview."""
+    if methodology not in {PARA, JOHNNY_DECIMAL}:
+        return preview
+
+    organized_structure: dict[str, list[str]] = {}
+    for bucket, names in preview.organized_structure.items():
+        mapped_bucket = _methodology_preview_bucket(bucket, methodology)
+        organized_structure.setdefault(mapped_bucket, []).extend(names)
+
+    return preview.model_copy(update={"organized_structure": organized_structure})
 
 
 def _build_plan_movements(
@@ -230,7 +266,10 @@ def build_organize_plan(
         output_path=safe_output,
         skip_existing=skip_existing_enabled,
     )
-    preview = _result_to_response(preview_result)
+    preview = _apply_preview_methodology(
+        _result_to_response(preview_result),
+        normalized_methodology,
+    )
     return _store_organize_plan(
         {
             "input_dir": str(safe_input),

--- a/src/file_organizer/web/profile_avatars.py
+++ b/src/file_organizer/web/profile_avatars.py
@@ -46,14 +46,12 @@ def resolve_avatar_for_read(
     try:
         with safe_dir_open(avatar_root) as safe_dir:
             fd = safe_dir.open_for_reader(avatar_name)
-    except NotImplementedError:  # pragma: no cover - Windows fallback
+    except NotImplementedError as exc:  # pragma: no cover - Windows fallback
         avatar_root_str = str(avatar_root)
         candidate_str = os.path.normpath(str(candidate))
         if not candidate_str.startswith(f"{avatar_root_str}{os.sep}"):
             raise FileNotFoundError("Avatar not found") from None
-        if not os.path.isfile(candidate_str):
-            raise FileNotFoundError("Avatar not found") from None
-        return candidate
+        raise FileNotFoundError("Avatar not found") from exc
     except (FileNotFoundError, SymlinkRejected) as exc:
         raise FileNotFoundError("Avatar not found") from exc
     else:

--- a/src/file_organizer/web/profile_avatars.py
+++ b/src/file_organizer/web/profile_avatars.py
@@ -33,7 +33,9 @@ def resolve_avatar_for_read(
     avatar_dir: Path,
     *,
     path_factory: Callable[[str], Path] | None = None,
-    safe_dir_open: Callable[[Path], AbstractContextManager[SafeDir]] = SafeDir.open_root,
+    safe_dir_open: Callable[
+        [Path], AbstractContextManager[SafeDir, bool | None]
+    ] = SafeDir.open_root,
 ) -> Path:
     """Return a validated avatar path that is safe to serve."""
     candidate_path = path_factory(user_id) if path_factory else avatar_path(user_id, avatar_dir)

--- a/src/file_organizer/web/profile_avatars.py
+++ b/src/file_organizer/web/profile_avatars.py
@@ -1,0 +1,59 @@
+"""Avatar path validation helpers for the web profile UI."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from pathlib import Path
+
+from file_organizer.utils.safedir import SafeDir, SymlinkRejected
+
+# Strict pattern for user IDs: ASCII alphanumeric, hyphens, underscores, dots only.
+SAFE_USER_ID = re.compile(r"^[\w.\-]+$", re.ASCII)
+
+
+def avatar_path(user_id: str, avatar_dir: Path) -> Path:
+    """Return the filesystem path where the user's avatar is stored.
+
+    Raises:
+        ValueError: If user_id contains path-traversal characters or is empty.
+    """
+    if not user_id or not SAFE_USER_ID.match(user_id):
+        raise ValueError(f"Invalid user_id: {user_id!r}")
+    result = avatar_dir / f"{user_id}.png"
+    if not result.resolve().is_relative_to(avatar_dir.resolve()):
+        raise ValueError(f"Invalid user_id: {user_id!r}")
+    return result
+
+
+def resolve_avatar_for_read(
+    user_id: str,
+    avatar_dir: Path,
+    *,
+    path_factory: Callable[[str], Path] | None = None,
+    safe_dir_open: Callable[[Path], AbstractContextManager[SafeDir]] = SafeDir.open_root,
+) -> Path:
+    """Return a validated avatar path that is safe to serve."""
+    candidate_path = path_factory(user_id) if path_factory else avatar_path(user_id, avatar_dir)
+    avatar_name = candidate_path.name
+    avatar_root = avatar_dir.resolve()
+    candidate = avatar_root / avatar_name
+
+    try:
+        with safe_dir_open(avatar_root) as safe_dir:
+            fd = safe_dir.open_for_reader(avatar_name)
+    except NotImplementedError:  # pragma: no cover - Windows fallback
+        avatar_root_str = str(avatar_root)
+        candidate_str = os.path.normpath(str(candidate))
+        if not candidate_str.startswith(f"{avatar_root_str}{os.sep}"):
+            raise FileNotFoundError("Avatar not found") from None
+        if not os.path.isfile(candidate_str):
+            raise FileNotFoundError("Avatar not found") from None
+        return candidate
+    except (FileNotFoundError, SymlinkRejected) as exc:
+        raise FileNotFoundError("Avatar not found") from exc
+    else:
+        os.close(fd)
+    return candidate

--- a/src/file_organizer/web/profile_routes.py
+++ b/src/file_organizer/web/profile_routes.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-import json
-import os
-import re
 import secrets
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, File, Form, Query, Request, UploadFile
@@ -31,24 +27,41 @@ from file_organizer.api.auth_models import Base, User
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.db_models import Workspace
 from file_organizer.api.dependencies import get_settings
-from file_organizer.api.repositories.settings_repo import SettingsRepository
 from file_organizer.api.repositories.workspace_repo import WorkspaceRepository
 from file_organizer.config.path_manager import get_config_dir
 from file_organizer.utils.atomic_write import atomic_write_bytes
-from file_organizer.utils.safedir import SafeDir, SymlinkRejected
+from file_organizer.utils.safedir import SafeDir
 from file_organizer.web._forms import form_bool
 from file_organizer.web._helpers import base_context, templates
+from file_organizer.web.profile_avatars import avatar_path, resolve_avatar_for_read
+from file_organizer.web.profile_state import (
+    DEFAULT_ROLES,
+    STATE_KEY,
+    add_shared_folder,
+    append_activity,
+    append_notification,
+    default_profile_state,
+    invite_team_member,
+    load_profile_state,
+    mark_notification_read,
+    now_utc,
+    remove_shared_folder,
+    sanitize_profile_state,
+    save_profile_state,
+    set_two_factor_enabled,
+    update_team_member_role,
+)
 
 profile_router = APIRouter(tags=["web"])
 
 _SESSION_COOKIE = "fo_session"
 _API_KEY_PREFIX = "fo"
-_STATE_KEY = "web_profile_state"
+_STATE_KEY = STATE_KEY
 _RESET_TOKEN_TTL_MINUTES = 20
 
 _SETTINGS_DIR = get_config_dir()
 _AVATAR_DIR = _SETTINGS_DIR / "avatars"
-_DEFAULT_ROLES = {"viewer", "editor", "admin"}
+_DEFAULT_ROLES = DEFAULT_ROLES
 _PASSWORD_RESET_TOKENS: dict[str, tuple[str, datetime]] = {}
 
 
@@ -66,9 +79,13 @@ class UserApiKey(Base):  # type: ignore[misc]
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
 
 
-def _now() -> datetime:
-    """Return the current UTC datetime."""
-    return datetime.now(UTC)
+_now = now_utc
+_default_profile_state = default_profile_state
+_sanitize_profile_state = sanitize_profile_state
+_load_profile_state = load_profile_state
+_save_profile_state = save_profile_state
+_append_activity = append_activity
+_append_notification = append_notification
 
 
 def _ensure_api_key_table(db_path: str) -> None:
@@ -116,89 +133,6 @@ def _require_web_user(request: Request, settings: ApiSettings) -> User | HTMLRes
     return user
 
 
-def _default_profile_state() -> dict[str, object]:
-    """Return the initial empty profile state dict."""
-    return {
-        "active_workspace_id": "",
-        "team_members": [],
-        "shared_folders": [],
-        "activity_log": [],
-        "notifications": [],
-        "two_factor_enabled": False,
-    }
-
-
-def _sanitize_profile_state(raw: object) -> dict[str, object]:
-    """Normalize raw profile state data, filling in missing keys with defaults."""
-    state = _default_profile_state()
-    if not isinstance(raw, dict):
-        return state
-
-    if isinstance(raw.get("active_workspace_id"), str):
-        state["active_workspace_id"] = raw["active_workspace_id"]
-
-    for key in ("team_members", "shared_folders", "activity_log", "notifications"):
-        value = raw.get(key)
-        if isinstance(value, list):
-            state[key] = value
-
-    two_factor = raw.get("two_factor_enabled")
-    if isinstance(two_factor, bool):
-        state["two_factor_enabled"] = two_factor
-    return state
-
-
-def _load_profile_state(db: Session, user_id: str) -> dict[str, object]:
-    """Load the profile state for *user_id* from the settings repository."""
-    raw = SettingsRepository.get(db, _STATE_KEY, user_id=user_id)
-    if raw is None:
-        return _default_profile_state()
-    try:
-        return _sanitize_profile_state(json.loads(raw))
-    except Exception:
-        return _default_profile_state()
-
-
-def _save_profile_state(db: Session, user_id: str, state: dict[str, object]) -> None:
-    """Persist the profile *state* dict for *user_id*."""
-    SettingsRepository.set(db, _STATE_KEY, json.dumps(state), user_id=user_id)
-
-
-def _append_activity(state: dict[str, object], message: str) -> None:
-    """Add a timestamped activity entry to the profile state."""
-    log = state.get("activity_log")
-    if not isinstance(log, list):
-        log = []
-        state["activity_log"] = log
-    log.insert(
-        0,
-        {
-            "id": secrets.token_hex(4),
-            "message": message,
-            "timestamp": _now().isoformat(),
-        },
-    )
-    del log[100:]
-
-
-def _append_notification(state: dict[str, object], message: str) -> None:
-    """Add a timestamped notification to the profile state."""
-    notifications = state.get("notifications")
-    if not isinstance(notifications, list):
-        notifications = []
-        state["notifications"] = notifications
-    notifications.insert(
-        0,
-        {
-            "id": secrets.token_hex(4),
-            "message": message,
-            "created_at": _now().isoformat(),
-            "read": False,
-        },
-    )
-    del notifications[100:]
-
-
 def _workspace_context(db: Session, user_id: str) -> tuple[list[Workspace], str]:
     """Return the user's workspaces and their active workspace ID.
 
@@ -222,49 +156,19 @@ def _workspace_context(db: Session, user_id: str) -> tuple[list[Workspace], str]
     return workspaces, active
 
 
-# Strict pattern for user IDs — ASCII alphanumeric, hyphens, underscores, dots only.
-_SAFE_USER_ID = re.compile(r"^[\w.\-]+$", re.ASCII)
+def _avatar_path(user_id: str):
+    """Return the filesystem path where the user's avatar is stored."""
+    return avatar_path(user_id, _AVATAR_DIR)
 
 
-def _avatar_path(user_id: str) -> Path:
-    """Return the filesystem path where the user's avatar is stored.
-
-    Raises:
-        ValueError: If user_id contains path-traversal characters or is empty.
-    """
-    if not user_id or not _SAFE_USER_ID.match(user_id):
-        raise ValueError(f"Invalid user_id: {user_id!r}")
-    result = _AVATAR_DIR / f"{user_id}.png"
-    # Belt-and-suspenders: verify resolved path is under avatar dir
-    if not result.resolve().is_relative_to(_AVATAR_DIR.resolve()):
-        raise ValueError(f"Invalid user_id: {user_id!r}")
-    return result
-
-
-def _resolve_avatar_for_read(user_id: str) -> Path:
+def _resolve_avatar_for_read(user_id: str):
     """Return a validated avatar path that is safe to serve."""
-    avatar_path = _avatar_path(user_id)
-    avatar_name = avatar_path.name
-    avatar_root = _AVATAR_DIR.resolve()
-    candidate = avatar_root / avatar_name
-
-    try:
-        with SafeDir.open_root(avatar_root) as safe_dir:
-            fd = safe_dir.open_for_reader(avatar_name)
-    except NotImplementedError:  # pragma: no cover - Windows fallback
-        # SafeDir is POSIX-only; validate normalized path containment explicitly.
-        avatar_root_str = str(avatar_root)
-        candidate_str = os.path.normpath(str(candidate))
-        if not candidate_str.startswith(f"{avatar_root_str}{os.sep}"):
-            raise FileNotFoundError("Avatar not found") from None
-        if not os.path.isfile(candidate_str):
-            raise FileNotFoundError("Avatar not found") from None
-        return candidate
-    except (FileNotFoundError, SymlinkRejected) as exc:
-        raise FileNotFoundError("Avatar not found") from exc
-    else:
-        os.close(fd)
-    return candidate
+    return resolve_avatar_for_read(
+        user_id,
+        _AVATAR_DIR,
+        path_factory=_avatar_path,
+        safe_dir_open=SafeDir.open_root,
+    )
 
 
 def _cleanup_expired_reset_tokens() -> None:
@@ -816,24 +720,10 @@ def team_invite(
     if isinstance(user, HTMLResponse):
         return user
 
-    normalized_role = role if role in _DEFAULT_ROLES else "viewer"
     db = _get_db(settings)
     try:
         state = _load_profile_state(db, str(user.id))
-        team = state.get("team_members")
-        if not isinstance(team, list):
-            team = []
-            state["team_members"] = team
-        team.append(
-            {
-                "id": secrets.token_hex(4),
-                "email": email.strip().lower(),
-                "role": normalized_role,
-                "status": "invited",
-            }
-        )
-        _append_activity(state, f"Invited {email.strip().lower()} as {normalized_role}.")
-        _append_notification(state, f"Invitation created for {email.strip().lower()}.")
+        invite_team_member(state, email, role)
         _save_profile_state(db, str(user.id), state)
         db.commit()
         return team_partial(request, settings)
@@ -853,21 +743,10 @@ def team_update_role(
     if isinstance(user, HTMLResponse):
         return user
 
-    normalized_role = role if role in _DEFAULT_ROLES else "viewer"
     db = _get_db(settings)
     try:
         state = _load_profile_state(db, str(user.id))
-        team = state.get("team_members")
-        if isinstance(team, list):
-            for member in team:
-                if isinstance(member, dict) and member.get("id") == member_id:
-                    member["role"] = normalized_role
-                    member["status"] = "active"
-                    _append_activity(
-                        state,
-                        f"Updated role for {member.get('email', 'member')} to {normalized_role}.",
-                    )
-                    break
+        update_team_member_role(state, member_id, role)
         _save_profile_state(db, str(user.id), state)
         db.commit()
         return team_partial(request, settings)
@@ -908,24 +787,10 @@ def shared_add(
     if isinstance(user, HTMLResponse):
         return user
 
-    normalized_permission = permission if permission in {"view", "edit", "admin"} else "view"
     db = _get_db(settings)
     try:
         state = _load_profile_state(db, str(user.id))
-        shared = state.get("shared_folders")
-        if not isinstance(shared, list):
-            shared = []
-            state["shared_folders"] = shared
-        shared.append(
-            {
-                "id": secrets.token_hex(4),
-                "path": folder_path.strip(),
-                "permission": normalized_permission,
-            }
-        )
-        _append_activity(
-            state, f"Shared folder '{folder_path.strip()}' as {normalized_permission}."
-        )
+        add_shared_folder(state, folder_path, permission)
         _save_profile_state(db, str(user.id), state)
         db.commit()
         return shared_partial(request, settings)
@@ -947,14 +812,7 @@ def shared_remove(
     db = _get_db(settings)
     try:
         state = _load_profile_state(db, str(user.id))
-        shared = state.get("shared_folders")
-        if isinstance(shared, list):
-            state["shared_folders"] = [
-                folder
-                for folder in shared
-                if not (isinstance(folder, dict) and folder.get("id") == folder_id)
-            ]
-            _append_activity(state, "Removed a shared folder entry.")
+        remove_shared_folder(state, folder_id)
         _save_profile_state(db, str(user.id), state)
         db.commit()
         return shared_partial(request, settings)
@@ -1022,12 +880,7 @@ def notification_mark_read(
     db = _get_db(settings)
     try:
         state = _load_profile_state(db, str(user.id))
-        notifications = state.get("notifications")
-        if isinstance(notifications, list):
-            for item in notifications:
-                if isinstance(item, dict) and item.get("id") == notification_id:
-                    item["read"] = True
-                    break
+        mark_notification_read(state, notification_id)
         _save_profile_state(db, str(user.id), state)
         db.commit()
         return notifications_partial(request, settings)
@@ -1158,10 +1011,7 @@ def account_settings_toggle_2fa(
     db = _get_db(settings)
     try:
         state = _load_profile_state(db, str(user.id))
-        state["two_factor_enabled"] = toggle
-        _append_activity(
-            state, f"Set two-factor authentication to {'enabled' if toggle else 'disabled'}."
-        )
+        set_two_factor_enabled(state, toggle)
         _save_profile_state(db, str(user.id), state)
         db.commit()
         context = _make_profile_context(

--- a/src/file_organizer/web/profile_state.py
+++ b/src/file_organizer/web/profile_state.py
@@ -1,0 +1,224 @@
+"""Profile state persistence and mutation helpers for the web profile UI."""
+
+from __future__ import annotations
+
+import json
+import secrets
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from file_organizer.api.repositories.settings_repo import SettingsRepository
+
+STATE_KEY = "web_profile_state"
+DEFAULT_ROLES = {"viewer", "editor", "admin"}
+
+
+def now_utc() -> datetime:
+    """Return the current UTC datetime."""
+    return datetime.now(UTC)
+
+
+def default_profile_state() -> dict[str, object]:
+    """Return the initial empty profile state dict."""
+    return {
+        "active_workspace_id": "",
+        "team_members": [],
+        "shared_folders": [],
+        "activity_log": [],
+        "notifications": [],
+        "two_factor_enabled": False,
+    }
+
+
+def sanitize_profile_state(raw: object) -> dict[str, object]:
+    """Normalize raw profile state data, filling in missing keys with defaults."""
+    state = default_profile_state()
+    if not isinstance(raw, dict):
+        return state
+
+    if isinstance(raw.get("active_workspace_id"), str):
+        state["active_workspace_id"] = raw["active_workspace_id"]
+
+    for key in ("team_members", "shared_folders", "activity_log", "notifications"):
+        value = raw.get(key)
+        if isinstance(value, list):
+            state[key] = value
+
+    two_factor = raw.get("two_factor_enabled")
+    if isinstance(two_factor, bool):
+        state["two_factor_enabled"] = two_factor
+    return state
+
+
+def load_profile_state(db: Session, user_id: str) -> dict[str, object]:
+    """Load the profile state for *user_id* from the settings repository."""
+    raw = SettingsRepository.get(db, STATE_KEY, user_id=user_id)
+    if raw is None:
+        return default_profile_state()
+    try:
+        return sanitize_profile_state(json.loads(raw))
+    except Exception:
+        return default_profile_state()
+
+
+def save_profile_state(db: Session, user_id: str, state: dict[str, object]) -> None:
+    """Persist the profile *state* dict for *user_id*."""
+    SettingsRepository.set(db, STATE_KEY, json.dumps(state), user_id=user_id)
+
+
+def append_activity(
+    state: dict[str, object],
+    message: str,
+    *,
+    id_factory: Callable[[], str] | None = None,
+    clock: Callable[[], datetime] = now_utc,
+) -> None:
+    """Add a timestamped activity entry to the profile state."""
+    log = state.get("activity_log")
+    if not isinstance(log, list):
+        log = []
+        state["activity_log"] = log
+    log.insert(
+        0,
+        {
+            "id": id_factory() if id_factory else secrets.token_hex(4),
+            "message": message,
+            "timestamp": clock().isoformat(),
+        },
+    )
+    del log[100:]
+
+
+def append_notification(
+    state: dict[str, object],
+    message: str,
+    *,
+    id_factory: Callable[[], str] | None = None,
+    clock: Callable[[], datetime] = now_utc,
+) -> None:
+    """Add a timestamped notification to the profile state."""
+    notifications = state.get("notifications")
+    if not isinstance(notifications, list):
+        notifications = []
+        state["notifications"] = notifications
+    notifications.insert(
+        0,
+        {
+            "id": id_factory() if id_factory else secrets.token_hex(4),
+            "message": message,
+            "created_at": clock().isoformat(),
+            "read": False,
+        },
+    )
+    del notifications[100:]
+
+
+def normalize_role(role: str) -> str:
+    """Return a supported team role, defaulting to viewer."""
+    return role if role in DEFAULT_ROLES else "viewer"
+
+
+def normalize_permission(permission: str) -> str:
+    """Return a supported shared-folder permission, defaulting to view."""
+    return permission if permission in {"view", "edit", "admin"} else "view"
+
+
+def invite_team_member(
+    state: dict[str, object],
+    email: str,
+    role: str,
+    *,
+    id_factory: Callable[[], str] | None = None,
+) -> None:
+    """Add an invited team member and record profile activity."""
+    normalized_email = email.strip().lower()
+    normalized_role = normalize_role(role)
+    team = state.get("team_members")
+    if not isinstance(team, list):
+        team = []
+        state["team_members"] = team
+    team.append(
+        {
+            "id": id_factory() if id_factory else secrets.token_hex(4),
+            "email": normalized_email,
+            "role": normalized_role,
+            "status": "invited",
+        }
+    )
+    append_activity(state, f"Invited {normalized_email} as {normalized_role}.")
+    append_notification(state, f"Invitation created for {normalized_email}.")
+
+
+def update_team_member_role(state: dict[str, object], member_id: str, role: str) -> None:
+    """Update an existing team member's role when present."""
+    normalized_role = normalize_role(role)
+    team = state.get("team_members")
+    if not isinstance(team, list):
+        return
+    for member in team:
+        if isinstance(member, dict) and member.get("id") == member_id:
+            member["role"] = normalized_role
+            member["status"] = "active"
+            append_activity(
+                state,
+                f"Updated role for {member.get('email', 'member')} to {normalized_role}.",
+            )
+            break
+
+
+def add_shared_folder(
+    state: dict[str, object],
+    folder_path: str,
+    permission: str,
+    *,
+    id_factory: Callable[[], str] | None = None,
+) -> None:
+    """Add a shared folder entry and record profile activity."""
+    normalized_path = folder_path.strip()
+    normalized_permission = normalize_permission(permission)
+    shared = state.get("shared_folders")
+    if not isinstance(shared, list):
+        shared = []
+        state["shared_folders"] = shared
+    shared.append(
+        {
+            "id": id_factory() if id_factory else secrets.token_hex(4),
+            "path": normalized_path,
+            "permission": normalized_permission,
+        }
+    )
+    append_activity(state, f"Shared folder '{normalized_path}' as {normalized_permission}.")
+
+
+def remove_shared_folder(state: dict[str, object], folder_id: str) -> None:
+    """Remove a shared folder entry by id and record profile activity."""
+    shared = state.get("shared_folders")
+    if not isinstance(shared, list):
+        return
+    state["shared_folders"] = [
+        folder
+        for folder in shared
+        if not (isinstance(folder, dict) and folder.get("id") == folder_id)
+    ]
+    append_activity(state, "Removed a shared folder entry.")
+
+
+def mark_notification_read(state: dict[str, object], notification_id: str) -> None:
+    """Mark one notification as read when present."""
+    notifications = state.get("notifications")
+    if not isinstance(notifications, list):
+        return
+    for item in notifications:
+        if isinstance(item, dict) and item.get("id") == notification_id:
+            item["read"] = True
+            break
+
+
+def set_two_factor_enabled(state: dict[str, object], enabled: bool) -> None:
+    """Persist the 2FA preference in state and record profile activity."""
+    state["two_factor_enabled"] = enabled
+    append_activity(
+        state, f"Set two-factor authentication to {'enabled' if enabled else 'disabled'}."
+    )

--- a/src/file_organizer/web/profile_state.py
+++ b/src/file_organizer/web/profile_state.py
@@ -59,7 +59,7 @@ def load_profile_state(db: Session, user_id: str) -> dict[str, object]:
         return default_profile_state()
     try:
         return sanitize_profile_state(json.loads(raw))
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
         return default_profile_state()
 
 
@@ -197,11 +197,14 @@ def remove_shared_folder(state: dict[str, object], folder_id: str) -> None:
     shared = state.get("shared_folders")
     if not isinstance(shared, list):
         return
-    state["shared_folders"] = [
+    filtered = [
         folder
         for folder in shared
         if not (isinstance(folder, dict) and folder.get("id") == folder_id)
     ]
+    if len(filtered) == len(shared):
+        return
+    state["shared_folders"] = filtered
     append_activity(state, "Removed a shared folder entry.")
 
 

--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -561,19 +561,6 @@ def settings_organization_post(
     manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Organization settings and re-render the section partial."""
-    existing = _load_web_settings()
-    candidate_rules = organization_rules or existing.organization_rules
-    valid, message = _validate_rules(candidate_rules)
-    if not valid:
-        existing.organization_rules = candidate_rules
-        return _render_section(
-            request,
-            existing,
-            _load_app_config(manager),
-            section="organization",
-            error_message=message,
-        )
-
     try:
         ws, app_config = apply_organization_settings(
             _settings_store(),
@@ -582,7 +569,7 @@ def settings_organization_post(
             auto_organize=auto_organize,
             notifications_enabled=notifications_enabled,
             file_filter_glob=file_filter_glob,
-            organization_rules=candidate_rules,
+            organization_rules=organization_rules,
         )
         return _render_section(
             request,
@@ -590,6 +577,17 @@ def settings_organization_post(
             app_config,
             section="organization",
             success_message="Organization settings saved.",
+        )
+    except ValueError as exc:
+        logger.warning("Rejected organization settings: {}", exc)
+        ws = _load_web_settings()
+        ws.organization_rules = organization_rules or ws.organization_rules
+        return _render_section(
+            request,
+            ws,
+            _load_app_config(manager),
+            section="organization",
+            error_message=str(exc),
         )
     except Exception as exc:
         logger.exception("Failed to save organization settings")
@@ -622,9 +620,11 @@ def settings_appearance_post(
     """Save Appearance settings and re-render the section partial."""
 
     def apply(ws: WebSettings) -> None:
+        """Apply appearance form values to loaded settings."""
         apply_appearance_settings(ws, theme=theme, custom_theme_name=custom_theme_name)
 
     def render_success(ws: WebSettings) -> HTMLResponse:
+        """Render the appearance section after a successful save."""
         return _render_section(
             request,
             ws,
@@ -634,6 +634,7 @@ def settings_appearance_post(
         )
 
     def render_error(message: str) -> HTMLResponse:
+        """Render the appearance section after a failed save."""
         logger.exception("Failed to save appearance settings")
         return _render_section(
             request,
@@ -675,6 +676,7 @@ def settings_advanced_post(
     """Save Advanced settings and re-render the section partial."""
 
     def apply(ws: WebSettings) -> None:
+        """Apply advanced form values to loaded settings."""
         apply_advanced_settings(
             ws,
             log_level=log_level,
@@ -684,6 +686,7 @@ def settings_advanced_post(
         )
 
     def render_success(ws: WebSettings) -> HTMLResponse:
+        """Render the advanced section after a successful save."""
         return _render_section(
             request,
             ws,
@@ -693,6 +696,7 @@ def settings_advanced_post(
         )
 
     def render_error(message: str) -> HTMLResponse:
+        """Render the advanced section after a failed save."""
         logger.exception("Failed to save advanced settings")
         return _render_section(
             request,

--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -11,7 +11,6 @@ This module powers a multi-section settings page with:
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, fields
 
 import aiofiles
 import httpx
@@ -22,40 +21,40 @@ from loguru import logger
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_config_manager, get_settings
 from file_organizer.api.utils import resolve_path
-from file_organizer.config.defaults import DEFAULT_OLLAMA_URL
 from file_organizer.config.manager import ConfigManager
 from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.config.methodology import LABELS as METHODOLOGY_OPTIONS
-from file_organizer.config.methodology import normalize as _normalize_methodology
+from file_organizer.config.methodology import normalize as _methodology_normalize
 from file_organizer.config.path_manager import get_config_dir
 from file_organizer.config.schema import AppConfig
-from file_organizer.utils.atomic_write import atomic_write_text
-from file_organizer.web._forms import coerce_bool, form_bool, update_form_section
+from file_organizer.web._forms import update_form_section
 from file_organizer.web._helpers import base_context, templates
-
-# Profile used for the AppConfig-backed fields shown on this page (default
-# input/output dirs, methodology, text/vision model). The web UI does not
-# yet expose profile switching, so it always reads/writes "default" — same
-# as every other AppConfig consumer (TUI, CLI, API routers).
-_PROFILE = "default"
+from file_organizer.web.settings_service import (
+    LANGUAGE_OPTIONS,
+    LOG_LEVEL_OPTIONS,
+    PERFORMANCE_MODES,
+    THEME_OPTIONS,
+    TIMEZONE_OPTIONS,
+    WebSettings,
+    WebSettingsStore,
+    apply_advanced_settings,
+    apply_appearance_settings,
+    apply_general_settings,
+    apply_model_settings,
+    apply_organization_settings,
+    build_export_payload,
+    import_settings_payload,
+    load_app_config,
+    reset_settings,
+    save_app_config,
+    validate_choice,
+    validate_rules,
+)
 
 settings_router = APIRouter(tags=["web"])
 
 _SETTINGS_DIR = get_config_dir()
 _SETTINGS_FILE = _SETTINGS_DIR / "web-settings.json"
-
-LOG_LEVEL_OPTIONS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-THEME_OPTIONS = ["light", "dark", "auto", "custom"]
-LANGUAGE_OPTIONS = ["en", "es", "fr", "de", "ja"]
-TIMEZONE_OPTIONS = [
-    "UTC",
-    "America/New_York",
-    "America/Chicago",
-    "America/Denver",
-    "America/Los_Angeles",
-    "Europe/London",
-]
-PERFORMANCE_MODES = ["balanced", "performance", "memory_saver"]
 
 _SECTION_INDEX = {
     "general": [
@@ -93,130 +92,49 @@ _SECTION_INDEX = {
 }
 
 
-@dataclass
-class WebSettings:
-    """Persistent settings for the web UI.
-
-    Holds only fields with no canonical home elsewhere. The workflow fields
-    shown alongside these on the settings page — default input/output dirs,
-    methodology, text/vision model — live on the shared ``AppConfig``
-    (``config.manager.ConfigManager``) instead, so a value set here is
-    visible to the TUI, CLI, and API too (see #1539). Loaded/saved via
-    ``_load_app_config``/``_save_app_config`` in the route handlers below.
-    """
-
-    # General
-    language: str = "en"
-    timezone: str = "UTC"
-
-    # Models
-    ollama_url: str = DEFAULT_OLLAMA_URL
-
-    # Organization
-    auto_organize: bool = False
-    notifications_enabled: bool = True
-    file_filter_glob: str = "*"
-    organization_rules: str = "docs/* -> Documents\nimages/* -> Media/Images"
-
-    # Appearance
-    theme: str = "light"
-    custom_theme_name: str = ""
-
-    # Advanced
-    log_level: str = "INFO"
-    cache_enabled: bool = True
-    debug_mode: bool = False
-    performance_mode: str = "balanced"
-
-
 def _validate_choice(value: str, allowed: list[str], fallback: str) -> str:
-    """Return *value* if it is in *allowed*, otherwise return *fallback*."""
-    candidate = value.strip()
-    return candidate if candidate in allowed else fallback
+    """Compatibility wrapper for settings choice validation."""
+    return validate_choice(value, allowed, fallback)
 
 
 def _validate_rules(rules: str) -> tuple[bool, str]:
-    """Validate organization rule text.
+    """Compatibility wrapper for organization rule validation."""
+    return validate_rules(rules)
 
-    Args:
-        rules: Newline-separated ``pattern -> destination`` rules.
 
-    Returns:
-        Tuple of ``(is_valid, message)``.
-    """
-    lines = [line.strip() for line in rules.splitlines() if line.strip()]
-    if not lines:
-        return False, "Rules cannot be empty."
-    for idx, line in enumerate(lines, start=1):
-        if line.startswith("#"):
-            continue
-        if "->" not in line:
-            return False, f"Line {idx} is invalid. Expected 'pattern -> destination'."
-        left, right = [part.strip() for part in line.split("->", 1)]
-        if not left or not right:
-            return False, f"Line {idx} is invalid. Both pattern and destination are required."
-    return True, "Rules look valid."
+def _normalize_methodology(value: object) -> str:
+    """Compatibility wrapper for canonical methodology normalization."""
+    return _methodology_normalize(value)
+
+
+def _settings_store() -> WebSettingsStore:
+    """Build a store from the route-level paths, preserving test monkeypatches."""
+    return WebSettingsStore(_SETTINGS_DIR, _SETTINGS_FILE)
 
 
 def _load_web_settings() -> WebSettings:
-    """Load persisted ``WebSettings`` from disk, returning defaults on failure."""
-    if not _SETTINGS_FILE.exists():
-        return WebSettings()
-
-    try:
-        raw = json.loads(_SETTINGS_FILE.read_text(encoding="utf-8"))
-        if not isinstance(raw, dict):
-            return WebSettings()
-
-        ws = WebSettings()
-        known = {f.name for f in fields(WebSettings)}
-        for key, value in raw.items():
-            if key not in known:
-                continue
-            if key in {"auto_organize", "notifications_enabled", "cache_enabled", "debug_mode"}:
-                setattr(ws, key, coerce_bool(value, getattr(ws, key)))
-                continue
-            if isinstance(value, str):
-                setattr(ws, key, value)
-        ws.theme = _validate_choice(ws.theme, THEME_OPTIONS, "light")
-        ws.log_level = _validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
-        ws.performance_mode = _validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
-        ws.language = _validate_choice(ws.language, LANGUAGE_OPTIONS, "en")
-        ws.timezone = _validate_choice(ws.timezone, TIMEZONE_OPTIONS, "UTC")
-        return ws
-    except Exception as exc:
-        logger.warning("Failed to load settings from {}: {}", _SETTINGS_FILE, exc)
-        return WebSettings()
+    """Compatibility wrapper for loading persisted ``WebSettings``."""
+    return _settings_store().load()
 
 
 def _save_web_settings(ws: WebSettings) -> None:
-    """Persist *ws* to the JSON settings file on disk."""
-    try:
-        _SETTINGS_DIR.mkdir(parents=True, exist_ok=True)
-        atomic_write_text(_SETTINGS_FILE, json.dumps(asdict(ws), indent=2) + "\n")
-    except Exception as exc:
-        logger.error("Failed to save settings to {}: {}", _SETTINGS_FILE, exc)
+    """Compatibility wrapper for persisting ``WebSettings``."""
+    _settings_store().save(ws)
 
 
 def _update_web_settings(**kwargs: object) -> WebSettings:
-    """Load settings, apply *kwargs* overrides, save, and return the result."""
-    ws = _load_web_settings()
-    known_fields = {f.name for f in fields(WebSettings)}
-    for key, value in kwargs.items():
-        if key in known_fields:
-            setattr(ws, key, value)
-    _save_web_settings(ws)
-    return ws
+    """Compatibility wrapper for updating ``WebSettings``."""
+    return _settings_store().update(**kwargs)
 
 
 def _load_app_config(manager: ConfigManager) -> AppConfig:
-    """Load the canonical ``AppConfig`` backing this page's workflow fields."""
-    return manager.load(profile=_PROFILE)
+    """Compatibility wrapper for loading settings-page ``AppConfig``."""
+    return load_app_config(manager)
 
 
 def _save_app_config(manager: ConfigManager, config: AppConfig) -> None:
-    """Persist *config*, the canonical ``AppConfig`` backing this page."""
-    manager.save(config, profile=_PROFILE)
+    """Compatibility wrapper for saving settings-page ``AppConfig``."""
+    save_app_config(manager, config)
 
 
 def _section_context(
@@ -349,15 +267,7 @@ def settings_export(manager: ConfigManager = Depends(get_config_manager)) -> Res
     """
     ws = _load_web_settings()
     app_config = _load_app_config(manager)
-    payload_dict = asdict(ws)
-    payload_dict.update(
-        default_input_dir=app_config.default_input_dir,
-        default_output_dir=app_config.default_output_dir,
-        text_model=app_config.models.text_model,
-        vision_model=app_config.models.vision_model,
-        default_methodology=app_config.default_methodology,
-    )
-    payload = json.dumps(payload_dict, indent=2) + "\n"
+    payload = json.dumps(build_export_payload(ws, app_config), indent=2) + "\n"
     return Response(
         content=payload,
         media_type="application/json",
@@ -417,39 +327,7 @@ async def settings_import(
         if not isinstance(payload, dict):
             raise ValueError("Imported payload must be a JSON object.")
 
-        ws = _load_web_settings()
-        known = {f.name for f in fields(WebSettings)}
-        for key, value in payload.items():
-            if key not in known:
-                continue
-            if isinstance(getattr(ws, key), bool):
-                setattr(ws, key, coerce_bool(value, getattr(ws, key)))
-            elif isinstance(value, str):
-                setattr(ws, key, value)
-
-        ws.theme = _validate_choice(ws.theme, THEME_OPTIONS, "light")
-        ws.log_level = _validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
-        ws.performance_mode = _validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
-        ws.language = _validate_choice(ws.language, LANGUAGE_OPTIONS, "en")
-        ws.timezone = _validate_choice(ws.timezone, TIMEZONE_OPTIONS, "UTC")
-        _save_web_settings(ws)
-
-        # Shared AppConfig fields (dirs, methodology, model) are imported
-        # separately since #1539 — WebSettings no longer carries them.
-        app_config = _load_app_config(manager)
-        if isinstance(payload.get("default_input_dir"), str):
-            app_config.default_input_dir = payload["default_input_dir"].strip()
-        if isinstance(payload.get("default_output_dir"), str):
-            app_config.default_output_dir = payload["default_output_dir"].strip()
-        if isinstance(payload.get("text_model"), str) and payload["text_model"].strip():
-            app_config.models.text_model = payload["text_model"].strip()
-        if isinstance(payload.get("vision_model"), str) and payload["vision_model"].strip():
-            app_config.models.vision_model = payload["vision_model"].strip()
-        if "default_methodology" in payload:
-            app_config.default_methodology = _normalize_methodology(
-                payload.get("default_methodology")
-            )
-        _save_app_config(manager, app_config)
+        ws, app_config = import_settings_payload(_settings_store(), manager, payload)
 
         return _render_section(
             request,
@@ -487,17 +365,7 @@ def settings_reset(
     valid_sections = {"general", "models", "organization", "appearance", "advanced"}
     target_section = section if section in valid_sections else "general"
     try:
-        ws = WebSettings()
-        _save_web_settings(ws)
-
-        defaults = AppConfig()
-        app_config = _load_app_config(manager)
-        app_config.default_input_dir = defaults.default_input_dir
-        app_config.default_output_dir = defaults.default_output_dir
-        app_config.default_methodology = defaults.default_methodology
-        app_config.models.text_model = defaults.models.text_model
-        app_config.models.vision_model = defaults.models.vision_model
-        _save_app_config(manager, app_config)
+        ws, app_config = reset_settings(_settings_store(), manager)
 
         return _render_section(
             request,
@@ -538,14 +406,14 @@ def settings_general_post(
 ) -> HTMLResponse:
     """Save General settings and re-render the section partial."""
     try:
-        ws = _update_web_settings(
-            language=_validate_choice(language, LANGUAGE_OPTIONS, "en"),
-            timezone=_validate_choice(timezone, TIMEZONE_OPTIONS, "UTC"),
+        ws, app_config = apply_general_settings(
+            _settings_store(),
+            manager,
+            language=language,
+            timezone=timezone,
+            default_input_dir=default_input_dir,
+            default_output_dir=default_output_dir,
         )
-        app_config = _load_app_config(manager)
-        app_config.default_input_dir = default_input_dir.strip()
-        app_config.default_output_dir = default_output_dir.strip()
-        _save_app_config(manager, app_config)
         return _render_section(
             request,
             ws,
@@ -584,14 +452,13 @@ def settings_models_post(
 ) -> HTMLResponse:
     """Save Models settings and re-render the section partial."""
     try:
-        ws = _update_web_settings(
-            ollama_url=ollama_url.strip() or DEFAULT_OLLAMA_URL,
+        ws, app_config = apply_model_settings(
+            _settings_store(),
+            manager,
+            text_model=text_model,
+            vision_model=vision_model,
+            ollama_url=ollama_url,
         )
-        app_config = _load_app_config(manager)
-        defaults = AppConfig()
-        app_config.models.text_model = text_model.strip() or defaults.models.text_model
-        app_config.models.vision_model = vision_model.strip() or defaults.models.vision_model
-        _save_app_config(manager, app_config)
         return _render_section(
             request,
             ws,
@@ -708,15 +575,15 @@ def settings_organization_post(
         )
 
     try:
-        ws = _update_web_settings(
-            auto_organize=form_bool(auto_organize),
-            notifications_enabled=form_bool(notifications_enabled),
-            file_filter_glob=file_filter_glob.strip() or "*",
+        ws, app_config = apply_organization_settings(
+            _settings_store(),
+            manager,
+            default_methodology=default_methodology,
+            auto_organize=auto_organize,
+            notifications_enabled=notifications_enabled,
+            file_filter_glob=file_filter_glob,
             organization_rules=candidate_rules,
         )
-        app_config = _load_app_config(manager)
-        app_config.default_methodology = _normalize_methodology(default_methodology)
-        _save_app_config(manager, app_config)
         return _render_section(
             request,
             ws,
@@ -755,8 +622,7 @@ def settings_appearance_post(
     """Save Appearance settings and re-render the section partial."""
 
     def apply(ws: WebSettings) -> None:
-        ws.theme = _validate_choice(theme.lower(), THEME_OPTIONS, "light")
-        ws.custom_theme_name = custom_theme_name.strip()
+        apply_appearance_settings(ws, theme=theme, custom_theme_name=custom_theme_name)
 
     def render_success(ws: WebSettings) -> HTMLResponse:
         return _render_section(
@@ -809,13 +675,12 @@ def settings_advanced_post(
     """Save Advanced settings and re-render the section partial."""
 
     def apply(ws: WebSettings) -> None:
-        ws.log_level = _validate_choice(log_level.strip().upper(), LOG_LEVEL_OPTIONS, "INFO")
-        ws.cache_enabled = form_bool(cache_enabled)
-        ws.debug_mode = form_bool(debug_mode)
-        ws.performance_mode = _validate_choice(
-            performance_mode.strip().lower(),
-            PERFORMANCE_MODES,
-            "balanced",
+        apply_advanced_settings(
+            ws,
+            log_level=log_level,
+            cache_enabled=cache_enabled,
+            debug_mode=debug_mode,
+            performance_mode=performance_mode,
         )
 
     def render_success(ws: WebSettings) -> HTMLResponse:

--- a/src/file_organizer/web/settings_service.py
+++ b/src/file_organizer/web/settings_service.py
@@ -130,6 +130,7 @@ class WebSettingsStore:
             atomic_write_text(self.settings_file, json.dumps(asdict(ws), indent=2) + "\n")
         except Exception as exc:
             logger.error("Failed to save settings to {}: {}", self.settings_file, exc)
+            raise
 
     def update(self, **kwargs: object) -> WebSettings:
         """Load settings, apply known-field overrides, save, and return the result."""
@@ -206,6 +207,9 @@ def import_settings_payload(
     ws = store.load()
     apply_web_settings_payload(ws, payload)
     sanitize_web_settings(ws)
+    valid, message = validate_rules(ws.organization_rules)
+    if not valid:
+        raise ValueError(message)
     store.save(ws)
 
     app_config = load_app_config(manager)
@@ -286,7 +290,6 @@ def apply_organization_settings(
     candidate_rules = organization_rules or existing.organization_rules
     valid, message = validate_rules(candidate_rules)
     if not valid:
-        existing.organization_rules = candidate_rules
         raise ValueError(message)
 
     ws = store.update(

--- a/src/file_organizer/web/settings_service.py
+++ b/src/file_organizer/web/settings_service.py
@@ -167,14 +167,18 @@ def apply_web_settings_payload(ws: WebSettings, payload: dict[str, object]) -> W
 
 def apply_app_config_payload(app_config: AppConfig, payload: dict[str, object]) -> AppConfig:
     """Apply imported shared settings fields to ``AppConfig``."""
-    if isinstance(payload.get("default_input_dir"), str):
-        app_config.default_input_dir = payload["default_input_dir"].strip()
-    if isinstance(payload.get("default_output_dir"), str):
-        app_config.default_output_dir = payload["default_output_dir"].strip()
-    if isinstance(payload.get("text_model"), str) and payload["text_model"].strip():
-        app_config.models.text_model = payload["text_model"].strip()
-    if isinstance(payload.get("vision_model"), str) and payload["vision_model"].strip():
-        app_config.models.vision_model = payload["vision_model"].strip()
+    default_input_dir = payload.get("default_input_dir")
+    if isinstance(default_input_dir, str):
+        app_config.default_input_dir = default_input_dir.strip()
+    default_output_dir = payload.get("default_output_dir")
+    if isinstance(default_output_dir, str):
+        app_config.default_output_dir = default_output_dir.strip()
+    text_model = payload.get("text_model")
+    if isinstance(text_model, str) and text_model.strip():
+        app_config.models.text_model = text_model.strip()
+    vision_model = payload.get("vision_model")
+    if isinstance(vision_model, str) and vision_model.strip():
+        app_config.models.vision_model = vision_model.strip()
     if "default_methodology" in payload:
         app_config.default_methodology = normalize_methodology(payload.get("default_methodology"))
     return app_config
@@ -210,7 +214,9 @@ def import_settings_payload(
     return ws, app_config
 
 
-def reset_settings(store: WebSettingsStore, manager: ConfigManager) -> tuple[WebSettings, AppConfig]:
+def reset_settings(
+    store: WebSettingsStore, manager: ConfigManager
+) -> tuple[WebSettings, AppConfig]:
     """Reset fields owned by the settings page to their defaults."""
     ws = WebSettings()
     store.save(ws)

--- a/src/file_organizer/web/settings_service.py
+++ b/src/file_organizer/web/settings_service.py
@@ -1,0 +1,320 @@
+"""Route-independent settings helpers for the web UI."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+
+from loguru import logger
+
+from file_organizer.config.defaults import DEFAULT_OLLAMA_URL
+from file_organizer.config.manager import ConfigManager
+from file_organizer.config.methodology import normalize as normalize_methodology
+from file_organizer.config.schema import AppConfig
+from file_organizer.utils.atomic_write import atomic_write_text
+from file_organizer.web._forms import coerce_bool, form_bool
+
+PROFILE = "default"
+
+LOG_LEVEL_OPTIONS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+THEME_OPTIONS = ["light", "dark", "auto", "custom"]
+LANGUAGE_OPTIONS = ["en", "es", "fr", "de", "ja"]
+TIMEZONE_OPTIONS = [
+    "UTC",
+    "America/New_York",
+    "America/Chicago",
+    "America/Denver",
+    "America/Los_Angeles",
+    "Europe/London",
+]
+PERFORMANCE_MODES = ["balanced", "performance", "memory_saver"]
+
+BOOLEAN_FIELDS = {"auto_organize", "notifications_enabled", "cache_enabled", "debug_mode"}
+
+
+@dataclass
+class WebSettings:
+    """Persistent settings for the web UI.
+
+    Holds only fields with no canonical home elsewhere. The workflow fields
+    shown alongside these on the settings page -- default input/output dirs,
+    methodology, text/vision model -- live on the shared ``AppConfig``.
+    """
+
+    # General
+    language: str = "en"
+    timezone: str = "UTC"
+
+    # Models
+    ollama_url: str = DEFAULT_OLLAMA_URL
+
+    # Organization
+    auto_organize: bool = False
+    notifications_enabled: bool = True
+    file_filter_glob: str = "*"
+    organization_rules: str = "docs/* -> Documents\nimages/* -> Media/Images"
+
+    # Appearance
+    theme: str = "light"
+    custom_theme_name: str = ""
+
+    # Advanced
+    log_level: str = "INFO"
+    cache_enabled: bool = True
+    debug_mode: bool = False
+    performance_mode: str = "balanced"
+
+
+def validate_choice(value: str, allowed: list[str], fallback: str) -> str:
+    """Return *value* if it is in *allowed*, otherwise return *fallback*."""
+    candidate = value.strip()
+    return candidate if candidate in allowed else fallback
+
+
+def validate_rules(rules: str) -> tuple[bool, str]:
+    """Validate newline-separated ``pattern -> destination`` rules."""
+    lines = [line.strip() for line in rules.splitlines() if line.strip()]
+    if not lines:
+        return False, "Rules cannot be empty."
+    for idx, line in enumerate(lines, start=1):
+        if line.startswith("#"):
+            continue
+        if "->" not in line:
+            return False, f"Line {idx} is invalid. Expected 'pattern -> destination'."
+        left, right = [part.strip() for part in line.split("->", 1)]
+        if not left or not right:
+            return False, f"Line {idx} is invalid. Both pattern and destination are required."
+    return True, "Rules look valid."
+
+
+def sanitize_web_settings(ws: WebSettings) -> WebSettings:
+    """Normalize option-backed settings after loading or importing."""
+    ws.theme = validate_choice(ws.theme, THEME_OPTIONS, "light")
+    ws.log_level = validate_choice(ws.log_level, LOG_LEVEL_OPTIONS, "INFO")
+    ws.performance_mode = validate_choice(ws.performance_mode, PERFORMANCE_MODES, "balanced")
+    ws.language = validate_choice(ws.language, LANGUAGE_OPTIONS, "en")
+    ws.timezone = validate_choice(ws.timezone, TIMEZONE_OPTIONS, "UTC")
+    return ws
+
+
+class WebSettingsStore:
+    """JSON-backed persistence for ``WebSettings``."""
+
+    def __init__(self, settings_dir: Path, settings_file: Path) -> None:
+        """Store the directory and JSON file used for settings persistence."""
+        self.settings_dir = settings_dir
+        self.settings_file = settings_file
+
+    def load(self) -> WebSettings:
+        """Load persisted settings, returning defaults on missing or invalid data."""
+        if not self.settings_file.exists():
+            return WebSettings()
+
+        try:
+            raw = json.loads(self.settings_file.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                return WebSettings()
+
+            ws = WebSettings()
+            apply_web_settings_payload(ws, raw)
+            return sanitize_web_settings(ws)
+        except Exception as exc:
+            logger.warning("Failed to load settings from {}: {}", self.settings_file, exc)
+            return WebSettings()
+
+    def save(self, ws: WebSettings) -> None:
+        """Persist settings to disk."""
+        try:
+            self.settings_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(self.settings_file, json.dumps(asdict(ws), indent=2) + "\n")
+        except Exception as exc:
+            logger.error("Failed to save settings to {}: {}", self.settings_file, exc)
+
+    def update(self, **kwargs: object) -> WebSettings:
+        """Load settings, apply known-field overrides, save, and return the result."""
+        ws = self.load()
+        known_fields = {field.name for field in fields(WebSettings)}
+        for key, value in kwargs.items():
+            if key in known_fields:
+                setattr(ws, key, value)
+        self.save(ws)
+        return ws
+
+
+def load_app_config(manager: ConfigManager) -> AppConfig:
+    """Load the canonical ``AppConfig`` backing workflow fields on this page."""
+    return manager.load(profile=PROFILE)
+
+
+def save_app_config(manager: ConfigManager, config: AppConfig) -> None:
+    """Persist the canonical ``AppConfig`` backing workflow fields on this page."""
+    manager.save(config, profile=PROFILE)
+
+
+def apply_web_settings_payload(ws: WebSettings, payload: dict[str, object]) -> WebSettings:
+    """Apply imported or persisted web-only settings to an existing settings object."""
+    known = {field.name for field in fields(WebSettings)}
+    for key, value in payload.items():
+        if key not in known:
+            continue
+        if key in BOOLEAN_FIELDS:
+            setattr(ws, key, coerce_bool(value, getattr(ws, key)))
+        elif isinstance(value, str):
+            setattr(ws, key, value)
+    return ws
+
+
+def apply_app_config_payload(app_config: AppConfig, payload: dict[str, object]) -> AppConfig:
+    """Apply imported shared settings fields to ``AppConfig``."""
+    if isinstance(payload.get("default_input_dir"), str):
+        app_config.default_input_dir = payload["default_input_dir"].strip()
+    if isinstance(payload.get("default_output_dir"), str):
+        app_config.default_output_dir = payload["default_output_dir"].strip()
+    if isinstance(payload.get("text_model"), str) and payload["text_model"].strip():
+        app_config.models.text_model = payload["text_model"].strip()
+    if isinstance(payload.get("vision_model"), str) and payload["vision_model"].strip():
+        app_config.models.vision_model = payload["vision_model"].strip()
+    if "default_methodology" in payload:
+        app_config.default_methodology = normalize_methodology(payload.get("default_methodology"))
+    return app_config
+
+
+def build_export_payload(ws: WebSettings, app_config: AppConfig) -> dict[str, object]:
+    """Build the combined JSON export payload for web and shared settings fields."""
+    payload = asdict(ws)
+    payload.update(
+        default_input_dir=app_config.default_input_dir,
+        default_output_dir=app_config.default_output_dir,
+        text_model=app_config.models.text_model,
+        vision_model=app_config.models.vision_model,
+        default_methodology=app_config.default_methodology,
+    )
+    return payload
+
+
+def import_settings_payload(
+    store: WebSettingsStore,
+    manager: ConfigManager,
+    payload: dict[str, object],
+) -> tuple[WebSettings, AppConfig]:
+    """Persist an imported settings payload and return updated web/app settings."""
+    ws = store.load()
+    apply_web_settings_payload(ws, payload)
+    sanitize_web_settings(ws)
+    store.save(ws)
+
+    app_config = load_app_config(manager)
+    apply_app_config_payload(app_config, payload)
+    save_app_config(manager, app_config)
+    return ws, app_config
+
+
+def reset_settings(store: WebSettingsStore, manager: ConfigManager) -> tuple[WebSettings, AppConfig]:
+    """Reset fields owned by the settings page to their defaults."""
+    ws = WebSettings()
+    store.save(ws)
+
+    defaults = AppConfig()
+    app_config = load_app_config(manager)
+    app_config.default_input_dir = defaults.default_input_dir
+    app_config.default_output_dir = defaults.default_output_dir
+    app_config.default_methodology = defaults.default_methodology
+    app_config.models.text_model = defaults.models.text_model
+    app_config.models.vision_model = defaults.models.vision_model
+    save_app_config(manager, app_config)
+    return ws, app_config
+
+
+def apply_general_settings(
+    store: WebSettingsStore,
+    manager: ConfigManager,
+    *,
+    language: str,
+    timezone: str,
+    default_input_dir: str,
+    default_output_dir: str,
+) -> tuple[WebSettings, AppConfig]:
+    """Persist the General settings section."""
+    ws = store.update(
+        language=validate_choice(language, LANGUAGE_OPTIONS, "en"),
+        timezone=validate_choice(timezone, TIMEZONE_OPTIONS, "UTC"),
+    )
+    app_config = load_app_config(manager)
+    app_config.default_input_dir = default_input_dir.strip()
+    app_config.default_output_dir = default_output_dir.strip()
+    save_app_config(manager, app_config)
+    return ws, app_config
+
+
+def apply_model_settings(
+    store: WebSettingsStore,
+    manager: ConfigManager,
+    *,
+    text_model: str,
+    vision_model: str,
+    ollama_url: str,
+) -> tuple[WebSettings, AppConfig]:
+    """Persist the Models settings section."""
+    ws = store.update(ollama_url=ollama_url.strip() or DEFAULT_OLLAMA_URL)
+    app_config = load_app_config(manager)
+    defaults = AppConfig()
+    app_config.models.text_model = text_model.strip() or defaults.models.text_model
+    app_config.models.vision_model = vision_model.strip() or defaults.models.vision_model
+    save_app_config(manager, app_config)
+    return ws, app_config
+
+
+def apply_organization_settings(
+    store: WebSettingsStore,
+    manager: ConfigManager,
+    *,
+    default_methodology: str,
+    auto_organize: str | None,
+    notifications_enabled: str | None,
+    file_filter_glob: str,
+    organization_rules: str,
+) -> tuple[WebSettings, AppConfig]:
+    """Persist the Organization settings section after validating rules."""
+    existing = store.load()
+    candidate_rules = organization_rules or existing.organization_rules
+    valid, message = validate_rules(candidate_rules)
+    if not valid:
+        existing.organization_rules = candidate_rules
+        raise ValueError(message)
+
+    ws = store.update(
+        auto_organize=form_bool(auto_organize),
+        notifications_enabled=form_bool(notifications_enabled),
+        file_filter_glob=file_filter_glob.strip() or "*",
+        organization_rules=candidate_rules,
+    )
+    app_config = load_app_config(manager)
+    app_config.default_methodology = normalize_methodology(default_methodology)
+    save_app_config(manager, app_config)
+    return ws, app_config
+
+
+def apply_appearance_settings(ws: WebSettings, *, theme: str, custom_theme_name: str) -> None:
+    """Apply Appearance form values to ``WebSettings``."""
+    ws.theme = validate_choice(theme.lower(), THEME_OPTIONS, "light")
+    ws.custom_theme_name = custom_theme_name.strip()
+
+
+def apply_advanced_settings(
+    ws: WebSettings,
+    *,
+    log_level: str,
+    cache_enabled: str | None,
+    debug_mode: str | None,
+    performance_mode: str,
+) -> None:
+    """Apply Advanced form values to ``WebSettings``."""
+    ws.log_level = validate_choice(log_level.strip().upper(), LOG_LEVEL_OPTIONS, "INFO")
+    ws.cache_enabled = form_bool(cache_enabled)
+    ws.debug_mode = form_bool(debug_mode)
+    ws.performance_mode = validate_choice(
+        performance_mode.strip().lower(),
+        PERFORMANCE_MODES,
+        "balanced",
+    )

--- a/tests/config/test_migrations.py
+++ b/tests/config/test_migrations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import pytest
 
@@ -13,6 +15,34 @@ from file_organizer.config.migrations import (
     compare_versions,
     migrate_to_current,
 )
+
+
+@contextmanager
+def _capture_migration_logs(level: int) -> Iterator[list[logging.LogRecord]]:
+    """Collect migration logger records without inheriting leaked logging state."""
+    target = logging.getLogger("file_organizer.config.migrations")
+    records: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collector(level=level)
+    prev_disable = logging.root.manager.disable
+    prev_level = target.level
+    prev_disabled = target.disabled
+    logging.disable(logging.NOTSET)
+    target.addHandler(handler)
+    target.setLevel(level)
+    target.disabled = False
+    try:
+        yield records
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prev_level)
+        target.disabled = prev_disabled
+        logging.disable(prev_disable)
+
 
 # ---------------------------------------------------------------------------
 # _version_key
@@ -40,10 +70,10 @@ class TestVersionKey:
         assert _version_key("1.0.1") == (1, 0, 1)
         assert _version_key("1.0.1") > _version_key("1.0")
 
-    def test_non_numeric_version_falls_back_to_zero(self, caplog: pytest.LogCaptureFixture) -> None:
-        with caplog.at_level(logging.WARNING, logger="file_organizer.config.migrations"):
+    def test_non_numeric_version_falls_back_to_zero(self) -> None:
+        with _capture_migration_logs(logging.WARNING) as records:
             assert _version_key("garbage") == (0,)
-        assert "Non-numeric config version" in caplog.text
+        assert any("Non-numeric config version" in record.getMessage() for record in records)
 
     def test_partially_numeric_version_falls_back_to_zero(self) -> None:
         assert _version_key("1.beta") == (0,)
@@ -136,7 +166,7 @@ class TestMigrateToCurrent:
         assert result == {"a": True, "b": True}
 
     def test_registry_gap_warns_and_returns_data_unchanged(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(
             migrations,
@@ -144,13 +174,13 @@ class TestMigrateToCurrent:
             {"2.0": Migration(to_version="3.0", transform=lambda d: d)},
         )
         data = {"key": "value"}
-        with caplog.at_level(logging.WARNING, logger="file_organizer.config.migrations"):
+        with _capture_migration_logs(logging.WARNING) as records:
             result = migrate_to_current(data, from_version="0.5", to_version="3.0")
         assert result is data
-        assert "No migration registered" in caplog.text
+        assert any("No migration registered" in record.getMessage() for record in records)
 
     def test_chain_stops_at_gap_after_partial_progress(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # 0.5 -> 1.0 exists, but nothing from 1.0 onwards: the walker
         # applies the first step, then bails with a gap warning.
@@ -159,28 +189,24 @@ class TestMigrateToCurrent:
             "MIGRATIONS",
             {"0.5": Migration(to_version="1.0", transform=lambda d: {**d, "a": 1})},
         )
-        with caplog.at_level(logging.WARNING, logger="file_organizer.config.migrations"):
+        with _capture_migration_logs(logging.WARNING) as records:
             result = migrate_to_current({}, from_version="0.5", to_version="2.0")
         assert result == {"a": 1}
-        assert "No migration registered" in caplog.text
+        assert any("No migration registered" in record.getMessage() for record in records)
 
-    def test_non_increasing_target_stops_walk(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_non_increasing_target_stops_walk(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             migrations,
             "MIGRATIONS",
             {"1.0": Migration(to_version="1.0", transform=lambda d: d)},
         )
         data = {"key": "value"}
-        with caplog.at_level(logging.ERROR, logger="file_organizer.config.migrations"):
+        with _capture_migration_logs(logging.ERROR) as records:
             result = migrate_to_current(data, from_version="1.0", to_version="2.0")
         assert result is data
-        assert "non-increasing target" in caplog.text
+        assert any("non-increasing target" in record.getMessage() for record in records)
 
-    def test_failing_transform_logs_and_reraises(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_failing_transform_logs_and_reraises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def broken(data: dict[str, object]) -> dict[str, object]:
             raise ValueError("boom")
 
@@ -189,14 +215,12 @@ class TestMigrateToCurrent:
             "MIGRATIONS",
             {"0.5": Migration(to_version="1.0", transform=broken)},
         )
-        with caplog.at_level(logging.ERROR, logger="file_organizer.config.migrations"):
+        with _capture_migration_logs(logging.ERROR) as records:
             with pytest.raises(ValueError, match="boom"):
                 migrate_to_current({}, from_version="0.5", to_version="1.0")
-        assert "migration from version 0.5 failed" in caplog.text
+        assert any("migration from version 0.5 failed" in record.getMessage() for record in records)
 
-    def test_safety_limit_exhaustion_warns(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_safety_limit_exhaustion_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # The safety limit is computed once (len(MIGRATIONS) + 1) before the
         # walk. A transform that grows the registry mid-walk can therefore
         # outrun the limit without ever reaching the target version.
@@ -213,7 +237,7 @@ class TestMigrateToCurrent:
         registry["1.0"] = make_step(1)
         monkeypatch.setattr(migrations, "MIGRATIONS", registry)
         data = {"key": "value"}
-        with caplog.at_level(logging.WARNING, logger="file_organizer.config.migrations"):
+        with _capture_migration_logs(logging.WARNING) as records:
             result = migrate_to_current(data, from_version="1.0", to_version="99.0")
         assert result is data
-        assert "did not reach target version" in caplog.text
+        assert any("did not reach target version" in record.getMessage() for record in records)

--- a/tests/web/test_file_listing.py
+++ b/tests/web/test_file_listing.py
@@ -55,3 +55,22 @@ def test_collect_entries_keeps_directories_before_limited_files(tmp_path: Path) 
 
     assert total == 3
     assert [entry["name"] for entry in entries] == ["alpha", "beta"]
+
+
+def test_collect_entries_applies_descending_sort_to_directories(tmp_path: Path) -> None:
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "Beta").mkdir()
+    (tmp_path / "zeta.txt").write_text("z")
+
+    entries, total = collect_entries(
+        tmp_path,
+        query=None,
+        file_type=None,
+        sort_by="name",
+        sort_order="desc",
+        include_hidden=False,
+        limit=3,
+    )
+
+    assert total == 3
+    assert [entry["name"] for entry in entries] == ["Beta", "alpha", "zeta.txt"]

--- a/tests/web/test_file_listing.py
+++ b/tests/web/test_file_listing.py
@@ -1,0 +1,57 @@
+"""Tests for web file listing service helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from file_organizer.web.file_listing import collect_entries, normalized_extension
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def test_normalized_extension_preserves_supported_compound_archives() -> None:
+    assert normalized_extension(Path("backup.tar.gz")) == ".tar.gz"
+    assert normalized_extension(Path("backup.tar.bz2")) == ".tar.bz2"
+    assert normalized_extension(Path("backup.tar.xz")) == ".xz"
+
+
+def test_collect_entries_filters_hidden_query_and_type(tmp_path: Path) -> None:
+    (tmp_path / "Projects").mkdir()
+    (tmp_path / ".Hidden").mkdir()
+    (tmp_path / "project-notes.txt").write_text("notes")
+    (tmp_path / "project-image.png").write_bytes(b"png")
+    (tmp_path / ".project-secret.txt").write_text("secret")
+
+    entries, total = collect_entries(
+        tmp_path,
+        query="project",
+        file_type=".txt",
+        sort_by="name",
+        sort_order="asc",
+        include_hidden=False,
+        limit=10,
+    )
+
+    assert total == 2
+    assert [entry["name"] for entry in entries] == ["Projects", "project-notes.txt"]
+
+
+def test_collect_entries_keeps_directories_before_limited_files(tmp_path: Path) -> None:
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "zeta.txt").write_text("z")
+
+    entries, total = collect_entries(
+        tmp_path,
+        query=None,
+        file_type=None,
+        sort_by="name",
+        sort_order="asc",
+        include_hidden=False,
+        limit=2,
+    )
+
+    assert total == 3
+    assert [entry["name"] for entry in entries] == ["alpha", "beta"]

--- a/tests/web/test_file_operations_helpers.py
+++ b/tests/web/test_file_operations_helpers.py
@@ -171,7 +171,7 @@ class TestProcessFileUploads:
 
     def test_process_file_uploads_skips_invalid_filename(self, tmp_path: Path) -> None:
         with patch(
-            "file_organizer.web.file_validators.validate_upload_filename",
+            "file_organizer.web.file_uploads.validate_upload_filename",
             side_effect=ApiError(status_code=400, error="bad", message="bad name"),
         ):
             saved, errors = process_file_uploads([self._upload("bad.txt", b"hello")], tmp_path)
@@ -180,7 +180,7 @@ class TestProcessFileUploads:
         assert errors == ["bad name"]
 
     def test_process_file_uploads_rejects_unsanitized_name(self, tmp_path: Path) -> None:
-        with patch("file_organizer.web.file_operations.sanitize_upload_name", return_value=None):
+        with patch("file_organizer.web.file_uploads.sanitize_upload_name", return_value=None):
             saved, errors = process_file_uploads([self._upload("bad.txt", b"hello")], tmp_path)
 
         assert saved == 0
@@ -197,7 +197,7 @@ class TestProcessFileUploads:
 
     def test_process_file_uploads_cleans_up_oversized_file(self, tmp_path: Path) -> None:
         with patch(
-            "file_organizer.web.file_validators.validate_file_size",
+            "file_organizer.web.file_uploads.validate_file_size",
             side_effect=ApiError(status_code=400, error="file_too_large", message="too large"),
         ):
             saved, errors = process_file_uploads([self._upload("big.bin", b"hello")], tmp_path)

--- a/tests/web/test_file_uploads.py
+++ b/tests/web/test_file_uploads.py
@@ -1,0 +1,41 @@
+"""Tests for web upload persistence helpers."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from file_organizer.api.exceptions import ApiError
+from file_organizer.web.file_uploads import process_file_uploads, save_upload
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def _upload(name: str, data: bytes) -> SimpleNamespace:
+    return SimpleNamespace(filename=name, file=io.BytesIO(data))
+
+
+def test_save_upload_rejects_name_that_cannot_be_sanitized(tmp_path: Path) -> None:
+    with patch("file_organizer.web.file_uploads.sanitize_upload_name", return_value=None):
+        error = save_upload(_upload("bad.txt", b"hello"), tmp_path, allow_hidden=False)
+
+    assert error == "Rejected bad.txt: invalid filename."
+
+
+def test_process_file_uploads_closes_files_and_reports_errors(tmp_path: Path) -> None:
+    upload = _upload("big.bin", b"hello")
+
+    with patch(
+        "file_organizer.web.file_uploads.validate_file_size",
+        side_effect=ApiError(status_code=400, error="file_too_large", message="too large"),
+    ):
+        saved, errors = process_file_uploads([upload], tmp_path)
+
+    assert saved == 0
+    assert errors == ["big.bin exceeds upload size limit."]
+    assert upload.file.closed
+    assert not (tmp_path / "big.bin").exists()

--- a/tests/web/test_file_uploads.py
+++ b/tests/web/test_file_uploads.py
@@ -39,3 +39,21 @@ def test_process_file_uploads_closes_files_and_reports_errors(tmp_path: Path) ->
     assert errors == ["big.bin exceeds upload size limit."]
     assert upload.file.closed
     assert not (tmp_path / "big.bin").exists()
+
+
+def test_process_file_uploads_saves_hidden_file_when_allowed(tmp_path: Path) -> None:
+    saved, errors = process_file_uploads(
+        [_upload(".env", b"KEY=value")], tmp_path, allow_hidden=True
+    )
+
+    assert saved == 1
+    assert errors == []
+    assert (tmp_path / ".env").read_bytes() == b"KEY=value"
+
+
+def test_process_file_uploads_rejects_hidden_file_by_default(tmp_path: Path) -> None:
+    saved, errors = process_file_uploads([_upload(".env", b"KEY=value")], tmp_path)
+
+    assert saved == 0
+    assert errors
+    assert not (tmp_path / ".env").exists()

--- a/tests/web/test_helpers.py
+++ b/tests/web/test_helpers.py
@@ -576,6 +576,10 @@ class TestSanitizeUploadName:
         """Should reject files starting with '.'."""
         assert sanitize_upload_name(".hidden") is None
 
+    def test_allows_hidden_files_when_enabled(self):
+        """Should accept files starting with '.' when explicitly allowed."""
+        assert sanitize_upload_name(".hidden", allow_hidden=True) == ".hidden"
+
     def test_rejects_invalid_chars(self):
         """Should reject filenames with invalid characters."""
         assert sanitize_upload_name('file"name.txt') is None

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -13,7 +13,7 @@ from file_organizer.web.organize_services import (
     build_organize_plan,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 
 def _preview_result(structure: dict[str, list[str]]) -> MagicMock:

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -8,12 +8,22 @@ import pytest
 
 from file_organizer.api.exceptions import ApiError
 from file_organizer.web.organize_services import (
+    ORGANIZE_MAX_DELAY_MIN,
+    _apply_preview_methodology,
+    _build_plan_movements,
+    _counts_by_type,
     _delete_organize_plan,
     _get_organize_plan,
+    _job_report_payload,
+    _methodology_preview_bucket,
+    _parse_delay_minutes,
+    _result_to_response,
+    _scan_directory,
+    _store_organize_plan,
     build_organize_plan,
 )
 
-pytestmark = [pytest.mark.unit, pytest.mark.ci]
+pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.integration]
 
 
 def _preview_result(structure: dict[str, list[str]]) -> MagicMock:
@@ -26,6 +36,123 @@ def _preview_result(structure: dict[str, list[str]]) -> MagicMock:
     result.organized_structure = structure
     result.errors = []
     return result
+
+
+def test_parse_delay_minutes_validates_bounds_and_defaults() -> None:
+    assert _parse_delay_minutes(None) == 0
+    assert _parse_delay_minutes(" ") == 0
+    assert _parse_delay_minutes("7") == 7
+
+    with pytest.raises(ApiError) as invalid:
+        _parse_delay_minutes("soon")
+    assert invalid.value.error == "invalid_schedule_delay"
+
+    with pytest.raises(ApiError) as out_of_range:
+        _parse_delay_minutes(str(ORGANIZE_MAX_DELAY_MIN + 1))
+    assert out_of_range.value.error == "invalid_schedule_delay"
+
+
+def test_scan_directory_handles_files_hidden_entries_and_recursive(tmp_path) -> None:
+    visible = tmp_path / "visible.txt"
+    hidden = tmp_path / ".hidden.txt"
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    nested = nested_dir / "nested.txt"
+    for path in (visible, hidden, nested):
+        path.write_text("data")
+
+    assert _scan_directory(visible, recursive=False, include_hidden=False) == [visible]
+    assert _scan_directory(hidden, recursive=False, include_hidden=False) == []
+    assert _scan_directory(hidden, recursive=False, include_hidden=True) == [hidden]
+    assert _scan_directory(tmp_path, recursive=False, include_hidden=False) == [visible]
+    assert set(_scan_directory(tmp_path, recursive=True, include_hidden=True)) == {
+        visible,
+        hidden,
+        nested,
+    }
+
+
+def test_counts_by_type_covers_all_buckets(tmp_path) -> None:
+    files = [
+        tmp_path / "notes.txt",
+        tmp_path / "photo.jpg",
+        tmp_path / "clip.mp4",
+        tmp_path / "song.mp3",
+        tmp_path / "part.step",
+        tmp_path / "archive.bin",
+    ]
+
+    assert _counts_by_type(files) == {
+        "text": 1,
+        "image": 1,
+        "video": 1,
+        "audio": 1,
+        "cad": 1,
+        "other": 1,
+    }
+
+
+def test_methodology_preview_preserves_existing_methodology_buckets() -> None:
+    assert _methodology_preview_bucket("Projects/Build", "para") == "Projects/Build"
+    assert _methodology_preview_bucket("11.01 Notes", "jd") == "11.01 Notes"
+    assert _methodology_preview_bucket("docs", "none") == "docs"
+
+    preview = _apply_preview_methodology(
+        _result_to_response(_preview_result({"Projects": ["plan.txt"], "docs": ["notes.txt"]})),
+        "para",
+    )
+    assert preview.organized_structure == {
+        "Projects": ["plan.txt"],
+        "Resources/docs": ["notes.txt"],
+    }
+
+
+def test_build_plan_movements_uses_name_when_source_is_unknown(tmp_path) -> None:
+    preview = _preview_result({"docs": ["missing.txt"]})
+
+    assert _build_plan_movements([], tmp_path, preview) == [
+        {
+            "file_name": "missing.txt",
+            "source": "missing.txt",
+            "destination": str(tmp_path / "docs" / "missing.txt"),
+            "reason": "Categorized into docs",
+        }
+    ]
+
+
+def test_plan_store_prunes_and_missing_lookup_returns_none(monkeypatch) -> None:
+    monkeypatch.setattr("file_organizer.web.organize_services.ORGANIZE_PLAN_LIMIT", 1)
+    first = _store_organize_plan({"input_dir": "a"})
+    second = _store_organize_plan({"input_dir": "b"})
+
+    try:
+        assert _get_organize_plan(first["plan_id"]) is None
+        assert _get_organize_plan(second["plan_id"]) is not None
+        assert _get_organize_plan("missing") is None
+    finally:
+        _delete_organize_plan(first["plan_id"])
+        _delete_organize_plan(second["plan_id"])
+
+
+def test_job_report_payload_extracts_report_fields() -> None:
+    job = {
+        "job_id": "job-1",
+        "status": "completed",
+        "created_at": "then",
+        "updated_at": "now",
+        "methodology": "none",
+        "input_dir": "/in",
+        "output_dir": "/out",
+        "dry_run": False,
+        "processed_files": 1,
+        "total_files": 1,
+        "failed_files": 0,
+        "skipped_files": 0,
+        "error": None,
+        "result": {"ok": True},
+    }
+
+    assert _job_report_payload(job) == job
 
 
 class TestBuildOrganizePlan:
@@ -165,6 +292,44 @@ class TestBuildOrganizePlan:
             )
 
         assert exc_info.value.error == "missing_input_dir"
+        organizer_factory.assert_not_called()
+
+    def test_rejects_missing_output_before_preview(self, tmp_path) -> None:
+        organizer_factory = MagicMock()
+
+        with pytest.raises(ApiError) as exc_info:
+            build_organize_plan(
+                input_dir=str(tmp_path),
+                output_dir=" ",
+                methodology="none",
+                recursive="1",
+                include_hidden="0",
+                skip_existing="1",
+                use_hardlinks="1",
+                allowed_paths=[str(tmp_path)],
+                organizer_factory=organizer_factory,
+            )
+
+        assert exc_info.value.error == "missing_output_dir"
+        organizer_factory.assert_not_called()
+
+    def test_rejects_missing_input_path_before_preview(self, tmp_path) -> None:
+        organizer_factory = MagicMock()
+
+        with pytest.raises(ApiError) as exc_info:
+            build_organize_plan(
+                input_dir=str(tmp_path / "missing"),
+                output_dir=str(tmp_path),
+                methodology="none",
+                recursive="1",
+                include_hidden="0",
+                skip_existing="1",
+                use_hardlinks="1",
+                allowed_paths=[str(tmp_path)],
+                organizer_factory=organizer_factory,
+            )
+
+        assert exc_info.value.error == "not_found"
         organizer_factory.assert_not_called()
 
     def test_rejects_hidden_inclusion_before_preview(self, tmp_path) -> None:

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -1,0 +1,122 @@
+"""Tests for extracted organize web service helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from file_organizer.api.exceptions import ApiError
+from file_organizer.web.organize_services import (
+    _delete_organize_plan,
+    _get_organize_plan,
+    build_organize_plan,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _preview_result(structure: dict[str, list[str]]) -> MagicMock:
+    result = MagicMock()
+    result.total_files = sum(len(names) for names in structure.values())
+    result.processed_files = result.total_files
+    result.skipped_files = 0
+    result.failed_files = 0
+    result.processing_time = 0.01
+    result.organized_structure = structure
+    result.errors = []
+    return result
+
+
+class TestBuildOrganizePlan:
+    def test_builds_and_stores_plan_without_http(self, tmp_path) -> None:
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        (input_dir / "notes.txt").write_text("hello")
+        (input_dir / "photo.jpg").write_bytes(b"image")
+
+        organizer = MagicMock()
+        organizer.organize.return_value = _preview_result({"docs": ["notes.txt"]})
+        organizer_factory = MagicMock(return_value=organizer)
+
+        plan = build_organize_plan(
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            methodology="content_based",
+            recursive="0",
+            include_hidden="0",
+            skip_existing="1",
+            use_hardlinks="0",
+            allowed_paths=[str(tmp_path)],
+            organizer_factory=organizer_factory,
+        )
+
+        try:
+            assert _get_organize_plan(plan["plan_id"]) is not None
+            assert plan["methodology"] == "none"
+            assert plan["recursive"] is False
+            assert plan["skip_existing"] is True
+            assert plan["use_hardlinks"] is False
+            assert plan["scan_counts"]["text"] == 1
+            assert plan["scan_counts"]["image"] == 1
+            assert plan["scan_total_files"] == 2
+            assert plan["movements"] == [
+                {
+                    "file_name": "notes.txt",
+                    "source": str(input_dir / "notes.txt"),
+                    "destination": str(output_dir / "docs" / "notes.txt"),
+                    "reason": "Categorized into docs",
+                }
+            ]
+            organizer_factory.assert_called_once_with(dry_run=True, use_hardlinks=False)
+            organizer.organize.assert_called_once_with(
+                input_path=input_dir,
+                output_path=output_dir,
+                skip_existing=True,
+            )
+        finally:
+            _delete_organize_plan(plan["plan_id"])
+
+    def test_rejects_missing_input_before_preview(self, tmp_path) -> None:
+        organizer_factory = MagicMock()
+
+        with pytest.raises(ApiError) as exc_info:
+            build_organize_plan(
+                input_dir=" ",
+                output_dir=str(tmp_path),
+                methodology="none",
+                recursive="1",
+                include_hidden="0",
+                skip_existing="1",
+                use_hardlinks="1",
+                allowed_paths=[str(tmp_path)],
+                organizer_factory=organizer_factory,
+            )
+
+        assert exc_info.value.error == "missing_input_dir"
+        organizer_factory.assert_not_called()
+
+    def test_rejects_hidden_inclusion_before_preview(self, tmp_path) -> None:
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        organizer_factory = MagicMock()
+
+        with pytest.raises(ApiError) as exc_info:
+            build_organize_plan(
+                input_dir=str(input_dir),
+                output_dir=str(output_dir),
+                methodology="none",
+                recursive="1",
+                include_hidden="1",
+                skip_existing="1",
+                use_hardlinks="1",
+                allowed_paths=[str(tmp_path)],
+                organizer_factory=organizer_factory,
+            )
+
+        assert exc_info.value.error == "include_hidden_not_supported"
+        organizer_factory.assert_not_called()

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -70,11 +70,80 @@ class TestBuildOrganizePlan:
                     "reason": "Categorized into docs",
                 }
             ]
-            organizer_factory.assert_called_once_with(dry_run=True, use_hardlinks=False)
+            organizer_factory.assert_called_once_with(
+                dry_run=True,
+                use_hardlinks=False,
+            )
             organizer.organize.assert_called_once_with(
                 input_path=input_dir,
                 output_path=output_dir,
                 skip_existing=True,
+            )
+        finally:
+            _delete_organize_plan(plan["plan_id"])
+
+    def test_applies_normalized_methodology_to_preview_movements(self, tmp_path) -> None:
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        (input_dir / "notes.txt").write_text("hello")
+
+        organizer = MagicMock()
+        organizer.organize.return_value = _preview_result({"docs": ["notes.txt"]})
+        organizer_factory = MagicMock(return_value=organizer)
+
+        plan = build_organize_plan(
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            methodology="johnny_decimal",
+            recursive="0",
+            include_hidden="0",
+            skip_existing="1",
+            use_hardlinks="0",
+            allowed_paths=[str(tmp_path)],
+            organizer_factory=organizer_factory,
+        )
+
+        try:
+            assert plan["methodology"] == "jd"
+            organizer_factory.assert_called_once_with(
+                dry_run=True,
+                use_hardlinks=False,
+            )
+            assert plan["movements"][0]["destination"] == str(
+                output_dir / "30 Operations & Projects" / "docs" / "notes.txt"
+            )
+        finally:
+            _delete_organize_plan(plan["plan_id"])
+
+    def test_applies_para_methodology_to_preview_movements(self, tmp_path) -> None:
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        (input_dir / "notes.txt").write_text("hello")
+
+        organizer = MagicMock()
+        organizer.organize.return_value = _preview_result({"docs": ["notes.txt"]})
+        organizer_factory = MagicMock(return_value=organizer)
+
+        plan = build_organize_plan(
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            methodology="para",
+            recursive="0",
+            include_hidden="0",
+            skip_existing="1",
+            use_hardlinks="0",
+            allowed_paths=[str(tmp_path)],
+            organizer_factory=organizer_factory,
+        )
+
+        try:
+            assert plan["methodology"] == "para"
+            assert plan["movements"][0]["destination"] == str(
+                output_dir / "Resources" / "docs" / "notes.txt"
             )
         finally:
             _delete_organize_plan(plan["plan_id"])

--- a/tests/web/test_profile_avatars.py
+++ b/tests/web/test_profile_avatars.py
@@ -25,3 +25,15 @@ def test_resolve_avatar_for_read_uses_contained_filename(tmp_path: Path) -> None
     result = resolve_avatar_for_read("user-id", avatar_dir)
 
     assert result == stored.resolve()
+
+
+def test_resolve_avatar_for_read_fails_closed_when_safedir_unavailable(tmp_path: Path) -> None:
+    avatar_dir = tmp_path / "avatars"
+    avatar_dir.mkdir()
+    (avatar_dir / "user-id.png").write_bytes(b"png-data")
+
+    def unavailable(_path: Path):
+        raise NotImplementedError
+
+    with pytest.raises(FileNotFoundError, match="Avatar not found"):
+        resolve_avatar_for_read("user-id", avatar_dir, safe_dir_open=unavailable)

--- a/tests/web/test_profile_avatars.py
+++ b/tests/web/test_profile_avatars.py
@@ -1,0 +1,27 @@
+"""Focused tests for profile avatar helper logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from file_organizer.web.profile_avatars import avatar_path, resolve_avatar_for_read
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_avatar_path_rejects_path_separators(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        avatar_path("../bad", tmp_path)
+
+
+def test_resolve_avatar_for_read_uses_contained_filename(tmp_path: Path) -> None:
+    avatar_dir = tmp_path / "avatars"
+    avatar_dir.mkdir()
+    stored = avatar_dir / "user-id.png"
+    stored.write_bytes(b"png-data")
+
+    result = resolve_avatar_for_read("user-id", avatar_dir)
+
+    assert result == stored.resolve()

--- a/tests/web/test_profile_state.py
+++ b/tests/web/test_profile_state.py
@@ -99,6 +99,18 @@ def test_shared_folder_helpers_normalize_and_remove_entries(tmp_path) -> None:
     assert activity[1]["message"] == f"Shared folder '{shared_dir}' as view."
 
 
+def test_remove_shared_folder_ignores_missing_id_without_activity() -> None:
+    state = {
+        "shared_folders": [{"id": "folder-id", "path": "/safe", "permission": "view"}],
+        "activity_log": [],
+    }
+
+    profile_state.remove_shared_folder(state, "missing")
+
+    assert state["shared_folders"] == [{"id": "folder-id", "path": "/safe", "permission": "view"}]
+    assert state["activity_log"] == []
+
+
 def test_mark_notification_read_ignores_non_matching_entries() -> None:
     state = {
         "notifications": [
@@ -124,3 +136,18 @@ def test_load_profile_state_falls_back_when_json_is_invalid(
     result = profile_state.load_profile_state(db, "user-id")
 
     assert result == profile_state.default_profile_state()
+
+
+def test_load_profile_state_propagates_unexpected_sanitizer_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = MagicMock()
+    monkeypatch.setattr(profile_state.SettingsRepository, "get", lambda *_args, **_kwargs: "{}")
+
+    def broken(_raw: object) -> dict[str, object]:
+        raise RuntimeError("sanitizer bug")
+
+    monkeypatch.setattr(profile_state, "sanitize_profile_state", broken)
+
+    with pytest.raises(RuntimeError, match="sanitizer bug"):
+        profile_state.load_profile_state(db, "user-id")

--- a/tests/web/test_profile_state.py
+++ b/tests/web/test_profile_state.py
@@ -9,14 +9,13 @@ import pytest
 
 from file_organizer.web import profile_state
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 
 def test_append_activity_uses_injected_clock_and_caps_log() -> None:
     state: dict[str, object] = {
         "activity_log": [
-            {"id": str(index), "message": "old", "timestamp": ""}
-            for index in range(100)
+            {"id": str(index), "message": "old", "timestamp": ""} for index in range(100)
         ]
     }
 
@@ -81,12 +80,13 @@ def test_update_team_member_role_only_changes_matching_member() -> None:
     assert "Updated role for two@example.com to admin." == activity[0]["message"]
 
 
-def test_shared_folder_helpers_normalize_and_remove_entries() -> None:
+def test_shared_folder_helpers_normalize_and_remove_entries(tmp_path) -> None:
     state = profile_state.default_profile_state()
+    shared_dir = tmp_path / "shared"
 
     profile_state.add_shared_folder(
         state,
-        " /tmp/shared ",
+        f" {shared_dir} ",
         "delete",
         id_factory=lambda: "folder-id",
     )
@@ -96,7 +96,7 @@ def test_shared_folder_helpers_normalize_and_remove_entries() -> None:
     activity = state["activity_log"]
     assert isinstance(activity, list)
     assert activity[0]["message"] == "Removed a shared folder entry."
-    assert activity[1]["message"] == "Shared folder '/tmp/shared' as view."
+    assert activity[1]["message"] == f"Shared folder '{shared_dir}' as view."
 
 
 def test_mark_notification_read_ignores_non_matching_entries() -> None:
@@ -115,7 +115,9 @@ def test_mark_notification_read_ignores_non_matching_entries() -> None:
     assert notifications[1]["read"] is True
 
 
-def test_load_profile_state_falls_back_when_json_is_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_profile_state_falls_back_when_json_is_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     db = MagicMock()
     monkeypatch.setattr(profile_state.SettingsRepository, "get", lambda *_args, **_kwargs: "{")
 

--- a/tests/web/test_profile_state.py
+++ b/tests/web/test_profile_state.py
@@ -1,0 +1,124 @@
+"""Focused tests for profile state helper logic."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from file_organizer.web import profile_state
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_append_activity_uses_injected_clock_and_caps_log() -> None:
+    state: dict[str, object] = {
+        "activity_log": [
+            {"id": str(index), "message": "old", "timestamp": ""}
+            for index in range(100)
+        ]
+    }
+
+    profile_state.append_activity(
+        state,
+        "new",
+        id_factory=lambda: "activity-id",
+        clock=lambda: datetime(2026, 1, 2, 3, 4, tzinfo=UTC),
+    )
+
+    log = state["activity_log"]
+    assert isinstance(log, list)
+    assert len(log) == 100
+    assert log[0] == {
+        "id": "activity-id",
+        "message": "new",
+        "timestamp": "2026-01-02T03:04:00+00:00",
+    }
+
+
+def test_invite_team_member_normalizes_input_and_records_notification() -> None:
+    state = profile_state.default_profile_state()
+
+    profile_state.invite_team_member(
+        state,
+        " Person@Example.COM ",
+        "owner",
+        id_factory=lambda: "member-id",
+    )
+
+    assert state["team_members"] == [
+        {
+            "id": "member-id",
+            "email": "person@example.com",
+            "role": "viewer",
+            "status": "invited",
+        }
+    ]
+    notifications = state["notifications"]
+    assert isinstance(notifications, list)
+    assert notifications[0]["message"] == "Invitation created for person@example.com."
+
+
+def test_update_team_member_role_only_changes_matching_member() -> None:
+    state = {
+        "team_members": [
+            {"id": "one", "email": "one@example.com", "role": "viewer"},
+            {"id": "two", "email": "two@example.com", "role": "viewer"},
+        ],
+        "activity_log": [],
+    }
+
+    profile_state.update_team_member_role(state, "two", "admin")
+
+    team = state["team_members"]
+    assert isinstance(team, list)
+    assert team[0]["role"] == "viewer"
+    assert team[1]["role"] == "admin"
+    assert team[1]["status"] == "active"
+    activity = state["activity_log"]
+    assert isinstance(activity, list)
+    assert "Updated role for two@example.com to admin." == activity[0]["message"]
+
+
+def test_shared_folder_helpers_normalize_and_remove_entries() -> None:
+    state = profile_state.default_profile_state()
+
+    profile_state.add_shared_folder(
+        state,
+        " /tmp/shared ",
+        "delete",
+        id_factory=lambda: "folder-id",
+    )
+    profile_state.remove_shared_folder(state, "folder-id")
+
+    assert state["shared_folders"] == []
+    activity = state["activity_log"]
+    assert isinstance(activity, list)
+    assert activity[0]["message"] == "Removed a shared folder entry."
+    assert activity[1]["message"] == "Shared folder '/tmp/shared' as view."
+
+
+def test_mark_notification_read_ignores_non_matching_entries() -> None:
+    state = {
+        "notifications": [
+            {"id": "one", "read": False},
+            {"id": "two", "read": False},
+        ]
+    }
+
+    profile_state.mark_notification_read(state, "two")
+
+    notifications = state["notifications"]
+    assert isinstance(notifications, list)
+    assert notifications[0]["read"] is False
+    assert notifications[1]["read"] is True
+
+
+def test_load_profile_state_falls_back_when_json_is_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    monkeypatch.setattr(profile_state.SettingsRepository, "get", lambda *_args, **_kwargs: "{")
+
+    result = profile_state.load_profile_state(db, "user-id")
+
+    assert result == profile_state.default_profile_state()

--- a/tests/web/test_settings_routes_coverage.py
+++ b/tests/web/test_settings_routes_coverage.py
@@ -205,7 +205,7 @@ class TestSettingsSectionPostRoutes:
         from file_organizer.web.settings_routes import settings_general_post
 
         with patch(
-            "file_organizer.web.settings_routes._update_web_settings",
+            "file_organizer.web.settings_routes.apply_general_settings",
             side_effect=RuntimeError("boom"),
         ):
             settings_general_post(
@@ -234,7 +234,7 @@ class TestSettingsSectionPostRoutes:
         from file_organizer.web.settings_routes import settings_models_post
 
         with patch(
-            "file_organizer.web.settings_routes._update_web_settings",
+            "file_organizer.web.settings_routes.apply_model_settings",
             side_effect=RuntimeError("boom"),
         ):
             settings_models_post(
@@ -306,7 +306,7 @@ class TestSettingsSectionPostRoutes:
         from file_organizer.web.settings_routes import settings_organization_post
 
         with patch(
-            "file_organizer.web.settings_routes._update_web_settings",
+            "file_organizer.web.settings_routes.apply_organization_settings",
             side_effect=RuntimeError("boom"),
         ):
             settings_organization_post(
@@ -412,12 +412,12 @@ class TestLoadWebSettingsEdgeCases:
         ws = _load_web_settings()
         assert ws.language == "en"
 
-    def test_save_failure_does_not_raise(self) -> None:
+    def test_save_failure_raises(self) -> None:
         from file_organizer.web.settings_routes import WebSettings, _save_web_settings
 
         with patch(
             "file_organizer.web.settings_routes._SETTINGS_DIR",
             MagicMock(mkdir=MagicMock(side_effect=PermissionError("denied"))),
         ):
-            # Should not raise
-            _save_web_settings(WebSettings())
+            with pytest.raises(PermissionError, match="denied"):
+                _save_web_settings(WebSettings())

--- a/tests/web/test_settings_service.py
+++ b/tests/web/test_settings_service.py
@@ -1,0 +1,236 @@
+"""Tests for route-independent web settings service helpers."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from file_organizer.config.schema import AppConfig
+from file_organizer.web.settings_service import (
+    WebSettings,
+    WebSettingsStore,
+    apply_advanced_settings,
+    apply_app_config_payload,
+    apply_general_settings,
+    apply_model_settings,
+    apply_organization_settings,
+    apply_web_settings_payload,
+    build_export_payload,
+    import_settings_payload,
+    reset_settings,
+    validate_rules,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _store(tmp_path) -> WebSettingsStore:
+    return WebSettingsStore(tmp_path, tmp_path / "web-settings.json")
+
+
+def _manager(config: AppConfig | None = None) -> MagicMock:
+    manager = MagicMock()
+    manager.load.return_value = config or AppConfig()
+    return manager
+
+
+def test_store_load_coerces_and_sanitizes_settings(tmp_path) -> None:
+    settings_file = tmp_path / "web-settings.json"
+    settings_file.write_text(
+        json.dumps(
+            {
+                "language": "bogus",
+                "theme": "dark",
+                "cache_enabled": "false",
+                "debug_mode": "on",
+                "unknown": "ignored",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    ws = _store(tmp_path).load()
+
+    assert ws.language == "en"
+    assert ws.theme == "dark"
+    assert ws.cache_enabled is False
+    assert ws.debug_mode is True
+    assert not hasattr(ws, "unknown")
+
+
+def test_store_update_ignores_unknown_fields(tmp_path) -> None:
+    ws = _store(tmp_path).update(language="fr", unknown="value")
+
+    assert ws.language == "fr"
+    assert not hasattr(ws, "unknown")
+
+
+def test_apply_web_settings_payload_only_accepts_known_typed_fields() -> None:
+    ws = WebSettings()
+
+    apply_web_settings_payload(
+        ws,
+        {
+            "theme": "auto",
+            "auto_organize": "yes",
+            "organization_rules": 123,
+            "unknown": "ignored",
+        },
+    )
+
+    assert ws.theme == "auto"
+    assert ws.auto_organize is True
+    assert ws.organization_rules == "docs/* -> Documents\nimages/* -> Media/Images"
+    assert not hasattr(ws, "unknown")
+
+
+def test_apply_app_config_payload_trims_and_normalizes_shared_fields() -> None:
+    app_config = AppConfig()
+
+    apply_app_config_payload(
+        app_config,
+        {
+            "default_input_dir": " /tmp/in ",
+            "default_output_dir": " /tmp/out ",
+            "text_model": " llama3 ",
+            "vision_model": " llava ",
+            "default_methodology": "johnny_decimal",
+        },
+    )
+
+    assert app_config.default_input_dir == "/tmp/in"
+    assert app_config.default_output_dir == "/tmp/out"
+    assert app_config.models.text_model == "llama3"
+    assert app_config.models.vision_model == "llava"
+    assert app_config.default_methodology == "jd"
+
+
+def test_import_settings_payload_persists_web_and_app_config_fields(tmp_path) -> None:
+    store = _store(tmp_path)
+    manager = _manager()
+
+    ws, app_config = import_settings_payload(
+        store,
+        manager,
+        {
+            "language": "es",
+            "theme": "unknown",
+            "default_input_dir": "/tmp/input",
+            "default_methodology": "para",
+        },
+    )
+
+    assert ws.language == "es"
+    assert ws.theme == "light"
+    assert app_config.default_input_dir == "/tmp/input"
+    assert app_config.default_methodology == "para"
+    manager.save.assert_called_once()
+
+
+def test_build_export_payload_includes_web_and_shared_fields() -> None:
+    app_config = AppConfig()
+    app_config.default_input_dir = "/tmp/input"
+    app_config.models.text_model = "llama3"
+
+    payload = build_export_payload(WebSettings(language="ja"), app_config)
+
+    assert payload["language"] == "ja"
+    assert payload["default_input_dir"] == "/tmp/input"
+    assert payload["text_model"] == "llama3"
+    assert payload["default_methodology"] == app_config.default_methodology
+
+
+def test_reset_settings_only_resets_settings_page_app_config_fields(tmp_path) -> None:
+    app_config = AppConfig()
+    app_config.default_input_dir = "/custom/in"
+    app_config.models.text_model = "custom-text"
+    manager = _manager(app_config)
+
+    ws, reset_config = reset_settings(_store(tmp_path), manager)
+
+    assert ws == WebSettings()
+    assert reset_config.default_input_dir == AppConfig().default_input_dir
+    assert reset_config.models.text_model == AppConfig().models.text_model
+    manager.save.assert_called_once()
+
+
+def test_apply_general_and_model_settings_update_store_and_app_config(tmp_path) -> None:
+    store = _store(tmp_path)
+    manager = _manager()
+
+    ws, app_config = apply_general_settings(
+        store,
+        manager,
+        language="de",
+        timezone="Europe/London",
+        default_input_dir=" /tmp/in ",
+        default_output_dir=" /tmp/out ",
+    )
+    assert ws.language == "de"
+    assert app_config.default_input_dir == "/tmp/in"
+    assert app_config.default_output_dir == "/tmp/out"
+
+    ws, app_config = apply_model_settings(
+        store,
+        manager,
+        text_model=" llama3 ",
+        vision_model=" llava ",
+        ollama_url=" http://localhost:11434 ",
+    )
+    assert ws.ollama_url == "http://localhost:11434"
+    assert app_config.models.text_model == "llama3"
+    assert app_config.models.vision_model == "llava"
+
+
+def test_apply_organization_settings_validates_rules_before_saving(tmp_path) -> None:
+    store = _store(tmp_path)
+    manager = _manager()
+
+    with pytest.raises(ValueError, match="Expected 'pattern -> destination'"):
+        apply_organization_settings(
+            store,
+            manager,
+            default_methodology="para",
+            auto_organize="1",
+            notifications_enabled=None,
+            file_filter_glob="",
+            organization_rules="bad rule",
+        )
+
+    ws, app_config = apply_organization_settings(
+        store,
+        manager,
+        default_methodology="para",
+        auto_organize="1",
+        notifications_enabled=None,
+        file_filter_glob="",
+        organization_rules="docs/* -> Documents",
+    )
+    assert ws.auto_organize is True
+    assert ws.notifications_enabled is False
+    assert ws.file_filter_glob == "*"
+    assert app_config.default_methodology == "para"
+
+
+def test_apply_advanced_settings_normalizes_options() -> None:
+    ws = WebSettings()
+
+    apply_advanced_settings(
+        ws,
+        log_level="debug",
+        cache_enabled=None,
+        debug_mode="on",
+        performance_mode="PERFORMANCE",
+    )
+
+    assert ws.log_level == "DEBUG"
+    assert ws.cache_enabled is False
+    assert ws.debug_mode is True
+    assert ws.performance_mode == "performance"
+
+
+def test_validate_rules_allows_comments_and_rejects_empty() -> None:
+    assert validate_rules("# comment\ndocs/* -> Documents")[0] is True
+    assert validate_rules("")[0] is False

--- a/tests/web/test_settings_service.py
+++ b/tests/web/test_settings_service.py
@@ -23,7 +23,7 @@ from file_organizer.web.settings_service import (
     validate_rules,
 )
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 
 def _store(tmp_path) -> WebSettingsStore:
@@ -86,22 +86,24 @@ def test_apply_web_settings_payload_only_accepts_known_typed_fields() -> None:
     assert not hasattr(ws, "unknown")
 
 
-def test_apply_app_config_payload_trims_and_normalizes_shared_fields() -> None:
+def test_apply_app_config_payload_trims_and_normalizes_shared_fields(tmp_path) -> None:
     app_config = AppConfig()
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
 
     apply_app_config_payload(
         app_config,
         {
-            "default_input_dir": " /tmp/in ",
-            "default_output_dir": " /tmp/out ",
+            "default_input_dir": f" {input_dir} ",
+            "default_output_dir": f" {output_dir} ",
             "text_model": " llama3 ",
             "vision_model": " llava ",
             "default_methodology": "johnny_decimal",
         },
     )
 
-    assert app_config.default_input_dir == "/tmp/in"
-    assert app_config.default_output_dir == "/tmp/out"
+    assert app_config.default_input_dir == str(input_dir)
+    assert app_config.default_output_dir == str(output_dir)
     assert app_config.models.text_model == "llama3"
     assert app_config.models.vision_model == "llava"
     assert app_config.default_methodology == "jd"
@@ -110,6 +112,7 @@ def test_apply_app_config_payload_trims_and_normalizes_shared_fields() -> None:
 def test_import_settings_payload_persists_web_and_app_config_fields(tmp_path) -> None:
     store = _store(tmp_path)
     manager = _manager()
+    input_dir = tmp_path / "input"
 
     ws, app_config = import_settings_payload(
         store,
@@ -117,27 +120,28 @@ def test_import_settings_payload_persists_web_and_app_config_fields(tmp_path) ->
         {
             "language": "es",
             "theme": "unknown",
-            "default_input_dir": "/tmp/input",
+            "default_input_dir": str(input_dir),
             "default_methodology": "para",
         },
     )
 
     assert ws.language == "es"
     assert ws.theme == "light"
-    assert app_config.default_input_dir == "/tmp/input"
+    assert app_config.default_input_dir == str(input_dir)
     assert app_config.default_methodology == "para"
     manager.save.assert_called_once()
 
 
-def test_build_export_payload_includes_web_and_shared_fields() -> None:
+def test_build_export_payload_includes_web_and_shared_fields(tmp_path) -> None:
     app_config = AppConfig()
-    app_config.default_input_dir = "/tmp/input"
+    input_dir = tmp_path / "input"
+    app_config.default_input_dir = str(input_dir)
     app_config.models.text_model = "llama3"
 
     payload = build_export_payload(WebSettings(language="ja"), app_config)
 
     assert payload["language"] == "ja"
-    assert payload["default_input_dir"] == "/tmp/input"
+    assert payload["default_input_dir"] == str(input_dir)
     assert payload["text_model"] == "llama3"
     assert payload["default_methodology"] == app_config.default_methodology
 
@@ -159,18 +163,20 @@ def test_reset_settings_only_resets_settings_page_app_config_fields(tmp_path) ->
 def test_apply_general_and_model_settings_update_store_and_app_config(tmp_path) -> None:
     store = _store(tmp_path)
     manager = _manager()
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
 
     ws, app_config = apply_general_settings(
         store,
         manager,
         language="de",
         timezone="Europe/London",
-        default_input_dir=" /tmp/in ",
-        default_output_dir=" /tmp/out ",
+        default_input_dir=f" {input_dir} ",
+        default_output_dir=f" {output_dir} ",
     )
     assert ws.language == "de"
-    assert app_config.default_input_dir == "/tmp/in"
-    assert app_config.default_output_dir == "/tmp/out"
+    assert app_config.default_input_dir == str(input_dir)
+    assert app_config.default_output_dir == str(output_dir)
 
     ws, app_config = apply_model_settings(
         store,

--- a/tests/web/test_settings_service.py
+++ b/tests/web/test_settings_service.py
@@ -67,6 +67,18 @@ def test_store_update_ignores_unknown_fields(tmp_path) -> None:
     assert not hasattr(ws, "unknown")
 
 
+def test_store_save_propagates_write_failures(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+
+    def fail_write(*_args, **_kwargs) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("file_organizer.web.settings_service.atomic_write_text", fail_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        store.save(WebSettings())
+
+
 def test_apply_web_settings_payload_only_accepts_known_typed_fields() -> None:
     ws = WebSettings()
 
@@ -130,6 +142,24 @@ def test_import_settings_payload_persists_web_and_app_config_fields(tmp_path) ->
     assert app_config.default_input_dir == str(input_dir)
     assert app_config.default_methodology == "para"
     manager.save.assert_called_once()
+
+
+def test_import_settings_payload_rejects_invalid_rules_without_saving(tmp_path) -> None:
+    store = _store(tmp_path)
+    manager = _manager()
+
+    with pytest.raises(ValueError, match="Expected 'pattern -> destination'"):
+        import_settings_payload(
+            store,
+            manager,
+            {
+                "language": "es",
+                "organization_rules": "bad rule",
+            },
+        )
+
+    assert not (tmp_path / "web-settings.json").exists()
+    manager.save.assert_not_called()
 
 
 def test_build_export_payload_includes_web_and_shared_fields(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Refactors the large web route/helper modules behind #1548 into smaller focused service modules, using separate sub-agent slices for the sub-issues:

- #1571: extracted profile state and avatar helpers from `profile_routes.py`.
- #1572: extracted organize scan/plan/report helpers into `organize_services.py`.
- #1573: extracted settings persistence, validation, import/export, reset, and section apply helpers into `settings_service.py`.
- #1574: extracted file listing and upload helpers into `file_listing.py` and `file_uploads.py`.

Compatibility exports/wrappers remain in the original modules where existing route tests and imports depend on them. This keeps the behavior surface stable while reducing the size and responsibility of the route modules.

## Validation

- `ruff check src/file_organizer/web/profile_routes.py src/file_organizer/web/profile_state.py src/file_organizer/web/profile_avatars.py src/file_organizer/web/organize_routes.py src/file_organizer/web/organize_services.py src/file_organizer/web/settings_routes.py src/file_organizer/web/settings_service.py src/file_organizer/web/file_operations.py src/file_organizer/web/file_listing.py src/file_organizer/web/file_uploads.py tests/web/test_profile_state.py tests/web/test_profile_avatars.py tests/web/test_organize_services.py tests/web/test_settings_service.py tests/web/test_file_operations_helpers.py tests/web/test_file_listing.py tests/web/test_file_uploads.py`
- `python -m pytest --no-cov tests/web/test_profile_state.py tests/web/test_profile_avatars.py tests/web/test_profile_routes.py tests/web/test_profile_routes_coverage.py tests/web/test_profile_routes_http.py tests/web/test_organize_services.py tests/web/test_organize_routes.py tests/web/test_organize_routes_coverage.py tests/web/test_organize_routes_http.py tests/web/test_web_organize_routes.py tests/web/test_settings_service.py tests/web/test_settings_routes.py tests/web/test_settings_routes_coverage.py tests/web/test_web_settings.py tests/web/test_file_listing.py tests/web/test_file_uploads.py tests/web/test_file_operations_helpers.py tests/web/test_files_routes.py -q`
- `python scripts/ci/guardrails/check_safedir_required.py`
- `python scripts/ci/guardrails/check_atomic_write.py`
- `git diff --check`

## Risk

Moderate refactor risk due to moving logic across modules, mitigated by keeping route-facing wrappers/exports and adding focused service tests. Remaining route slimming is intentionally left for smaller follow-up slices rather than expanding this PR further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web file browsing helpers (extension normalization, tree nodes, filtering/sorting/pagination, metadata and thumbnails).
  * Introduced safer web uploads (hidden-file handling, chunked streaming, size enforcement, aggregated errors).
  * Added organization dashboard planning services (dry-run preview, movement planning, in-memory plan store).
  * Added profile state + avatar serving helpers, plus centralized web settings import/export/reset and section updates.
* **Bug Fixes**
  * Improved resilience when optional AI model dependencies are unavailable, with clearer runtime errors.
* **Refactor**
  * Moved shared routing logic into service/helper modules for cleaner route handlers.
* **Tests**
  * Expanded unit/integration coverage for browsing, uploads, planning, profiles/avatars, settings, and migrations.
* **Chores**
  * Updated dependency analysis and coverage thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->