### PR TITLE
feat: add canonical capability registry

### DIFF
--- a/docs/developer/capability-registry.md
+++ b/docs/developer/capability-registry.md
@@ -1,0 +1,66 @@
+# Capability Registry
+
+The canonical capability registry is the source of truth for cross-surface product intent and
+current parity evidence. It lives in
+`src/file_organizer/core/capability_registry.json` and is validated through the transport-neutral
+types in `file_organizer.core.capabilities`.
+
+The registry covers the CLI, REST API, Python SDK, TypeScript SDK, Web/Desktop, and TUI. It does
+not include developer-only utilities such as documentation serving or benchmarks unless they are
+deliberately promoted to public product capabilities.
+
+## Status dimensions
+
+Do not collapse these fields:
+
+- `target_support` records the intended support decision: `full`, `read-only`,
+  `redirect/deep-link`, or `not-applicable`.
+- `implementation_status` records whether that target currently exists: `implemented`, `partial`,
+  `not-implemented`, or `not-applicable`.
+- `conformance_status` records whether executable parity evidence exists: `verified`, `unverified`,
+  or `not-applicable`.
+
+For example, a surface can target full support while remaining not implemented and unverified.
+That is planned work, not a shipped claim.
+
+`execution_scopes` records the modes available for the capability. `local-only` means at least one
+adapter executes locally without a remote service. `remote` means a service-backed path exists or
+is intended. `auth-gated` qualifies remote execution and therefore must appear with `remote`.
+
+## Adding or changing a capability
+
+1. Reuse an existing stable ID when behavior is evolving without changing its product meaning.
+2. Add a new namespaced ID only for a distinct user-visible capability.
+3. Declare all six surfaces. Omitting a surface is a validation error.
+4. Set the target decision before recording current implementation state.
+5. Add concrete public entry points for `implemented` and `partial` surfaces. Planned,
+   not-implemented surfaces have no entry points.
+6. List relevant project extras in `optional_dependencies` and restrict `platforms` when support is
+   not cross-platform.
+7. Leave conformance `unverified` until an executable adapter driver proves the declared behavior.
+8. Update tests when a public client method or surface entry point changes.
+
+Never mark a capability verified because a route, command, view, or method exists. Verification is
+owned by the conformance workstream and requires behavior-level evidence against the canonical
+application service.
+
+## Validation and serialization
+
+Run the focused CI validation with:
+
+```bash
+pytest tests/core/test_capabilities.py -q --override-ini=addopts=
+```
+
+Consumers load a validated immutable registry and can serialize it deterministically:
+
+```python
+from file_organizer.core.capabilities import get_capability_registry
+
+registry = get_capability_registry()
+payload = registry.to_json()
+```
+
+The serialization schema is versioned independently through
+`CAPABILITY_REGISTRY_SCHEMA_VERSION`. Change that version only when consumers cannot safely read
+the prior shape.

--- a/docs/developer/capability-registry.md
+++ b/docs/developer/capability-registry.md
@@ -61,6 +61,10 @@ registry = get_capability_registry()
 payload = registry.to_json()
 ```
 
+The packaged JSON is stored in that canonical serialized form. The registry tests compare the
+file byte-for-byte with `to_json()`, so edits must preserve canonical key and capability ordering
+as well as the explicit defaults emitted by the serializer.
+
 The serialization schema is versioned independently through
 `CAPABILITY_REGISTRY_SCHEMA_VERSION`. Change that version only when consumers cannot safely read
 the prior shape.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
   - Developer Guide:
       - Overview: developer/index.md
       - Architecture: developer/architecture.md
+      - Capability Registry: developer/capability-registry.md
       - Plugin Development: developer/plugin-development.md
       - API Clients: developer/api-clients.md
       - Contributing: developer/contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,7 @@ where = ["src"]
 [tool.setuptools.package-data]
 file_organizer = [
     "py.typed",
+    "core/*.json",
     "config/*.yaml",
     "web/templates/**/*.html",
     "web/static/**/*",

--- a/src/file_organizer/cli/lazy.py
+++ b/src/file_organizer/cli/lazy.py
@@ -41,6 +41,9 @@ LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
     ),
 }
 
+DEVELOPER_ONLY_COMMANDS: frozenset[str] = frozenset({"benchmark", "docs"})
+"""Commands excluded from the public product capability registry."""
+
 COMMAND_CATEGORIES: dict[str, str] = {
     # Core
     "start": "Core",

--- a/src/file_organizer/core/capabilities.py
+++ b/src/file_organizer/core/capabilities.py
@@ -1,0 +1,419 @@
+"""Transport-neutral capability registry contracts.
+
+The registry records product intent and current evidence without importing any
+presentation framework.  Consumers such as conformance tests and documentation
+generators should load :func:`get_capability_registry` instead of maintaining a
+surface-specific capability list.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from importlib.resources import files
+from typing import Any, TypeVar
+
+from file_organizer._compat import StrEnum
+
+CAPABILITY_REGISTRY_SCHEMA_VERSION = 1
+_EnumT = TypeVar("_EnumT", bound=StrEnum)
+
+
+class Surface(StrEnum):
+    """Public product surfaces governed by the parity program."""
+
+    CLI = "cli"
+    REST_API = "rest-api"
+    PYTHON_SDK = "python-sdk"
+    TYPESCRIPT_SDK = "typescript-sdk"
+    WEB_DESKTOP = "web-desktop"
+    TUI = "tui"
+
+
+class SupportLevel(StrEnum):
+    """The intended support level for a capability on a surface."""
+
+    FULL = "full"
+    READ_ONLY = "read-only"
+    REDIRECT_DEEP_LINK = "redirect/deep-link"
+    NOT_APPLICABLE = "not-applicable"
+
+
+class ImplementationStatus(StrEnum):
+    """Whether the intended adapter behavior currently exists."""
+
+    IMPLEMENTED = "implemented"
+    PARTIAL = "partial"
+    NOT_IMPLEMENTED = "not-implemented"
+    NOT_APPLICABLE = "not-applicable"
+
+
+class ConformanceStatus(StrEnum):
+    """Whether executable parity evidence currently exists."""
+
+    VERIFIED = "verified"
+    UNVERIFIED = "unverified"
+    NOT_APPLICABLE = "not-applicable"
+
+
+class CapabilityMaturity(StrEnum):
+    """Product maturity of a capability independent of surface support."""
+
+    EXPERIMENTAL = "experimental"
+    BETA = "beta"
+    STABLE = "stable"
+    DEPRECATED = "deprecated"
+
+
+class ExecutionScope(StrEnum):
+    """Available execution modes or access boundaries for a capability."""
+
+    LOCAL_ONLY = "local-only"
+    REMOTE = "remote"
+    AUTH_GATED = "auth-gated"
+
+
+class Platform(StrEnum):
+    """Platforms on which a capability is intended to be available."""
+
+    LINUX = "linux"
+    MACOS = "macos"
+    WINDOWS = "windows"
+
+
+class CapabilityRegistryError(ValueError):
+    """Raised when registry data violates the capability contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceCapabilityStatus:
+    """Intent, implementation, and evidence for one capability surface."""
+
+    surface: Surface
+    target_support: SupportLevel
+    implementation_status: ImplementationStatus
+    conformance_status: ConformanceStatus
+    entry_points: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, surface: Surface, data: Mapping[str, Any]) -> SurfaceCapabilityStatus:
+        """Parse one serialized surface status."""
+        return cls(
+            surface=surface,
+            target_support=_enum_value(SupportLevel, data, "target_support"),
+            implementation_status=_enum_value(ImplementationStatus, data, "implementation_status"),
+            conformance_status=_enum_value(ConformanceStatus, data, "conformance_status"),
+            entry_points=_string_tuple(data.get("entry_points", ()), "entry_points"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-compatible representation."""
+        return {
+            "target_support": self.target_support.value,
+            "implementation_status": self.implementation_status.value,
+            "conformance_status": self.conformance_status.value,
+            "entry_points": list(self.entry_points),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Capability:
+    """A stable product capability and its cross-surface support decisions."""
+
+    capability_id: str
+    name: str
+    description: str
+    maturity: CapabilityMaturity
+    execution_scopes: tuple[ExecutionScope, ...]
+    surfaces: tuple[SurfaceCapabilityStatus, ...]
+    optional_dependencies: tuple[str, ...] = ()
+    platforms: tuple[Platform, ...] = tuple(Platform)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> Capability:
+        """Parse one serialized capability."""
+        raw_surfaces = data.get("surfaces")
+        if not isinstance(raw_surfaces, Mapping):
+            raise CapabilityRegistryError("capability surfaces must be an object")
+        expected_surface_names = {surface.value for surface in Surface}
+        if not all(isinstance(key, str) for key in raw_surfaces):
+            raise CapabilityRegistryError("capability surface names must be strings")
+        declared_surface_names = set(raw_surfaces)
+        if declared_surface_names != expected_surface_names:
+            missing = ", ".join(sorted(expected_surface_names - declared_surface_names)) or "none"
+            extra = ", ".join(sorted(declared_surface_names - expected_surface_names)) or "none"
+            raise CapabilityRegistryError(
+                f"capability surfaces are incomplete (missing: {missing}; extra: {extra})"
+            )
+        if not all(isinstance(value, Mapping) for value in raw_surfaces.values()):
+            raise CapabilityRegistryError("each capability surface must be an object")
+        raw_scopes = data.get("execution_scopes")
+        if not isinstance(raw_scopes, Sequence) or isinstance(raw_scopes, (str, bytes)):
+            raise CapabilityRegistryError("execution_scopes must be a list")
+        raw_platforms = data.get("platforms", [platform.value for platform in Platform])
+        if not isinstance(raw_platforms, Sequence) or isinstance(raw_platforms, (str, bytes)):
+            raise CapabilityRegistryError("platforms must be a list")
+        try:
+            return cls(
+                capability_id=_required_string(data, "id"),
+                name=_required_string(data, "name"),
+                description=_required_string(data, "description"),
+                maturity=_enum_value(CapabilityMaturity, data, "maturity"),
+                execution_scopes=tuple(ExecutionScope(value) for value in raw_scopes),
+                surfaces=tuple(
+                    SurfaceCapabilityStatus.from_dict(surface, raw_surfaces[surface.value])
+                    for surface in Surface
+                    if surface.value in raw_surfaces
+                ),
+                optional_dependencies=_string_tuple(
+                    data.get("optional_dependencies", ()), "optional_dependencies"
+                ),
+                platforms=tuple(Platform(value) for value in raw_platforms),
+            )
+        except (TypeError, ValueError) as exc:
+            if isinstance(exc, CapabilityRegistryError):
+                raise
+            raise CapabilityRegistryError(str(exc)) from exc
+
+    def support_for(self, surface: Surface) -> SurfaceCapabilityStatus:
+        """Return the declared status for ``surface``."""
+        for status in self.surfaces:
+            if status.surface is surface:
+                return status
+        raise CapabilityRegistryError(
+            f"capability {self.capability_id!r} does not declare surface {surface.value!r}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-compatible representation."""
+        return {
+            "id": self.capability_id,
+            "name": self.name,
+            "description": self.description,
+            "maturity": self.maturity.value,
+            "execution_scopes": [scope.value for scope in self.execution_scopes],
+            "optional_dependencies": list(self.optional_dependencies),
+            "platforms": [platform.value for platform in self.platforms],
+            "surfaces": {
+                status.surface.value: status.to_dict()
+                for status in sorted(self.surfaces, key=lambda item: item.surface.value)
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityRegistry:
+    """Validated collection of product capabilities."""
+
+    schema_version: int
+    capabilities: tuple[Capability, ...]
+
+    def __post_init__(self) -> None:
+        """Reject invalid state as soon as a registry is constructed."""
+        _validate_registry(self)
+        object.__setattr__(
+            self,
+            "capabilities",
+            tuple(sorted(self.capabilities, key=lambda item: item.capability_id)),
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> CapabilityRegistry:
+        """Parse and validate serialized registry data."""
+        schema_version = data.get("schema_version")
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+            raise CapabilityRegistryError("schema_version must be an integer")
+        raw_capabilities = data.get("capabilities")
+        if not isinstance(raw_capabilities, Sequence) or isinstance(raw_capabilities, (str, bytes)):
+            raise CapabilityRegistryError("capabilities must be a list")
+        if not all(isinstance(item, Mapping) for item in raw_capabilities):
+            raise CapabilityRegistryError("each capability must be an object")
+        return cls(
+            schema_version=schema_version,
+            capabilities=tuple(Capability.from_dict(item) for item in raw_capabilities),
+        )
+
+    @classmethod
+    def from_json(cls, content: str) -> CapabilityRegistry:
+        """Parse and validate a serialized JSON registry."""
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise CapabilityRegistryError(f"invalid registry JSON: {exc}") from exc
+        if not isinstance(data, Mapping):
+            raise CapabilityRegistryError("registry root must be an object")
+        return cls.from_dict(data)
+
+    def get(self, capability_id: str) -> Capability:
+        """Return a capability by stable ID."""
+        for capability in self.capabilities:
+            if capability.capability_id == capability_id:
+                return capability
+        raise KeyError(capability_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministically ordered JSON-compatible representation."""
+        return {
+            "schema_version": self.schema_version,
+            "surfaces": [surface.value for surface in Surface],
+            "capabilities": [
+                capability.to_dict()
+                for capability in sorted(self.capabilities, key=lambda item: item.capability_id)
+            ],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Serialize the registry deterministically for tests and generators."""
+        separators = (",", ":") if indent is None else None
+        return (
+            json.dumps(self.to_dict(), indent=indent, sort_keys=True, separators=separators) + "\n"
+        )
+
+
+def get_capability_registry() -> CapabilityRegistry:
+    """Load the packaged canonical capability registry."""
+    resource = files("file_organizer.core").joinpath("capability_registry.json")
+    return CapabilityRegistry.from_json(resource.read_text(encoding="utf-8"))
+
+
+def _validate_registry(registry: CapabilityRegistry) -> None:
+    """Validate registry-level invariants and each capability."""
+    if registry.schema_version != CAPABILITY_REGISTRY_SCHEMA_VERSION:
+        raise CapabilityRegistryError(
+            "unsupported capability registry schema version "
+            f"{registry.schema_version}; expected {CAPABILITY_REGISTRY_SCHEMA_VERSION}"
+        )
+    if not registry.capabilities:
+        raise CapabilityRegistryError("registry must contain at least one capability")
+
+    seen_ids: set[str] = set()
+    for capability in registry.capabilities:
+        _validate_capability(capability)
+        if capability.capability_id in seen_ids:
+            raise CapabilityRegistryError(f"duplicate capability ID: {capability.capability_id}")
+        seen_ids.add(capability.capability_id)
+
+
+_CAPABILITY_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$")
+
+
+def _validate_capability(capability: Capability) -> None:
+    """Validate identifiers, metadata, scopes, and the complete surface matrix."""
+    prefix = f"capability {capability.capability_id!r}"
+    if not _CAPABILITY_ID_PATTERN.fullmatch(capability.capability_id):
+        raise CapabilityRegistryError(f"{prefix} has an invalid stable ID")
+    if not capability.name.strip() or not capability.description.strip():
+        raise CapabilityRegistryError(f"{prefix} must have a name and description")
+    if not capability.execution_scopes:
+        raise CapabilityRegistryError(f"{prefix} must declare at least one execution scope")
+    if len(set(capability.execution_scopes)) != len(capability.execution_scopes):
+        raise CapabilityRegistryError(f"{prefix} has duplicate execution scopes")
+    if (
+        ExecutionScope.AUTH_GATED in capability.execution_scopes
+        and ExecutionScope.REMOTE not in capability.execution_scopes
+    ):
+        raise CapabilityRegistryError(f"{prefix} cannot be auth-gated without remote execution")
+    if not capability.platforms or len(set(capability.platforms)) != len(capability.platforms):
+        raise CapabilityRegistryError(f"{prefix} must declare unique supported platforms")
+    if len(set(capability.optional_dependencies)) != len(capability.optional_dependencies) or any(
+        not dependency.strip() for dependency in capability.optional_dependencies
+    ):
+        raise CapabilityRegistryError(f"{prefix} has invalid or duplicate optional dependencies")
+
+    declared_surfaces = [status.surface for status in capability.surfaces]
+    if len(set(declared_surfaces)) != len(declared_surfaces):
+        raise CapabilityRegistryError(f"{prefix} declares a surface more than once")
+    missing = set(Surface) - set(declared_surfaces)
+    extra = set(declared_surfaces) - set(Surface)
+    if missing or extra:
+        missing_names = ", ".join(sorted(item.value for item in missing)) or "none"
+        extra_names = ", ".join(sorted(item.value for item in extra)) or "none"
+        raise CapabilityRegistryError(
+            f"{prefix} has an incomplete surface matrix (missing: {missing_names}; extra: {extra_names})"
+        )
+
+    for status in capability.surfaces:
+        _validate_surface_status(capability.capability_id, status)
+
+
+def _validate_surface_status(capability_id: str, status: SurfaceCapabilityStatus) -> None:
+    """Validate one surface decision and its implementation evidence."""
+    prefix = f"capability {capability_id!r} surface {status.surface.value!r}"
+    target_is_na = status.target_support is SupportLevel.NOT_APPLICABLE
+    implementation_is_na = status.implementation_status is ImplementationStatus.NOT_APPLICABLE
+    conformance_is_na = status.conformance_status is ConformanceStatus.NOT_APPLICABLE
+    if len(set(status.entry_points)) != len(status.entry_points) or any(
+        not entry.strip() for entry in status.entry_points
+    ):
+        raise CapabilityRegistryError(f"{prefix} has invalid or duplicate entry points")
+    if target_is_na:
+        if not implementation_is_na or not conformance_is_na or status.entry_points:
+            raise CapabilityRegistryError(
+                f"{prefix} is not-applicable and cannot have implementation evidence"
+            )
+        return
+    if implementation_is_na or conformance_is_na:
+        raise CapabilityRegistryError(
+            f"{prefix} has applicable target support but a not-applicable status"
+        )
+    if status.implementation_status is ImplementationStatus.NOT_IMPLEMENTED:
+        if status.entry_points:
+            raise CapabilityRegistryError(f"{prefix} is not implemented but declares entry points")
+    elif not status.entry_points:
+        raise CapabilityRegistryError(f"{prefix} is implemented but has no entry point evidence")
+    if (
+        status.conformance_status is ConformanceStatus.VERIFIED
+        and status.implementation_status is not ImplementationStatus.IMPLEMENTED
+    ):
+        raise CapabilityRegistryError(
+            f"{prefix} cannot be verified until implementation is complete"
+        )
+
+
+def _required_string(data: Mapping[str, Any], key: str) -> str:
+    """Read a required non-empty string from serialized data."""
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CapabilityRegistryError(f"{key} must be a non-empty string")
+    return value
+
+
+def _string_tuple(value: Any, field: str) -> tuple[str, ...]:
+    """Convert a serialized string list to an immutable tuple."""
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise CapabilityRegistryError(f"{field} must be a list of strings")
+    if not all(isinstance(item, str) for item in value):
+        raise CapabilityRegistryError(f"{field} must be a list of strings")
+    return tuple(value)
+
+
+def _enum_value(enum_type: type[_EnumT], data: Mapping[str, Any], key: str) -> _EnumT:
+    """Read and validate one string enum value from serialized data."""
+    value = data.get(key)
+    if not isinstance(value, str):
+        allowed = ", ".join(item.value for item in enum_type)
+        raise CapabilityRegistryError(f"{key} must be one of: {allowed}")
+    try:
+        return enum_type(value)
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in enum_type)
+        raise CapabilityRegistryError(f"{key} must be one of: {allowed}") from exc
+
+
+__all__ = [
+    "CAPABILITY_REGISTRY_SCHEMA_VERSION",
+    "Capability",
+    "CapabilityMaturity",
+    "CapabilityRegistry",
+    "CapabilityRegistryError",
+    "ConformanceStatus",
+    "ExecutionScope",
+    "ImplementationStatus",
+    "Platform",
+    "SupportLevel",
+    "Surface",
+    "SurfaceCapabilityStatus",
+    "get_capability_registry",
+]

--- a/src/file_organizer/core/capability_registry.json
+++ b/src/file_organizer/core/capability_registry.json
@@ -1,533 +1,2283 @@
 {
-  "schema_version": 1,
   "capabilities": [
     {
-      "id": "setup.configure",
-      "name": "Initial setup",
-      "description": "Discover local capabilities and persist an initial working configuration.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo setup run", "fo start", "fo quickstart"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/setup/status", "GET /api/v1/setup/capabilities", "GET /api/v1/setup/browse-folder", "POST /api/v1/setup/complete"]},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/setup", "POST /ui/setup/defer"]},
-        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["SetupWizardView"]}
-      }
-    },
-    {
-      "id": "organization.scan",
-      "name": "Organization scan",
-      "description": "Collect candidate files using the canonical traversal and filtering policy.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo preview", "fo organize"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/organize/scan"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.scan", "AsyncFileOrganizerClient.scan"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.scan"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /ui/organize/scan"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileBrowserView", "OrganizationPreviewView"]}
-      }
-    },
-    {
-      "id": "organization.preview",
-      "name": "Organization preview",
-      "description": "Build and inspect an organization plan without applying filesystem changes.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo preview", "fo organize --dry-run"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/organize/preview"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.preview_organize", "AsyncFileOrganizerClient.preview_organize"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.previewOrganize"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/organize", "POST /ui/organize/scan", "POST /ui/organize/plan/clear"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["OrganizationPreviewView"]}
-      }
-    },
-    {
-      "id": "organization.execute",
-      "name": "Organization execution",
-      "description": "Apply an approved organization plan and return normalized operation results.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo organize"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/organize", "POST /api/v1/organize/execute"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.organize", "AsyncFileOrganizerClient.organize"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.organize"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /ui/organize/execute"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["OrganizationPreviewView"]}
-      }
-    },
-    {
-      "id": "organization.jobs-recovery",
-      "name": "Organization jobs and recovery",
-      "description": "Observe, cancel, roll back, and recover organization work using stable lifecycle semantics.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo recover", "fo undo", "fo history"]},
-        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /api/v1/organize/status/{job_id}", "WS /api/v1/ws/{client_id}"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_job", "AsyncFileOrganizerClient.get_job"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getJob"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/organize/jobs/{job_id}/status", "GET /ui/organize/jobs/{job_id}/events", "POST /ui/organize/jobs/{job_id}/cancel", "POST /ui/organize/jobs/{job_id}/rollback"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["UndoHistoryView"]}
-      }
-    },
-    {
-      "id": "files.browse",
-      "name": "File browsing",
-      "description": "Browse directory contents with filtering, sorting, pagination, and hidden-file policy.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo api files"]},
-        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/files"]},
-        "python-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.list_files", "AsyncFileOrganizerClient.list_files"]},
-        "typescript-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.listFiles"]},
-        "web-desktop": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/files", "GET /ui/files/list", "GET /ui/files/tree"]},
-        "tui": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileBrowserView"]}
-      }
-    },
-    {
-      "id": "files.inspect",
-      "name": "File inspection",
-      "description": "Read file metadata, supported content, previews, thumbnails, and downloads.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": ["parsers", "audio", "video"],
-      "surfaces": {
-        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo analyze"]},
-        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/files/info", "GET /api/v1/files/content", "GET /api/v1/files/{file_id}"]},
-        "python-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_file_info", "FileOrganizerClient.read_file_content", "AsyncFileOrganizerClient.get_file_info", "AsyncFileOrganizerClient.read_file_content"]},
-        "typescript-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getFileInfo", "FileOrganizerClient.readFileContent"]},
-        "web-desktop": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/files/preview", "GET /ui/files/raw", "GET /ui/files/thumbnail"]},
-        "tui": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FilePreviewView"]}
-      }
-    },
-    {
-      "id": "files.mutate",
-      "name": "Direct file mutations",
-      "description": "Upload, move, and delete individual files through guarded public operations.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/files/upload", "POST /api/v1/files/move", "DELETE /api/v1/files", "DELETE /api/v1/files/{file_id}"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.move_file", "FileOrganizerClient.delete_file", "AsyncFileOrganizerClient.move_file", "AsyncFileOrganizerClient.delete_file"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.moveFile", "FileOrganizerClient.deleteFile"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /ui/files/upload"]},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
-      }
-    },
-    {
-      "id": "search.query",
-      "name": "File search",
-      "description": "Search indexed or local files with consistent query and result semantics.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": ["search"],
-      "surfaces": {
-        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo search"]},
-        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/search"]},
-        "python-sdk": {"target_support": "read-only", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "read-only", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/search"]},
-        "tui": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileBrowserView"]}
-      }
-    },
-    {
-      "id": "analysis.inspect",
-      "name": "AI-assisted file analysis",
-      "description": "Analyze file content and metadata, including optional vision, audio, and video features.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": ["parsers", "audio", "video", "cloud", "claude", "llama", "mlx"],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo analyze", "fo organize --vision", "fo organize --transcribe-audio"]},
-        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /api/v1/analyze"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/files/preview", "POST /ui/settings/models/test"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["AudioView", "FilePreviewView"]}
-      }
-    },
-    {
-      "id": "deduplication.manage",
-      "name": "Duplicate management",
-      "description": "Scan, preview, report, and resolve duplicate file groups.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": ["dedup"],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo dedupe scan", "fo dedupe report", "fo dedupe resolve"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/dedupe/scan", "POST /api/v1/dedupe/preview", "POST /api/v1/dedupe/execute"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.dedupe_scan", "FileOrganizerClient.dedupe_preview", "FileOrganizerClient.dedupe_execute", "AsyncFileOrganizerClient.dedupe_scan", "AsyncFileOrganizerClient.dedupe_preview", "AsyncFileOrganizerClient.dedupe_execute"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.dedupeScan", "FileOrganizerClient.dedupePreview", "FileOrganizerClient.dedupeExecute"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
-      }
-    },
-    {
-      "id": "audio.transcribe",
-      "name": "Audio transcription",
-      "description": "Transcribe supported local audio content for analysis and organization.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": ["audio"],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo organize --transcribe-audio"]},
-        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /api/v1/analyze"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["AudioView"]}
-      }
-    },
-    {
-      "id": "video.analyze",
-      "name": "Video analysis",
-      "description": "Detect scenes and extract representative keyframes from supported videos.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": ["video"],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo analyze"]},
-        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /api/v1/analyze"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/files/preview"]},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
-      }
-    },
-    {
-      "id": "automation.tags",
-      "name": "Automatic tagging",
-      "description": "Suggest, apply, inspect, and batch-manage file tags.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo autotag suggest", "fo autotag apply", "fo autotag popular", "fo autotag batch", "fo autotag recent"]},
-        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
-      }
-    },
-    {
-      "id": "automation.rules",
-      "name": "Organization rules",
-      "description": "Create, preview, apply, import, export, and watch declarative organization rules.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo rules list", "fo rules sets", "fo rules add", "fo rules remove", "fo rules toggle", "fo rules preview", "fo rules apply", "fo rules watch", "fo rules export", "fo rules import"]},
-        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
-      }
-    },
-    {
-      "id": "automation.suggestions",
-      "name": "Smart suggestions",
-      "description": "Generate, inspect, and apply learned file-placement suggestions.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo suggest files", "fo suggest patterns", "fo suggest apply"]},
-        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
-      }
-    },
-    {
-      "id": "automation.watcher",
-      "name": "Background watcher",
-      "description": "Start, stop, inspect, and configure continuous directory watching.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo daemon start", "fo daemon stop", "fo daemon status", "fo daemon watch", "fo daemon process"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/daemon/start", "POST /api/v1/daemon/stop", "POST /api/v1/daemon/toggle", "GET /api/v1/daemon/status"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/advanced", "POST /ui/settings/advanced"]},
-        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
-      }
-    },
-    {
-      "id": "methodology.configure",
-      "name": "Organization methodology",
-      "description": "Select and configure default, PARA, or Johnny Decimal organization policy.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo organize --methodology", "fo config edit"]},
-        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /api/v1/config", "PUT /api/v1/config"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_config", "FileOrganizerClient.update_config", "AsyncFileOrganizerClient.get_config", "AsyncFileOrganizerClient.update_config"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getConfig", "FileOrganizerClient.updateConfig"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/organization", "POST /ui/settings/organization/validate", "POST /ui/settings/organization"]},
-        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["MethodologyView"]}
-      }
-    },
-    {
-      "id": "analytics.inspect",
-      "name": "Organization analytics",
-      "description": "Inspect organization activity, storage metrics, trends, and exported reports.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo analytics"]},
-        "rest-api": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /api/v1/system/stats"]},
-        "python-sdk": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.system_stats", "AsyncFileOrganizerClient.system_stats"]},
-        "typescript-sdk": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.systemStats"]},
-        "web-desktop": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/organize/stats", "GET /ui/organize/stats/events", "GET /ui/organize/report/{job_id}"]},
-        "tui": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["AnalyticsView"]}
-      }
-    },
-    {
-      "id": "history.manage",
-      "name": "Operation history and undo",
-      "description": "Review operation history and perform supported undo and redo actions.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo history", "fo undo", "fo redo"]},
-        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/organize/history", "GET /ui/organize/history/events", "POST /ui/organize/jobs/{job_id}/rollback"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["UndoHistoryView"]}
-      }
-    },
-    {
-      "id": "copilot.chat",
-      "name": "Copilot chat",
-      "description": "Interpret natural-language file-management requests and propose explicit actions.",
-      "maturity": "experimental",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": ["cloud", "claude", "llama", "mlx"],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo copilot chat", "fo copilot status"]},
-        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["CopilotView"]}
-      }
-    },
-    {
-      "id": "configuration.manage",
-      "name": "Configuration management",
-      "description": "Read, validate, update, import, export, and reset application configuration.",
-      "maturity": "stable",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo config show", "fo config list", "fo config edit"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/config", "PUT /api/v1/config", "POST /api/v1/config/reset", "GET /api/v1/system/config", "PATCH /api/v1/system/config"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_config", "FileOrganizerClient.update_config", "AsyncFileOrganizerClient.get_config", "AsyncFileOrganizerClient.update_config"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getConfig", "FileOrganizerClient.updateConfig"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/settings", "GET /ui/settings/general", "POST /ui/settings/general", "GET /ui/settings/appearance", "POST /ui/settings/appearance", "GET /ui/settings/export", "POST /ui/settings/import", "POST /ui/settings/reset"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["SettingsView"]}
-      }
-    },
-    {
-      "id": "configuration.profiles",
-      "name": "Named configuration profiles",
-      "description": "Create, activate, merge, migrate, validate, import, and export named local profiles.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo profile list", "fo profile create", "fo profile activate", "fo profile delete", "fo profile current", "fo profile export", "fo profile import", "fo profile merge", "fo profile template list", "fo profile template preview", "fo profile template apply", "fo profile migrate", "fo profile validate"]},
-        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
-      }
-    },
-    {
-      "id": "models.manage",
-      "name": "AI model management",
-      "description": "Inspect, acquire, select, test, and cache supported AI models.",
-      "maturity": "beta",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": ["cloud", "claude", "llama", "mlx"],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo model list", "fo model pull", "fo model cache"]},
-        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/models", "POST /ui/settings/models", "POST /ui/settings/models/test"]},
-        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["SettingsView"]}
-      }
-    },
-    {
-      "id": "authentication.manage",
-      "name": "User authentication",
-      "description": "Register, sign in, refresh identity, inspect the current user, and sign out.",
-      "maturity": "stable",
-      "execution_scopes": ["remote", "auth-gated"],
-      "optional_dependencies": [],
-      "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo api login", "fo api me", "fo api logout"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/auth/register", "POST /api/v1/auth/login", "POST /api/v1/auth/refresh", "GET /api/v1/auth/me", "POST /api/v1/auth/logout"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.register", "FileOrganizerClient.login", "FileOrganizerClient.refresh_token", "FileOrganizerClient.me", "FileOrganizerClient.logout", "AsyncFileOrganizerClient.register", "AsyncFileOrganizerClient.login", "AsyncFileOrganizerClient.refresh_token", "AsyncFileOrganizerClient.me", "AsyncFileOrganizerClient.logout"]},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.register", "FileOrganizerClient.login", "FileOrganizerClient.refreshToken", "FileOrganizerClient.me", "FileOrganizerClient.logout"]},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/profile/register", "POST /ui/profile/register", "GET /ui/profile/login", "POST /ui/profile/login", "POST /ui/profile/logout", "GET /ui/profile/reset-password", "POST /ui/profile/reset-password"]},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
-      }
-    },
-    {
-      "id": "accounts.manage",
-      "name": "Account and workspace management",
       "description": "Manage account details, security, activity, teams, sharing, notifications, and workspaces.",
+      "execution_scopes": [
+        "remote",
+        "auth-gated"
+      ],
+      "id": "accounts.manage",
       "maturity": "beta",
-      "execution_scopes": ["remote", "auth-gated"],
+      "name": "Account and workspace management",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/profile", "GET /ui/profile/account-settings", "POST /ui/profile/account-settings/2fa", "POST /ui/profile/account-settings/password", "GET /ui/profile/activity", "GET /ui/profile/avatar/{user_id}", "GET /ui/profile/edit", "POST /ui/profile/edit", "POST /ui/profile/edit-avatar", "GET /ui/profile/forgot-password", "POST /ui/profile/forgot-password", "GET /ui/profile/team", "POST /ui/profile/team/invite", "POST /ui/profile/team/role", "GET /ui/profile/shared", "POST /ui/profile/shared/add", "POST /ui/profile/shared/remove", "GET /ui/profile/notifications", "POST /ui/profile/notifications/mark-read", "GET /ui/profile/workspaces", "POST /ui/profile/workspaces/create", "POST /ui/profile/workspaces/switch"]},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+        "cli": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/profile",
+            "GET /ui/profile/account-settings",
+            "POST /ui/profile/account-settings/2fa",
+            "POST /ui/profile/account-settings/password",
+            "GET /ui/profile/activity",
+            "GET /ui/profile/avatar/{user_id}",
+            "GET /ui/profile/edit",
+            "POST /ui/profile/edit",
+            "POST /ui/profile/edit-avatar",
+            "GET /ui/profile/forgot-password",
+            "POST /ui/profile/forgot-password",
+            "GET /ui/profile/team",
+            "POST /ui/profile/team/invite",
+            "POST /ui/profile/team/role",
+            "GET /ui/profile/shared",
+            "POST /ui/profile/shared/add",
+            "POST /ui/profile/shared/remove",
+            "GET /ui/profile/notifications",
+            "POST /ui/profile/notifications/mark-read",
+            "GET /ui/profile/workspaces",
+            "POST /ui/profile/workspaces/create",
+            "POST /ui/profile/workspaces/switch"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
       }
     },
     {
-      "id": "api-keys.manage",
-      "name": "API key management",
+      "description": "Analyze file content and metadata, including optional vision, audio, and video features.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "analysis.inspect",
+      "maturity": "beta",
+      "name": "AI-assisted file analysis",
+      "optional_dependencies": [
+        "parsers",
+        "audio",
+        "video",
+        "cloud",
+        "claude",
+        "llama",
+        "mlx"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo analyze",
+            "fo organize",
+            "fo organize --transcribe-audio"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/analyze"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "AudioView",
+            "FilePreviewView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/files/preview",
+            "POST /ui/settings/models/test"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Inspect organization activity, storage metrics, trends, and exported reports.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "analytics.inspect",
+      "maturity": "beta",
+      "name": "Organization analytics",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo analytics"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.system_stats",
+            "AsyncFileOrganizerClient.system_stats"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/system/stats"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "AnalyticsView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.systemStats"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/organize/stats",
+            "GET /ui/organize/stats/events",
+            "GET /ui/organize/report/{job_id}"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        }
+      }
+    },
+    {
       "description": "Generate, list, and revoke credentials used for authenticated API access.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "api-keys.manage",
       "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "name": "API key management",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo api-keys generate"]},
-        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/profile/api-keys", "POST /ui/profile/api-keys/generate", "POST /ui/profile/api-keys/revoke"]},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo api-keys generate"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/profile/api-keys",
+            "POST /ui/profile/api-keys/generate",
+            "POST /ui/profile/api-keys/revoke"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
       }
     },
     {
-      "id": "system.inspect",
-      "name": "System health and status",
-      "description": "Inspect service health, runtime status, hardware capabilities, and storage statistics.",
+      "description": "Transcribe supported local audio content for analysis and organization.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "audio.transcribe",
+      "maturity": "beta",
+      "name": "Audio transcription",
+      "optional_dependencies": [
+        "audio"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo organize --transcribe-audio"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/analyze"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "AudioView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Register, sign in, refresh identity, inspect the current user, and sign out.",
+      "execution_scopes": [
+        "remote",
+        "auth-gated"
+      ],
+      "id": "authentication.manage",
       "maturity": "stable",
-      "execution_scopes": ["local-only", "remote"],
+      "name": "User authentication",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo version", "fo doctor", "fo hardware-info", "fo api health", "fo api system-status", "fo api system-stats"]},
-        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/health", "GET /api/v1/system/status", "GET /api/v1/system/stats"]},
-        "python-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.health", "FileOrganizerClient.system_status", "FileOrganizerClient.system_stats", "AsyncFileOrganizerClient.health", "AsyncFileOrganizerClient.system_status", "AsyncFileOrganizerClient.system_stats"]},
-        "typescript-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.health", "FileOrganizerClient.systemStatus", "FileOrganizerClient.systemStats"]},
-        "web-desktop": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/"]},
-        "tui": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["AnalyticsView"]}
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo api login",
+            "fo api me",
+            "fo api logout"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.register",
+            "FileOrganizerClient.login",
+            "FileOrganizerClient.refresh_token",
+            "FileOrganizerClient.me",
+            "FileOrganizerClient.logout",
+            "AsyncFileOrganizerClient.register",
+            "AsyncFileOrganizerClient.login",
+            "AsyncFileOrganizerClient.refresh_token",
+            "AsyncFileOrganizerClient.me",
+            "AsyncFileOrganizerClient.logout"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/auth/register",
+            "POST /api/v1/auth/login",
+            "POST /api/v1/auth/refresh",
+            "GET /api/v1/auth/me",
+            "POST /api/v1/auth/logout"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.register",
+            "FileOrganizerClient.login",
+            "FileOrganizerClient.refreshToken",
+            "FileOrganizerClient.me",
+            "FileOrganizerClient.logout"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/profile/register",
+            "POST /ui/profile/register",
+            "GET /ui/profile/login",
+            "POST /ui/profile/login",
+            "POST /ui/profile/logout",
+            "GET /ui/profile/reset-password",
+            "POST /ui/profile/reset-password"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
       }
     },
     {
-      "id": "integrations.manage",
-      "name": "External integrations",
+      "description": "Create, preview, apply, import, export, and watch declarative organization rules.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "automation.rules",
+      "maturity": "beta",
+      "name": "Organization rules",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo rules list",
+            "fo rules sets",
+            "fo rules add",
+            "fo rules remove",
+            "fo rules toggle",
+            "fo rules preview",
+            "fo rules apply",
+            "fo rules watch",
+            "fo rules export",
+            "fo rules import"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Generate, inspect, and apply learned file-placement suggestions.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "automation.suggestions",
+      "maturity": "beta",
+      "name": "Smart suggestions",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo suggest files",
+            "fo suggest patterns",
+            "fo suggest apply"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Suggest, apply, inspect, and batch-manage file tags.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "automation.tags",
+      "maturity": "beta",
+      "name": "Automatic tagging",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo autotag suggest",
+            "fo autotag apply",
+            "fo autotag popular",
+            "fo autotag batch",
+            "fo autotag recent"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Start, stop, inspect, and configure continuous directory watching.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "automation.watcher",
+      "maturity": "stable",
+      "name": "Background watcher",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo daemon start",
+            "fo daemon stop",
+            "fo daemon status",
+            "fo daemon watch",
+            "fo daemon process"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/daemon/start",
+            "POST /api/v1/daemon/stop",
+            "POST /api/v1/daemon/toggle",
+            "GET /api/v1/daemon/status"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/settings/advanced",
+            "POST /ui/settings/advanced"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Read, validate, update, import, export, and reset application configuration.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "configuration.manage",
+      "maturity": "stable",
+      "name": "Configuration management",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo config show",
+            "fo config list",
+            "fo config edit"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.get_config",
+            "FileOrganizerClient.update_config",
+            "AsyncFileOrganizerClient.get_config",
+            "AsyncFileOrganizerClient.update_config"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/config",
+            "PUT /api/v1/config",
+            "POST /api/v1/config/reset",
+            "GET /api/v1/system/config",
+            "PATCH /api/v1/system/config"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "SettingsView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.getConfig",
+            "FileOrganizerClient.updateConfig"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/settings",
+            "GET /ui/settings/general",
+            "POST /ui/settings/general",
+            "GET /ui/settings/appearance",
+            "POST /ui/settings/appearance",
+            "GET /ui/settings/export",
+            "POST /ui/settings/import",
+            "POST /ui/settings/reset"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Create, activate, merge, migrate, validate, import, and export named local profiles.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "configuration.profiles",
+      "maturity": "beta",
+      "name": "Named configuration profiles",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo profile"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        }
+      }
+    },
+    {
+      "description": "Interpret natural-language file-management requests and propose explicit actions.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "copilot.chat",
+      "maturity": "experimental",
+      "name": "Copilot chat",
+      "optional_dependencies": [
+        "cloud",
+        "claude",
+        "llama",
+        "mlx"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo copilot chat",
+            "fo copilot status"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "CopilotView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        }
+      }
+    },
+    {
+      "description": "Scan, preview, report, and resolve duplicate file groups.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "deduplication.manage",
+      "maturity": "stable",
+      "name": "Duplicate management",
+      "optional_dependencies": [
+        "dedup"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo dedupe scan",
+            "fo dedupe report",
+            "fo dedupe resolve"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.dedupe_scan",
+            "FileOrganizerClient.dedupe_preview",
+            "FileOrganizerClient.dedupe_execute",
+            "AsyncFileOrganizerClient.dedupe_scan",
+            "AsyncFileOrganizerClient.dedupe_preview",
+            "AsyncFileOrganizerClient.dedupe_execute"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/dedupe/scan",
+            "POST /api/v1/dedupe/preview",
+            "POST /api/v1/dedupe/execute"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.dedupeScan",
+            "FileOrganizerClient.dedupePreview",
+            "FileOrganizerClient.dedupeExecute"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Browse directory contents with filtering, sorting, pagination, and hidden-file policy.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "files.browse",
+      "maturity": "stable",
+      "name": "File browsing",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo api files"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.list_files",
+            "AsyncFileOrganizerClient.list_files"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/files"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileBrowserView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.listFiles"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/files",
+            "GET /ui/files/list",
+            "GET /ui/files/tree"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        }
+      }
+    },
+    {
+      "description": "Read file metadata, supported content, previews, thumbnails, and downloads.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "files.inspect",
+      "maturity": "stable",
+      "name": "File inspection",
+      "optional_dependencies": [
+        "parsers",
+        "audio",
+        "video"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo analyze"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.get_file_info",
+            "FileOrganizerClient.read_file_content",
+            "AsyncFileOrganizerClient.get_file_info",
+            "AsyncFileOrganizerClient.read_file_content"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/files/info",
+            "GET /api/v1/files/content",
+            "GET /api/v1/files/{file_id}"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FilePreviewView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.getFileInfo",
+            "FileOrganizerClient.readFileContent"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/files/preview",
+            "GET /ui/files/raw",
+            "GET /ui/files/thumbnail"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        }
+      }
+    },
+    {
+      "description": "Upload, move, and delete individual files through guarded public operations.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "files.mutate",
+      "maturity": "beta",
+      "name": "Direct file mutations",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.move_file",
+            "FileOrganizerClient.delete_file",
+            "AsyncFileOrganizerClient.move_file",
+            "AsyncFileOrganizerClient.delete_file"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/files/upload",
+            "POST /api/v1/files/move",
+            "DELETE /api/v1/files",
+            "DELETE /api/v1/files/{file_id}"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.moveFile",
+            "FileOrganizerClient.deleteFile"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /ui/files/upload"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Review operation history and perform supported undo and redo actions.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "history.manage",
+      "maturity": "stable",
+      "name": "Operation history and undo",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo history",
+            "fo undo",
+            "fo redo"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "UndoHistoryView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/organize/history",
+            "GET /ui/organize/history/events",
+            "POST /ui/organize/jobs/{job_id}/rollback"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        }
+      }
+    },
+    {
       "description": "Configure, connect, disconnect, and send files through supported integrations.",
+      "execution_scopes": [
+        "remote",
+        "auth-gated"
+      ],
+      "id": "integrations.manage",
       "maturity": "experimental",
-      "execution_scopes": ["remote", "auth-gated"],
+      "name": "External integrations",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/integrations", "POST /api/v1/integrations/{integration_name}/settings", "POST /api/v1/integrations/{integration_name}/connect", "POST /api/v1/integrations/{integration_name}/disconnect", "POST /api/v1/integrations/{integration_name}/send", "GET /api/v1/integrations/browser/config", "POST /api/v1/integrations/browser/token", "POST /api/v1/integrations/browser/verify"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+        "cli": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/integrations",
+            "POST /api/v1/integrations/{integration_name}/settings",
+            "POST /api/v1/integrations/{integration_name}/connect",
+            "POST /api/v1/integrations/{integration_name}/disconnect",
+            "POST /api/v1/integrations/{integration_name}/send",
+            "GET /api/v1/integrations/browser/config",
+            "POST /api/v1/integrations/browser/token",
+            "POST /api/v1/integrations/browser/verify"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        }
       }
     },
     {
-      "id": "interfaces.launch",
-      "name": "Interactive interface launchers",
       "description": "Launch the supported local Web, Desktop, and terminal user interfaces.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "interfaces.launch",
       "maturity": "stable",
-      "execution_scopes": ["local-only"],
-      "optional_dependencies": ["desktop"],
+      "name": "Interactive interface launchers",
+      "optional_dependencies": [
+        "desktop"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo serve", "fo desktop", "fo tui"]},
-        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo serve",
+            "fo desktop",
+            "fo tui"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        }
       }
     },
     {
-      "id": "marketplace.manage",
-      "name": "Plugin marketplace",
       "description": "Browse, inspect, install, remove, update, and review marketplace plugins.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "marketplace.manage",
       "maturity": "beta",
-      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "name": "Plugin marketplace",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo marketplace list", "fo marketplace search", "fo marketplace info", "fo marketplace install", "fo marketplace uninstall", "fo marketplace update", "fo marketplace installed", "fo marketplace updates", "fo marketplace review"]},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/marketplace/plugins", "GET /api/v1/marketplace/plugins/{name}", "GET /api/v1/marketplace/installed", "GET /api/v1/marketplace/updates", "POST /api/v1/marketplace/plugins/{name}/install", "DELETE /api/v1/marketplace/plugins/{name}", "POST /api/v1/marketplace/plugins/{name}/update", "GET /api/v1/marketplace/plugins/{name}/reviews", "POST /api/v1/marketplace/plugins/{name}/reviews"]},
-        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
-        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/marketplace", "GET /ui/marketplace/plugins/{name}/details", "POST /ui/marketplace/plugins/{name}/install", "POST /ui/marketplace/plugins/{name}/uninstall", "POST /ui/marketplace/plugins/{name}/update"]},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo marketplace list",
+            "fo marketplace search",
+            "fo marketplace info",
+            "fo marketplace install",
+            "fo marketplace uninstall",
+            "fo marketplace update",
+            "fo marketplace installed",
+            "fo marketplace updates",
+            "fo marketplace review"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/marketplace/plugins",
+            "GET /api/v1/marketplace/plugins/{name}",
+            "GET /api/v1/marketplace/installed",
+            "GET /api/v1/marketplace/updates",
+            "POST /api/v1/marketplace/plugins/{name}/install",
+            "DELETE /api/v1/marketplace/plugins/{name}",
+            "POST /api/v1/marketplace/plugins/{name}/update",
+            "GET /api/v1/marketplace/plugins/{name}/reviews",
+            "POST /api/v1/marketplace/plugins/{name}/reviews"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/marketplace",
+            "GET /ui/marketplace/plugins/{name}/details",
+            "POST /ui/marketplace/plugins/{name}/install",
+            "POST /ui/marketplace/plugins/{name}/uninstall",
+            "POST /ui/marketplace/plugins/{name}/update"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
       }
     },
     {
-      "id": "plugins.runtime",
-      "name": "Plugin runtime API",
-      "description": "Expose guarded file, configuration, and lifecycle hook operations to plugins.",
-      "maturity": "experimental",
-      "execution_scopes": ["remote", "auth-gated"],
+      "description": "Select and configure default, PARA, or Johnny Decimal organization policy.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "methodology.configure",
+      "maturity": "beta",
+      "name": "Organization methodology",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/plugins/files/list", "GET /api/v1/plugins/files/metadata", "POST /api/v1/plugins/files/organize", "GET /api/v1/plugins/config/get", "GET /api/v1/plugins/hooks", "POST /api/v1/plugins/hooks/register", "POST /api/v1/plugins/hooks/unregister", "POST /api/v1/plugins/hooks/trigger"]},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo config edit"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.get_config",
+            "FileOrganizerClient.update_config",
+            "AsyncFileOrganizerClient.get_config",
+            "AsyncFileOrganizerClient.update_config"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/config",
+            "PUT /api/v1/config"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "MethodologyView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.getConfig",
+            "FileOrganizerClient.updateConfig"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/settings/organization",
+            "POST /ui/settings/organization/validate",
+            "POST /ui/settings/organization"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        }
       }
     },
     {
-      "id": "updates.manage",
-      "name": "Application updates",
-      "description": "Check, install, and roll back supported application updates.",
+      "description": "Inspect, acquire, select, test, and cache supported AI models.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "models.manage",
+      "maturity": "beta",
+      "name": "AI model management",
+      "optional_dependencies": [
+        "cloud",
+        "claude",
+        "llama",
+        "mlx"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo model list",
+            "fo model pull",
+            "fo model cache"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "SettingsView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/settings/models",
+            "POST /ui/settings/models",
+            "POST /ui/settings/models/test"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Apply an approved organization plan and return normalized operation results.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "organization.execute",
       "maturity": "stable",
-      "execution_scopes": ["local-only"],
+      "name": "Organization execution",
       "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
       "surfaces": {
-        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo update check", "fo update install", "fo update rollback"]},
-        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
-        "tui": {"target_support": "redirect/deep-link", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerApp._check_for_updates"]}
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo organize"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.organize",
+            "AsyncFileOrganizerClient.organize"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/organize",
+            "POST /api/v1/organize/execute"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "OrganizationPreviewView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.organize"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /ui/organize/execute"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Observe, cancel, roll back, and recover organization work using stable lifecycle semantics.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "organization.jobs-recovery",
+      "maturity": "beta",
+      "name": "Organization jobs and recovery",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo recover",
+            "fo undo",
+            "fo history"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.get_job",
+            "AsyncFileOrganizerClient.get_job"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/organize/status/{job_id}",
+            "WS /api/v1/ws/{client_id}"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "UndoHistoryView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.getJob"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/organize/jobs/{job_id}/status",
+            "GET /ui/organize/jobs/{job_id}/events",
+            "POST /ui/organize/jobs/{job_id}/cancel",
+            "POST /ui/organize/jobs/{job_id}/rollback"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Build and inspect an organization plan without applying filesystem changes.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "organization.preview",
+      "maturity": "stable",
+      "name": "Organization preview",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo preview",
+            "fo organize --dry-run"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.preview_organize",
+            "AsyncFileOrganizerClient.preview_organize"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/organize/preview"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "OrganizationPreviewView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.previewOrganize"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/organize",
+            "POST /ui/organize/scan",
+            "POST /ui/organize/plan/clear"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Collect candidate files using the canonical traversal and filtering policy.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "organization.scan",
+      "maturity": "stable",
+      "name": "Organization scan",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo preview",
+            "fo organize"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.scan",
+            "AsyncFileOrganizerClient.scan"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/organize/scan"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileBrowserView",
+            "OrganizationPreviewView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.scan"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /ui/organize/scan"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Expose guarded file, configuration, and lifecycle hook operations to plugins.",
+      "execution_scopes": [
+        "remote",
+        "auth-gated"
+      ],
+      "id": "plugins.runtime",
+      "maturity": "experimental",
+      "name": "Plugin runtime API",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/plugins/files/list",
+            "GET /api/v1/plugins/files/metadata",
+            "POST /api/v1/plugins/files/organize",
+            "GET /api/v1/plugins/config/get",
+            "GET /api/v1/plugins/hooks",
+            "POST /api/v1/plugins/hooks/register",
+            "POST /api/v1/plugins/hooks/unregister",
+            "POST /api/v1/plugins/hooks/trigger"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        }
+      }
+    },
+    {
+      "description": "Search indexed or local files with consistent query and result semantics.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "search.query",
+      "maturity": "stable",
+      "name": "File search",
+      "optional_dependencies": [
+        "search"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo search"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "read-only"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/search"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileBrowserView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "read-only"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/settings/search"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        }
+      }
+    },
+    {
+      "description": "Discover local capabilities and persist an initial working configuration.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "setup.configure",
+      "maturity": "stable",
+      "name": "Initial setup",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo setup run",
+            "fo start",
+            "fo quickstart"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/setup/status",
+            "GET /api/v1/setup/capabilities",
+            "GET /api/v1/setup/browse-folder",
+            "POST /api/v1/setup/complete"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "SetupWizardView"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/setup",
+            "POST /ui/setup/defer"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        }
+      }
+    },
+    {
+      "description": "Inspect service health, runtime status, hardware capabilities, and storage statistics.",
+      "execution_scopes": [
+        "local-only",
+        "remote"
+      ],
+      "id": "system.inspect",
+      "maturity": "stable",
+      "name": "System health and status",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo version",
+            "fo doctor",
+            "fo hardware-info",
+            "fo api health",
+            "fo api system-status",
+            "fo api system-stats"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.health",
+            "FileOrganizerClient.system_status",
+            "FileOrganizerClient.system_stats",
+            "AsyncFileOrganizerClient.health",
+            "AsyncFileOrganizerClient.system_status",
+            "AsyncFileOrganizerClient.system_stats"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /api/v1/health",
+            "GET /api/v1/system/status",
+            "GET /api/v1/system/stats"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "AnalyticsView"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerClient.health",
+            "FileOrganizerClient.systemStatus",
+            "FileOrganizerClient.systemStats"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "read-only"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        }
+      }
+    },
+    {
+      "description": "Check, install, and roll back supported application updates.",
+      "execution_scopes": [
+        "local-only"
+      ],
+      "id": "updates.manage",
+      "maturity": "stable",
+      "name": "Application updates",
+      "optional_dependencies": [],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo update check",
+            "fo update install",
+            "fo update rollback"
+          ],
+          "implementation_status": "implemented",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "rest-api": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "tui": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "FileOrganizerApp._check_for_updates"
+          ],
+          "implementation_status": "partial",
+          "target_support": "redirect/deep-link"
+        },
+        "typescript-sdk": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "web-desktop": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        }
+      }
+    },
+    {
+      "description": "Detect scenes and extract representative keyframes from supported videos.",
+      "execution_scopes": [
+        "local-only",
+        "remote",
+        "auth-gated"
+      ],
+      "id": "video.analyze",
+      "maturity": "beta",
+      "name": "Video analysis",
+      "optional_dependencies": [
+        "video"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "surfaces": {
+        "cli": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "fo analyze"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "python-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "rest-api": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "POST /api/v1/analyze"
+          ],
+          "implementation_status": "partial",
+          "target_support": "full"
+        },
+        "tui": {
+          "conformance_status": "not-applicable",
+          "entry_points": [],
+          "implementation_status": "not-applicable",
+          "target_support": "not-applicable"
+        },
+        "typescript-sdk": {
+          "conformance_status": "unverified",
+          "entry_points": [],
+          "implementation_status": "not-implemented",
+          "target_support": "full"
+        },
+        "web-desktop": {
+          "conformance_status": "unverified",
+          "entry_points": [
+            "GET /ui/files/preview"
+          ],
+          "implementation_status": "partial",
+          "target_support": "read-only"
+        }
       }
     }
+  ],
+  "schema_version": 1,
+  "surfaces": [
+    "cli",
+    "rest-api",
+    "python-sdk",
+    "typescript-sdk",
+    "web-desktop",
+    "tui"
   ]
 }

--- a/src/file_organizer/core/capability_registry.json
+++ b/src/file_organizer/core/capability_registry.json
@@ -1,0 +1,533 @@
+{
+  "schema_version": 1,
+  "capabilities": [
+    {
+      "id": "setup.configure",
+      "name": "Initial setup",
+      "description": "Discover local capabilities and persist an initial working configuration.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo setup run", "fo start", "fo quickstart"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/setup/status", "GET /api/v1/setup/capabilities", "GET /api/v1/setup/browse-folder", "POST /api/v1/setup/complete"]},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/setup", "POST /ui/setup/defer"]},
+        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["SetupWizardView"]}
+      }
+    },
+    {
+      "id": "organization.scan",
+      "name": "Organization scan",
+      "description": "Collect candidate files using the canonical traversal and filtering policy.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo preview", "fo organize"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/organize/scan"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.scan", "AsyncFileOrganizerClient.scan"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.scan"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /ui/organize/scan"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileBrowserView", "OrganizationPreviewView"]}
+      }
+    },
+    {
+      "id": "organization.preview",
+      "name": "Organization preview",
+      "description": "Build and inspect an organization plan without applying filesystem changes.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo preview", "fo organize --dry-run"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/organize/preview"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.preview_organize", "AsyncFileOrganizerClient.preview_organize"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.previewOrganize"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/organize", "POST /ui/organize/scan", "POST /ui/organize/plan/clear"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["OrganizationPreviewView"]}
+      }
+    },
+    {
+      "id": "organization.execute",
+      "name": "Organization execution",
+      "description": "Apply an approved organization plan and return normalized operation results.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo organize"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/organize", "POST /api/v1/organize/execute"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.organize", "AsyncFileOrganizerClient.organize"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.organize"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /ui/organize/execute"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["OrganizationPreviewView"]}
+      }
+    },
+    {
+      "id": "organization.jobs-recovery",
+      "name": "Organization jobs and recovery",
+      "description": "Observe, cancel, roll back, and recover organization work using stable lifecycle semantics.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo recover", "fo undo", "fo history"]},
+        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /api/v1/organize/status/{job_id}", "WS /api/v1/ws/{client_id}"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_job", "AsyncFileOrganizerClient.get_job"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getJob"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/organize/jobs/{job_id}/status", "GET /ui/organize/jobs/{job_id}/events", "POST /ui/organize/jobs/{job_id}/cancel", "POST /ui/organize/jobs/{job_id}/rollback"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["UndoHistoryView"]}
+      }
+    },
+    {
+      "id": "files.browse",
+      "name": "File browsing",
+      "description": "Browse directory contents with filtering, sorting, pagination, and hidden-file policy.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo api files"]},
+        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/files"]},
+        "python-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.list_files", "AsyncFileOrganizerClient.list_files"]},
+        "typescript-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.listFiles"]},
+        "web-desktop": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/files", "GET /ui/files/list", "GET /ui/files/tree"]},
+        "tui": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileBrowserView"]}
+      }
+    },
+    {
+      "id": "files.inspect",
+      "name": "File inspection",
+      "description": "Read file metadata, supported content, previews, thumbnails, and downloads.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": ["parsers", "audio", "video"],
+      "surfaces": {
+        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo analyze"]},
+        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/files/info", "GET /api/v1/files/content", "GET /api/v1/files/{file_id}"]},
+        "python-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_file_info", "FileOrganizerClient.read_file_content", "AsyncFileOrganizerClient.get_file_info", "AsyncFileOrganizerClient.read_file_content"]},
+        "typescript-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getFileInfo", "FileOrganizerClient.readFileContent"]},
+        "web-desktop": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/files/preview", "GET /ui/files/raw", "GET /ui/files/thumbnail"]},
+        "tui": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FilePreviewView"]}
+      }
+    },
+    {
+      "id": "files.mutate",
+      "name": "Direct file mutations",
+      "description": "Upload, move, and delete individual files through guarded public operations.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/files/upload", "POST /api/v1/files/move", "DELETE /api/v1/files", "DELETE /api/v1/files/{file_id}"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.move_file", "FileOrganizerClient.delete_file", "AsyncFileOrganizerClient.move_file", "AsyncFileOrganizerClient.delete_file"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.moveFile", "FileOrganizerClient.deleteFile"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /ui/files/upload"]},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "search.query",
+      "name": "File search",
+      "description": "Search indexed or local files with consistent query and result semantics.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": ["search"],
+      "surfaces": {
+        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo search"]},
+        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/search"]},
+        "python-sdk": {"target_support": "read-only", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "read-only", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/search"]},
+        "tui": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileBrowserView"]}
+      }
+    },
+    {
+      "id": "analysis.inspect",
+      "name": "AI-assisted file analysis",
+      "description": "Analyze file content and metadata, including optional vision, audio, and video features.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": ["parsers", "audio", "video", "cloud", "claude", "llama", "mlx"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo analyze", "fo organize --vision", "fo organize --transcribe-audio"]},
+        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /api/v1/analyze"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/files/preview", "POST /ui/settings/models/test"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["AudioView", "FilePreviewView"]}
+      }
+    },
+    {
+      "id": "deduplication.manage",
+      "name": "Duplicate management",
+      "description": "Scan, preview, report, and resolve duplicate file groups.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": ["dedup"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo dedupe scan", "fo dedupe report", "fo dedupe resolve"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/dedupe/scan", "POST /api/v1/dedupe/preview", "POST /api/v1/dedupe/execute"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.dedupe_scan", "FileOrganizerClient.dedupe_preview", "FileOrganizerClient.dedupe_execute", "AsyncFileOrganizerClient.dedupe_scan", "AsyncFileOrganizerClient.dedupe_preview", "AsyncFileOrganizerClient.dedupe_execute"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.dedupeScan", "FileOrganizerClient.dedupePreview", "FileOrganizerClient.dedupeExecute"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
+      }
+    },
+    {
+      "id": "audio.transcribe",
+      "name": "Audio transcription",
+      "description": "Transcribe supported local audio content for analysis and organization.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": ["audio"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo organize --transcribe-audio"]},
+        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /api/v1/analyze"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["AudioView"]}
+      }
+    },
+    {
+      "id": "video.analyze",
+      "name": "Video analysis",
+      "description": "Detect scenes and extract representative keyframes from supported videos.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": ["video"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo analyze"]},
+        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["POST /api/v1/analyze"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/files/preview"]},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "automation.tags",
+      "name": "Automatic tagging",
+      "description": "Suggest, apply, inspect, and batch-manage file tags.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo autotag suggest", "fo autotag apply", "fo autotag popular", "fo autotag batch", "fo autotag recent"]},
+        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
+      }
+    },
+    {
+      "id": "automation.rules",
+      "name": "Organization rules",
+      "description": "Create, preview, apply, import, export, and watch declarative organization rules.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo rules list", "fo rules sets", "fo rules add", "fo rules remove", "fo rules toggle", "fo rules preview", "fo rules apply", "fo rules watch", "fo rules export", "fo rules import"]},
+        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
+      }
+    },
+    {
+      "id": "automation.suggestions",
+      "name": "Smart suggestions",
+      "description": "Generate, inspect, and apply learned file-placement suggestions.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo suggest files", "fo suggest patterns", "fo suggest apply"]},
+        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
+      }
+    },
+    {
+      "id": "automation.watcher",
+      "name": "Background watcher",
+      "description": "Start, stop, inspect, and configure continuous directory watching.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo daemon start", "fo daemon stop", "fo daemon status", "fo daemon watch", "fo daemon process"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/daemon/start", "POST /api/v1/daemon/stop", "POST /api/v1/daemon/toggle", "GET /api/v1/daemon/status"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/advanced", "POST /ui/settings/advanced"]},
+        "tui": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []}
+      }
+    },
+    {
+      "id": "methodology.configure",
+      "name": "Organization methodology",
+      "description": "Select and configure default, PARA, or Johnny Decimal organization policy.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo organize --methodology", "fo config edit"]},
+        "rest-api": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /api/v1/config", "PUT /api/v1/config"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_config", "FileOrganizerClient.update_config", "AsyncFileOrganizerClient.get_config", "AsyncFileOrganizerClient.update_config"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getConfig", "FileOrganizerClient.updateConfig"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/organization", "POST /ui/settings/organization/validate", "POST /ui/settings/organization"]},
+        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["MethodologyView"]}
+      }
+    },
+    {
+      "id": "analytics.inspect",
+      "name": "Organization analytics",
+      "description": "Inspect organization activity, storage metrics, trends, and exported reports.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo analytics"]},
+        "rest-api": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /api/v1/system/stats"]},
+        "python-sdk": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.system_stats", "AsyncFileOrganizerClient.system_stats"]},
+        "typescript-sdk": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.systemStats"]},
+        "web-desktop": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/organize/stats", "GET /ui/organize/stats/events", "GET /ui/organize/report/{job_id}"]},
+        "tui": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["AnalyticsView"]}
+      }
+    },
+    {
+      "id": "history.manage",
+      "name": "Operation history and undo",
+      "description": "Review operation history and perform supported undo and redo actions.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo history", "fo undo", "fo redo"]},
+        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/organize/history", "GET /ui/organize/history/events", "POST /ui/organize/jobs/{job_id}/rollback"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["UndoHistoryView"]}
+      }
+    },
+    {
+      "id": "copilot.chat",
+      "name": "Copilot chat",
+      "description": "Interpret natural-language file-management requests and propose explicit actions.",
+      "maturity": "experimental",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": ["cloud", "claude", "llama", "mlx"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo copilot chat", "fo copilot status"]},
+        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "tui": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["CopilotView"]}
+      }
+    },
+    {
+      "id": "configuration.manage",
+      "name": "Configuration management",
+      "description": "Read, validate, update, import, export, and reset application configuration.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo config show", "fo config list", "fo config edit"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/config", "PUT /api/v1/config", "POST /api/v1/config/reset", "GET /api/v1/system/config", "PATCH /api/v1/system/config"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.get_config", "FileOrganizerClient.update_config", "AsyncFileOrganizerClient.get_config", "AsyncFileOrganizerClient.update_config"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.getConfig", "FileOrganizerClient.updateConfig"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/settings", "GET /ui/settings/general", "POST /ui/settings/general", "GET /ui/settings/appearance", "POST /ui/settings/appearance", "GET /ui/settings/export", "POST /ui/settings/import", "POST /ui/settings/reset"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["SettingsView"]}
+      }
+    },
+    {
+      "id": "configuration.profiles",
+      "name": "Named configuration profiles",
+      "description": "Create, activate, merge, migrate, validate, import, and export named local profiles.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo profile list", "fo profile create", "fo profile activate", "fo profile delete", "fo profile current", "fo profile export", "fo profile import", "fo profile merge", "fo profile template list", "fo profile template preview", "fo profile template apply", "fo profile migrate", "fo profile validate"]},
+        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "models.manage",
+      "name": "AI model management",
+      "description": "Inspect, acquire, select, test, and cache supported AI models.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": ["cloud", "claude", "llama", "mlx"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo model list", "fo model pull", "fo model cache"]},
+        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/settings/models", "POST /ui/settings/models", "POST /ui/settings/models/test"]},
+        "tui": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["SettingsView"]}
+      }
+    },
+    {
+      "id": "authentication.manage",
+      "name": "User authentication",
+      "description": "Register, sign in, refresh identity, inspect the current user, and sign out.",
+      "maturity": "stable",
+      "execution_scopes": ["remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo api login", "fo api me", "fo api logout"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["POST /api/v1/auth/register", "POST /api/v1/auth/login", "POST /api/v1/auth/refresh", "GET /api/v1/auth/me", "POST /api/v1/auth/logout"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.register", "FileOrganizerClient.login", "FileOrganizerClient.refresh_token", "FileOrganizerClient.me", "FileOrganizerClient.logout", "AsyncFileOrganizerClient.register", "AsyncFileOrganizerClient.login", "AsyncFileOrganizerClient.refresh_token", "AsyncFileOrganizerClient.me", "AsyncFileOrganizerClient.logout"]},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.register", "FileOrganizerClient.login", "FileOrganizerClient.refreshToken", "FileOrganizerClient.me", "FileOrganizerClient.logout"]},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/profile/register", "POST /ui/profile/register", "GET /ui/profile/login", "POST /ui/profile/login", "POST /ui/profile/logout", "GET /ui/profile/reset-password", "POST /ui/profile/reset-password"]},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "accounts.manage",
+      "name": "Account and workspace management",
+      "description": "Manage account details, security, activity, teams, sharing, notifications, and workspaces.",
+      "maturity": "beta",
+      "execution_scopes": ["remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/profile", "GET /ui/profile/account-settings", "POST /ui/profile/account-settings/2fa", "POST /ui/profile/account-settings/password", "GET /ui/profile/activity", "GET /ui/profile/avatar/{user_id}", "GET /ui/profile/edit", "POST /ui/profile/edit", "POST /ui/profile/edit-avatar", "GET /ui/profile/forgot-password", "POST /ui/profile/forgot-password", "GET /ui/profile/team", "POST /ui/profile/team/invite", "POST /ui/profile/team/role", "GET /ui/profile/shared", "POST /ui/profile/shared/add", "POST /ui/profile/shared/remove", "GET /ui/profile/notifications", "POST /ui/profile/notifications/mark-read", "GET /ui/profile/workspaces", "POST /ui/profile/workspaces/create", "POST /ui/profile/workspaces/switch"]},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "api-keys.manage",
+      "name": "API key management",
+      "description": "Generate, list, and revoke credentials used for authenticated API access.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["fo api-keys generate"]},
+        "rest-api": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/profile/api-keys", "POST /ui/profile/api-keys/generate", "POST /ui/profile/api-keys/revoke"]},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "system.inspect",
+      "name": "System health and status",
+      "description": "Inspect service health, runtime status, hardware capabilities, and storage statistics.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only", "remote"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo version", "fo doctor", "fo hardware-info", "fo api health", "fo api system-status", "fo api system-stats"]},
+        "rest-api": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/health", "GET /api/v1/system/status", "GET /api/v1/system/stats"]},
+        "python-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.health", "FileOrganizerClient.system_status", "FileOrganizerClient.system_stats", "AsyncFileOrganizerClient.health", "AsyncFileOrganizerClient.system_status", "AsyncFileOrganizerClient.system_stats"]},
+        "typescript-sdk": {"target_support": "read-only", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["FileOrganizerClient.health", "FileOrganizerClient.systemStatus", "FileOrganizerClient.systemStats"]},
+        "web-desktop": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["GET /ui/"]},
+        "tui": {"target_support": "read-only", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["AnalyticsView"]}
+      }
+    },
+    {
+      "id": "integrations.manage",
+      "name": "External integrations",
+      "description": "Configure, connect, disconnect, and send files through supported integrations.",
+      "maturity": "experimental",
+      "execution_scopes": ["remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/integrations", "POST /api/v1/integrations/{integration_name}/settings", "POST /api/v1/integrations/{integration_name}/connect", "POST /api/v1/integrations/{integration_name}/disconnect", "POST /api/v1/integrations/{integration_name}/send", "GET /api/v1/integrations/browser/config", "POST /api/v1/integrations/browser/token", "POST /api/v1/integrations/browser/verify"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "interfaces.launch",
+      "name": "Interactive interface launchers",
+      "description": "Launch the supported local Web, Desktop, and terminal user interfaces.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": ["desktop"],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo serve", "fo desktop", "fo tui"]},
+        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "marketplace.manage",
+      "name": "Plugin marketplace",
+      "description": "Browse, inspect, install, remove, update, and review marketplace plugins.",
+      "maturity": "beta",
+      "execution_scopes": ["local-only", "remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo marketplace list", "fo marketplace search", "fo marketplace info", "fo marketplace install", "fo marketplace uninstall", "fo marketplace update", "fo marketplace installed", "fo marketplace updates", "fo marketplace review"]},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/marketplace/plugins", "GET /api/v1/marketplace/plugins/{name}", "GET /api/v1/marketplace/installed", "GET /api/v1/marketplace/updates", "POST /api/v1/marketplace/plugins/{name}/install", "DELETE /api/v1/marketplace/plugins/{name}", "POST /api/v1/marketplace/plugins/{name}/update", "GET /api/v1/marketplace/plugins/{name}/reviews", "POST /api/v1/marketplace/plugins/{name}/reviews"]},
+        "python-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "typescript-sdk": {"target_support": "full", "implementation_status": "not-implemented", "conformance_status": "unverified", "entry_points": []},
+        "web-desktop": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /ui/marketplace", "GET /ui/marketplace/plugins/{name}/details", "POST /ui/marketplace/plugins/{name}/install", "POST /ui/marketplace/plugins/{name}/uninstall", "POST /ui/marketplace/plugins/{name}/update"]},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "plugins.runtime",
+      "name": "Plugin runtime API",
+      "description": "Expose guarded file, configuration, and lifecycle hook operations to plugins.",
+      "maturity": "experimental",
+      "execution_scopes": ["remote", "auth-gated"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "rest-api": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["GET /api/v1/plugins/files/list", "GET /api/v1/plugins/files/metadata", "POST /api/v1/plugins/files/organize", "GET /api/v1/plugins/config/get", "GET /api/v1/plugins/hooks", "POST /api/v1/plugins/hooks/register", "POST /api/v1/plugins/hooks/unregister", "POST /api/v1/plugins/hooks/trigger"]},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "tui": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []}
+      }
+    },
+    {
+      "id": "updates.manage",
+      "name": "Application updates",
+      "description": "Check, install, and roll back supported application updates.",
+      "maturity": "stable",
+      "execution_scopes": ["local-only"],
+      "optional_dependencies": [],
+      "surfaces": {
+        "cli": {"target_support": "full", "implementation_status": "implemented", "conformance_status": "unverified", "entry_points": ["fo update check", "fo update install", "fo update rollback"]},
+        "rest-api": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "python-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "typescript-sdk": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "web-desktop": {"target_support": "not-applicable", "implementation_status": "not-applicable", "conformance_status": "not-applicable", "entry_points": []},
+        "tui": {"target_support": "redirect/deep-link", "implementation_status": "partial", "conformance_status": "unverified", "entry_points": ["FileOrganizerApp._check_for_updates"]}
+      }
+    }
+  ]
+}

--- a/tests/api/test_capability_registry_inventory.py
+++ b/tests/api/test_capability_registry_inventory.py
@@ -1,0 +1,31 @@
+"""Guard public HTTP and Web entry points against capability-registry drift."""
+
+from __future__ import annotations
+
+import pytest
+
+from file_organizer.api.config import ApiSettings
+from file_organizer.api.main import create_app
+from file_organizer.core.capabilities import get_capability_registry
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def test_public_routes_are_assigned_to_capabilities() -> None:
+    app = create_app(ApiSettings(environment="test", auth_enabled=False, enable_docs=False))
+    registered_entry_points = {
+        entry_point
+        for capability in get_capability_registry().capabilities
+        for status in capability.surfaces
+        for entry_point in status.entry_points
+    }
+    public_routes: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", "")
+        if not path.startswith(("/api/v1", "/ui")):
+            continue
+        methods = getattr(route, "methods", None) or {"WS"}
+        public_routes.update(f"{method} {path}" for method in methods)
+
+    missing = public_routes - registered_entry_points
+    assert not missing, f"public routes missing capability ownership: {sorted(missing)}"

--- a/tests/api/test_capability_registry_inventory.py
+++ b/tests/api/test_capability_registry_inventory.py
@@ -6,26 +6,34 @@ import pytest
 
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.main import create_app
-from file_organizer.core.capabilities import get_capability_registry
+from file_organizer.core.capabilities import Surface, get_capability_registry
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
 
-def test_public_routes_are_assigned_to_capabilities() -> None:
+@pytest.mark.parametrize(
+    ("path_prefix", "surface"),
+    [
+        ("/api/v1", Surface.REST_API),
+        ("/ui", Surface.WEB_DESKTOP),
+    ],
+)
+def test_public_routes_match_registered_entry_points(path_prefix: str, surface: Surface) -> None:
     app = create_app(ApiSettings(environment="test", auth_enabled=False, enable_docs=False))
     registered_entry_points = {
         entry_point
         for capability in get_capability_registry().capabilities
-        for status in capability.surfaces
-        for entry_point in status.entry_points
+        for entry_point in capability.support_for(surface).entry_points
     }
     public_routes: set[str] = set()
     for route in app.routes:
         path = getattr(route, "path", "")
-        if not path.startswith(("/api/v1", "/ui")):
+        if not path.startswith(path_prefix):
             continue
         methods = getattr(route, "methods", None) or {"WS"}
         public_routes.update(f"{method} {path}" for method in methods)
 
     missing = public_routes - registered_entry_points
-    assert not missing, f"public routes missing capability ownership: {sorted(missing)}"
+    stale = registered_entry_points - public_routes
+    assert not missing, f"{surface.value} routes missing capability ownership: {sorted(missing)}"
+    assert not stale, f"stale {surface.value} registry entry points: {sorted(stale)}"

--- a/tests/cli/test_capability_registry_inventory.py
+++ b/tests/cli/test_capability_registry_inventory.py
@@ -6,40 +6,57 @@ import click
 import pytest
 import typer.main
 
+from file_organizer.cli.lazy import DEVELOPER_ONLY_COMMANDS
 from file_organizer.cli.main import app
 from file_organizer.core.capabilities import Surface, get_capability_registry
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
-_DEVELOPER_ONLY_COMMANDS = {"benchmark", "docs"}
 
-
-def test_public_cli_commands_are_assigned_to_capabilities() -> None:
-    root = typer.main.get_group(app)
-    root_context = click.Context(root)
-    discovered: set[str] = set()
-    for command_name in root.list_commands(root_context):
-        if command_name in _DEVELOPER_ONLY_COMMANDS:
+def _discover_entry_points(
+    group: click.Group,
+    context: click.Context,
+    path: tuple[str, ...] = ("fo",),
+) -> tuple[set[str], set[str]]:
+    """Recursively discover command paths and resolvable command/option entry points."""
+    commands: set[str] = set()
+    resolvable: set[str] = set()
+    for command_name in group.list_commands(context):
+        if len(path) == 1 and command_name in DEVELOPER_ONLY_COMMANDS:
             continue
-        command = root.get_command(root_context, command_name)
+        command = group.get_command(context, command_name)
+        assert command is not None, f"listed CLI command {command_name!r} did not resolve"
+        command_path = (*path, command_name)
+        serialized_path = " ".join(command_path)
+        resolvable.add(serialized_path)
+        child_context = click.Context(command, parent=context)
+        for parameter in command.get_params(child_context):
+            if isinstance(parameter, click.Option):
+                resolvable.update(
+                    f"{serialized_path} {option}"
+                    for option in (*parameter.opts, *parameter.secondary_opts)
+                )
         if isinstance(command, click.Group):
-            context = click.Context(command, parent=root_context)
-            discovered.update(
-                f"fo {command_name} {subcommand}" for subcommand in command.list_commands(context)
+            child_commands, child_resolvable = _discover_entry_points(
+                command, child_context, command_path
             )
+            commands.update(child_commands)
+            resolvable.update(child_resolvable)
         else:
-            discovered.add(f"fo {command_name}")
+            commands.add(serialized_path)
+    return commands, resolvable
 
+
+def test_public_cli_commands_and_registry_entries_match() -> None:
+    root = typer.main.get_group(app)
+    discovered, resolvable = _discover_entry_points(root, click.Context(root))
     registered = {
         entry_point
         for capability in get_capability_registry().capabilities
         for entry_point in capability.support_for(Surface.CLI).entry_points
     }
-    missing = {
-        command
-        for command in discovered
-        if command not in registered
-        and not any(entry_point.startswith(f"{command} ") for entry_point in registered)
-    }
 
+    missing = discovered - registered
+    stale = registered - resolvable
     assert not missing, f"public CLI commands missing capability ownership: {sorted(missing)}"
+    assert not stale, f"registry CLI entry points that do not resolve: {sorted(stale)}"

--- a/tests/cli/test_capability_registry_inventory.py
+++ b/tests/cli/test_capability_registry_inventory.py
@@ -1,0 +1,45 @@
+"""Guard public CLI entry points against capability-registry drift."""
+
+from __future__ import annotations
+
+import click
+import pytest
+import typer.main
+
+from file_organizer.cli.main import app
+from file_organizer.core.capabilities import Surface, get_capability_registry
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+_DEVELOPER_ONLY_COMMANDS = {"benchmark", "docs"}
+
+
+def test_public_cli_commands_are_assigned_to_capabilities() -> None:
+    root = typer.main.get_group(app)
+    root_context = click.Context(root)
+    discovered: set[str] = set()
+    for command_name in root.list_commands(root_context):
+        if command_name in _DEVELOPER_ONLY_COMMANDS:
+            continue
+        command = root.get_command(root_context, command_name)
+        if isinstance(command, click.Group):
+            context = click.Context(command, parent=root_context)
+            discovered.update(
+                f"fo {command_name} {subcommand}" for subcommand in command.list_commands(context)
+            )
+        else:
+            discovered.add(f"fo {command_name}")
+
+    registered = {
+        entry_point
+        for capability in get_capability_registry().capabilities
+        for entry_point in capability.support_for(Surface.CLI).entry_points
+    }
+    missing = {
+        command
+        for command in discovered
+        if command not in registered
+        and not any(entry_point.startswith(f"{command} ") for entry_point in registered)
+    }
+
+    assert not missing, f"public CLI commands missing capability ownership: {sorted(missing)}"

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -1,0 +1,254 @@
+"""Tests for the canonical cross-surface capability registry."""
+
+from __future__ import annotations
+
+import copy
+import inspect
+import json
+import re
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from file_organizer.client.async_client import AsyncFileOrganizerClient
+from file_organizer.client.sync_client import FileOrganizerClient
+from file_organizer.core.capabilities import (
+    CapabilityRegistry,
+    CapabilityRegistryError,
+    ConformanceStatus,
+    ImplementationStatus,
+    Surface,
+    get_capability_registry,
+)
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def _registry_data() -> dict[str, object]:
+    registry = get_capability_registry()
+    return copy.deepcopy(registry.to_dict())
+
+
+def test_packaged_registry_is_complete_and_queryable() -> None:
+    registry = get_capability_registry()
+
+    assert len(registry.capabilities) >= 30
+    assert registry.get("organization.execute").name == "Organization execution"
+    for capability in registry.capabilities:
+        assert {status.surface for status in capability.surfaces} == set(Surface)
+
+
+def test_target_implementation_and_conformance_are_independent() -> None:
+    registry = get_capability_registry()
+    planned = registry.get("deduplication.manage").support_for(Surface.WEB_DESKTOP)
+
+    assert planned.target_support.value == "full"
+    assert planned.implementation_status is ImplementationStatus.NOT_IMPLEMENTED
+    assert planned.conformance_status is ConformanceStatus.UNVERIFIED
+
+
+def test_serialization_is_deterministic_and_round_trips() -> None:
+    registry = get_capability_registry()
+    serialized = registry.to_json()
+
+    assert CapabilityRegistry.from_json(serialized) == registry
+    assert CapabilityRegistry.from_dict(registry.to_dict()).to_json() == serialized
+    ids = [item["id"] for item in json.loads(serialized)["capabilities"]]
+    assert ids == sorted(ids)
+
+
+def test_duplicate_capability_ids_are_rejected() -> None:
+    data = _registry_data()
+    capabilities = cast(list[dict[str, object]], data["capabilities"])
+    capabilities.append(copy.deepcopy(capabilities[0]))
+
+    with pytest.raises(CapabilityRegistryError, match="duplicate capability ID"):
+        CapabilityRegistry.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("{", "invalid registry JSON"),
+        ("[]", "registry root must be an object"),
+        ('{"schema_version": true, "capabilities": []}', "schema_version must be an integer"),
+        ('{"schema_version": 1, "capabilities": {}}', "capabilities must be a list"),
+        ('{"schema_version": 1, "capabilities": [1]}', "each capability must be an object"),
+    ],
+)
+def test_malformed_registry_payload_is_rejected(payload: str, message: str) -> None:
+    with pytest.raises(CapabilityRegistryError, match=message):
+        CapabilityRegistry.from_json(payload)
+
+
+def test_unsupported_or_empty_registry_is_rejected() -> None:
+    data = _registry_data()
+    data["schema_version"] = 999
+    with pytest.raises(CapabilityRegistryError, match="unsupported capability registry schema"):
+        CapabilityRegistry.from_dict(data)
+
+    data["schema_version"] = 1
+    data["capabilities"] = []
+    with pytest.raises(CapabilityRegistryError, match="at least one capability"):
+        CapabilityRegistry.from_dict(data)
+
+
+def test_missing_surface_is_rejected() -> None:
+    data = _registry_data()
+    capability = data["capabilities"][0]  # type: ignore[index]
+    del capability["surfaces"][Surface.TUI.value]
+
+    with pytest.raises(CapabilityRegistryError, match="surfaces are incomplete"):
+        CapabilityRegistry.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("id", "INVALID", "invalid stable ID"),
+        ("execution_scopes", [], "at least one execution scope"),
+        ("execution_scopes", ["local-only", "local-only"], "duplicate execution scopes"),
+        ("platforms", [], "unique supported platforms"),
+        ("optional_dependencies", ["audio", "audio"], "optional dependencies"),
+    ],
+)
+def test_invalid_capability_metadata_is_rejected(field: str, value: object, message: str) -> None:
+    data = _registry_data()
+    capability = data["capabilities"][0]  # type: ignore[index]
+    capability[field] = value
+
+    with pytest.raises(CapabilityRegistryError, match=message):
+        CapabilityRegistry.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            {
+                "target_support": "not-applicable",
+                "implementation_status": "implemented",
+                "conformance_status": "unverified",
+                "entry_points": ["fo invalid"],
+            },
+            "not-applicable and cannot have implementation evidence",
+        ),
+        (
+            {
+                "target_support": "full",
+                "implementation_status": "implemented",
+                "conformance_status": "unverified",
+                "entry_points": [],
+            },
+            "implemented but has no entry point evidence",
+        ),
+        (
+            {
+                "target_support": "full",
+                "implementation_status": "partial",
+                "conformance_status": "verified",
+                "entry_points": ["fo partial"],
+            },
+            "cannot be verified until implementation is complete",
+        ),
+        (
+            {
+                "target_support": "full",
+                "implementation_status": "not-applicable",
+                "conformance_status": "not-applicable",
+                "entry_points": [],
+            },
+            "applicable target support but a not-applicable status",
+        ),
+        (
+            {
+                "target_support": "full",
+                "implementation_status": "not-implemented",
+                "conformance_status": "unverified",
+                "entry_points": ["fo impossible"],
+            },
+            "not implemented but declares entry points",
+        ),
+        (
+            {
+                "target_support": "full",
+                "implementation_status": "implemented",
+                "conformance_status": "unverified",
+                "entry_points": ["fo duplicate", "fo duplicate"],
+            },
+            "invalid or duplicate entry points",
+        ),
+    ],
+)
+def test_invalid_surface_state_is_rejected(mutation: dict[str, object], message: str) -> None:
+    data = _registry_data()
+    capability = data["capabilities"][0]  # type: ignore[index]
+    capability["surfaces"][Surface.CLI.value] = mutation
+
+    with pytest.raises(CapabilityRegistryError, match=message):
+        CapabilityRegistry.from_dict(data)
+
+
+def test_auth_gated_scope_requires_remote_scope() -> None:
+    data = _registry_data()
+    capability = data["capabilities"][0]  # type: ignore[index]
+    capability["execution_scopes"] = ["auth-gated"]
+
+    with pytest.raises(CapabilityRegistryError, match="auth-gated without remote"):
+        CapabilityRegistry.from_dict(data)
+
+
+def test_unknown_capability_lookup_raises_key_error() -> None:
+    with pytest.raises(KeyError, match="missing.capability"):
+        get_capability_registry().get("missing.capability")
+
+
+def test_optional_dependencies_name_project_extras() -> None:
+    registry = get_capability_registry()
+    project_extras = {
+        "audio",
+        "claude",
+        "cloud",
+        "dedup",
+        "desktop",
+        "llama",
+        "mlx",
+        "parsers",
+        "search",
+        "video",
+    }
+
+    declared = {
+        dependency
+        for capability in registry.capabilities
+        for dependency in capability.optional_dependencies
+    }
+    assert declared <= project_extras
+
+
+def test_official_client_product_methods_are_inventoried() -> None:
+    registry_text = get_capability_registry().to_json(indent=None)
+    ignored_methods = {"aclose", "close", "set_token"}
+
+    for client_type in (FileOrganizerClient, AsyncFileOrganizerClient):
+        methods = {
+            name
+            for name, member in inspect.getmembers(client_type, inspect.isfunction)
+            if not name.startswith("_") and name not in ignored_methods
+        }
+        missing = {
+            name for name in methods if f"{client_type.__name__}.{name}" not in registry_text
+        }
+        assert not missing, f"unregistered {client_type.__name__} methods: {sorted(missing)}"
+
+
+def test_typescript_client_product_methods_are_inventoried() -> None:
+    source_path = Path("src") / "file_organizer" / "client" / "typescript" / "client.ts"
+    source = source_path.read_text(encoding="utf-8")
+    methods = set(re.findall(r"^  (?:async )?([A-Za-z][A-Za-z0-9]*)\(", source, re.MULTILINE))
+    methods -= {"constructor", "setToken"}
+    registry_text = get_capability_registry().to_json(indent=None)
+    missing = {name for name in methods if f"FileOrganizerClient.{name}" not in registry_text}
+
+    assert not missing, f"unregistered TypeScript client methods: {sorted(missing)}"

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -58,6 +58,12 @@ def test_serialization_is_deterministic_and_round_trips() -> None:
     assert ids == sorted(ids)
 
 
+def test_packaged_registry_uses_canonical_serialization() -> None:
+    registry_path = Path("src") / "file_organizer" / "core" / "capability_registry.json"
+
+    assert registry_path.read_text(encoding="utf-8") == get_capability_registry().to_json()
+
+
 def test_duplicate_capability_ids_are_rejected() -> None:
     data = _registry_data()
     capabilities = cast(list[dict[str, object]], data["capabilities"])
@@ -228,19 +234,25 @@ def test_optional_dependencies_name_project_extras() -> None:
 
 
 def test_official_client_product_methods_are_inventoried() -> None:
-    registry_text = get_capability_registry().to_json(indent=None)
     ignored_methods = {"aclose", "close", "set_token"}
+    registered = {
+        entry_point
+        for capability in get_capability_registry().capabilities
+        for entry_point in capability.support_for(Surface.PYTHON_SDK).entry_points
+    }
+    live: set[str] = set()
 
     for client_type in (FileOrganizerClient, AsyncFileOrganizerClient):
-        methods = {
-            name
+        live.update(
+            f"{client_type.__name__}.{name}"
             for name, member in inspect.getmembers(client_type, inspect.isfunction)
             if not name.startswith("_") and name not in ignored_methods
-        }
-        missing = {
-            name for name in methods if f"{client_type.__name__}.{name}" not in registry_text
-        }
-        assert not missing, f"unregistered {client_type.__name__} methods: {sorted(missing)}"
+        )
+
+    missing = live - registered
+    stale = registered - live
+    assert not missing, f"unregistered Python client methods: {sorted(missing)}"
+    assert not stale, f"stale Python SDK registry entry points: {sorted(stale)}"
 
 
 def test_typescript_client_product_methods_are_inventoried() -> None:
@@ -248,7 +260,14 @@ def test_typescript_client_product_methods_are_inventoried() -> None:
     source = source_path.read_text(encoding="utf-8")
     methods = set(re.findall(r"^  (?:async )?([A-Za-z][A-Za-z0-9]*)\(", source, re.MULTILINE))
     methods -= {"constructor", "setToken"}
-    registry_text = get_capability_registry().to_json(indent=None)
-    missing = {name for name in methods if f"FileOrganizerClient.{name}" not in registry_text}
+    live = {f"FileOrganizerClient.{name}" for name in methods}
+    registered = {
+        entry_point
+        for capability in get_capability_registry().capabilities
+        for entry_point in capability.support_for(Surface.TYPESCRIPT_SDK).entry_points
+    }
+    missing = live - registered
+    stale = registered - live
 
     assert not missing, f"unregistered TypeScript client methods: {sorted(missing)}"
+    assert not stale, f"stale TypeScript SDK registry entry points: {sorted(stale)}"


### PR DESCRIPTION
## Summary

- add a versioned, packaged capability registry with 33 stable product capability IDs
- model target support, implementation status, and conformance status independently for CLI, REST API, Python SDK, TypeScript SDK, Web/Desktop, and TUI
- record execution scope, maturity, optional dependencies, platform requirements, and concrete public entry points
- validate duplicate IDs, incomplete surface matrices, invalid state combinations, and deterministic serialization
- add bidirectional CI inventory guards: live public entry points must be registered and declared entry points must resolve
- scope HTTP inventory checks explicitly to REST (`/api/v1`) and Web/Desktop (`/ui`)
- recursively discover CLI command groups and derive developer-only exclusions from the CLI command taxonomy
- store the packaged registry in canonical `to_json()` form and enforce byte-for-byte equality
- document the contributor workflow for changing capability declarations

Developer-only `benchmark` and `docs` commands remain outside the product registry. No README, UI, or capability-matrix generation is included; that remains owned by #1609.

## User and developer impact

This establishes the machine-readable source of truth required by the remaining parity slices. Planned support can no longer be mistaken for implemented or conformance-verified behavior, and additions, removals, or renames of public routes, CLI commands/options, or SDK methods now fail CI until the registry is updated accurately.

The review hardening also corrected three CLI claims: methodology is exposed through `fo config edit` only; vision has no positive `--vision` flag; and `fo profile` is currently a partial guidance shim rather than the declared subcommand tree.

All conformance statuses begin as `unverified`; later adapter drivers are responsible for promoting them based on executable evidence.

## Validation

- focused capability and bidirectional inventory suite — 31 passed
- branch-aware coverage for `file_organizer.core.capabilities` — 88%
- capability plus documentation-path suite — 100 passed
- `mkdocs build --strict` — passed
- isolated wheel build — passed; registry JSON is present in the wheel
- repository pre-commit suite — passed, including smoke, CI guardrails, WebSocket, Web UI, full diff-cover, typing, docstrings, link integrity, dependency checks, CI rails, and PyMarkdown

## Risk

Moderate coordination risk, low runtime risk. The new registry is additive and does not alter organization behavior, but its target-support decisions become inputs to later adapter and claims work. Bidirectional existence guards reduce stale-claim risk, while the separate implementation and conformance fields keep intent from being presented as shipped behavior.

Fixes #1601.
Part of #1593.
