### PR TITLE
test: add fixture corpus and direct-service conformance driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,28 @@ jobs:
           pip install diff-cover --quiet
           diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
 
+  conformance-advisory:
+    # Parity conformance scaffold (#1605). Advisory while contracts stabilize:
+    # continue-on-error keeps a red run from blocking merges until #1606
+    # promotes adapter suites to required gates per the gate-promotion policy
+    # in docs/architecture/cross-surface-parity-execution.md.
+    name: "Conformance scaffold (advisory)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e ".[dev,search]"
+      - name: Run conformance suite
+        run: pytest tests/conformance --strict-markers -m conformance --timeout=30 --override-ini="addopts="
+
   test-full:
     name: "Test (shard ${{ matrix.shard }}, py${{ matrix.python-version }})"
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,28 +182,6 @@ jobs:
           pip install diff-cover --quiet
           diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
 
-  conformance-advisory:
-    # Parity conformance scaffold (#1605). Advisory while contracts stabilize:
-    # continue-on-error keeps a red run from blocking merges until #1606
-    # promotes adapter suites to required gates per the gate-promotion policy
-    # in docs/architecture/cross-surface-parity-execution.md.
-    name: "Conformance scaffold (advisory)"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
-        with:
-          python-version: "3.12"
-          cache: pip
-      - name: Install dependencies
-        run: pip install -e ".[dev,search]"
-      - name: Run conformance suite
-        run: pytest tests/conformance --strict-markers -m conformance --timeout=30 --override-ini="addopts="
-
   test-full:
     name: "Test (shard ${{ matrix.shard }}, py${{ matrix.python-version }})"
     needs: changes

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,39 @@
+name: Conformance
+
+# Parity conformance scaffold (#1605). The main CI workflow only triggers for
+# PRs based at main/epic/**, so this workflow adds coverage for the parity
+# integration branch itself. Advisory while contracts stabilize:
+# continue-on-error keeps a red run from blocking merges until #1606 promotes
+# adapter suites to required gates per the gate-promotion policy in
+# docs/architecture/cross-surface-parity-execution.md.
+on:
+  push:
+    branches: [main, "epic/**", feature/cross-surface-parity]
+  pull_request:
+    branches: [main, "epic/**", feature/cross-surface-parity]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  conformance-advisory:
+    name: "Conformance scaffold (advisory)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e ".[dev,search]"
+      - name: Run conformance suite
+        run: pytest tests/conformance --strict-markers -m conformance --timeout=30 --override-ini="addopts="

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -76,5 +76,8 @@ Rules for adapter drivers (#1595–#1598):
 pytest tests/conformance -m conformance --override-ini="addopts="
 ```
 
-CI runs the suite as the advisory `conformance-advisory` job (and inside the
-full-suite shards). It stays advisory until #1606 promotes required gates.
+CI runs the suite as the advisory `conformance-advisory` job in the
+dedicated `Conformance` workflow — which, unlike the main CI workflow, also
+triggers for pushes and pull requests on `feature/cross-surface-parity` — and
+inside the full-suite shards. It stays advisory until #1606 promotes required
+gates.

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -12,7 +12,7 @@ never from any adapter.
 | Module | Role |
 | --- | --- |
 | `tests/conformance/corpus.py` | Deterministic fixture corpus: pinned bytes and mtimes, tagged cases |
-| `tests/conformance/normalize.py` | Strips presentation-only differences from scans, plans, results, errors, audit events, and (provisionally) job events |
+| `tests/conformance/normalize.py` | Strips presentation-only differences while preserving executable ordering and complete source fingerprints |
 | `tests/conformance/driver.py` | `OrganizationConformanceDriver` protocol and the `DirectServiceDriver` reference oracle |
 | `tests/conformance/test_direct_service_conformance.py` | Golden expectations for canonical semantics |
 
@@ -56,6 +56,9 @@ Rules for adapter drivers (#1595–#1598):
   the reviewed-plan handoff must cross your surface as serialized data.
 - Normalize with `tests/conformance/normalize.py` helpers; do not hand-roll
   comparisons.
+- Preserve plan operation order. Return audit events in chronological
+  execution order; identifiers and timestamps are removed, but ordering is
+  part of the conformance contract.
 - Reuse the corpus and the golden expectations unchanged. A mismatch is
   either an adapter bug or a contract decision that belongs in the parity
   epic — not a reason to fork expectations.

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -1,0 +1,80 @@
+# Conformance Scaffold
+
+The conformance scaffold (`tests/conformance/`) is the executable behavioral
+oracle for the cross-surface parity epic. The direct
+`OrganizationService` defines canonical behavior; every surface adapter must
+reproduce the same normalized outputs when driven over the shared fixture
+corpus. Golden expectations always come from canonical service semantics,
+never from any adapter.
+
+## Layout
+
+| Module | Role |
+| --- | --- |
+| `tests/conformance/corpus.py` | Deterministic fixture corpus: pinned bytes and mtimes, tagged cases |
+| `tests/conformance/normalize.py` | Strips presentation-only differences from scans, plans, results, errors, audit events, and (provisionally) job events |
+| `tests/conformance/driver.py` | `OrganizationConformanceDriver` protocol and the `DirectServiceDriver` reference oracle |
+| `tests/conformance/test_direct_service_conformance.py` | Golden expectations for canonical semantics |
+
+## Fixture corpus
+
+Each `CorpusCase` materializes an identical tree on every run: file content is
+fixed, and mtimes are pinned with `os.utime` so source fingerprints and
+year-based image folders never drift. Cases are tagged (`traversal`, `hidden`,
+`collision`, `duplicates`, `symlink`, `media`, `methodology`, `plan`,
+`recovery`) so adapter suites can select the divergence classes they migrate.
+Symlink cases are POSIX-only.
+
+Audio and video byte parsing (mutagen/cv2) varies by environment, so the
+corpus contract pins per-filename metadata in
+`driver.AUDIO_METADATA_BY_NAME` / `driver.VIDEO_METADATA_BY_NAME`. The
+canonical classifier and path-generation policy still run unmodified; only
+the byte-level extraction seam is stubbed. Adapter drivers must install the
+same stubs.
+
+## Writing an adapter driver
+
+Implement the protocol for your transport and return the same normalized
+envelopes:
+
+```python
+from tests.conformance.driver import OrganizationConformanceDriver
+
+class CliDriver:
+    name = "cli"
+
+    def scan(self, request): ...      # {"outcome": "ok", "scan": {...}} | error envelope
+    def preview(self, request): ...   # {"outcome": "ok", "plan": ..., "result": ..., "plan_payload": ...}
+    def execute(self, request, plan_payload=None): ...  # adds "audit_events"
+```
+
+Rules for adapter drivers (#1595–#1598):
+
+- Map surface inputs onto `OrganizeRequest` / `OrganizeOptions`; never add
+  surface-specific defaults to pass a scenario.
+- `plan_payload` is the transport-neutral `OrganizationPlan.to_dict()` form —
+  the reviewed-plan handoff must cross your surface as serialized data.
+- Normalize with `tests/conformance/normalize.py` helpers; do not hand-roll
+  comparisons.
+- Reuse the corpus and the golden expectations unchanged. A mismatch is
+  either an adapter bug or a contract decision that belongs in the parity
+  epic — not a reason to fork expectations.
+
+## Extension points
+
+- Transfer semantics and methodologies (#1602) extend the `media`,
+  `methodology`, and transfer expectations.
+- Errors, jobs, scheduling, and recovery (#1604) replace the provisional
+  `normalize_job_events` contract and extend audit-event coverage.
+- Required gates (#1606) promote adapter suites from advisory to blocking
+  per the gate-promotion policy in the
+  [parity execution plan](../architecture/cross-surface-parity-execution.md).
+
+## Running
+
+```bash
+pytest tests/conformance -m conformance --override-ini="addopts="
+```
+
+CI runs the suite as the advisory `conformance-advisory` job (and inside the
+full-suite shards). It stays advisory until #1606 promotes required gates.

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -29,6 +29,7 @@ pytest -k "backup or dedup"                     # Filter by name
 @pytest.mark.security      # Security hardening / regression tests (tests/security)
 @pytest.mark.extras        # Optional-dependency matrix tests (tests/extras)
 @pytest.mark.uses_setup_gate # Opts out of the autouse setup-gate bypass to exercise the real gate
+@pytest.mark.conformance  # Cross-surface conformance scaffold (tests/conformance; advisory until #1606)
 @pytest.mark.keep_default_paths # Opts out of the autouse tmp_path re-routing in TUI conftest (use on tests that verify default '.' path behaviour)
 
 def test_example():

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
       - Architecture: developer/architecture.md
       - Capability Registry: developer/capability-registry.md
       - Canonical Organization Service: developer/organization-service.md
+      - Conformance Scaffold: developer/conformance-scaffold.md
       - Plugin Development: developer/plugin-development.md
       - API Clients: developer/api-clients.md
       - Contributing: developer/contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,6 +462,7 @@ markers = [
     "uses_setup_gate: opts out of the autouse setup-gate bypass to exercise the real gate",
     "asyncio: marks tests as async (requires pytest-asyncio)",
     "keep_default_paths: opts out of the autouse tmp_path re-routing in TUI conftest (use on tests that verify default '.' path behaviour)",
+    "conformance: cross-surface conformance scaffold (tests/conformance; advisory in CI until #1606 promotes required gates)",
     "playwright: browser-based E2E tests (requires `playwright install <browser>` for chromium, firefox, or webkit; select with --browser=<name>; run with --override-ini='addopts=')",
 ]
 filterwarnings = [

--- a/scripts/ci_shard_paths.sh
+++ b/scripts/ci_shard_paths.sh
@@ -27,7 +27,7 @@ case "$SHARD" in
     2) PATHS="tests/services tests/models tests/events tests/optimization" ;;
     3) PATHS="tests/api" ;;
     4) PATHS="tests/cli tests/methodologies tests/ci tests/unit tests/plugins tests/tui tests/parallel tests/pipeline" ;;
-    5) PATHS="tests/utils tests/undo tests/history tests/daemon tests/deploy tests/watcher tests/updater tests/core tests/config tests/client tests/docs tests/desktop tests/integrations tests/interfaces tests/security tests/smoke tests/extras tests/infrastructure" ;;
+    5) PATHS="tests/conformance tests/utils tests/undo tests/history tests/daemon tests/deploy tests/watcher tests/updater tests/core tests/config tests/client tests/docs tests/desktop tests/integrations tests/interfaces tests/security tests/smoke tests/extras tests/infrastructure" ;;
     6) PATHS="tests/web" ;;
     *)
         echo "Unknown shard: $SHARD (valid: 1-6)" >&2

--- a/tests/conformance/__init__.py
+++ b/tests/conformance/__init__.py
@@ -1,0 +1,16 @@
+"""Cross-surface conformance scaffold (parity slice #1605).
+
+The direct application service is the behavioral oracle for the parity epic
+(#1593).  This package supplies the three pieces adapter suites build on:
+
+- :mod:`tests.conformance.corpus`: the deterministic fixture corpus.
+- :mod:`tests.conformance.normalize`: helpers that strip presentation-only
+  differences from requests, plans, results, errors, and audit events.
+- :mod:`tests.conformance.driver`: the adapter-driver protocol and the
+  direct-service reference driver.
+
+Adapter drivers (#1595-#1598) implement
+:class:`tests.conformance.driver.OrganizationConformanceDriver` and reuse the
+corpus and normalization helpers unchanged; golden expectations always come
+from canonical service semantics, never from any adapter.
+"""

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from tests.conformance.corpus import CorpusCase, get_case, materialize_case
-from tests.conformance.driver import DirectServiceDriver
+from tests.conformance.driver import DirectServiceDriver, OrganizationConformanceDriver
 
 
 @dataclass
@@ -18,7 +18,7 @@ class ConformanceContext:
 
     input_root: Path
     output_root: Path
-    driver: DirectServiceDriver
+    driver: OrganizationConformanceDriver
 
     def stage(self, case_id: str) -> CorpusCase:
         """Materialize the corpus case under this context's roots."""

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for the cross-surface conformance scaffold (#1605)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
+from tests.conformance.corpus import CorpusCase, get_case, materialize_case
+from tests.conformance.driver import DirectServiceDriver
+
+
+@dataclass
+class ConformanceContext:
+    """A staged conformance workspace bound to one driver instance."""
+
+    input_root: Path
+    output_root: Path
+    driver: DirectServiceDriver
+
+    def stage(self, case_id: str) -> CorpusCase:
+        """Materialize the corpus case under this context's roots."""
+        case = get_case(case_id)
+        materialize_case(case, self.input_root, self.output_root)
+        return case
+
+    def request(self, **option_overrides: object) -> OrganizeRequest:
+        """Build a canonical request for the staged roots."""
+        return OrganizeRequest(
+            self.input_root,
+            self.output_root,
+            OrganizeOptions(**option_overrides),  # type: ignore[arg-type]
+        )
+
+
+@pytest.fixture
+def conformance(tmp_path: Path) -> ConformanceContext:
+    """Fully isolated conformance context: fresh roots, fresh audit workspace."""
+    return ConformanceContext(
+        input_root=tmp_path / "input",
+        output_root=tmp_path / "output",
+        driver=DirectServiceDriver(tmp_path / "workspace"),
+    )

--- a/tests/conformance/corpus.py
+++ b/tests/conformance/corpus.py
@@ -1,0 +1,217 @@
+"""Deterministic fixture corpus for cross-surface conformance (#1605).
+
+Every case materializes an identical byte-for-byte input tree with fixed
+modification times, so scans, plans, fingerprints, and image year-folders are
+reproducible across runs and supported platforms.  Cases are tagged so adapter
+suites can select the divergence-prone scenarios they migrate (#1595-#1598)
+and so the transfer (#1602), methodology (#1602), and jobs/recovery (#1604)
+slices can extend the corpus without touching existing golden expectations.
+
+Symlink cases are POSIX-only: creating symlinks on Windows requires elevated
+privileges, and canonical traversal excludes symlinks everywhere anyway.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+#: 2026-01-01T00:00:00Z — fixed mtime applied to every corpus file unless a
+#: spec overrides it (image fallback folders embed the mtime year).
+FIXED_MTIME_NS = 1_767_225_600 * 10**9
+
+#: 2020-01-01T00:00:00Z — used by media cases to pin a second image year.
+MTIME_2020_NS = 1_577_836_800 * 10**9
+
+
+@dataclass(frozen=True)
+class FileSpec:
+    """One regular file in a corpus case, relative to the input root."""
+
+    path: str
+    content: bytes
+    mtime_ns: int = FIXED_MTIME_NS
+
+
+@dataclass(frozen=True)
+class SymlinkSpec:
+    """One symlink in a corpus case (POSIX-only).
+
+    ``target`` is interpreted relative to the symlink's parent directory, so
+    ``../outside.txt`` can point outside the input root.
+    """
+
+    path: str
+    target: str
+
+
+@dataclass(frozen=True)
+class OutputSpec:
+    """A file pre-created under the output root before preview/execute."""
+
+    path: str
+    content: bytes
+
+
+@dataclass(frozen=True)
+class CorpusCase:
+    """A named, deterministic fixture scenario."""
+
+    case_id: str
+    description: str
+    tags: frozenset[str]
+    files: tuple[FileSpec, ...]
+    symlinks: tuple[SymlinkSpec, ...] = ()
+    preexisting_output: tuple[OutputSpec, ...] = ()
+
+    @property
+    def requires_symlinks(self) -> bool:
+        """Whether materializing this case creates symlinks (POSIX-only)."""
+        return bool(self.symlinks)
+
+
+def materialize_case(case: CorpusCase, input_root: Path, output_root: Path) -> None:
+    """Create the case's input tree (and any pre-existing output entries).
+
+    File mtimes are pinned after every write so fingerprints and year-based
+    fallback folders are identical on every run.
+    """
+    input_root.mkdir(parents=True, exist_ok=True)
+    output_root.mkdir(parents=True, exist_ok=True)
+    for spec in case.files:
+        target = input_root / spec.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(spec.content)
+        os.utime(target, ns=(spec.mtime_ns, spec.mtime_ns))
+    for link in case.symlinks:
+        link_path = input_root / link.path
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(link.target)
+    for out in case.preexisting_output:
+        target = output_root / out.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(out.content)
+
+
+CORPUS_CASES: tuple[CorpusCase, ...] = (
+    CorpusCase(
+        case_id="flat-documents",
+        description="Flat directory of text documents; baseline traversal and planning.",
+        tags=frozenset({"traversal", "plan", "recovery"}),
+        files=(
+            FileSpec("alpha.txt", b"alpha body\n"),
+            FileSpec("bravo.md", b"# bravo\n"),
+            FileSpec("ledger.csv", b"a,b\n1,2\n"),
+        ),
+    ),
+    CorpusCase(
+        case_id="nested-mixed",
+        description="Nested tree with mixed media; recursion policy must hold end to end.",
+        tags=frozenset({"traversal", "media"}),
+        files=(
+            FileSpec("top.txt", b"top-level\n"),
+            FileSpec("docs/report.pdf", b"%PDF-1.4 fixture\n"),
+            FileSpec("docs/deep/inner.md", b"inner\n"),
+            FileSpec("media/photo.jpg", b"jpg-bytes"),
+            FileSpec("media/clip.mp4", b"mp4-bytes"),
+            FileSpec("media/song.mp3", b"mp3-bytes"),
+            FileSpec("cad/part.dxf", b"dxf-bytes"),
+            FileSpec("misc/data.zzz", b"unknown-bytes"),
+        ),
+    ),
+    CorpusCase(
+        case_id="hidden-entries",
+        description="Dot-prefixed files and directories at several depths.",
+        tags=frozenset({"traversal", "hidden"}),
+        files=(
+            FileSpec("visible.txt", b"visible\n"),
+            FileSpec(".hidden.txt", b"hidden\n"),
+            FileSpec(".hiddendir/inside.txt", b"inside hidden dir\n"),
+            FileSpec("nested/.dotfile.md", b"dot file\n"),
+            FileSpec("nested/plain.md", b"plain\n"),
+        ),
+    ),
+    CorpusCase(
+        case_id="collision-stems",
+        description=(
+            "Distinct sources sharing a destination name, plus a pre-existing "
+            "destination; exercises skip-existing and rename-with-counter."
+        ),
+        tags=frozenset({"collision", "plan"}),
+        files=(
+            FileSpec("archive/summary.txt", b"archived summary\n"),
+            FileSpec("reports/summary.txt", b"reported summary\n"),
+            FileSpec("notes/draft.txt", b"note draft\n"),
+            FileSpec("old/draft.txt", b"old draft\n"),
+        ),
+        preexisting_output=(OutputSpec("Documents/summary.txt", b"already organized\n"),),
+    ),
+    CorpusCase(
+        case_id="duplicate-content",
+        description="Byte-identical files in different directories; content dedup.",
+        tags=frozenset({"duplicates"}),
+        files=(
+            FileSpec("copy/two.txt", b"same bytes\n"),
+            FileSpec("one.txt", b"same bytes\n"),
+            FileSpec("unique.txt", b"different bytes\n"),
+        ),
+    ),
+    CorpusCase(
+        case_id="symlink-entries",
+        description="Symlinked file and directory inside the tree; both are excluded.",
+        tags=frozenset({"traversal", "symlink"}),
+        files=(FileSpec("real.txt", b"real file\n"),),
+        symlinks=(
+            SymlinkSpec("escape.txt", "../outside.txt"),
+            SymlinkSpec("loopdir", "../elsewhere"),
+        ),
+    ),
+    CorpusCase(
+        case_id="media-optional",
+        description=(
+            "Optional media routed through deterministic metadata stubs; image "
+            "year folders come from pinned mtimes."
+        ),
+        tags=frozenset({"media"}),
+        files=(
+            FileSpec("photo_recent.jpg", b"jpg-recent"),
+            FileSpec("photo_older.png", b"png-older", mtime_ns=MTIME_2020_NS),
+            FileSpec("song.mp3", b"mp3-song"),
+            FileSpec("movie.mkv", b"mkv-movie"),
+            FileSpec("clip.mp4", b"mp4-clip"),
+            FileSpec("widget.step", b"step-widget"),
+            FileSpec("data.zzz", b"unknown"),
+        ),
+    ),
+    CorpusCase(
+        case_id="methodology-seed",
+        description=(
+            "Stable seed tree for methodology semantics; #1602 will extend the "
+            "expectations when PARA/Johnny Decimal remapping is canonical."
+        ),
+        tags=frozenset({"methodology"}),
+        files=(
+            FileSpec("projects/alpha/plan.txt", b"project plan\n"),
+            FileSpec("areas/finance/budget.csv", b"q1,q2\n10,20\n"),
+            FileSpec("resources/reading/paper.pdf", b"%PDF-1.4 paper\n"),
+            FileSpec("archive/2020/notes.md", b"archived notes\n"),
+        ),
+    ),
+)
+
+_CASES_BY_ID = {case.case_id: case for case in CORPUS_CASES}
+
+
+def get_case(case_id: str) -> CorpusCase:
+    """Return the corpus case registered under *case_id*."""
+    try:
+        return _CASES_BY_ID[case_id]
+    except KeyError as exc:
+        known = ", ".join(sorted(_CASES_BY_ID))
+        raise KeyError(f"Unknown corpus case {case_id!r}; known cases: {known}") from exc
+
+
+def cases_tagged(tag: str) -> tuple[CorpusCase, ...]:
+    """Return all corpus cases carrying *tag*, in registration order."""
+    return tuple(case for case in CORPUS_CASES if tag in case.tags)

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -255,7 +255,13 @@ class DirectServiceDriver:
         if not isinstance(result.plan, OrganizationPlan):
             raise AssertionError("Canonical execution must retain its executable plan.")
         assert self._last_history is not None  # execute always builds a non-dry organizer
-        events = normalize_audit_events(self._last_history.get_operations(), *roots)
+        recorded_operations = self._last_history.get_operations()
+        # OperationHistory is a newest-first query API. Conformance exposes
+        # audit events in their stable insertion/execution order instead.
+        recorded_operations.sort(
+            key=lambda operation: operation.id if operation.id is not None else -1
+        )
+        events = normalize_audit_events(recorded_operations, *roots)
         return {
             "outcome": "ok",
             "plan": normalize_plan(result.plan, *roots),

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -1,0 +1,264 @@
+"""Adapter-driver protocol and direct-service oracle driver (#1605).
+
+Every surface adapter (#1595-#1598) implements
+:class:`OrganizationConformanceDriver` for its own transport and runs the same
+corpus through it.  :class:`DirectServiceDriver` drives the canonical
+:class:`~file_organizer.core.organization_service.OrganizationService` and is
+the behavioral oracle: golden expectations are captured from it and never from
+an adapter.
+
+Determinism seams
+-----------------
+The oracle keeps model-free canonical semantics deterministic by:
+
+- leaving the text/vision processors uninitialized so classification uses the
+  canonical extension-fallback policy;
+- replacing byte-level audio/video metadata *parsing* (mutagen/cv2, which vary
+  by environment) with fixed per-filename metadata, while the canonical
+  classifier and path-generation policy still run unmodified;
+- recording audit events in an isolated per-execution history database.
+
+Adapter drivers run in-process (CliRunner, TestClient, Textual pilot) and are
+expected to install the same extractor stubs so all surfaces are compared on
+identical inputs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from file_organizer.core import dispatcher
+from file_organizer.core.organization_service import OrganizationService
+from file_organizer.core.organize_options import OrganizeRequest
+from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.plan import OrganizationPlan
+from file_organizer.history.tracker import OperationHistory
+from file_organizer.models.base import ModelConfig, ModelType
+from file_organizer.services.audio.metadata_extractor import (
+    AudioMetadata,
+    AudioMetadataExtractor,
+)
+from file_organizer.services.video.metadata_extractor import (
+    VideoMetadata,
+    VideoMetadataExtractor,
+)
+from file_organizer.undo import UndoManager
+from tests.conformance.normalize import (
+    normalize_audit_events,
+    normalize_error,
+    normalize_plan,
+    normalize_result,
+    normalize_scan,
+)
+
+#: Model identity every driver must resolve requests against, so plans are
+#: byte-comparable across surfaces without contacting any provider.
+CONFORMANCE_TEXT_MODEL = ModelConfig("conformance-text", ModelType.TEXT)
+CONFORMANCE_VISION_MODEL = ModelConfig("conformance-vision", ModelType.VISION)
+
+#: Fixed audio metadata keyed by filename; unknown filenames get untagged
+#: defaults.  Part of the published corpus contract: adapter drivers must
+#: stub the same values.
+AUDIO_METADATA_BY_NAME: dict[str, dict[str, Any]] = {
+    "song.mp3": {
+        "title": "Fixture Song",
+        "artist": "Fixture Artist",
+        "album": "Fixture Album",
+        "genre": "Rock",
+        "duration": 240.0,
+    },
+}
+
+#: Fixed video metadata keyed by filename; unknown filenames get metadata-less
+#: defaults that route to the canonical unsorted fallback.
+VIDEO_METADATA_BY_NAME: dict[str, dict[str, Any]] = {
+    "movie.mkv": {
+        "duration": 5400.0,
+        "width": 1920,
+        "height": 1080,
+        "creation_date": datetime(2026, 1, 1, tzinfo=UTC),
+    },
+    "clip.mp4": {"duration": 12.0, "width": 1280, "height": 720},
+}
+
+
+class DeterministicAudioExtractor(AudioMetadataExtractor):
+    """Return pinned audio metadata so canonical routing has fixed inputs."""
+
+    def extract(self, audio_path: str | Path) -> AudioMetadata:
+        """Build metadata from the corpus table instead of parsing bytes."""
+        path = Path(audio_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Audio file not found: {path}")
+        overrides = AUDIO_METADATA_BY_NAME.get(path.name, {})
+        return AudioMetadata(
+            file_path=path,
+            file_size=path.stat().st_size,
+            format=path.suffix.lstrip(".").lower(),
+            duration=overrides.get("duration", 0.0),
+            bitrate=0,
+            sample_rate=44100,
+            channels=2,
+            title=overrides.get("title"),
+            artist=overrides.get("artist"),
+            album=overrides.get("album"),
+            genre=overrides.get("genre"),
+        )
+
+
+class DeterministicVideoExtractor(VideoMetadataExtractor):
+    """Return pinned video metadata so canonical routing has fixed inputs."""
+
+    def extract(self, video_path: str | Path) -> VideoMetadata:
+        """Build metadata from the corpus table instead of probing with cv2."""
+        path = Path(video_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Video file not found: {path}")
+        overrides = VIDEO_METADATA_BY_NAME.get(path.name, {})
+        return VideoMetadata(
+            file_path=path,
+            file_size=path.stat().st_size,
+            format=path.suffix.lstrip(".").lower(),
+            duration=overrides.get("duration"),
+            width=overrides.get("width"),
+            height=overrides.get("height"),
+            creation_date=overrides.get("creation_date"),
+        )
+
+
+@runtime_checkable
+class OrganizationConformanceDriver(Protocol):
+    """The seam adapter suites implement to run the shared conformance corpus.
+
+    Every method returns a normalized envelope:
+
+    - ``{"outcome": "ok", ...}`` with method-specific normalized payloads, or
+    - ``{"outcome": "error", "error": {...}}`` from
+      :func:`tests.conformance.normalize.normalize_error`.
+
+    ``execute`` accepts an optional ``plan_payload`` — the transport-neutral
+    ``OrganizationPlan.to_dict()`` form returned by ``preview`` — so the
+    reviewed-plan handoff crosses every surface as serialized data.
+    """
+
+    name: str
+
+    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return the normalized canonical scan for *request*."""
+        ...
+
+    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return the normalized plan, result, and serialized plan payload."""
+        ...
+
+    def execute(
+        self, request: OrganizeRequest, plan_payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Apply a reviewed plan (or build one) and return normalized outcomes."""
+        ...
+
+
+class _OracleOrganizer(FileOrganizer):
+    """Canonical organizer with the deterministic extractor seams installed."""
+
+    def _init_text_processor(self) -> None:
+        """Leave the text model uninitialized; extension fallback is canonical."""
+        self.text_processor = None
+
+    def _init_vision_processor(self) -> None:
+        """Leave the vision model uninitialized; extension fallback is canonical."""
+        self.vision_processor = None
+
+    def _process_audio_files(self, files: list[Path]) -> list[Any]:
+        """Route audio through canonical policy fed by pinned metadata."""
+        return dispatcher.process_audio_files(
+            files,
+            extractor_cls=DeterministicAudioExtractor,
+            transcriber=None,
+            max_transcribe_seconds=self.max_transcribe_seconds,
+        )
+
+    def _process_video_files(self, files: list[Path]) -> list[Any]:
+        """Route video through canonical policy fed by pinned metadata."""
+        return dispatcher.process_video_files(files, extractor_cls=DeterministicVideoExtractor)
+
+
+class DirectServiceDriver:
+    """Reference driver: the canonical application service itself.
+
+    *workspace* holds the isolated per-execution history databases; use a
+    fresh temporary directory per test so audit state can never leak between
+    scenarios or into user data.
+    """
+
+    name = "direct-service"
+
+    def __init__(self, workspace: Path) -> None:
+        """Create a driver whose audit databases live under *workspace*."""
+        self._workspace = workspace
+        self._workspace.mkdir(parents=True, exist_ok=True)
+        self._executions = 0
+        self._last_history: OperationHistory | None = None
+        self._service = OrganizationService(
+            text_model_config=CONFORMANCE_TEXT_MODEL,
+            vision_model_config=CONFORMANCE_VISION_MODEL,
+            organizer_factory=self._create_organizer,
+        )
+
+    def _create_organizer(self, **kwargs: Any) -> FileOrganizer:
+        organizer = _OracleOrganizer(**kwargs)
+        if not organizer.dry_run:
+            self._executions += 1
+            self._last_history = OperationHistory(
+                db_path=self._workspace / f"audit-{self._executions}.db"
+            )
+            organizer._undo_manager = UndoManager(history=self._last_history)
+        return organizer
+
+    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return the normalized canonical scan for *request*."""
+        roots = (request.input_path, request.output_path)
+        try:
+            scan = self._service.scan(request)
+        except (ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
+
+    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return the normalized plan, result, and serialized plan payload."""
+        roots = (request.input_path, request.output_path)
+        try:
+            result = self._service.preview(request)
+        except (ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        if not isinstance(result.plan, OrganizationPlan):
+            raise AssertionError("Canonical preview must produce an executable plan.")
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(result.plan, *roots),
+            "result": normalize_result(result, *roots),
+            "plan_payload": result.plan.to_dict(),
+        }
+
+    def execute(
+        self, request: OrganizeRequest, plan_payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Apply a reviewed plan (or build one) and return normalized outcomes."""
+        roots = (request.input_path, request.output_path)
+        try:
+            plan = OrganizationPlan.from_dict(plan_payload) if plan_payload is not None else None
+            result = self._service.execute(request, plan)
+        except (ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        if not isinstance(result.plan, OrganizationPlan):
+            raise AssertionError("Canonical execution must retain its executable plan.")
+        assert self._last_history is not None  # execute always builds a non-dry organizer
+        events = normalize_audit_events(self._last_history.get_operations(), *roots)
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(result.plan, *roots),
+            "result": normalize_result(result, *roots),
+            "audit_events": events,
+        }

--- a/tests/conformance/normalize.py
+++ b/tests/conformance/normalize.py
@@ -35,11 +35,14 @@ def normalize_path(path: str | Path, input_root: Path, output_root: Path) -> str
     """Map an absolute path onto a root-relative, POSIX-style token path."""
     candidate = Path(path)
     resolved = candidate.resolve(strict=False)
-    for root, token in (
-        (input_root, INPUT_ROOT_TOKEN),
-        (output_root, OUTPUT_ROOT_TOKEN),
-    ):
-        resolved_root = root.resolve(strict=False)
+    roots = (
+        (input_root.resolve(strict=False), INPUT_ROOT_TOKEN),
+        (output_root.resolve(strict=False), OUTPUT_ROOT_TOKEN),
+    )
+    # A number of surfaces default to an output directory below the input
+    # root (for example ``./organized_output``). Match the most-specific root
+    # first so destinations are not mislabeled as input files.
+    for resolved_root, token in sorted(roots, key=lambda item: len(item[0].parts), reverse=True):
         for probe in (candidate, resolved):
             try:
                 relative = probe.relative_to(resolved_root)
@@ -79,10 +82,12 @@ def _normalize_operation(
 ) -> dict[str, Any]:
     fingerprint = None
     if operation.fingerprint is not None:
-        # mtime_ns is environment-echo (the corpus pins it); size and content
-        # hash are the behavior-affecting identity of the planned source.
+        # All three fields participate in reviewed-plan validation. The
+        # corpus pins mtime_ns specifically so it is safe to compare across
+        # drivers and must not be normalized away.
         fingerprint = {
             "size": operation.fingerprint.size,
+            "mtime_ns": operation.fingerprint.mtime_ns,
             "sha256": operation.fingerprint.sha256,
         }
     error = operation.error
@@ -107,10 +112,12 @@ def normalize_plan(plan: OrganizationPlan, input_root: Path, output_root: Path) 
     ``plan_id``, ``created_at``, per-operation ids, and prose descriptions are
     presentation/bookkeeping; everything needed to reproduce execution stays.
     """
-    operations = sorted(
-        (_normalize_operation(operation, input_root, output_root) for operation in plan.operations),
-        key=lambda item: (item["source"], item["destination"]),
-    )
+    # Operation order is executable plan behavior: it controls collision
+    # allocation and the order in which mutations are attempted. Preserve it
+    # so normalization cannot hide adapter reordering.
+    operations = [
+        _normalize_operation(operation, input_root, output_root) for operation in plan.operations
+    ]
     return {
         "schema_version": plan.schema_version,
         "input_path": normalize_path(plan.input_path, input_root, output_root),
@@ -197,7 +204,9 @@ def normalize_audit_events(
     committed transaction.  #1604 owns extending this with job and recovery
     lifecycle events.
     """
-    normalized = [
+    # History order is observable recovery behavior. Preserve the store's
+    # order rather than sorting it into a presentation-friendly shape.
+    return [
         {
             "operation_type": operation.operation_type.value,
             "status": operation.status.value,
@@ -212,7 +221,6 @@ def normalize_audit_events(
         }
         for operation in operations
     ]
-    return sorted(normalized, key=lambda item: (item["source"], item["destination"] or ""))
 
 
 def normalize_job_events(events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/conformance/normalize.py
+++ b/tests/conformance/normalize.py
@@ -1,0 +1,229 @@
+"""Normalization helpers for cross-surface conformance comparisons (#1605).
+
+These helpers reduce scans, plans, results, errors, audit events, and job
+events to transport-neutral dictionaries so the same golden expectations apply
+to every driver.  Only presentation-only or environment-dependent details are
+removed (identifiers, timestamps, prose descriptions, absolute path prefixes);
+everything behavior-affecting is preserved.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from file_organizer.core.organization_service import OrganizationScan
+from file_organizer.core.plan import (
+    OrganizationOperation,
+    OrganizationPlan,
+    PlanValidationError,
+)
+from file_organizer.core.types import OrganizationResult
+from file_organizer.history.models import Operation
+
+#: Placeholder prefixes substituted for the request roots in normalized paths.
+INPUT_ROOT_TOKEN = "<input>"
+OUTPUT_ROOT_TOKEN = "<output>"
+EXTERNAL_TOKEN = "<external>"
+
+#: Job-event keys treated as volatile until #1604 finalizes job semantics.
+VOLATILE_JOB_KEYS = frozenset({"job_id", "timestamp", "created_at", "updated_at", "duration"})
+
+
+def normalize_path(path: str | Path, input_root: Path, output_root: Path) -> str:
+    """Map an absolute path onto a root-relative, POSIX-style token path."""
+    candidate = Path(path)
+    resolved = candidate.resolve(strict=False)
+    for root, token in (
+        (input_root, INPUT_ROOT_TOKEN),
+        (output_root, OUTPUT_ROOT_TOKEN),
+    ):
+        resolved_root = root.resolve(strict=False)
+        for probe in (candidate, resolved):
+            try:
+                relative = probe.relative_to(resolved_root)
+            except ValueError:
+                continue
+            if not relative.parts:
+                return token
+            return f"{token}/{relative.as_posix()}"
+    return f"{EXTERNAL_TOKEN}/{candidate.name}"
+
+
+def redact_roots(text: str, input_root: Path, output_root: Path) -> str:
+    """Replace absolute root prefixes embedded in *text* with stable tokens."""
+    replacements = [
+        (str(input_root.resolve(strict=False)), INPUT_ROOT_TOKEN),
+        (str(output_root.resolve(strict=False)), OUTPUT_ROOT_TOKEN),
+        (str(input_root), INPUT_ROOT_TOKEN),
+        (str(output_root), OUTPUT_ROOT_TOKEN),
+    ]
+    # Longest prefix first so nested roots cannot partially rewrite each other.
+    for raw, token in sorted(replacements, key=lambda item: len(item[0]), reverse=True):
+        text = text.replace(raw, token)
+    return text
+
+
+def normalize_scan(scan: OrganizationScan, input_root: Path, output_root: Path) -> dict[str, Any]:
+    """Normalize a canonical scan into comparable primitives."""
+    return {
+        "total_files": scan.total_files,
+        "files": [normalize_path(path, input_root, output_root) for path in scan.files],
+        "counts": dict(sorted(scan.counts.items())),
+    }
+
+
+def _normalize_operation(
+    operation: OrganizationOperation, input_root: Path, output_root: Path
+) -> dict[str, Any]:
+    fingerprint = None
+    if operation.fingerprint is not None:
+        # mtime_ns is environment-echo (the corpus pins it); size and content
+        # hash are the behavior-affecting identity of the planned source.
+        fingerprint = {
+            "size": operation.fingerprint.size,
+            "sha256": operation.fingerprint.sha256,
+        }
+    error = operation.error
+    if error is not None:
+        error = redact_roots(error, input_root, output_root)
+    return {
+        "source": normalize_path(operation.source_path, input_root, output_root),
+        "destination": normalize_path(operation.destination_path, input_root, output_root),
+        "operation_type": operation.operation_type.value,
+        "collision_action": operation.collision_action.value,
+        "status": operation.status.value,
+        "folder": operation.folder_name,
+        "file_name": operation.file_name,
+        "fingerprint": fingerprint,
+        "error": error,
+    }
+
+
+def normalize_plan(plan: OrganizationPlan, input_root: Path, output_root: Path) -> dict[str, Any]:
+    """Normalize an executable plan, dropping identifiers and timestamps.
+
+    ``plan_id``, ``created_at``, per-operation ids, and prose descriptions are
+    presentation/bookkeeping; everything needed to reproduce execution stays.
+    """
+    operations = sorted(
+        (_normalize_operation(operation, input_root, output_root) for operation in plan.operations),
+        key=lambda item: (item["source"], item["destination"]),
+    )
+    return {
+        "schema_version": plan.schema_version,
+        "input_path": normalize_path(plan.input_path, input_root, output_root),
+        "output_path": normalize_path(plan.output_path, input_root, output_root),
+        "skip_existing": plan.skip_existing,
+        "use_hardlinks": plan.use_hardlinks,
+        "counts": {
+            "total_files": plan.total_files,
+            "processed_files": plan.processed_files,
+            "skipped_files": plan.skipped_files,
+            "failed_files": plan.failed_files,
+            "deduplicated_files": plan.deduplicated_files,
+        },
+        "options": plan.options.to_dict(),
+        "operations": operations,
+        "errors": normalize_error_pairs(plan.errors, input_root, output_root),
+        "metadata": dict(plan.metadata),
+    }
+
+
+def normalize_error_pairs(
+    errors: Iterable[tuple[str, str]], input_root: Path, output_root: Path
+) -> list[dict[str, str]]:
+    """Normalize ``(path, message)`` error tuples shared by plans and results."""
+    normalized = [
+        {
+            "path": normalize_path(path, input_root, output_root),
+            "message": redact_roots(message, input_root, output_root),
+        }
+        for path, message in errors
+    ]
+    return sorted(normalized, key=lambda item: (item["path"], item["message"]))
+
+
+def normalize_result(
+    result: OrganizationResult, input_root: Path, output_root: Path
+) -> dict[str, Any]:
+    """Normalize an execution/preview result; the plan is normalized separately.
+
+    ``processing_time`` is wall-clock noise and is dropped.
+    """
+    return {
+        "counts": {
+            "total_files": result.total_files,
+            "processed_files": result.processed_files,
+            "skipped_files": result.skipped_files,
+            "failed_files": result.failed_files,
+            "deduplicated_files": result.deduplicated_files,
+        },
+        "organized_structure": {
+            folder: sorted(files) for folder, files in sorted(result.organized_structure.items())
+        },
+        "errors": normalize_error_pairs(result.errors, input_root, output_root),
+    }
+
+
+def normalize_error(exc: BaseException, input_root: Path, output_root: Path) -> dict[str, Any]:
+    """Normalize a raised error into a surface-neutral envelope payload."""
+    normalized: dict[str, Any] = {
+        "error_type": type(exc).__name__,
+        "message": redact_roots(str(exc), input_root, output_root),
+    }
+    if isinstance(exc, PlanValidationError):
+        normalized["conflicts"] = sorted(
+            (
+                {
+                    "conflict_type": conflict.conflict_type.value,
+                    "path": normalize_path(conflict.path, input_root, output_root),
+                }
+                for conflict in exc.validation.conflicts
+            ),
+            key=lambda item: (item["conflict_type"], item["path"]),
+        )
+    return normalized
+
+
+def normalize_audit_events(
+    operations: Iterable[Operation], input_root: Path, output_root: Path
+) -> list[dict[str, Any]]:
+    """Normalize history operations recorded by an execution.
+
+    Identifiers, timestamps, and file hashes stay out; the observable audit
+    contract is which sources landed where, through which operation type, in a
+    committed transaction.  #1604 owns extending this with job and recovery
+    lifecycle events.
+    """
+    normalized = [
+        {
+            "operation_type": operation.operation_type.value,
+            "status": operation.status.value,
+            "source": normalize_path(operation.source_path, input_root, output_root),
+            "destination": (
+                normalize_path(operation.destination_path, input_root, output_root)
+                if operation.destination_path is not None
+                else None
+            ),
+            "collision_action": operation.metadata.get("collision_action"),
+            "folder": operation.metadata.get("folder_name"),
+        }
+        for operation in operations
+    ]
+    return sorted(normalized, key=lambda item: (item["source"], item["destination"] or ""))
+
+
+def normalize_job_events(events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize job lifecycle events (provisional until #1604 lands).
+
+    Drops volatile identifiers/timestamps and preserves ordering, which is the
+    part of the lifecycle contract already observable today.  #1604 replaces
+    this with the canonical job/recovery event schema; keeping the seam here
+    lets adapter drivers adopt it without changing the oracle.
+    """
+    return [
+        {key: value for key, value in sorted(event.items()) if key not in VOLATILE_JOB_KEYS}
+        for event in events
+    ]

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -18,15 +18,22 @@ from __future__ import annotations
 import json
 import os
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
 from file_organizer.core.plan import OrganizationPlan
+from file_organizer.history.models import Operation, OperationType
 from tests.conformance.conftest import ConformanceContext
 from tests.conformance.corpus import FIXED_MTIME_NS, get_case, materialize_case
 from tests.conformance.driver import DirectServiceDriver, OrganizationConformanceDriver
-from tests.conformance.normalize import normalize_job_events
+from tests.conformance.normalize import (
+    normalize_audit_events,
+    normalize_job_events,
+    normalize_path,
+    normalize_plan,
+)
 
 pytestmark = [pytest.mark.conformance]
 
@@ -211,9 +218,69 @@ def test_plan_is_deterministic_and_round_trips(conformance: ConformanceContext) 
 
     payload = json.loads(json.dumps(first["plan_payload"], sort_keys=True))
     revived = OrganizationPlan.from_dict(payload)
-    from tests.conformance.normalize import normalize_plan
 
     assert normalize_plan(revived, conformance.input_root, conformance.output_root) == first["plan"]
+
+
+def test_plan_normalization_preserves_execution_order_and_full_fingerprint(
+    conformance: ConformanceContext,
+) -> None:
+    """Normalization must not erase behavior used by reviewed-plan execution."""
+    conformance.stage("flat-documents")
+    preview = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+    plan = OrganizationPlan.from_dict(preview["plan_payload"])
+
+    assert [
+        operation["fingerprint"]["mtime_ns"] for operation in preview["plan"]["operations"]
+    ] == [FIXED_MTIME_NS] * 3
+
+    expected_reversed_sources = [
+        operation["source"] for operation in reversed(preview["plan"]["operations"])
+    ]
+    plan.operations.reverse()
+
+    assert [
+        operation["source"]
+        for operation in normalize_plan(plan, conformance.input_root, conformance.output_root)[
+            "operations"
+        ]
+    ] == expected_reversed_sources
+
+
+def test_normalize_path_prefers_nested_output_root(tmp_path: Path) -> None:
+    """The common ``input/organized_output`` layout keeps output identity."""
+    input_root = tmp_path / "input"
+    output_root = input_root / "organized_output"
+
+    assert (
+        normalize_path(output_root / "Documents" / "alpha.txt", input_root, output_root)
+        == "<output>/Documents/alpha.txt"
+    )
+    assert normalize_path(input_root / "alpha.txt", input_root, output_root) == "<input>/alpha.txt"
+
+
+def test_audit_normalization_preserves_recorded_order(tmp_path: Path) -> None:
+    """An adapter cannot pass conformance after reordering audit events."""
+    input_root = tmp_path / "input"
+    output_root = tmp_path / "output"
+    operations = [
+        Operation(
+            operation_type=OperationType.COPY,
+            timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+            source_path=input_root / "bravo.txt",
+            destination_path=output_root / "Documents" / "bravo.txt",
+        ),
+        Operation(
+            operation_type=OperationType.COPY,
+            timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+            source_path=input_root / "alpha.txt",
+            destination_path=output_root / "Documents" / "alpha.txt",
+        ),
+    ]
+
+    assert [
+        event["source"] for event in normalize_audit_events(operations, input_root, output_root)
+    ] == ["<input>/bravo.txt", "<input>/alpha.txt"]
 
 
 def test_resolved_options_are_persisted(conformance: ConformanceContext) -> None:

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -1,0 +1,570 @@
+"""Golden conformance expectations for the direct-service oracle (#1605).
+
+Every expectation below is written from canonical service semantics — the
+transport-neutral :class:`OrganizationService` contract — and verified against
+the :class:`~tests.conformance.driver.DirectServiceDriver`.  Adapter drivers
+(#1595-#1598) must reproduce these normalized outputs byte for byte; the
+scenarios deliberately cover the known cross-surface divergence classes:
+recursion/hidden traversal, collision policy, duplicate handling, symlink
+exclusion, transfer mode, stale-plan recovery, and option persistence.
+
+Transfer-mode and methodology expectations cover today's canonical behavior;
+#1602 extends them (canonical transfer contract, PARA/Johnny Decimal
+remapping) and #1604 extends jobs/recovery, without changing this oracle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from file_organizer.core.plan import OrganizationPlan
+from tests.conformance.conftest import ConformanceContext
+from tests.conformance.corpus import FIXED_MTIME_NS, get_case, materialize_case
+from tests.conformance.driver import DirectServiceDriver, OrganizationConformanceDriver
+from tests.conformance.normalize import normalize_job_events
+
+pytestmark = [pytest.mark.conformance]
+
+requires_symlinks = pytest.mark.skipif(
+    sys.platform == "win32", reason="symlink fixtures require POSIX semantics"
+)
+
+
+def _ok(envelope: dict) -> dict:
+    assert envelope["outcome"] == "ok", envelope
+    return envelope
+
+
+def _operation_routes(envelope: dict) -> list[tuple[str, str, str, str]]:
+    """Project plan operations onto (source, destination, status, collision)."""
+    return [
+        (op["source"], op["destination"], op["status"], op["collision_action"])
+        for op in envelope["plan"]["operations"]
+    ]
+
+
+def test_direct_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
+    assert isinstance(conformance.driver, OrganizationConformanceDriver)
+    assert conformance.driver.name == "direct-service"
+
+
+def test_corpus_materialization_is_deterministic(tmp_path: Path) -> None:
+    case = get_case("nested-mixed")
+    first, second = tmp_path / "first", tmp_path / "second"
+    for root in (first, second):
+        materialize_case(case, root / "input", root / "output")
+
+    for spec in case.files:
+        left, right = first / "input" / spec.path, second / "input" / spec.path
+        assert left.read_bytes() == right.read_bytes() == spec.content
+        assert left.stat().st_mtime_ns == right.stat().st_mtime_ns == spec.mtime_ns
+
+
+@pytest.mark.parametrize(
+    ("case_id", "options", "expected_files"),
+    [
+        (
+            "flat-documents",
+            {},
+            ["<input>/alpha.txt", "<input>/bravo.md", "<input>/ledger.csv"],
+        ),
+        (
+            "nested-mixed",
+            {"recursive": False},
+            ["<input>/top.txt"],
+        ),
+        (
+            "nested-mixed",
+            {"recursive": True},
+            [
+                "<input>/cad/part.dxf",
+                "<input>/docs/deep/inner.md",
+                "<input>/docs/report.pdf",
+                "<input>/media/clip.mp4",
+                "<input>/media/photo.jpg",
+                "<input>/media/song.mp3",
+                "<input>/misc/data.zzz",
+                "<input>/top.txt",
+            ],
+        ),
+        (
+            "hidden-entries",
+            {"recursive": True, "include_hidden": False},
+            ["<input>/nested/plain.md", "<input>/visible.txt"],
+        ),
+        (
+            "hidden-entries",
+            {"recursive": True, "include_hidden": True},
+            [
+                "<input>/.hidden.txt",
+                "<input>/.hiddendir/inside.txt",
+                "<input>/nested/.dotfile.md",
+                "<input>/nested/plain.md",
+                "<input>/visible.txt",
+            ],
+        ),
+        (
+            "hidden-entries",
+            {"recursive": False, "include_hidden": True},
+            ["<input>/.hidden.txt", "<input>/visible.txt"],
+        ),
+        (
+            "hidden-entries",
+            {"recursive": False, "include_hidden": False},
+            ["<input>/visible.txt"],
+        ),
+    ],
+)
+def test_traversal_policy_goldens(
+    conformance: ConformanceContext,
+    case_id: str,
+    options: dict,
+    expected_files: list[str],
+) -> None:
+    conformance.stage(case_id)
+
+    envelope = _ok(conformance.driver.scan(conformance.request(**options)))
+
+    assert envelope["scan"]["files"] == expected_files
+    assert envelope["scan"]["total_files"] == len(expected_files)
+
+
+def test_scan_counts_golden(conformance: ConformanceContext) -> None:
+    conformance.stage("nested-mixed")
+
+    envelope = _ok(conformance.driver.scan(conformance.request()))
+
+    assert envelope["scan"]["counts"] == {
+        "audio": 1,
+        "cad": 1,
+        "image": 1,
+        "other": 1,
+        "text": 3,
+        "video": 1,
+    }
+
+
+def test_preview_sources_match_scan(conformance: ConformanceContext) -> None:
+    """Recursion policy must affect scan and preview identically (#1603)."""
+    conformance.stage("nested-mixed")
+    request = conformance.request(recursive=False, use_hardlinks=False)
+
+    scan = _ok(conformance.driver.scan(request))["scan"]
+    preview = _ok(conformance.driver.preview(request))
+
+    assert [op["source"] for op in preview["plan"]["operations"]] == scan["files"]
+    assert preview["plan"]["counts"]["total_files"] == scan["total_files"]
+
+
+def test_media_routing_golden(conformance: ConformanceContext) -> None:
+    """Optional media routes through canonical policy on pinned metadata."""
+    conformance.stage("media-optional")
+
+    envelope = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+
+    assert _operation_routes(envelope) == [
+        ("<input>/clip.mp4", "<output>/Short_Clips/clip.mp4", "ready", "create"),
+        ("<input>/movie.mkv", "<output>/Videos/2026/movie.mkv", "ready", "create"),
+        (
+            "<input>/photo_older.png",
+            "<output>/Images/2020/photo_older.png",
+            "ready",
+            "create",
+        ),
+        (
+            "<input>/photo_recent.jpg",
+            "<output>/Images/2026/photo_recent.jpg",
+            "ready",
+            "create",
+        ),
+        (
+            "<input>/song.mp3",
+            "<output>/Rock/Fixture Artist/Fixture Album/00 - Fixture Song.mp3",
+            "ready",
+            "create",
+        ),
+        ("<input>/widget.step", "<output>/CAD/widget.step", "ready", "create"),
+    ]
+    assert envelope["plan"]["counts"] == {
+        "total_files": 7,
+        "processed_files": 6,
+        "skipped_files": 1,  # data.zzz has no supported handler
+        "failed_files": 0,
+        "deduplicated_files": 0,
+    }
+
+
+def test_plan_is_deterministic_and_round_trips(conformance: ConformanceContext) -> None:
+    """Two previews and a serialization round-trip must normalize identically."""
+    conformance.stage("nested-mixed")
+    request = conformance.request(use_hardlinks=False)
+
+    first = _ok(conformance.driver.preview(request))
+    second = _ok(conformance.driver.preview(request))
+
+    assert first["plan"] == second["plan"]
+
+    payload = json.loads(json.dumps(first["plan_payload"], sort_keys=True))
+    revived = OrganizationPlan.from_dict(payload)
+    from tests.conformance.normalize import normalize_plan
+
+    assert normalize_plan(revived, conformance.input_root, conformance.output_root) == first["plan"]
+
+
+def test_resolved_options_are_persisted(conformance: ConformanceContext) -> None:
+    """A serialized plan carries every behavior-affecting option (#1603)."""
+    conformance.stage("flat-documents")
+
+    envelope = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+
+    assert envelope["plan"]["options"] == {
+        "recursive": True,
+        "include_hidden": False,
+        "skip_existing": True,
+        "use_hardlinks": False,
+        "enable_vision": True,
+        "transcribe_audio": False,
+        "max_transcribe_seconds": 600.0,
+        "whisper_model": "tiny",
+        "parallel_workers": None,
+        "prefetch_depth": 2,
+        "text_model": "conformance-text",
+        "vision_model": "conformance-vision",
+        "text_provider": "ollama",
+        "vision_provider": "ollama",
+    }
+    assert envelope["plan"]["schema_version"] == 2
+
+
+def test_collision_skip_existing_golden(conformance: ConformanceContext) -> None:
+    conformance.stage("collision-stems")
+
+    envelope = _ok(
+        conformance.driver.preview(conformance.request(use_hardlinks=False, skip_existing=True))
+    )
+
+    assert _operation_routes(envelope) == [
+        (
+            "<input>/archive/summary.txt",
+            "<output>/Documents/summary.txt",
+            "skipped",
+            "skip_existing",
+        ),
+        ("<input>/notes/draft.txt", "<output>/Documents/draft.txt", "ready", "create"),
+        (
+            "<input>/old/draft.txt",
+            "<output>/Documents/draft_1.txt",
+            "ready",
+            "rename_with_counter",
+        ),
+        (
+            "<input>/reports/summary.txt",
+            "<output>/Documents/summary.txt",
+            "skipped",
+            "skip_existing",
+        ),
+    ]
+    assert envelope["plan"]["counts"]["processed_files"] == 2
+    assert envelope["plan"]["counts"]["skipped_files"] == 2
+
+
+def test_collision_rename_with_counter_golden(conformance: ConformanceContext) -> None:
+    conformance.stage("collision-stems")
+
+    envelope = _ok(
+        conformance.driver.preview(conformance.request(use_hardlinks=False, skip_existing=False))
+    )
+
+    assert _operation_routes(envelope) == [
+        (
+            "<input>/archive/summary.txt",
+            "<output>/Documents/summary_1.txt",
+            "ready",
+            "rename_with_counter",
+        ),
+        ("<input>/notes/draft.txt", "<output>/Documents/draft.txt", "ready", "create"),
+        (
+            "<input>/old/draft.txt",
+            "<output>/Documents/draft_1.txt",
+            "ready",
+            "rename_with_counter",
+        ),
+        (
+            "<input>/reports/summary.txt",
+            "<output>/Documents/summary_2.txt",
+            "ready",
+            "rename_with_counter",
+        ),
+    ]
+    assert envelope["plan"]["counts"]["processed_files"] == 4
+
+
+def test_duplicate_content_golden(conformance: ConformanceContext) -> None:
+    """Content dedup keeps the lexicographically first source of each hash."""
+    conformance.stage("duplicate-content")
+
+    envelope = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+
+    assert _operation_routes(envelope) == [
+        ("<input>/copy/two.txt", "<output>/Documents/two.txt", "ready", "create"),
+        ("<input>/unique.txt", "<output>/Documents/unique.txt", "ready", "create"),
+    ]
+    assert envelope["plan"]["counts"] == {
+        "total_files": 3,
+        "processed_files": 2,
+        "skipped_files": 0,
+        "failed_files": 0,
+        "deduplicated_files": 1,
+    }
+    fingerprints = [op["fingerprint"] for op in envelope["plan"]["operations"]]
+    assert all(fp is not None and fp["sha256"] for fp in fingerprints)
+
+
+@requires_symlinks
+def test_symlinks_are_excluded(conformance: ConformanceContext) -> None:
+    """Symlinked files and directories never enter scan, plan, or execution."""
+    conformance.stage("symlink-entries")
+    request = conformance.request(recursive=True, include_hidden=True, use_hardlinks=False)
+
+    scan = _ok(conformance.driver.scan(request))["scan"]
+    preview = _ok(conformance.driver.preview(request))
+
+    assert scan["files"] == ["<input>/real.txt"]
+    assert [op["source"] for op in preview["plan"]["operations"]] == ["<input>/real.txt"]
+
+
+def test_execute_applies_previewed_plan_golden(conformance: ConformanceContext) -> None:
+    conformance.stage("flat-documents")
+    request = conformance.request(use_hardlinks=False)
+    preview = _ok(conformance.driver.preview(request))
+
+    envelope = _ok(conformance.driver.execute(request, preview["plan_payload"]))
+
+    assert envelope["result"] == {
+        "counts": {
+            "total_files": 3,
+            "processed_files": 3,
+            "skipped_files": 0,
+            "failed_files": 0,
+            "deduplicated_files": 0,
+        },
+        "organized_structure": {
+            "Documents": ["alpha.txt", "bravo.md"],
+            "Spreadsheets": ["ledger.csv"],
+        },
+        "errors": [],
+    }
+    assert envelope["audit_events"] == [
+        {
+            "operation_type": "copy",
+            "status": "completed",
+            "source": "<input>/alpha.txt",
+            "destination": "<output>/Documents/alpha.txt",
+            "collision_action": "create",
+            "folder": "Documents",
+        },
+        {
+            "operation_type": "copy",
+            "status": "completed",
+            "source": "<input>/bravo.md",
+            "destination": "<output>/Documents/bravo.md",
+            "collision_action": "create",
+            "folder": "Documents",
+        },
+        {
+            "operation_type": "copy",
+            "status": "completed",
+            "source": "<input>/ledger.csv",
+            "destination": "<output>/Spreadsheets/ledger.csv",
+            "collision_action": "create",
+            "folder": "Spreadsheets",
+        },
+    ]
+    organized = sorted(
+        path.relative_to(conformance.output_root).as_posix()
+        for path in conformance.output_root.rglob("*")
+        if path.is_file()
+    )
+    assert organized == [
+        "Documents/alpha.txt",
+        "Documents/bravo.md",
+        "Spreadsheets/ledger.csv",
+    ]
+    assert (conformance.output_root / "Documents" / "alpha.txt").read_bytes() == b"alpha body\n"
+
+
+def test_execute_without_payload_matches_previewed_execution(
+    conformance: ConformanceContext,
+) -> None:
+    """Build-and-apply must equal the preview-review-apply flow."""
+    conformance.stage("flat-documents")
+    request = conformance.request(use_hardlinks=False)
+
+    envelope = _ok(conformance.driver.execute(request))
+
+    assert envelope["result"]["organized_structure"] == {
+        "Documents": ["alpha.txt", "bravo.md"],
+        "Spreadsheets": ["ledger.csv"],
+    }
+
+
+def test_stale_source_is_rejected_without_mutation(
+    conformance: ConformanceContext,
+) -> None:
+    """A source changed after preview blocks execution before any write."""
+    conformance.stage("flat-documents")
+    request = conformance.request(use_hardlinks=False)
+    preview = _ok(conformance.driver.preview(request))
+    changed = conformance.input_root / "alpha.txt"
+    changed.write_bytes(b"alpha body CHANGED\n")
+    os.utime(changed, ns=(FIXED_MTIME_NS + 10**9, FIXED_MTIME_NS + 10**9))
+
+    envelope = conformance.driver.execute(request, preview["plan_payload"])
+
+    assert envelope["outcome"] == "error"
+    assert envelope["error"]["error_type"] == "PlanValidationError"
+    assert envelope["error"]["conflicts"] == [
+        {"conflict_type": "source_changed", "path": "<input>/alpha.txt"}
+    ]
+    assert list(conformance.output_root.rglob("*")) == []
+
+
+def test_plan_roots_mismatch_rejected(conformance: ConformanceContext, tmp_path: Path) -> None:
+    conformance.stage("flat-documents")
+    request = conformance.request(use_hardlinks=False)
+    preview = _ok(conformance.driver.preview(request))
+    other_input = tmp_path / "elsewhere"
+    other_input.mkdir()
+    foreign = ConformanceContext(
+        input_root=other_input,
+        output_root=conformance.output_root,
+        driver=conformance.driver,
+    )
+
+    envelope = conformance.driver.execute(
+        foreign.request(use_hardlinks=False), preview["plan_payload"]
+    )
+
+    assert envelope["outcome"] == "error"
+    assert envelope["error"]["error_type"] == "ValueError"
+    assert "roots do not match" in envelope["error"]["message"]
+
+
+def test_plan_options_mismatch_rejected(conformance: ConformanceContext) -> None:
+    conformance.stage("flat-documents")
+    preview = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+
+    envelope = conformance.driver.execute(
+        conformance.request(use_hardlinks=False, include_hidden=True),
+        preview["plan_payload"],
+    )
+
+    assert envelope["outcome"] == "error"
+    assert envelope["error"]["error_type"] == "ValueError"
+    assert "options do not match" in envelope["error"]["message"]
+
+
+def test_transfer_mode_hardlink_golden(conformance: ConformanceContext) -> None:
+    """``use_hardlinks`` selects the plan-wide operation type (#1602 extends)."""
+    conformance.stage("flat-documents")
+    request = conformance.request(use_hardlinks=True)
+    preview = _ok(conformance.driver.preview(request))
+
+    assert {op["operation_type"] for op in preview["plan"]["operations"]} == {"hardlink"}
+
+    envelope = _ok(conformance.driver.execute(request, preview["plan_payload"]))
+
+    assert {event["operation_type"] for event in envelope["audit_events"]} == {"hardlink"}
+    if sys.platform != "win32":
+        source_stat = (conformance.input_root / "alpha.txt").stat()
+        destination_stat = (conformance.output_root / "Documents" / "alpha.txt").stat()
+        assert (source_stat.st_dev, source_stat.st_ino) == (
+            destination_stat.st_dev,
+            destination_stat.st_ino,
+        )
+
+
+def test_missing_input_is_rejected(conformance: ConformanceContext) -> None:
+    envelope = conformance.driver.scan(conformance.request())
+
+    assert envelope["outcome"] == "error"
+    assert envelope["error"]["error_type"] == "ValueError"
+    assert envelope["error"]["message"] == "Input path does not exist: <input>"
+
+
+def test_methodology_seed_golden(conformance: ConformanceContext) -> None:
+    """Canonical routing for the methodology tree today; #1602 will extend
+    these expectations when PARA/Johnny Decimal remapping becomes canonical."""
+    conformance.stage("methodology-seed")
+
+    envelope = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+
+    assert _operation_routes(envelope) == [
+        (
+            "<input>/archive/2020/notes.md",
+            "<output>/Documents/notes.md",
+            "ready",
+            "create",
+        ),
+        (
+            "<input>/areas/finance/budget.csv",
+            "<output>/Spreadsheets/budget.csv",
+            "ready",
+            "create",
+        ),
+        (
+            "<input>/projects/alpha/plan.txt",
+            "<output>/Documents/plan.txt",
+            "ready",
+            "create",
+        ),
+        (
+            "<input>/resources/reading/paper.pdf",
+            "<output>/PDFs/paper.pdf",
+            "ready",
+            "create",
+        ),
+    ]
+
+
+def test_job_event_normalization_is_stable() -> None:
+    """Provisional job-event contract: order preserved, volatile keys dropped.
+
+    #1604 replaces this with the canonical job/recovery lifecycle schema.
+    """
+    events = [
+        {"state": "queued", "job_id": "abc", "timestamp": "2026-01-01T00:00:00Z"},
+        {"state": "running", "job_id": "abc", "duration": 1.5},
+        {
+            "state": "completed",
+            "job_id": "abc",
+            "created_at": "x",
+            "capability": "organize",
+        },
+    ]
+
+    assert normalize_job_events(events) == [
+        {"state": "queued"},
+        {"state": "running"},
+        {"capability": "organize", "state": "completed"},
+    ]
+
+
+def test_driver_workspaces_are_isolated(tmp_path: Path) -> None:
+    """Audit databases never leak outside the driver's workspace."""
+    workspace = tmp_path / "ws"
+    driver = DirectServiceDriver(workspace)
+    context = ConformanceContext(
+        input_root=tmp_path / "input", output_root=tmp_path / "output", driver=driver
+    )
+    context.stage("flat-documents")
+
+    _ok(driver.execute(context.request(use_hardlinks=False)))
+
+    databases = sorted(path.name for path in workspace.glob("*.db"))
+    assert databases == ["audit-1.db"]


### PR DESCRIPTION
Part of #1593. Closes #1605.

## What this adds

The executable behavioral oracle for the parity epic: a deterministic fixture corpus, normalization helpers, the adapter-driver protocol, and golden conformance assertions driven through the direct `OrganizationService`.

| Piece | Location |
| --- | --- |
| Fixture corpus (pinned bytes + mtimes, tagged cases) | `tests/conformance/corpus.py` |
| Normalization (requests, plans, results, errors, audit events, provisional job events) | `tests/conformance/normalize.py` |
| `OrganizationConformanceDriver` protocol + `DirectServiceDriver` oracle | `tests/conformance/driver.py` |
| Golden expectations (28 tests) | `tests/conformance/test_direct_service_conformance.py` |
| Adapter-owner guide | `docs/developer/conformance-scaffold.md` |

## Contract boundary

- Publishes the driver protocol adapter suites (#1595–#1598) implement; adding a driver requires no oracle changes.
- Golden expectations are written from canonical service semantics and were verified against the direct service, never an adapter.
- Determinism seams: text/vision processors stay uninitialized (canonical extension-fallback policy applies); audio/video byte parsing is replaced by pinned per-filename metadata (`AUDIO_METADATA_BY_NAME` / `VIDEO_METADATA_BY_NAME`) while the canonical classifier/path policy runs unmodified; audit events use isolated per-execution history databases.
- Divergence classes represented: recursion/hidden traversal, collision policy (skip-existing and rename-with-counter), content dedup, symlink exclusion (POSIX), transfer mode, stale-fingerprint recovery, option persistence, plan round-trips, canonical error envelopes.
- Extension points for in-flight slices are explicit: transfer/methodology (#1602), errors/jobs/recovery (#1604) — `normalize_job_events` is documented as provisional.

## Compatibility / migration impact

None at runtime — no `src/` changes. New `conformance` pytest marker (registered + documented). CI: new **advisory** `conformance-advisory` job in a dedicated `Conformance` workflow (`continue-on-error: true`; required gates belong to #1606). The main CI workflow only triggers for PRs based at `main`/`epic/**`, so the new workflow also triggers on `feature/cross-surface-parity` — giving parity PRs their first executable check. Suite also added to `tests/conformance` added to full-suite shard 5.

## Conformance status / registry changes

None. Adapter `conformance_status` flips to `verified` only when adapter drivers land (#1606).

## Tests actually run

- `pytest tests/conformance` — 28 passed (also under `-n 4` and with randomized ordering).
- Full suite `-m "not benchmark and not e2e and not integration"` with coverage: green except one **pre-existing** failure also present on the clean integration branch (see follow-up below).
- `pre-commit run` on all changed files: all hooks pass except `diff-cover`, which fails only because its embedded full-suite run hits the pre-existing failure below.

## Follow-up (pre-existing, not addressed here)

`tests/api/test_capability_registry_inventory.py::test_public_routes_match_registered_entry_points` fails deterministically in local full-suite runs (macOS venv with `[dev,web,parsers]` extras) on the clean `feature/cross-surface-parity` branch — the app under test registers no matching routes, so every entry point reports stale. Passes in isolation and in CI. Looks order/environment-dependent; worth its own issue rather than an opportunistic fix in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nvei17ZvMvYYsJxcerJT8
