### PR TITLE
Consolidate web form coercion and section-update pattern

### DIFF
--- a/src/file_organizer/web/_forms.py
+++ b/src/file_organizer/web/_forms.py
@@ -9,14 +9,16 @@ from fastapi.responses import HTMLResponse
 
 T = TypeVar("T")
 
-_TRUE_FORM_VALUES = {"1", "true", "yes", "on"}
+# Canonical truthy form values for the whole web layer; other modules
+# (e.g. _helpers.TRUE_VALUES) alias this set instead of redefining it.
+TRUE_FORM_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
 def form_bool(value: str | None) -> bool:
     """Convert an HTML checkbox value to ``bool``."""
     if value is None:
         return False
-    return value.strip().lower() in _TRUE_FORM_VALUES
+    return value.strip().lower() in TRUE_FORM_VALUES
 
 
 def coerce_bool(value: object, default: bool) -> bool:
@@ -24,7 +26,7 @@ def coerce_bool(value: object, default: bool) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        return value.strip().lower() in _TRUE_FORM_VALUES
+        return value.strip().lower() in TRUE_FORM_VALUES
     return default
 
 

--- a/src/file_organizer/web/_helpers.py
+++ b/src/file_organizer/web/_helpers.py
@@ -17,6 +17,7 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.utils import is_hidden, resolve_path
 from file_organizer.core.organizer import FileOrganizer
+from file_organizer.web._forms import TRUE_FORM_VALUES, form_bool
 
 BASE_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
@@ -60,7 +61,7 @@ ALLOWED_VIEWS = {"grid", "list"}
 ALLOWED_SORT_BY = {"name", "size", "created", "modified", "type"}
 ALLOWED_SORT_ORDER = {"asc", "desc"}
 FILENAME_FALLBACK_RE = re.compile(r"[^A-Za-z0-9._-]+")
-TRUE_VALUES = {"1", "true", "yes", "on"}
+TRUE_VALUES = TRUE_FORM_VALUES  # canonical set lives in web._forms
 
 FILE_TYPE_GROUPS = {
     "image": FileOrganizer.IMAGE_EXTENSIONS,
@@ -281,10 +282,8 @@ def build_content_disposition(filename: str) -> str:
 
 
 def as_bool(value: str | None) -> bool:
-    """Interpret a form value as a boolean."""
-    if value is None:
-        return False
-    return value.strip().lower() in TRUE_VALUES
+    """Interpret a form value as a boolean (compat alias for ``_forms.form_bool``)."""
+    return form_bool(value)
 
 
 def render_placeholder_thumbnail(label: str, size: tuple[int, int]) -> bytes:

--- a/src/file_organizer/web/organize_routes.py
+++ b/src/file_organizer/web/organize_routes.py
@@ -25,9 +25,9 @@ from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.config.methodology import LABELS as ORGANIZE_METHODOLOGIES
 from file_organizer.config.methodology import normalize as _normalize_methodology
 from file_organizer.core.organizer import FileOrganizer
+from file_organizer.web._forms import form_bool
 from file_organizer.web._helpers import (
     allowed_roots,
-    as_bool,
     build_content_disposition,
     format_timestamp,
     templates,
@@ -445,7 +445,7 @@ def organize_execute(
             )
 
         delay_minutes = _parse_delay_minutes(schedule_delay_minutes)
-        dry_run_enabled = as_bool(dry_run)
+        dry_run_enabled = form_bool(dry_run)
         safe_input = resolve_path(plan["input_dir"], settings.allowed_paths)
         safe_output = resolve_path(plan["output_dir"], settings.allowed_paths)
 

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -21,7 +21,7 @@ from file_organizer.config.methodology import (
 )
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.types import OrganizationResult
-from file_organizer.web._helpers import as_bool
+from file_organizer.web._forms import form_bool
 
 ORGANIZE_DEFAULT_DELAY_MIN = 0
 ORGANIZE_MAX_DELAY_MIN = 7 * 24 * 60
@@ -242,16 +242,16 @@ def build_organize_plan(
         raise ApiError(status_code=404, error="not_found", message="Input directory not found.")
 
     normalized_methodology = _normalize_methodology(methodology)
-    recursive_enabled = as_bool(recursive)
-    include_hidden_enabled = as_bool(include_hidden)
+    recursive_enabled = form_bool(recursive)
+    include_hidden_enabled = form_bool(include_hidden)
     if include_hidden_enabled:
         raise ApiError(
             status_code=400,
             error="include_hidden_not_supported",
             message="Including hidden files is not supported in this dashboard flow yet.",
         )
-    skip_existing_enabled = as_bool(skip_existing)
-    use_hardlinks_enabled = as_bool(use_hardlinks)
+    skip_existing_enabled = form_bool(skip_existing)
+    use_hardlinks_enabled = form_bool(use_hardlinks)
 
     scan_files = _scan_directory(
         safe_input,

--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -11,6 +11,7 @@ This module powers a multi-section settings page with:
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
 import aiofiles
 import httpx
@@ -196,6 +197,48 @@ def _render_section(
     return templates.TemplateResponse(request, f"settings/_{section}.html", context)
 
 
+def _run_section_post(
+    request: Request,
+    manager: ConfigManager,
+    *,
+    section: str,
+    action: Callable[[], tuple[WebSettings, AppConfig]],
+    success_message: str,
+    failure_log: str,
+    error_prefix: str = "Failed to save settings",
+    on_rejected: Callable[[ValueError], HTMLResponse] | None = None,
+) -> HTMLResponse:
+    """Run the shared action → render-success / render-error flow for a section POST.
+
+    ``action`` performs the persistence (usually a ``settings_service.apply_*``
+    call) and returns the updated ``(WebSettings, AppConfig)`` pair to render.
+    A ``ValueError`` is treated as a validation rejection and routed to
+    ``on_rejected`` when provided (which owns its own logging and rendering);
+    any other failure logs ``failure_log`` and re-renders the section from
+    freshly loaded state with an error flash.
+    """
+    try:
+        ws, app_config = action()
+    except Exception as exc:
+        if isinstance(exc, ValueError) and on_rejected is not None:
+            return on_rejected(exc)
+        logger.exception(failure_log)
+        return _render_section(
+            request,
+            _load_web_settings(),
+            _load_app_config(manager),
+            section=section,
+            error_message=f"{error_prefix}: {exc}",
+        )
+    return _render_section(
+        request,
+        ws,
+        app_config,
+        section=section,
+        success_message=success_message,
+    )
+
+
 @settings_router.get("/settings", response_class=HTMLResponse)
 def settings_page(
     request: Request,
@@ -364,25 +407,15 @@ def settings_reset(
     """
     valid_sections = {"general", "models", "organization", "appearance", "advanced"}
     target_section = section if section in valid_sections else "general"
-    try:
-        ws, app_config = reset_settings(_settings_store(), manager)
-
-        return _render_section(
-            request,
-            ws,
-            app_config,
-            section=target_section,
-            success_message="Settings reset to defaults.",
-        )
-    except Exception as exc:
-        logger.exception("Failed to reset settings")
-        return _render_section(
-            request,
-            _load_web_settings(),
-            _load_app_config(manager),
-            section=target_section,
-            error_message=f"Failed to reset settings: {exc}",
-        )
+    return _run_section_post(
+        request,
+        manager,
+        section=target_section,
+        action=lambda: reset_settings(_settings_store(), manager),
+        success_message="Settings reset to defaults.",
+        failure_log="Failed to reset settings",
+        error_prefix="Failed to reset settings",
+    )
 
 
 @settings_router.get("/settings/general", response_class=HTMLResponse)
@@ -405,31 +438,21 @@ def settings_general_post(
     manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save General settings and re-render the section partial."""
-    try:
-        ws, app_config = apply_general_settings(
+    return _run_section_post(
+        request,
+        manager,
+        section="general",
+        action=lambda: apply_general_settings(
             _settings_store(),
             manager,
             language=language,
             timezone=timezone,
             default_input_dir=default_input_dir,
             default_output_dir=default_output_dir,
-        )
-        return _render_section(
-            request,
-            ws,
-            app_config,
-            section="general",
-            success_message="General settings saved.",
-        )
-    except Exception as exc:
-        logger.exception("Failed to save general settings")
-        return _render_section(
-            request,
-            _load_web_settings(),
-            _load_app_config(manager),
-            section="general",
-            error_message=f"Failed to save settings: {exc}",
-        )
+        ),
+        success_message="General settings saved.",
+        failure_log="Failed to save general settings",
+    )
 
 
 @settings_router.get("/settings/models", response_class=HTMLResponse)
@@ -451,30 +474,20 @@ def settings_models_post(
     manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Models settings and re-render the section partial."""
-    try:
-        ws, app_config = apply_model_settings(
+    return _run_section_post(
+        request,
+        manager,
+        section="models",
+        action=lambda: apply_model_settings(
             _settings_store(),
             manager,
             text_model=text_model,
             vision_model=vision_model,
             ollama_url=ollama_url,
-        )
-        return _render_section(
-            request,
-            ws,
-            app_config,
-            section="models",
-            success_message="Model settings saved.",
-        )
-    except Exception as exc:
-        logger.exception("Failed to save model settings")
-        return _render_section(
-            request,
-            _load_web_settings(),
-            _load_app_config(manager),
-            section="models",
-            error_message=f"Failed to save settings: {exc}",
-        )
+        ),
+        success_message="Model settings saved.",
+        failure_log="Failed to save model settings",
+    )
 
 
 @settings_router.post("/settings/models/test", response_class=HTMLResponse)
@@ -561,24 +574,8 @@ def settings_organization_post(
     manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Save Organization settings and re-render the section partial."""
-    try:
-        ws, app_config = apply_organization_settings(
-            _settings_store(),
-            manager,
-            default_methodology=default_methodology,
-            auto_organize=auto_organize,
-            notifications_enabled=notifications_enabled,
-            file_filter_glob=file_filter_glob,
-            organization_rules=organization_rules,
-        )
-        return _render_section(
-            request,
-            ws,
-            app_config,
-            section="organization",
-            success_message="Organization settings saved.",
-        )
-    except ValueError as exc:
+
+    def render_rejected(exc: ValueError) -> HTMLResponse:
         logger.warning("Rejected organization settings: {}", exc)
         ws = _load_web_settings()
         ws.organization_rules = organization_rules or ws.organization_rules
@@ -589,15 +586,24 @@ def settings_organization_post(
             section="organization",
             error_message=str(exc),
         )
-    except Exception as exc:
-        logger.exception("Failed to save organization settings")
-        return _render_section(
-            request,
-            _load_web_settings(),
-            _load_app_config(manager),
-            section="organization",
-            error_message=f"Failed to save settings: {exc}",
-        )
+
+    return _run_section_post(
+        request,
+        manager,
+        section="organization",
+        action=lambda: apply_organization_settings(
+            _settings_store(),
+            manager,
+            default_methodology=default_methodology,
+            auto_organize=auto_organize,
+            notifications_enabled=notifications_enabled,
+            file_filter_glob=file_filter_glob,
+            organization_rules=organization_rules,
+        ),
+        success_message="Organization settings saved.",
+        failure_log="Failed to save organization settings",
+        on_rejected=render_rejected,
+    )
 
 
 @settings_router.get("/settings/appearance", response_class=HTMLResponse)

--- a/src/file_organizer/web/settings_routes.py
+++ b/src/file_organizer/web/settings_routes.py
@@ -220,6 +220,10 @@ def _run_section_post(
     try:
         ws, app_config = action()
     except Exception as exc:
+        # Deliberately broad: `action` is a settings_service.apply_* call whose
+        # failure modes aren't enumerable here, and this is a user-facing form
+        # POST handler — any unexpected error must degrade to a re-rendered
+        # section with an error flash rather than an unhandled 500.
         if isinstance(exc, ValueError) and on_rejected is not None:
             return on_rejected(exc)
         logger.exception(failure_log)

--- a/tests/web/test_forms.py
+++ b/tests/web/test_forms.py
@@ -1,0 +1,96 @@
+"""Unit tests for the shared web form helpers (issue #1545)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from file_organizer.web._forms import (
+    TRUE_FORM_VALUES,
+    coerce_bool,
+    form_bool,
+    update_form_section,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+class TestFormBool:
+    def test_truthy_values(self) -> None:
+        for value in ("1", "true", "yes", "on", "TRUE", "  Yes  "):
+            assert form_bool(value) is True, value
+
+    def test_falsy_values(self) -> None:
+        for value in (None, "", "0", "false", "no", "off", "banana"):
+            assert form_bool(value) is False, value
+
+
+class TestCoerceBool:
+    def test_bool_passthrough(self) -> None:
+        assert coerce_bool(True, default=False) is True
+        assert coerce_bool(False, default=True) is False
+
+    def test_string_coercion(self) -> None:
+        assert coerce_bool("yes", default=False) is True
+        assert coerce_bool("nope", default=True) is False
+
+    def test_non_string_falls_back_to_default(self) -> None:
+        assert coerce_bool(1, default=False) is False
+        assert coerce_bool(None, default=True) is True
+        assert coerce_bool([], default=True) is True
+
+
+class TestTrueFormValues:
+    def test_is_single_canonical_set(self) -> None:
+        from file_organizer.web import _helpers
+
+        assert _helpers.TRUE_VALUES is TRUE_FORM_VALUES
+
+    def test_expected_members(self) -> None:
+        assert TRUE_FORM_VALUES == {"1", "true", "yes", "on"}
+
+
+class TestUpdateFormSection:
+    def test_success_flow_runs_load_apply_save_render(self) -> None:
+        state = {"value": 0}
+        calls: list[str] = []
+        success_response = MagicMock()
+
+        def apply(s: dict) -> None:
+            calls.append("apply")
+            s["value"] = 1
+
+        result = update_form_section(
+            load=lambda: (calls.append("load"), state)[1],
+            apply=apply,
+            save=lambda s: calls.append("save"),
+            render_success=lambda s: (calls.append("render"), success_response)[1],
+            render_error=lambda msg: pytest.fail(f"unexpected error render: {msg}"),
+            error_prefix="Failed",
+        )
+
+        assert result is success_response
+        assert calls == ["load", "apply", "save", "render"]
+        assert state["value"] == 1
+
+    @pytest.mark.parametrize("failing_step", ["load", "apply", "save"])
+    def test_failure_renders_error_with_prefix(self, failing_step: str) -> None:
+        error_response = MagicMock()
+        seen: list[str] = []
+
+        def maybe_fail(step: str) -> None:
+            if step == failing_step:
+                raise RuntimeError("boom")
+
+        result = update_form_section(
+            load=lambda: (maybe_fail("load"), {})[1],
+            apply=lambda s: maybe_fail("apply"),
+            save=lambda s: maybe_fail("save"),
+            render_success=lambda s: pytest.fail("success render on failure path"),
+            render_error=lambda msg: (seen.append(msg), error_response)[1],
+            error_prefix="Failed to save settings",
+        )
+
+        assert result is error_response
+        assert seen == ["Failed to save settings: boom"]

--- a/tests/web/test_settings_routes_coverage.py
+++ b/tests/web/test_settings_routes_coverage.py
@@ -347,14 +347,17 @@ class TestSettingsSectionPostRoutes:
     def test_appearance_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_appearance_post
 
+        # The handler saves via update_form_section(save=_save_web_settings).
         with patch(
-            "file_organizer.web.settings_routes._update_web_settings",
+            "file_organizer.web.settings_routes._save_web_settings",
             side_effect=RuntimeError("boom"),
         ):
             settings_appearance_post(
                 MagicMock(), theme="dark", custom_theme_name="", manager=mock_manager
             )
         mock_templates.TemplateResponse.assert_called_once()
+        context = mock_templates.TemplateResponse.call_args[0][2]
+        assert "boom" in context["error_message"]
 
     def test_advanced_post(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_advanced_post
@@ -372,8 +375,9 @@ class TestSettingsSectionPostRoutes:
     def test_advanced_post_exception(self, mock_templates, mock_manager) -> None:
         from file_organizer.web.settings_routes import settings_advanced_post
 
+        # The handler saves via update_form_section(save=_save_web_settings).
         with patch(
-            "file_organizer.web.settings_routes._update_web_settings",
+            "file_organizer.web.settings_routes._save_web_settings",
             side_effect=RuntimeError("boom"),
         ):
             settings_advanced_post(
@@ -385,6 +389,8 @@ class TestSettingsSectionPostRoutes:
                 manager=mock_manager,
             )
         mock_templates.TemplateResponse.assert_called_once()
+        context = mock_templates.TemplateResponse.call_args[0][2]
+        assert "boom" in context["error_message"]
 
 
 class TestLoadWebSettingsEdgeCases:


### PR DESCRIPTION
## Description

Completes issue #1545 (shared web form-coercion helpers and section-update pattern). Most of the issue's original targets already landed via the #1548 route split — `web/_forms.py` exists with `form_bool`/`coerce_bool`/`update_form_section`, and the `settings_routes.py` `_as_form_bool`/`_coerce_bool` duplicates and the inline `profile_routes.py` parsing are already gone. This PR closes out the remainder:

**One truthy-value coercer.** `_forms.TRUE_FORM_VALUES` (now frozen) is the canonical set. `_helpers.TRUE_VALUES` aliases it and `_helpers.as_bool` delegates to `form_bool` instead of re-implementing the same parsing — the third duplicate the issue pointed at. `organize_routes`/`organize_services` call `form_bool` directly; `as_bool` remains as a compat shim with its existing tests as regression coverage.

**Section-update pattern everywhere.** New `_run_section_post` helper in `settings_routes.py` owns the shared `action → render-success / log-and-render-error` flow (with a `ValueError` rejection hook for validation failures). The `general`, `models`, `organization`, and `reset` POST handlers shrink to thin bindings around their `settings_service.apply_*` calls; `appearance`/`advanced` already used the generic `_forms.update_form_section`. Behavior (messages, log lines, rejected-rules re-render) is unchanged.

**Tests.** New `tests/web/test_forms.py` covers the coercers and `update_form_section` directly — the module previously had no dedicated tests and now measures 100%. Also fixed two silently-dead exception tests in `test_settings_routes_coverage.py`: they patched `_update_web_settings`, which the appearance/advanced handlers don't call, so they were exercising the success path. They now patch `_save_web_settings` and assert the error flash is actually rendered.

Fixes #1545

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `pytest tests/web/ -m unit`: 754 passed, 2 skipped (py3.11.15, Linux)
- [x] All touched modules above their unit coverage floors: `_forms` 100% (floor 90), `_helpers` 86.4% (85), `settings_routes` 97.1% (90), `organize_routes` 81.1% (80), `organize_services` 100% (95)
- [x] `ruff check` / `ruff format --check`, `mypy` (5 touched modules), `check_safedir_required.py`, `check_atomic_write.py` all clean

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwH7YJYNgQoiTeGdF1USa9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwH7YJYNgQoiTeGdF1USa9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified checkbox/boolean parsing across web workflows (including case-insensitive and whitespace-tolerant interpretation for fields like dry-run, recursive, and include-hidden).
  * Improved settings section POST handling so validation and save failures re-render with clearer, context-preserving error feedback.

* **Tests**
  * Added unit tests for boolean parsing and form processing success/failure paths.
  * Strengthened settings route error coverage by verifying error messages appear in the rendered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->