### PR TITLE
feat: add canonical organization service contract

### DIFF
--- a/docs/developer/organization-service.md
+++ b/docs/developer/organization-service.md
@@ -49,6 +49,13 @@ are upgraded in memory using their legacy `skip_existing`, `use_hardlinks`, and 
 Unknown schema versions are rejected with an actionable error. Schema-2 plans reject conflicting
 legacy and canonical values rather than silently choosing one.
 
+Schema-1 compatibility is load/inspect compatibility. The direct service requires callers to
+re-preview before execution because legacy plans do not record resolved model identity and cannot
+match a fully resolved schema-2 request safely.
+
+The REST plan payload exposes schema-2 options. Updating the Python SDK's mirrored plan model is
+owned by the REST/SDK adapter migration in #1596.
+
 Operations are ordered by source path before serialization. Existing `SourceFingerprint`
 validation remains the authority for detecting changed sources between preview and execution.
 

--- a/docs/developer/organization-service.md
+++ b/docs/developer/organization-service.md
@@ -1,0 +1,62 @@
+# Canonical Organization Service
+
+Cross-surface adapters must map their inputs into `OrganizeRequest` and call the direct
+`OrganizationService`. The service is transport-neutral: it does not import CLI, FastAPI,
+Textual, Jinja, or desktop bridge code.
+
+```python
+from pathlib import Path
+
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
+from file_organizer.core.organization_service import OrganizationService
+
+request = OrganizeRequest(
+    input_path=Path("Downloads"),
+    output_path=Path("Organized"),
+    options=OrganizeOptions(
+        recursive=True,
+        include_hidden=False,
+        skip_existing=True,
+        enable_vision=True,
+    ),
+)
+
+service = OrganizationService()
+scan = service.scan(request)
+preview = service.preview(request)
+result = service.execute(request, preview.plan)
+```
+
+`scan()` and `preview()` use the same secure collection policy. `execute()` applies the exact
+reviewed operations and rejects plans whose roots or resolved options differ from the request.
+Adapters may format results differently, but they must not reinterpret these inputs or rebuild
+plans themselves.
+
+## Canonical options
+
+`OrganizeOptions` contains traversal, hidden-file, collision, media, model-selection, and runtime
+controls. Defaults are validated once before work begins. The direct service resolves configured
+text and vision model names/providers before placing the options in a plan, so a plan records the
+behavioral inputs used to produce it rather than an unstable “current default.”
+
+`use_hardlinks` is deliberately retained as the existing transfer selector in this slice. The
+transfer-semantics work in #1602 owns its replacement with an explicit copy/hardlink/move model.
+
+## Plan compatibility
+
+Organization plan schema 2 adds the canonical `options` object. Schema-1 plans remain loadable and
+are upgraded in memory using their legacy `skip_existing`, `use_hardlinks`, and metadata fields.
+Unknown schema versions are rejected with an actionable error. Schema-2 plans reject conflicting
+legacy and canonical values rather than silently choosing one.
+
+Operations are ordered by source path before serialization. Existing `SourceFingerprint`
+validation remains the authority for detecting changed sources between preview and execution.
+
+Run the focused contract tests with:
+
+```bash
+pytest tests/core/test_organize_options.py \
+  tests/core/test_organization_service.py \
+  tests/core/test_organization_plan.py \
+  -q --override-ini=addopts=
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
       - Overview: developer/index.md
       - Architecture: developer/architecture.md
       - Capability Registry: developer/capability-registry.md
+      - Canonical Organization Service: developer/organization-service.md
       - Plugin Development: developer/plugin-development.md
       - API Clients: developer/api-clients.md
       - Contributing: developer/contributing.md

--- a/src/file_organizer/api/models.py
+++ b/src/file_organizer/api/models.py
@@ -181,6 +181,7 @@ class OrganizationPlanPayload(BaseModel):
     skipped_files: int
     failed_files: int
     deduplicated_files: int
+    options: dict[str, Any] | None = None
     operations: list[OrganizationOperationPayload] = Field(default_factory=list)
     errors: list[tuple[str, str]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/file_organizer/core/file_ops.py
+++ b/src/file_organizer/core/file_ops.py
@@ -30,12 +30,20 @@ from file_organizer.undo import UndoManager
 from file_organizer.utils.safe_copy import safe_copy2
 
 
-def collect_files(path: Path, console: Console) -> list[Path]:
+def collect_files(
+    path: Path,
+    console: Console | None = None,
+    *,
+    recursive: bool = True,
+    include_hidden: bool = False,
+) -> list[Path]:
     """Collect all non-hidden files from *path*.
 
     Args:
         path: Directory to scan or single file.
-        console: Rich console for status output.
+        console: Optional Rich console for status output.
+        recursive: Whether to descend into nested directories.
+        include_hidden: Whether to include dot-prefixed entries.
 
     Returns:
         List of discovered file paths.
@@ -49,15 +57,26 @@ def collect_files(path: Path, console: Console) -> list[Path]:
         # (fo-core#270, WP-2.2 #1227).
         if path.is_symlink():
             logger.warning("Skipping symlinked input file: {}", path)
+        elif not include_hidden and path.name.startswith("."):
+            logger.debug("Skipping hidden input file: {}", path)
         else:
             files.append(path)
     else:
         # safe_walk skips symlinked files/dirs and hidden entries: a symlink
         # planted in the scan tree (e.g. ``escape -> /etc/passwd``) is no longer
         # collected, organized, or read downstream (fo-core#270, WP-2.2 #1227).
-        files.extend(safe_walk(path, only_files=True))
+        files.extend(
+            safe_walk(
+                path,
+                only_files=True,
+                recursive=recursive,
+                include_hidden=include_hidden,
+            )
+        )
 
-    console.print(f"[green]✓[/green] Found {len(files)} files")
+    files.sort(key=lambda item: item.as_posix())
+    if console is not None:
+        console.print(f"[green]✓[/green] Found {len(files)} files")
     return files
 
 

--- a/src/file_organizer/core/organization_service.py
+++ b/src/file_organizer/core/organization_service.py
@@ -1,0 +1,153 @@
+"""Direct application service for canonical organization behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from file_organizer.core import file_ops
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
+from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.plan import OrganizationPlan
+from file_organizer.core.types import (
+    AUDIO_EXTENSIONS,
+    CAD_EXTENSIONS,
+    IMAGE_EXTENSIONS,
+    TEXT_EXTENSIONS,
+    VIDEO_EXTENSIONS,
+    OrganizationResult,
+)
+from file_organizer.models.base import ModelConfig
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationScan:
+    """Deterministic direct-service scan result."""
+
+    input_path: Path
+    files: tuple[Path, ...]
+    counts: dict[str, int]
+
+    @property
+    def total_files(self) -> int:
+        """Return the number of eligible files."""
+        return len(self.files)
+
+
+OrganizerFactory = Callable[..., FileOrganizer]
+
+
+class OrganizationService:
+    """Transport-neutral entry point for scan, preview, and execution."""
+
+    def __init__(
+        self,
+        *,
+        text_model_config: ModelConfig | None = None,
+        vision_model_config: ModelConfig | None = None,
+        organizer_factory: OrganizerFactory = FileOrganizer,
+    ) -> None:
+        """Initialize the service with optional model and organizer dependencies."""
+        if text_model_config is None or vision_model_config is None:
+            from file_organizer.config.provider_env import get_model_configs
+
+            default_text, default_vision = get_model_configs()
+            text_model_config = text_model_config or default_text
+            vision_model_config = vision_model_config or default_vision
+        self._text_model_config = text_model_config
+        self._vision_model_config = vision_model_config
+        self._organizer_factory = organizer_factory
+
+    def scan(self, request: OrganizeRequest) -> OrganizationScan:
+        """Collect exactly the files that preview and execution will consume."""
+        if not request.input_path.exists():
+            raise ValueError(f"Input path does not exist: {request.input_path}")
+        files = tuple(
+            file_ops.collect_files(
+                request.input_path,
+                recursive=request.options.recursive,
+                include_hidden=request.options.include_hidden,
+            )
+        )
+        counts = dict.fromkeys(("text", "image", "video", "audio", "cad", "other"), 0)
+        for path in files:
+            extension = path.suffix.lower()
+            if extension in TEXT_EXTENSIONS:
+                counts["text"] += 1
+            elif extension in IMAGE_EXTENSIONS:
+                counts["image"] += 1
+            elif extension in VIDEO_EXTENSIONS:
+                counts["video"] += 1
+            elif extension in AUDIO_EXTENSIONS:
+                counts["audio"] += 1
+            elif extension in CAD_EXTENSIONS:
+                counts["cad"] += 1
+            else:
+                counts["other"] += 1
+        return OrganizationScan(request.input_path, files, counts)
+
+    def preview(self, request: OrganizeRequest) -> OrganizationResult:
+        """Build a canonical executable plan without mutating the filesystem."""
+        organizer = self._create_organizer(self._resolve_options(request.options), dry_run=True)
+        return organizer.organize(
+            request.input_path,
+            request.output_path,
+            skip_existing=request.options.skip_existing,
+        )
+
+    def execute(
+        self,
+        request: OrganizeRequest,
+        plan: OrganizationPlan | None = None,
+    ) -> OrganizationResult:
+        """Apply a reviewed plan, or build and apply one through the same contract."""
+        if plan is None:
+            preview = self.preview(request)
+            if not isinstance(preview.plan, OrganizationPlan):
+                raise RuntimeError("Organization preview did not produce an executable plan.")
+            plan = preview.plan
+        if not plan.roots_match(request.input_path, request.output_path):
+            raise ValueError("Organization plan roots do not match request paths.")
+        resolved_options = self._resolve_options(request.options)
+        if plan.options != resolved_options:
+            raise ValueError("Organization plan options do not match request options.")
+        return self._create_organizer(resolved_options, dry_run=False).execute_plan(plan)
+
+    def _resolve_options(self, options: OrganizeOptions) -> OrganizeOptions:
+        """Resolve configured model defaults into reproducible plan values."""
+        return replace(
+            options,
+            text_model=options.text_model or self._text_model_config.name,
+            vision_model=options.vision_model or self._vision_model_config.name,
+            text_provider=options.text_provider or self._text_model_config.provider,
+            vision_provider=options.vision_provider or self._vision_model_config.provider,
+        )
+
+    def _create_organizer(self, options: OrganizeOptions, *, dry_run: bool) -> FileOrganizer:
+        """Map canonical options into the existing domain orchestrator."""
+        text_model_config = replace(
+            self._text_model_config,
+            name=options.text_model or self._text_model_config.name,
+            provider=options.text_provider or self._text_model_config.provider,
+        )
+        vision_model_config = replace(
+            self._vision_model_config,
+            name=options.vision_model or self._vision_model_config.name,
+            provider=options.vision_provider or self._vision_model_config.provider,
+        )
+        return self._organizer_factory(
+            text_model_config=text_model_config,
+            vision_model_config=vision_model_config,
+            dry_run=dry_run,
+            use_hardlinks=options.use_hardlinks,
+            parallel_workers=options.parallel_workers,
+            prefetch_depth=options.prefetch_depth,
+            enable_vision=options.enable_vision,
+            transcribe_audio=options.transcribe_audio,
+            max_transcribe_seconds=options.max_transcribe_seconds,
+            whisper_model=options.whisper_model,
+            recursive=options.recursive,
+            include_hidden=options.include_hidden,
+            organize_options=options,
+        )

--- a/src/file_organizer/core/organize_options.py
+++ b/src/file_organizer/core/organize_options.py
@@ -1,0 +1,112 @@
+"""Canonical, transport-neutral organization request contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+ModelProvider = Literal["ollama", "openai", "llama_cpp", "mlx", "claude"]
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizeOptions:
+    """Behavior-affecting options shared by every organization surface.
+
+    ``use_hardlinks`` is the existing transfer selector.  Parity slice #1602
+    will replace it with the canonical transfer-mode contract while retaining
+    plan compatibility.
+    """
+
+    recursive: bool = True
+    include_hidden: bool = False
+    skip_existing: bool = True
+    use_hardlinks: bool = True
+    enable_vision: bool = True
+    transcribe_audio: bool = False
+    max_transcribe_seconds: float | None = 600.0
+    whisper_model: str = "tiny"
+    parallel_workers: int | None = None
+    prefetch_depth: int = 2
+    text_model: str | None = None
+    vision_model: str | None = None
+    text_provider: ModelProvider | None = None
+    vision_provider: ModelProvider | None = None
+
+    def __post_init__(self) -> None:
+        """Reject invalid combinations before filesystem or model work starts."""
+        for field_name in (
+            "recursive",
+            "include_hidden",
+            "skip_existing",
+            "use_hardlinks",
+            "enable_vision",
+            "transcribe_audio",
+        ):
+            if not isinstance(getattr(self, field_name), bool):
+                raise ValueError(f"{field_name} must be a boolean")
+        if isinstance(self.parallel_workers, bool) or (
+            self.parallel_workers is not None and not isinstance(self.parallel_workers, int)
+        ):
+            raise ValueError("parallel_workers must be an integer or None")
+        if isinstance(self.prefetch_depth, bool) or not isinstance(self.prefetch_depth, int):
+            raise ValueError("prefetch_depth must be an integer")
+        if isinstance(self.max_transcribe_seconds, bool) or (
+            self.max_transcribe_seconds is not None
+            and not isinstance(self.max_transcribe_seconds, (int, float))
+        ):
+            raise ValueError("max_transcribe_seconds must be a number or None")
+        if self.parallel_workers is not None and self.parallel_workers < 1:
+            raise ValueError("parallel_workers must be at least 1 or None")
+        if self.prefetch_depth < 0:
+            raise ValueError("prefetch_depth must be at least 0")
+        if self.max_transcribe_seconds is not None and self.max_transcribe_seconds < 0:
+            raise ValueError("max_transcribe_seconds must be at least 0 or None")
+        if not isinstance(self.whisper_model, str) or not self.whisper_model.strip():
+            raise ValueError("whisper_model must not be empty")
+        if self.text_model is not None and (
+            not isinstance(self.text_model, str) or not self.text_model.strip()
+        ):
+            raise ValueError("text_model must not be empty when provided")
+        if self.vision_model is not None and (
+            not isinstance(self.vision_model, str) or not self.vision_model.strip()
+        ):
+            raise ValueError("vision_model must not be empty when provided")
+        supported_providers = {"ollama", "openai", "llama_cpp", "mlx", "claude"}
+        for field_name in ("text_provider", "vision_provider"):
+            provider = getattr(self, field_name)
+            if provider is not None and provider not in supported_providers:
+                raise ValueError(f"{field_name} is not a supported model provider")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-compatible representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> OrganizeOptions:
+        """Parse an options payload, applying defaults for omitted fields."""
+        if not isinstance(data, Mapping):
+            raise ValueError("organization options must be an object")
+        known_fields = set(cls.__dataclass_fields__)
+        unknown_fields = set(data) - known_fields
+        if unknown_fields:
+            names = ", ".join(sorted(str(field) for field in unknown_fields))
+            raise ValueError(f"unknown organization option fields: {names}")
+        return cls(**dict(data))
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizeRequest:
+    """Canonical request consumed by the direct organization service."""
+
+    input_path: Path
+    output_path: Path
+    options: OrganizeOptions = OrganizeOptions()
+
+    def __post_init__(self) -> None:
+        """Normalize path-like values without resolving untrusted filesystem state."""
+        if not isinstance(self.options, OrganizeOptions):
+            raise ValueError("options must be an OrganizeOptions instance")
+        object.__setattr__(self, "input_path", Path(self.input_path))
+        object.__setattr__(self, "output_path", Path(self.output_path))

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -23,6 +23,7 @@ from loguru import logger
 from rich.console import Console
 
 from file_organizer.core import dispatcher, display, file_ops, initializer
+from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.plan import (
     OrganizationPlan,
     build_plan_from_processed,
@@ -100,6 +101,9 @@ class FileOrganizer:
         transcribe_audio: bool = False,
         max_transcribe_seconds: float | None = 600.0,
         whisper_model: str = "tiny",
+        recursive: bool = True,
+        include_hidden: bool = False,
+        organize_options: OrganizeOptions | None = None,
     ) -> None:
         """Initialize file organizer.
 
@@ -131,6 +135,9 @@ class FileOrganizer:
                 ``whisper:`` prefix is accepted). Default "tiny" — the
                 fastest model; larger sizes improve transcript quality at
                 the cost of download size and inference time.
+            recursive: Whether collection descends into nested directories.
+            include_hidden: Whether collection includes dot-prefixed entries.
+            organize_options: Canonical options to persist with generated plans.
         """
         if text_model_config is None or vision_model_config is None:
             from file_organizer.config.provider_env import get_model_configs
@@ -144,6 +151,8 @@ class FileOrganizer:
         self.dry_run = dry_run
         self.use_hardlinks = use_hardlinks
         self.enable_vision = enable_vision
+        self.recursive = recursive
+        self.include_hidden = include_hidden
         self.no_prefetch = no_prefetch
         self.prefetch_depth = prefetch_depth
         if no_prefetch and prefetch_depth != 0:
@@ -174,6 +183,37 @@ class FileOrganizer:
             )
         self.max_transcribe_seconds = max_transcribe_seconds
         self.whisper_model = whisper_model
+        self.organize_options = organize_options or OrganizeOptions(
+            recursive=recursive,
+            include_hidden=include_hidden,
+            use_hardlinks=use_hardlinks,
+            enable_vision=enable_vision,
+            transcribe_audio=transcribe_audio,
+            max_transcribe_seconds=max_transcribe_seconds,
+            whisper_model=whisper_model,
+            parallel_workers=parallel_workers,
+            prefetch_depth=self.prefetch_depth,
+            text_model=(
+                self.text_model_config.name
+                if isinstance(self.text_model_config, ModelConfig)
+                else None
+            ),
+            vision_model=(
+                self.vision_model_config.name
+                if isinstance(self.vision_model_config, ModelConfig)
+                else None
+            ),
+            text_provider=(
+                self.text_model_config.provider
+                if isinstance(self.text_model_config, ModelConfig)
+                else None
+            ),
+            vision_provider=(
+                self.vision_model_config.provider
+                if isinstance(self.vision_model_config, ModelConfig)
+                else None
+            ),
+        )
         self._audio_model: Any = None
         self._undo_manager: UndoManager | None = None
         self._last_transaction_id: str | None = None
@@ -224,7 +264,12 @@ class FileOrganizer:
         scan_root = input_path if input_path.is_dir() else input_path.parent
 
         self.console.print(f"\n[bold blue]Scanning:[/bold blue] {input_path}")
-        files = file_ops.collect_files(input_path, self.console)
+        files = file_ops.collect_files(
+            input_path,
+            self.console,
+            recursive=self.recursive,
+            include_hidden=self.include_hidden,
+        )
 
         result = OrganizationResult(total_files=len(files))
         if not files:
@@ -237,10 +282,7 @@ class FileOrganizer:
                 total_files=0,
                 skipped_files=0,
                 deduplicated_files=0,
-                metadata={
-                    "enable_vision": self.enable_vision,
-                    "prefetch_depth": self.prefetch_depth,
-                },
+                options=self.organize_options,
             )
             result.processing_time = time.time() - start_time
             self.console.print("[yellow]No files found to organize[/yellow]")
@@ -404,10 +446,7 @@ class FileOrganizer:
             deduplicated_files=result.deduplicated_files,
             errors=result.errors,
             file_hashes=file_hashes,
-            metadata={
-                "enable_vision": self.enable_vision,
-                "prefetch_depth": self.prefetch_depth,
-            },
+            options=self.organize_options,
         )
         result.plan = plan
         result.processed_files = plan.processed_files
@@ -596,7 +635,12 @@ class FileOrganizer:
 
     def _collect_files(self, path: Path) -> list[Path]:
         """Walk the input root and return the list of files eligible for organization."""
-        return file_ops.collect_files(path, self.console)
+        return file_ops.collect_files(
+            path,
+            self.console,
+            recursive=self.recursive,
+            include_hidden=self.include_hidden,
+        )
 
     def _fallback_by_extension(self, files: list[Path]) -> list[ProcessedFile]:
         """Return a target subdirectory chosen from the file extension when the classifier fails."""

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -16,6 +16,7 @@ import hashlib
 import os
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -139,6 +140,19 @@ class FileOrganizer:
             include_hidden: Whether collection includes dot-prefixed entries.
             organize_options: Canonical options to persist with generated plans.
         """
+        self._organize_options_supplied = organize_options is not None
+        if organize_options is not None:
+            use_hardlinks = organize_options.use_hardlinks
+            parallel_workers = organize_options.parallel_workers
+            prefetch_depth = organize_options.prefetch_depth
+            no_prefetch = organize_options.prefetch_depth == 0
+            enable_vision = organize_options.enable_vision
+            transcribe_audio = organize_options.transcribe_audio
+            max_transcribe_seconds = organize_options.max_transcribe_seconds
+            whisper_model = organize_options.whisper_model
+            recursive = organize_options.recursive
+            include_hidden = organize_options.include_hidden
+
         if text_model_config is None or vision_model_config is None:
             from file_organizer.config.provider_env import get_model_configs
 
@@ -148,6 +162,17 @@ class FileOrganizer:
         else:
             self.text_model_config = text_model_config
             self.vision_model_config = vision_model_config
+        if organize_options is not None:
+            self.text_model_config = replace(
+                self.text_model_config,
+                name=organize_options.text_model or self.text_model_config.name,
+                provider=organize_options.text_provider or self.text_model_config.provider,
+            )
+            self.vision_model_config = replace(
+                self.vision_model_config,
+                name=organize_options.vision_model or self.vision_model_config.name,
+                provider=organize_options.vision_provider or self.vision_model_config.provider,
+            )
         self.dry_run = dry_run
         self.use_hardlinks = use_hardlinks
         self.enable_vision = enable_vision
@@ -183,37 +208,46 @@ class FileOrganizer:
             )
         self.max_transcribe_seconds = max_transcribe_seconds
         self.whisper_model = whisper_model
-        self.organize_options = organize_options or OrganizeOptions(
-            recursive=recursive,
-            include_hidden=include_hidden,
-            use_hardlinks=use_hardlinks,
-            enable_vision=enable_vision,
-            transcribe_audio=transcribe_audio,
-            max_transcribe_seconds=max_transcribe_seconds,
-            whisper_model=whisper_model,
-            parallel_workers=parallel_workers,
-            prefetch_depth=self.prefetch_depth,
-            text_model=(
-                self.text_model_config.name
-                if isinstance(self.text_model_config, ModelConfig)
-                else None
-            ),
-            vision_model=(
-                self.vision_model_config.name
-                if isinstance(self.vision_model_config, ModelConfig)
-                else None
-            ),
-            text_provider=(
-                self.text_model_config.provider
-                if isinstance(self.text_model_config, ModelConfig)
-                else None
-            ),
-            vision_provider=(
-                self.vision_model_config.provider
-                if isinstance(self.vision_model_config, ModelConfig)
-                else None
-            ),
-        )
+        if organize_options is not None:
+            self.organize_options = replace(
+                organize_options,
+                text_model=self.text_model_config.name,
+                vision_model=self.vision_model_config.name,
+                text_provider=self.text_model_config.provider,
+                vision_provider=self.vision_model_config.provider,
+            )
+        else:
+            self.organize_options = OrganizeOptions(
+                recursive=recursive,
+                include_hidden=include_hidden,
+                use_hardlinks=use_hardlinks,
+                enable_vision=enable_vision,
+                transcribe_audio=transcribe_audio,
+                max_transcribe_seconds=max_transcribe_seconds,
+                whisper_model=whisper_model,
+                parallel_workers=parallel_workers,
+                prefetch_depth=self.prefetch_depth,
+                text_model=(
+                    self.text_model_config.name
+                    if isinstance(self.text_model_config, ModelConfig)
+                    else None
+                ),
+                vision_model=(
+                    self.vision_model_config.name
+                    if isinstance(self.vision_model_config, ModelConfig)
+                    else None
+                ),
+                text_provider=(
+                    self.text_model_config.provider
+                    if isinstance(self.text_model_config, ModelConfig)
+                    else None
+                ),
+                vision_provider=(
+                    self.vision_model_config.provider
+                    if isinstance(self.vision_model_config, ModelConfig)
+                    else None
+                ),
+            )
         self._audio_model: Any = None
         self._undo_manager: UndoManager | None = None
         self._last_transaction_id: str | None = None
@@ -254,6 +288,8 @@ class FileOrganizer:
         start_time = time.time()
         input_path = Path(input_path)
         output_path = Path(output_path)
+        if self._organize_options_supplied:
+            skip_existing = self.organize_options.skip_existing
 
         if not input_path.exists():
             raise ValueError(f"Input path does not exist: {input_path}")

--- a/src/file_organizer/core/plan.py
+++ b/src/file_organizer/core/plan.py
@@ -13,7 +13,7 @@ import hashlib
 import os
 import sqlite3
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path, PurePath
 from typing import Any
@@ -22,12 +22,14 @@ from uuid import uuid4
 from loguru import logger
 
 from file_organizer._compat import StrEnum
+from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.history.models import OperationType
 from file_organizer.services import ProcessedFile, ProcessedImage
 from file_organizer.undo import UndoManager
 from file_organizer.utils.safedir import SafeDir, SymlinkRejected
 
-PLAN_SCHEMA_VERSION = 1
+PLAN_SCHEMA_VERSION = 2
+_LEGACY_PLAN_SCHEMA_VERSION = 1
 _CHUNK_SIZE = 65536
 
 
@@ -173,6 +175,7 @@ class OrganizationPlan:
     skipped_files: int
     failed_files: int
     deduplicated_files: int
+    options: OrganizeOptions = field(default_factory=OrganizeOptions)
     operations: list[OrganizationOperation] = field(default_factory=list)
     errors: list[tuple[str, str]] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -238,11 +241,29 @@ class OrganizationPlan:
     def from_dict(cls, data: dict[str, Any]) -> OrganizationPlan:
         """Deserialize a plan previously returned by :meth:`to_dict`."""
         schema_version = int(data.get("schema_version", PLAN_SCHEMA_VERSION))
-        if schema_version != PLAN_SCHEMA_VERSION:
+        if schema_version not in {_LEGACY_PLAN_SCHEMA_VERSION, PLAN_SCHEMA_VERSION}:
             raise ValueError(
                 f"Unsupported organization plan schema_version {schema_version}; "
-                f"expected {PLAN_SCHEMA_VERSION}."
+                f"expected {_LEGACY_PLAN_SCHEMA_VERSION} or {PLAN_SCHEMA_VERSION}."
             )
+
+        metadata = dict(data.get("metadata", {}))
+        if schema_version == _LEGACY_PLAN_SCHEMA_VERSION:
+            options = OrganizeOptions(
+                skip_existing=bool(data.get("skip_existing", True)),
+                use_hardlinks=bool(data.get("use_hardlinks", True)),
+                enable_vision=bool(metadata.get("enable_vision", True)),
+                prefetch_depth=int(metadata.get("prefetch_depth", 2)),
+            )
+        else:
+            raw_options = data.get("options")
+            if not isinstance(raw_options, dict):
+                raise ValueError("Organization plan schema 2 requires an options object.")
+            options = OrganizeOptions.from_dict(raw_options)
+            if options.skip_existing != bool(data.get("skip_existing", True)):
+                raise ValueError("Organization plan skip_existing does not match its options.")
+            if options.use_hardlinks != bool(data.get("use_hardlinks", True)):
+                raise ValueError("Organization plan use_hardlinks does not match its options.")
 
         operations: list[OrganizationOperation] = []
         for raw in data.get("operations", []):
@@ -284,7 +305,7 @@ class OrganizationPlan:
 
         return cls(
             plan_id=data["plan_id"],
-            schema_version=schema_version,
+            schema_version=PLAN_SCHEMA_VERSION,
             input_path=data["input_path"],
             output_path=data["output_path"],
             created_at=data["created_at"],
@@ -295,9 +316,10 @@ class OrganizationPlan:
             skipped_files=int(data.get("skipped_files", 0)),
             failed_files=int(data.get("failed_files", 0)),
             deduplicated_files=int(data.get("deduplicated_files", 0)),
+            options=options,
             operations=operations,
             errors=[tuple(error) for error in data.get("errors", [])],
-            metadata=dict(data.get("metadata", {})),
+            metadata=metadata,
         )
 
 
@@ -314,6 +336,7 @@ def build_plan_from_processed(
     errors: list[tuple[str, str]] | None = None,
     file_hashes: dict[Path, str | None] | None = None,
     metadata: dict[str, Any] | None = None,
+    options: OrganizeOptions | None = None,
 ) -> OrganizationPlan:
     """Create an executable plan from processed file classifications."""
     operations: list[OrganizationOperation] = []
@@ -321,7 +344,13 @@ def build_plan_from_processed(
     output_path = Path(output_path)
     file_hashes = file_hashes or {}
 
-    for result in processed:
+    options = replace(
+        options or OrganizeOptions(),
+        skip_existing=skip_existing,
+        use_hardlinks=use_hardlinks,
+    )
+
+    for result in sorted(processed, key=lambda item: str(item.file_path)):
         source = Path(result.file_path)
         base_name = f"{result.filename}{source.suffix}"
         destination = output_path / result.folder_name / base_name
@@ -397,6 +426,7 @@ def build_plan_from_processed(
         skipped_files=skipped_count,
         failed_files=error_count,
         deduplicated_files=deduplicated_files,
+        options=options,
         operations=operations,
         errors=list(errors or []),
         metadata=dict(metadata or {}),

--- a/tests/core/test_organization_plan.py
+++ b/tests/core/test_organization_plan.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.plan import (
     CollisionAction,
     OrganizationOperationStatus,
@@ -102,6 +103,64 @@ def test_plan_roots_display_rows_and_serialization_round_trip(tmp_path: Path) ->
     assert restored.operations[0].operation_type == plan.operations[0].operation_type
     assert restored.operations[0].fingerprint == plan.operations[0].fingerprint
     assert restored.metadata == {"methodology": "none"}
+
+
+def test_plan_serializes_behavior_affecting_options(tmp_path: Path) -> None:
+    plan = _single_op_plan(tmp_path)
+    plan.options = OrganizeOptions(
+        recursive=False,
+        include_hidden=True,
+        use_hardlinks=plan.use_hardlinks,
+        enable_vision=False,
+        text_model="qwen",
+        vision_model="llava",
+    )
+
+    restored = OrganizationPlan.from_dict(plan.to_dict())
+
+    assert restored.options == plan.options
+
+
+def test_schema_one_plan_is_upgraded_with_legacy_defaults(tmp_path: Path) -> None:
+    data = _single_op_plan(tmp_path).to_dict()
+    data["schema_version"] = 1
+    data.pop("options")
+    data["metadata"] = {"enable_vision": False, "prefetch_depth": 0}
+
+    restored = OrganizationPlan.from_dict(data)
+
+    assert restored.schema_version == 2
+    assert restored.options.enable_vision is False
+    assert restored.options.prefetch_depth == 0
+    assert restored.options.skip_existing is True
+
+
+def test_schema_two_plan_requires_matching_options(tmp_path: Path) -> None:
+    data = _single_op_plan(tmp_path).to_dict()
+    data["options"]["skip_existing"] = False
+
+    with pytest.raises(ValueError, match="skip_existing does not match"):
+        OrganizationPlan.from_dict(data)
+
+
+def test_plan_operations_are_sorted_by_source_path(tmp_path: Path) -> None:
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("a")
+    second.write_text("b")
+
+    plan = build_plan_from_processed(
+        input_path=tmp_path,
+        output_path=tmp_path / "out",
+        processed=[_processed(second), _processed(first)],
+        skip_existing=True,
+        use_hardlinks=False,
+        total_files=2,
+        skipped_files=0,
+        deduplicated_files=0,
+    )
+
+    assert [operation.source for operation in plan.operations] == [first, second]
 
 
 def test_from_dict_rejects_unsupported_schema_version(tmp_path: Path) -> None:

--- a/tests/core/test_organization_service.py
+++ b/tests/core/test_organization_service.py
@@ -1,0 +1,265 @@
+"""Tests for the transport-neutral organization application service."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from file_organizer.core.organization_service import OrganizationService
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
+from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.plan import OrganizationPlan, build_plan_from_processed
+from file_organizer.core.types import OrganizationResult
+from file_organizer.models.base import ModelConfig, ModelType
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def _service(**kwargs: object) -> OrganizationService:
+    return OrganizationService(
+        text_model_config=ModelConfig("text-model", ModelType.TEXT),
+        vision_model_config=ModelConfig("vision-model", ModelType.VISION),
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _resolved_options(**overrides: object) -> OrganizeOptions:
+    values: dict[str, object] = {
+        "text_model": "text-model",
+        "vision_model": "vision-model",
+        "text_provider": "ollama",
+        "vision_provider": "ollama",
+    }
+    values.update(overrides)
+    return OrganizeOptions.from_dict(values)
+
+
+def _empty_plan(tmp_path: Path, options: OrganizeOptions) -> OrganizationPlan:
+    input_path = tmp_path / "input"
+    input_path.mkdir(exist_ok=True)
+    return build_plan_from_processed(
+        input_path=input_path,
+        output_path=tmp_path / "out",
+        processed=[],
+        skip_existing=options.skip_existing,
+        use_hardlinks=options.use_hardlinks,
+        total_files=0,
+        skipped_files=0,
+        deduplicated_files=0,
+        options=options,
+    )
+
+
+def test_scan_obeys_recursive_and_hidden_policy(tmp_path: Path) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (tmp_path / "top.txt").write_text("top")
+    (tmp_path / ".hidden.txt").write_text("hidden")
+    (nested / "deep.jpg").write_bytes(b"image")
+    (nested / "clip.mp4").write_bytes(b"video")
+    (nested / "voice.mp3").write_bytes(b"audio")
+    (nested / "drawing.dxf").write_bytes(b"cad")
+    (nested / "archive.unknown").write_bytes(b"other")
+    service = _service()
+
+    shallow = service.scan(
+        OrganizeRequest(
+            tmp_path,
+            tmp_path / "out",
+            OrganizeOptions(recursive=False, include_hidden=False),
+        )
+    )
+    complete = service.scan(
+        OrganizeRequest(
+            tmp_path,
+            tmp_path / "out",
+            OrganizeOptions(recursive=True, include_hidden=True),
+        )
+    )
+
+    assert [path.name for path in shallow.files] == ["top.txt"]
+    assert shallow.counts["text"] == 1
+    assert {path.name for path in complete.files} == {
+        ".hidden.txt",
+        "archive.unknown",
+        "clip.mp4",
+        "deep.jpg",
+        "drawing.dxf",
+        "top.txt",
+        "voice.mp3",
+    }
+    assert complete.counts["image"] == 1
+    assert complete.counts["video"] == 1
+    assert complete.counts["audio"] == 1
+    assert complete.counts["cad"] == 1
+    assert complete.counts["other"] == 1
+
+
+def test_scan_excludes_direct_hidden_file_unless_requested(tmp_path: Path) -> None:
+    hidden = tmp_path / ".secret.txt"
+    hidden.write_text("secret")
+    service = _service()
+
+    excluded = service.scan(OrganizeRequest(hidden, tmp_path / "out"))
+    included = service.scan(
+        OrganizeRequest(
+            hidden,
+            tmp_path / "out",
+            OrganizeOptions(include_hidden=True),
+        )
+    )
+
+    assert excluded.total_files == 0
+    assert included.files == (hidden,)
+
+
+def test_scan_rejects_missing_input(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Input path does not exist"):
+        _service().scan(OrganizeRequest(tmp_path / "missing", tmp_path / "out"))
+
+
+def test_preview_persists_resolved_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (tmp_path / "top.txt").write_text("top")
+    (nested / "deep.txt").write_text("deep")
+    monkeypatch.setattr(FileOrganizer, "_init_text_processor", lambda self: None)
+    request = OrganizeRequest(
+        tmp_path,
+        tmp_path / "out",
+        OrganizeOptions(
+            recursive=False,
+            include_hidden=False,
+            use_hardlinks=False,
+            enable_vision=False,
+            parallel_workers=1,
+            prefetch_depth=0,
+        ),
+    )
+
+    result = _service().preview(request)
+
+    assert result.total_files == 1
+    assert isinstance(result.plan, OrganizationPlan)
+    assert result.plan.options.recursive is False
+    assert result.plan.options.text_model == "text-model"
+    assert result.plan.options.vision_model == "vision-model"
+    assert result.plan.options.prefetch_depth == 0
+
+
+def test_scan_preview_and_execute_share_traversal_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_path = tmp_path / "input"
+    nested = input_path / "nested"
+    nested.mkdir(parents=True)
+    top = input_path / "top.txt"
+    top.write_text("top")
+    (nested / "deep.txt").write_text("deep")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "state"))
+    monkeypatch.setattr(FileOrganizer, "_init_text_processor", lambda self: None)
+    request = OrganizeRequest(
+        input_path,
+        tmp_path / "out",
+        OrganizeOptions(
+            recursive=False,
+            use_hardlinks=False,
+            enable_vision=False,
+        ),
+    )
+    service = _service()
+
+    scan = service.scan(request)
+    preview = service.preview(request)
+    assert isinstance(preview.plan, OrganizationPlan)
+    result = service.execute(request, preview.plan)
+
+    assert scan.files == (top,)
+    assert [operation.source for operation in preview.plan.operations] == [top]
+    assert len(result.organized_structure) == 1
+    assert preview.plan.operations[0].destination.exists()
+    assert all("deep.txt" not in files for files in result.organized_structure.values())
+
+
+def test_execute_rejects_plan_from_different_options(tmp_path: Path) -> None:
+    organizer = MagicMock()
+    organizer.organize.return_value.plan = None
+    factory = MagicMock(return_value=organizer)
+    service = _service(organizer_factory=factory)
+    request = OrganizeRequest(tmp_path, tmp_path / "out", OrganizeOptions(use_hardlinks=False))
+    plan = MagicMock(spec=OrganizationPlan)
+    plan.roots_match.return_value = True
+    plan.options = OrganizeOptions(use_hardlinks=True)
+
+    with pytest.raises(ValueError, match="options do not match"):
+        service.execute(request, plan)
+
+
+def test_execute_applies_reviewed_plan_with_resolved_options(tmp_path: Path) -> None:
+    options = _resolved_options(use_hardlinks=False)
+    plan = _empty_plan(tmp_path, options)
+    expected = OrganizationResult(plan=plan)
+    organizer = MagicMock()
+    organizer.execute_plan.return_value = expected
+    factory = MagicMock(return_value=organizer)
+    service = _service(organizer_factory=factory)
+    request = OrganizeRequest(
+        tmp_path / "input",
+        tmp_path / "out",
+        OrganizeOptions(use_hardlinks=False),
+    )
+
+    result = service.execute(request, plan)
+
+    assert result is expected
+    organizer.execute_plan.assert_called_once_with(plan)
+    assert factory.call_args.kwargs["dry_run"] is False
+    assert factory.call_args.kwargs["text_model_config"].name == "text-model"
+
+
+def test_execute_can_build_then_apply_the_preview_plan(tmp_path: Path) -> None:
+    options = _resolved_options()
+    plan = _empty_plan(tmp_path, options)
+    preview_organizer = MagicMock()
+    preview_organizer.organize.return_value = OrganizationResult(plan=plan)
+    execute_organizer = MagicMock()
+    expected = OrganizationResult(plan=plan)
+    execute_organizer.execute_plan.return_value = expected
+    factory = MagicMock(side_effect=[preview_organizer, execute_organizer])
+    service = _service(organizer_factory=factory)
+    request = OrganizeRequest(tmp_path / "input", tmp_path / "out")
+
+    assert service.execute(request) is expected
+    preview_organizer.organize.assert_called_once()
+    execute_organizer.execute_plan.assert_called_once_with(plan)
+
+
+def test_execute_rejects_missing_preview_plan(tmp_path: Path) -> None:
+    organizer = MagicMock()
+    organizer.organize.return_value = OrganizationResult(plan=None)
+    service = _service(organizer_factory=MagicMock(return_value=organizer))
+    request = OrganizeRequest(tmp_path, tmp_path / "out")
+
+    with pytest.raises(RuntimeError, match="did not produce an executable plan"):
+        service.execute(request)
+
+
+def test_execute_rejects_plan_from_different_roots(tmp_path: Path) -> None:
+    plan = _empty_plan(tmp_path, _resolved_options())
+
+    with pytest.raises(ValueError, match="roots do not match"):
+        _service().execute(OrganizeRequest(tmp_path / "other", tmp_path / "out"), plan)
+
+
+def test_service_resolves_missing_model_dependencies() -> None:
+    text_config = ModelConfig("default-text", ModelType.TEXT)
+    vision_config = ModelConfig("default-vision", ModelType.VISION)
+
+    with patch(
+        "file_organizer.config.provider_env.get_model_configs",
+        return_value=(text_config, vision_config),
+    ):
+        service = OrganizationService()
+
+    assert service._text_model_config is text_config
+    assert service._vision_model_config is vision_config

--- a/tests/core/test_organize_options.py
+++ b/tests/core/test_organize_options.py
@@ -1,0 +1,44 @@
+"""Tests for canonical organization request options."""
+
+from pathlib import Path
+
+import pytest
+
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def test_options_defaults_round_trip() -> None:
+    options = OrganizeOptions()
+
+    assert OrganizeOptions.from_dict(options.to_dict()) == options
+    assert options.recursive is True
+    assert options.include_hidden is False
+    assert options.skip_existing is True
+
+
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        ({"parallel_workers": 0}, "parallel_workers"),
+        ({"prefetch_depth": -1}, "prefetch_depth"),
+        ({"max_transcribe_seconds": -1}, "max_transcribe_seconds"),
+        ({"whisper_model": " "}, "whisper_model"),
+        ({"text_model": ""}, "text_model"),
+        ({"vision_provider": "unknown"}, "vision_provider"),
+        ({"recursive": "yes"}, "recursive"),
+        ({"prefetch_depth": True}, "prefetch_depth"),
+        ({"future_option": True}, "unknown organization option"),
+    ],
+)
+def test_options_reject_invalid_values(values: dict[str, object], message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        OrganizeOptions.from_dict(values)
+
+
+def test_request_normalizes_path_like_values() -> None:
+    request = OrganizeRequest("input", "output")  # type: ignore[arg-type]
+
+    assert request.input_path == Path("input")
+    assert request.output_path == Path("output")

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -15,8 +15,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.organizer import FileOrganizer
-from file_organizer.core.plan import build_plan_from_processed
+from file_organizer.core.plan import (
+    OrganizationOperationStatus,
+    OrganizationPlan,
+    build_plan_from_processed,
+)
 from file_organizer.core.types import OrganizationResult
 from file_organizer.models.base import ModelConfig, ModelType
 from file_organizer.services.text_processor import ProcessedFile
@@ -111,6 +116,82 @@ class TestFileOrganizer:
         """Test organizing fails when input path does not exist."""
         with pytest.raises(ValueError, match="Input path does not exist"):
             organizer.organize(tmp_path / "missing", tmp_path / "out")
+
+    def test_canonical_options_override_legacy_behavior_kwargs(
+        self, text_config: ModelConfig, vision_config: ModelConfig
+    ) -> None:
+        options = OrganizeOptions(
+            recursive=False,
+            include_hidden=True,
+            skip_existing=False,
+            use_hardlinks=False,
+            enable_vision=False,
+            transcribe_audio=True,
+            max_transcribe_seconds=None,
+            whisper_model="base",
+            parallel_workers=1,
+            prefetch_depth=0,
+            text_model="canonical-text",
+            vision_model="canonical-vision",
+            text_provider="openai",
+            vision_provider="claude",
+        )
+
+        org = FileOrganizer(
+            text_model_config=text_config,
+            vision_model_config=vision_config,
+            use_hardlinks=True,
+            parallel_workers=8,
+            prefetch_depth=9,
+            enable_vision=True,
+            transcribe_audio=False,
+            max_transcribe_seconds=30,
+            whisper_model="tiny",
+            recursive=True,
+            include_hidden=False,
+            organize_options=options,
+        )
+
+        assert org.recursive is False
+        assert org.include_hidden is True
+        assert org.use_hardlinks is False
+        assert org.enable_vision is False
+        assert org.transcribe_audio is True
+        assert org.max_transcribe_seconds is None
+        assert org.whisper_model == "base"
+        assert org.parallel_config.max_workers == 1
+        assert org.parallel_config.prefetch_depth == 0
+        assert org.text_model_config.name == "canonical-text"
+        assert org.text_model_config.provider == "openai"
+        assert org.vision_model_config.name == "canonical-vision"
+        assert org.vision_model_config.provider == "claude"
+        assert org.organize_options == options
+
+    def test_canonical_options_override_organize_skip_argument(
+        self, text_config: ModelConfig, vision_config: ModelConfig, tmp_path: Path
+    ) -> None:
+        input_path = tmp_path / "input"
+        input_path.mkdir()
+        source = input_path / "notes.txt"
+        source.write_text("new")
+        output_path = tmp_path / "out"
+        destination = output_path / FileOrganizer._TEXT_FALLBACK_MAP[".txt"] / source.name
+        destination.parent.mkdir(parents=True)
+        destination.write_text("existing")
+        options = OrganizeOptions(skip_existing=True, use_hardlinks=False, enable_vision=False)
+        org = FileOrganizer(
+            text_model_config=text_config,
+            vision_model_config=vision_config,
+            organize_options=options,
+        )
+
+        with patch.object(org, "_init_text_processor"):
+            result = org.organize(input_path, output_path, skip_existing=False)
+
+        assert isinstance(result.plan, OrganizationPlan)
+        assert result.plan.options.skip_existing is True
+        assert result.plan.operations[0].status is OrganizationOperationStatus.SKIPPED
+        assert destination.read_text() == "existing"
 
     @patch("file_organizer.core.file_ops.collect_files")
     def test_organize_empty_directory(

--- a/tests/integration/test_executable_plan_review_regressions.py
+++ b/tests/integration/test_executable_plan_review_regressions.py
@@ -236,10 +236,11 @@ def test_plan_records_skipped_collisions_and_fingerprint_errors(tmp_path: Path) 
         deduplicated_files=0,
     )
 
-    assert plan.operations[0].status == OrganizationOperationStatus.SKIPPED
-    assert plan.operations[0].collision_action == CollisionAction.SKIP_EXISTING
-    assert plan.operations[1].status == OrganizationOperationStatus.ERROR
-    assert "Unable to fingerprint source" in (plan.operations[1].error or "")
+    operations = {operation.source: operation for operation in plan.operations}
+    assert operations[source].status == OrganizationOperationStatus.SKIPPED
+    assert operations[source].collision_action == CollisionAction.SKIP_EXISTING
+    assert operations[missing].status == OrganizationOperationStatus.ERROR
+    assert "Unable to fingerprint source" in (operations[missing].error or "")
 
 
 def test_validate_plan_reports_source_and_destination_conflicts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add immutable, transport-neutral `OrganizeOptions` and `OrganizeRequest` contracts
- add a direct `OrganizationService` entry point for scan, preview, and reviewed-plan execution
- make canonical options authoritative whenever a `FileOrganizer` receives them, overriding divergent legacy kwargs
- make recursive and hidden-file policy canonical in the secure collector used by preview and execution
- resolve text/vision model names and providers before persisting plan inputs
- extend the existing organization plan to schema 2 with canonical options and deterministic source-path operation ordering
- retain schema-1 loading for inspection/re-preview and reject conflicting schema-2 fields
- expose schema-2 options through the existing REST plan payload
- document the direct-service protocol for adapter and conformance-harness contributors

The existing `use_hardlinks` selector is intentionally retained. #1602 owns the explicit copy/hardlink/true-move contract and will extend `OrganizeOptions` rather than introducing a second request model.

The Python SDK's mirrored plan payload remains a deliberate #1596 follow-up. This slice updates the REST/domain contract but does not preempt the REST/SDK adapter migration.

## User and developer impact

The organization domain now has one executable request contract independent of CLI, FastAPI, Web, TUI, or desktop presentation code. Adapter work can map into this service instead of rebuilding traversal, defaults, preview, or execution semantics.

When canonical options are supplied, legacy constructor and `organize()` behavior arguments cannot make execution diverge from the plan's recorded inputs. A plan records all current behavior-affecting traversal, collision, media, model-selection, and runtime inputs.

Schema-1 plans remain loadable for inspection, but direct-service execution requires a fresh preview because legacy plans do not contain resolved model identity.

## Validation

- canonical options, direct-service, and plan contract suite — passed
- review-fix core/service/plan regression suite — 92 passed
- adapter-adjacent core/API/Web/TUI and executable-plan regressions — 235 passed
- documentation path suite — 69 passed
- direct-service coverage — 100%; combined changed contract/plan coverage — 91%
- `mkdocs build --strict` — passed
- repository pre-commit suite — passed, including smoke, CI guardrails, WebSocket, Web UI, full diff-cover, typing, docstrings, link integrity, dependency checks, CI rails, and PyMarkdown

## Risk

Moderate contract risk, low presentation risk. Plan schema advances from 1 to 2; schema-1 plans load but require re-preview before direct-service execution. Existing adapters are not migrated in this slice; their migration remains owned by #1595–#1598. Deterministic collection ordering is intentional and repository-wide, and may change positional presentation of mixed plan outcomes while preserving operation identity and semantics.

Fixes #1603.
Part of #1593.
