### PR TITLE
feat: define canonical job lifecycle contracts

### DIFF
--- a/alembic/versions/20260721_0002_job_lifecycle.py
+++ b/alembic/versions/20260721_0002_job_lifecycle.py
@@ -1,0 +1,52 @@
+"""Add canonical organization job lifecycle fields.
+
+Revision ID: 20260721_0002
+Revises: 20260216_0001
+Create Date: 2026-07-21
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260721_0002"
+down_revision = "20260216_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Persist canonical scheduling, recovery, and concurrency metadata."""
+    with op.batch_alter_table("organization_jobs") as batch_op:
+        batch_op.add_column(sa.Column("error_code", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column("error_retryable", sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+        batch_op.add_column(sa.Column("error_details_json", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("revision", sa.Integer(), nullable=False, server_default="0"))
+        batch_op.add_column(sa.Column("idempotency_key", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("scheduled_for", sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column("transaction_id", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column("recovery_action", sa.String(), nullable=False, server_default="none")
+        )
+        batch_op.create_unique_constraint(
+            "uq_organization_jobs_type_idempotency",
+            ["job_type", "idempotency_key"],
+        )
+
+
+def downgrade() -> None:
+    """Remove canonical organization job lifecycle fields."""
+    with op.batch_alter_table("organization_jobs") as batch_op:
+        batch_op.drop_constraint("uq_organization_jobs_type_idempotency", type_="unique")
+        batch_op.drop_column("recovery_action")
+        batch_op.drop_column("transaction_id")
+        batch_op.drop_column("scheduled_for")
+        batch_op.drop_column("idempotency_key")
+        batch_op.drop_column("revision")
+        batch_op.drop_column("error_details_json")
+        batch_op.drop_column("error_retryable")
+        batch_op.drop_column("error_code")

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -67,8 +67,8 @@ Rules for adapter drivers (#1595–#1598):
 
 - Transfer semantics and methodologies (#1602) define the `methodology` fixture and canonical
   copy/hardlink expectations. Adapter suites reuse these assertions as they migrate.
-- Errors, jobs, scheduling, and recovery (#1604) replace the provisional
-  `normalize_job_events` contract and extend audit-event coverage.
+- Errors, jobs, scheduling, and recovery (#1604) define stable domain error envelopes,
+  ordered lifecycle events, recovery actions, and transaction-specific rollback expectations.
 - Required gates (#1606) promote adapter suites from advisory to blocking
   per the gate-promotion policy in the
   [parity execution plan](../architecture/cross-surface-parity-execution.md).

--- a/docs/developer/job-lifecycle.md
+++ b/docs/developer/job-lifecycle.md
@@ -29,7 +29,8 @@ revision cannot reduce any completed counter.
 
 Callers may supply an idempotency key when creating a job. The key is scoped by job type. Repeated
 or concurrent creation with the same `(job_type, idempotency_key)` returns the original job rather
-than scheduling duplicate work. Persistent stores enforce the same pair as a unique constraint.
+than scheduling duplicate work. Persistent stores enforce the same pair as a unique constraint and
+recover a concurrent insert conflict by reading and returning the winning job.
 
 ## Scheduling ownership
 
@@ -56,6 +57,10 @@ A cancelled job uses `cancelled`, never `failed`.
   manual inspection is required.
 - `rolled_back`: the transaction associated with that job—not the globally latest operation—was
   undone successfully.
+
+Recovery transitions preserve the error that caused recovery, so observers retain the original
+structured evidence while rollback is in progress and after its outcome is recorded. A retry
+transition clears the old error before the next execution attempt.
 
 Copy and hardlink rollback both remove only destinations and preserve sources. Crash recovery for
 durable moves remains separate because true move is not a supported organization transfer mode.

--- a/docs/developer/job-lifecycle.md
+++ b/docs/developer/job-lifecycle.md
@@ -1,0 +1,80 @@
+# Organization Job Lifecycle
+
+Every adapter represents background organization work with the contracts in
+`file_organizer.core.lifecycle`. HTTP status codes, CLI exit codes, UI banners, and SDK exceptions
+are translations of this contract; they do not define additional lifecycle states.
+
+## States and transitions
+
+| From | Allowed next states |
+|---|---|
+| `scheduled` | `running`, `cancelled`, `failed` |
+| `queued` | `running`, `completed`, `failed`, `cancelled` |
+| `running` | `completed`, `partial`, `failed`, `recovery_required` |
+| `partial` | `queued`, `rolling_back`, `recovery_required` |
+| `failed` | `queued`, `rolling_back`, `recovery_required` |
+| `recovery_required` | `queued`, `rolling_back`, `failed` |
+| `completed` | `rolling_back` |
+| `rolling_back` | `rolled_back`, `recovery_required`, `failed` |
+| `cancelled`, `rolled_back` | none |
+
+Duplicate and illegal transitions fail with `invalid_job_transition`. Mutations may include an
+`expected_revision`; a concurrent winner increments the revision and stale writers fail with
+`stale_job_revision`. Adapters should retry only after re-reading the current snapshot.
+
+Progress counters are monotonic. `completed + failed + skipped` cannot exceed `total`, and a later
+revision cannot reduce any completed counter.
+
+## Idempotency
+
+Callers may supply an idempotency key when creating a job. The key is scoped by job type. Repeated
+or concurrent creation with the same `(job_type, idempotency_key)` returns the original job rather
+than scheduling duplicate work. Persistent stores enforce the same pair as a unique constraint.
+
+## Scheduling ownership
+
+Delayed organization is a canonical one-shot schedule represented by `status=scheduled` and a
+timezone-aware `scheduled_for` timestamp. The adapter hosting the worker owns the timer or queue,
+but must perform the canonical transition before execution. Scheduling metadata is serialized in
+the job snapshot and persisted by the organization-job repository.
+
+Daemon and watcher automation are separate capabilities. They may create organization jobs, but
+their recurring watches and task definitions are not organization-job lifecycle states.
+
+Cancellation is currently guaranteed before work starts (`scheduled` or `queued`). Running file
+operations are not advertised as cancellable until a cooperative cancellation boundary exists.
+A cancelled job uses `cancelled`, never `failed`.
+
+## Completion and recovery
+
+- `completed`: all executable operations succeeded. If a history transaction exists, the job may
+  transition to `rolling_back`.
+- `partial`: at least one operation failed and at least one may have committed. The job records its
+  exact history transaction and exposes retry or rollback as its recovery action.
+- `failed`: execution did not produce a successful result. Retry is the default recovery action.
+- `recovery_required`: automatic rollback or recovery could not establish a safe final state;
+  manual inspection is required.
+- `rolled_back`: the transaction associated with that job—not the globally latest operation—was
+  undone successfully.
+
+Copy and hardlink rollback both remove only destinations and preserve sources. Crash recovery for
+durable moves remains separate because true move is not a supported organization transfer mode.
+
+## Errors
+
+`file_organizer.core.errors.DomainError` carries a stable `code`, message, retryability flag, and
+optional structured details. Known optional-dependency failures use
+`optional_feature_unavailable`; adapters must not turn them into a generic internal error.
+
+The REST layer maps domain codes to HTTP status codes while preserving the code and retryability.
+Other adapters should make equivalent translations appropriate to their transport.
+
+## Shared persistence
+
+The API/Web in-memory store serializes mutations under one lock, returns copies rather than mutable
+store objects, and uses revision checks to prevent lost updates. The SQL organization-job model
+persists revision, idempotency, schedule, transaction, recovery, and error-code fields.
+
+History uses one re-entrant lock per database manager across connection creation, cursor reads, and
+commit/rollback boundaries. Transaction status changes and undo/redo status flips are committed as
+single database transactions so concurrent surfaces cannot interleave them silently.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
       - Architecture: developer/architecture.md
       - Capability Registry: developer/capability-registry.md
       - Canonical Organization Service: developer/organization-service.md
+      - Organization Job Lifecycle: developer/job-lifecycle.md
       - Conformance Scaffold: developer/conformance-scaffold.md
       - Plugin Development: developer/plugin-development.md
       - API Clients: developer/api-clients.md

--- a/src/file_organizer/api/db_models.py
+++ b/src/file_organizer/api/db_models.py
@@ -68,9 +68,31 @@ class OrganizationJob(Base):  # type: ignore[misc]
     failed_files = Column(Integer, default=0)
     skipped_files = Column(Integer, default=0)
     error = Column(String, nullable=True)
+    error_code = Column(String, nullable=True)
+    error_retryable = Column(Boolean, nullable=False, default=False)
+    error_details_json = Column(Text, nullable=True)
     result_json = Column(String, nullable=True)
+    revision = Column(Integer, nullable=False, default=0)
+    idempotency_key = Column(String, nullable=True)
+    scheduled_for = Column(DateTime(timezone=True), nullable=True)
+    transaction_id = Column(String, nullable=True)
+    recovery_action = Column(String, nullable=False, default="none")
     created_at = Column(DateTime(timezone=True), default=_utcnow)
     updated_at = Column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "job_type",
+            "idempotency_key",
+            name="uq_organization_jobs_type_idempotency",
+        ),
+    )
+    __mapper_args__ = {
+        "version_id_col": revision,
+        # Repositories increment revision explicitly so persisted values start at
+        # zero while SQLAlchemy still adds revision to every UPDATE predicate.
+        "version_id_generator": False,
+    }
 
     def __repr__(self) -> str:
         """Return string representation of OrganizationJob."""

--- a/src/file_organizer/api/exceptions.py
+++ b/src/file_organizer/api/exceptions.py
@@ -10,6 +10,21 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from loguru import logger
 
+from file_organizer.core.errors import DomainError, DomainErrorCode
+
+_DOMAIN_HTTP_STATUS = {
+    DomainErrorCode.INVALID_REQUEST: 400,
+    DomainErrorCode.NOT_FOUND: 404,
+    DomainErrorCode.CONFLICT: 409,
+    DomainErrorCode.OPTIONAL_FEATURE_UNAVAILABLE: 503,
+    DomainErrorCode.PLAN_MISMATCH: 409,
+    DomainErrorCode.INVALID_JOB_TRANSITION: 409,
+    DomainErrorCode.STALE_JOB_REVISION: 409,
+    DomainErrorCode.EXECUTION_FAILED: 500,
+    DomainErrorCode.RECOVERY_REQUIRED: 409,
+    DomainErrorCode.CANCELLED: 409,
+}
+
 
 @dataclass
 class ApiError(Exception):
@@ -59,6 +74,18 @@ def setup_exception_handlers(app: FastAPI) -> None:
         if exc.details is not None:
             payload["details"] = exc.details
         return JSONResponse(status_code=exc.status_code, content=payload)
+
+    @app.exception_handler(DomainError)
+    async def domain_error_handler(
+        request: Request,
+        exc: DomainError,
+    ) -> JSONResponse:
+        """Translate a stable domain error without changing its meaning."""
+        logger.warning("Domain error on {}: {}", request.url.path, exc.code.value)
+        return JSONResponse(
+            status_code=_DOMAIN_HTTP_STATUS[exc.code],
+            content={"error": exc.code.value, **exc.to_dict()},
+        )
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(

--- a/src/file_organizer/api/jobs.py
+++ b/src/file_organizer/api/jobs.py
@@ -3,32 +3,101 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from dataclasses import dataclass, fields
+from copy import deepcopy
+from dataclasses import dataclass, field, fields, replace
 from datetime import UTC, datetime, timedelta
 from threading import Lock
-from typing import Any, Literal
+from typing import Any
 from uuid import uuid4
 
 from file_organizer.api.realtime import realtime_manager
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.lifecycle import (
+    ACTIVE_JOB_STATUSES,
+    JobProgress,
+    JobSnapshot,
+    JobStatus,
+    RecoveryAction,
+    create_job_snapshot,
+    transition_job,
+)
 
-JobStateStatus = Literal["queued", "running", "completed", "failed"]
+JobStateStatus = JobStatus
 
 
 @dataclass
 class JobState:
-    """State record for a background API job."""
+    """Backward-compatible API view of the canonical lifecycle snapshot."""
 
     job_id: str
     job_type: str
-    status: JobStateStatus
+    status: JobStatus
     created_at: datetime
     updated_at: datetime
     result: dict[str, Any] | None = None
     error: str | None = None
+    error_code: DomainErrorCode | None = None
+    error_retryable: bool = False
+    error_details: dict[str, Any] = field(default_factory=dict)
+    revision: int = 0
+    idempotency_key: str | None = None
+    scheduled_for: datetime | None = None
+    progress: JobProgress = field(default_factory=JobProgress)
+    transaction_id: str | None = None
+    recovery_action: RecoveryAction = RecoveryAction.NONE
+
+    @classmethod
+    def from_snapshot(cls, snapshot: JobSnapshot) -> JobState:
+        """Build the compatibility view from an immutable domain snapshot."""
+        return cls(
+            job_id=snapshot.job_id,
+            job_type=snapshot.job_type,
+            status=snapshot.status,
+            created_at=snapshot.created_at,
+            updated_at=snapshot.updated_at,
+            result=deepcopy(snapshot.result),
+            error=snapshot.error.message if snapshot.error is not None else None,
+            error_code=snapshot.error.code if snapshot.error is not None else None,
+            error_retryable=snapshot.error.retryable if snapshot.error is not None else False,
+            error_details=deepcopy(snapshot.error.details) if snapshot.error is not None else {},
+            revision=snapshot.revision,
+            idempotency_key=snapshot.idempotency_key,
+            scheduled_for=snapshot.scheduled_for,
+            progress=snapshot.progress,
+            transaction_id=snapshot.transaction_id,
+            recovery_action=snapshot.recovery_action,
+        )
+
+    def to_snapshot(self) -> JobSnapshot:
+        """Return the canonical immutable snapshot represented by this view."""
+        domain_error = None
+        if self.error is not None:
+            domain_error = DomainError(
+                self.error_code or DomainErrorCode.EXECUTION_FAILED,
+                self.error,
+                retryable=self.error_retryable,
+                details=deepcopy(self.error_details),
+            )
+        return JobSnapshot(
+            job_id=self.job_id,
+            job_type=self.job_type,
+            status=self.status,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            revision=self.revision,
+            idempotency_key=self.idempotency_key,
+            scheduled_for=self.scheduled_for,
+            progress=self.progress,
+            transaction_id=self.transaction_id,
+            recovery_action=self.recovery_action,
+            result=deepcopy(self.result),
+            error=domain_error,
+        )
 
 
-_ACTIVE_STATUSES = {"queued", "running"}
+_ACTIVE_STATUSES = ACTIVE_JOB_STATUSES
 _JOB_STORE: OrderedDict[str, JobState] = OrderedDict()
+_IDEMPOTENCY_INDEX: dict[tuple[str, str], str] = {}
 _JOB_STORE_LOCK = Lock()
 _JOB_FIELDS = {field.name for field in fields(JobState)}
 _MAX_JOBS = 1000
@@ -45,29 +114,44 @@ def _prune_jobs(now: datetime) -> None:
     cutoff = now - _JOB_TTL
     expired = [job_id for job_id, job in _JOB_STORE.items() if job.updated_at < cutoff]
     for job_id in expired:
-        _JOB_STORE.pop(job_id, None)
+        removed = _JOB_STORE.pop(job_id, None)
+        if removed is not None and removed.idempotency_key is not None:
+            _IDEMPOTENCY_INDEX.pop((removed.job_type, removed.idempotency_key), None)
     while len(_JOB_STORE) > _MAX_JOBS:
-        _JOB_STORE.popitem(last=False)
+        _, removed = _JOB_STORE.popitem(last=False)
+        if removed.idempotency_key is not None:
+            _IDEMPOTENCY_INDEX.pop((removed.job_type, removed.idempotency_key), None)
 
 
-def create_job(job_type: str) -> JobState:
+def create_job(
+    job_type: str,
+    *,
+    idempotency_key: str | None = None,
+    scheduled_for: datetime | None = None,
+) -> JobState:
     """Create a new background job and return its initial state."""
-    job_id = uuid4().hex
     ts = _now()
-    job = JobState(
-        job_id=job_id,
-        job_type=job_type,
-        status="queued",
-        created_at=ts,
-        updated_at=ts,
-    )
     with _JOB_STORE_LOCK:
-        _JOB_STORE[job_id] = job
-        _JOB_STORE.move_to_end(job_id)
+        if idempotency_key is not None:
+            existing_id = _IDEMPOTENCY_INDEX.get((job_type, idempotency_key))
+            if existing_id is not None and existing_id in _JOB_STORE:
+                return deepcopy(_JOB_STORE[existing_id])
+        snapshot = create_job_snapshot(
+            job_id=uuid4().hex,
+            job_type=job_type,
+            now=ts,
+            idempotency_key=idempotency_key,
+            scheduled_for=scheduled_for,
+        )
+        job = JobState.from_snapshot(snapshot)
+        _JOB_STORE[job.job_id] = job
+        _JOB_STORE.move_to_end(job.job_id)
+        if idempotency_key is not None:
+            _IDEMPOTENCY_INDEX[(job_type, idempotency_key)] = job.job_id
         _prune_jobs(ts)
         payload = _build_job_payload(job, event_type="job.created")
     _notify_job_event(payload)
-    return job
+    return deepcopy(job)
 
 
 def get_job(job_id: str) -> JobState | None:
@@ -77,7 +161,7 @@ def get_job(job_id: str) -> JobState | None:
         job = _JOB_STORE.get(job_id)
         if job:
             _JOB_STORE.move_to_end(job_id)
-        return job
+        return deepcopy(job) if job is not None else None
 
 
 def update_job(job_id: str, **updates: Any) -> JobState | None:
@@ -86,17 +170,52 @@ def update_job(job_id: str, **updates: Any) -> JobState | None:
         job = _JOB_STORE.get(job_id)
         if not job:
             return None
+        expected_revision = updates.pop("expected_revision", None)
         invalid_keys = [key for key in updates if key not in _JOB_FIELDS]
         if invalid_keys:
             raise ValueError(f"Unknown job fields: {', '.join(invalid_keys)}")
-        for key, value in updates.items():
-            setattr(job, key, value)
-        job.updated_at = _now()
+        status = updates.pop("status", None)
+        now = _now()
+        if status is not None:
+            error_text = updates.pop("error", None)
+            error_code = updates.pop("error_code", None)
+            error_retryable = bool(updates.pop("error_retryable", False))
+            error_details = updates.pop("error_details", None)
+            domain_error = None
+            if error_text is not None:
+                domain_error = DomainError(
+                    DomainErrorCode(error_code or DomainErrorCode.EXECUTION_FAILED),
+                    str(error_text),
+                    retryable=error_retryable,
+                    details=deepcopy(error_details),
+                )
+            snapshot = transition_job(
+                job.to_snapshot(),
+                status,
+                now=now,
+                expected_revision=expected_revision,
+                progress=updates.pop("progress", None),
+                transaction_id=updates.pop("transaction_id", None),
+                recovery_action=updates.pop("recovery_action", None),
+                result=updates.pop("result", None),
+                error=domain_error,
+            )
+            job = JobState.from_snapshot(snapshot)
+        else:
+            if expected_revision is not None and expected_revision != job.revision:
+                raise DomainError(
+                    DomainErrorCode.STALE_JOB_REVISION,
+                    "Job state changed before this mutation could be applied.",
+                    retryable=True,
+                    details={"expected": expected_revision, "actual": job.revision},
+                )
+            job = replace(job, updated_at=now, revision=job.revision + 1, **updates)
+        _JOB_STORE[job_id] = job
         _JOB_STORE.move_to_end(job_id)
         _prune_jobs(job.updated_at)
         payload = _build_job_payload(job, event_type="job.updated")
     _notify_job_event(payload)
-    return job
+    return deepcopy(job)
 
 
 def list_jobs(
@@ -115,7 +234,7 @@ def list_jobs(
     if statuses is not None:
         jobs = [job for job in jobs if job.status in statuses]
     jobs.sort(key=lambda job: job.updated_at, reverse=True)
-    return jobs[:safe_limit]
+    return deepcopy(jobs[:safe_limit])
 
 
 def job_count() -> int:
@@ -134,6 +253,20 @@ def _build_job_payload(job: JobState, event_type: str) -> dict[str, Any]:
         "status": job.status,
         "created_at": job.created_at.isoformat(),
         "updated_at": job.updated_at.isoformat(),
+        "revision": job.revision,
+        "scheduled_for": job.scheduled_for.isoformat() if job.scheduled_for else None,
+        "progress": {
+            "total": job.progress.total,
+            "completed": job.progress.completed,
+            "failed": job.progress.failed,
+            "skipped": job.progress.skipped,
+            "percent": job.progress.percent,
+        },
+        "transaction_id": job.transaction_id,
+        "recovery_action": job.recovery_action.value,
+        "error_code": job.error_code.value if job.error_code is not None else None,
+        "error_retryable": job.error_retryable,
+        "error_details": deepcopy(job.error_details),
         "error": job.error,
         "result": job.result,
     }

--- a/src/file_organizer/api/models.py
+++ b/src/file_organizer/api/models.py
@@ -224,6 +224,7 @@ class OrganizationResultResponse(BaseModel):
     organized_structure: dict[str, list[str]]
     errors: list[OrganizationError]
     plan: OrganizationPlanPayload | None = None
+    transaction_id: str | None = None
 
 
 class OrganizeExecuteResponse(BaseModel):
@@ -239,11 +240,30 @@ class JobStatusResponse(BaseModel):
     """Status of a background organization job."""
 
     job_id: str
-    status: Literal["queued", "running", "completed", "failed"]
+    status: Literal[
+        "scheduled",
+        "queued",
+        "running",
+        "completed",
+        "partial",
+        "failed",
+        "cancelled",
+        "recovery_required",
+        "rolling_back",
+        "rolled_back",
+    ]
     created_at: datetime
     updated_at: datetime
     result: OrganizationResultResponse | None = None
     error: str | None = None
+    error_code: str | None = None
+    error_retryable: bool = False
+    error_details: dict[str, Any] | None = None
+    revision: int = 0
+    scheduled_for: datetime | None = None
+    progress: dict[str, int | float] = Field(default_factory=dict)
+    transaction_id: str | None = None
+    recovery_action: Literal["none", "retry", "rollback", "manual"] = "none"
 
 
 class DedupeScanRequest(BaseModel):

--- a/src/file_organizer/api/repositories/job_repo.py
+++ b/src/file_organizer/api/repositories/job_repo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import StaleDataError
 
@@ -80,8 +81,29 @@ class JobRepository:
         job.scheduled_for = scheduled_for
         job.revision = 0
         job.recovery_action = RecoveryAction.NONE.value
-        session.add(job)
-        session.flush()
+        if idempotency_key is None:
+            session.add(job)
+            session.flush()
+            return job
+
+        try:
+            # Isolate the insert so a concurrent unique-key winner does not
+            # invalidate the caller's outer transaction.
+            with session.begin_nested():
+                session.add(job)
+                session.flush()
+        except IntegrityError:
+            existing = (
+                session.query(OrganizationJob)
+                .filter(
+                    OrganizationJob.job_type == job_type,
+                    OrganizationJob.idempotency_key == idempotency_key,
+                )
+                .one_or_none()
+            )
+            if existing is None:
+                raise
+            return existing
         return job
 
     # ------------------------------------------------------------------

--- a/src/file_organizer/api/repositories/job_repo.py
+++ b/src/file_organizer/api/repositories/job_repo.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import StaleDataError
 
 from file_organizer.api.db_models import OrganizationJob
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.lifecycle import (
+    LEGAL_JOB_TRANSITIONS,
+    JobStatus,
+    RecoveryAction,
+)
 
 
 class JobRepository:
@@ -27,6 +35,8 @@ class JobRepository:
         job_type: str = "organize",
         methodology: str = "content_based",
         dry_run: bool = False,
+        idempotency_key: str | None = None,
+        scheduled_for: datetime | None = None,
     ) -> OrganizationJob:
         """Create and persist a new organization job.
 
@@ -39,10 +49,24 @@ class JobRepository:
             job_type: Job type label (default ``"organize"``).
             methodology: Organization methodology name.
             dry_run: Whether the job is a dry run.
+            idempotency_key: Optional caller key used to return an existing job.
+            scheduled_for: Optional one-shot execution time.
 
         Returns:
             The newly created :class:`OrganizationJob` instance.
         """
+        if idempotency_key is not None:
+            existing = (
+                session.query(OrganizationJob)
+                .filter(
+                    OrganizationJob.job_type == job_type,
+                    OrganizationJob.idempotency_key == idempotency_key,
+                )
+                .one_or_none()
+            )
+            if existing is not None:
+                return existing
+
         job = OrganizationJob()
         job.input_dir = input_dir
         job.output_dir = output_dir
@@ -51,6 +75,11 @@ class JobRepository:
         job.job_type = job_type
         job.methodology = methodology
         job.dry_run = dry_run
+        job.status = "scheduled" if scheduled_for is not None else "queued"
+        job.idempotency_key = idempotency_key
+        job.scheduled_for = scheduled_for
+        job.revision = 0
+        job.recovery_action = RecoveryAction.NONE.value
         session.add(job)
         session.flush()
         return job
@@ -100,6 +129,13 @@ class JobRepository:
         job_id: str,
         status: str,
         error: str | None = None,
+        *,
+        expected_revision: int | None = None,
+        error_code: str | None = None,
+        error_retryable: bool = False,
+        error_details: dict[str, object] | None = None,
+        transaction_id: str | None = None,
+        recovery_action: RecoveryAction | str | None = None,
     ) -> OrganizationJob | None:
         """Transition a job to a new status.
 
@@ -108,6 +144,12 @@ class JobRepository:
             job_id: Primary key of the job.
             status: New status string.
             error: Optional error message (typically set when status is ``"failed"``).
+            expected_revision: Optional compare-and-swap revision guard.
+            error_code: Stable domain error code associated with ``error``.
+            error_retryable: Whether retrying the same operation may succeed.
+            error_details: Structured transport-neutral error evidence.
+            transaction_id: History transaction associated with execution.
+            recovery_action: Canonical next recovery action.
 
         Returns:
             The updated :class:`OrganizationJob`, or ``None`` if not found.
@@ -115,10 +157,49 @@ class JobRepository:
         job = session.get(OrganizationJob, job_id)
         if job is None:
             return None
-        job.status = status
+        current = JobStatus(job.status)
+        target = JobStatus(status)
+        if target == current or target not in LEGAL_JOB_TRANSITIONS[current]:
+            raise DomainError(
+                DomainErrorCode.INVALID_JOB_TRANSITION,
+                f"Cannot transition job from {current.value} to {target.value}.",
+                details={"from": current.value, "to": target.value},
+            )
+        if expected_revision is not None and expected_revision != job.revision:
+            raise DomainError(
+                DomainErrorCode.STALE_JOB_REVISION,
+                "Job state changed before this mutation could be applied.",
+                retryable=True,
+                details={"expected": expected_revision, "actual": job.revision},
+            )
+        job.status = target.value
         job.error = error
+        job.error_code = error_code
+        job.error_retryable = error_retryable
+        job.error_details_json = (
+            json.dumps(error_details, sort_keys=True) if error_details is not None else None
+        )
+        job.transaction_id = transaction_id or job.transaction_id
+        if recovery_action is not None:
+            job.recovery_action = RecoveryAction(recovery_action).value
+        elif target in {JobStatus.PARTIAL, JobStatus.FAILED}:
+            job.recovery_action = RecoveryAction.RETRY.value
+        elif target == JobStatus.RECOVERY_REQUIRED:
+            job.recovery_action = RecoveryAction.MANUAL.value
+        else:
+            job.recovery_action = RecoveryAction.NONE.value
+        prior_revision = job.revision
+        job.revision = prior_revision + 1
         job.updated_at = datetime.now(UTC)
-        session.flush()
+        try:
+            session.flush()
+        except StaleDataError as exc:
+            raise DomainError(
+                DomainErrorCode.STALE_JOB_REVISION,
+                "Job state changed before this mutation could be applied.",
+                retryable=True,
+                details={"expected": prior_revision},
+            ) from exc
         return job
 
     @staticmethod
@@ -154,6 +235,16 @@ class JobRepository:
         if result_json is not None:
             job.result_json = result_json
 
+        prior_revision = job.revision
+        job.revision = prior_revision + 1
         job.updated_at = datetime.now(UTC)
-        session.flush()
+        try:
+            session.flush()
+        except StaleDataError as exc:
+            raise DomainError(
+                DomainErrorCode.STALE_JOB_REVISION,
+                "Job state changed before this mutation could be applied.",
+                retryable=True,
+                details={"expected": prior_revision},
+            ) from exc
         return job

--- a/src/file_organizer/api/routers/organize.py
+++ b/src/file_organizer/api/routers/organize.py
@@ -32,6 +32,8 @@ from file_organizer.api.openapi_responses import (
     validation_error_response,
 )
 from file_organizer.api.utils import is_hidden, resolve_path
+from file_organizer.core.errors import DomainError
+from file_organizer.core.lifecycle import JobProgress, JobStatus, RecoveryAction
 from file_organizer.core.organizer import FileOrganizer, OrganizationResult
 from file_organizer.core.plan import OrganizationPlan
 
@@ -104,6 +106,7 @@ def _result_to_response(result: OrganizationResult) -> OrganizationResultRespons
         organized_structure=result.organized_structure,
         errors=[OrganizationError(file=err[0], error=err[1]) for err in result.errors],
         plan=plan,
+        transaction_id=result.transaction_id,
     )
 
 
@@ -152,7 +155,30 @@ def _run_organize_job(job_id: str, request: OrganizeRequest) -> None:
                 skip_existing=request.skip_existing,
             )
         response = _result_to_response(result).model_dump()
-        update_job(job_id, status="completed", result=response)
+        progress = JobProgress(
+            total=result.total_files,
+            completed=result.processed_files,
+            failed=result.failed_files,
+            skipped=result.skipped_files + result.deduplicated_files,
+        )
+        status = JobStatus.PARTIAL if result.failed_files else JobStatus.COMPLETED
+        update_job(
+            job_id,
+            status=status,
+            result=response,
+            progress=progress,
+            transaction_id=result.transaction_id,
+            recovery_action=(RecoveryAction.ROLLBACK if result.transaction_id else None),
+        )
+    except DomainError as exc:
+        update_job(
+            job_id,
+            status=JobStatus.FAILED,
+            error=exc.message,
+            error_code=exc.code,
+            error_retryable=exc.retryable,
+            error_details=exc.details,
+        )
     except Exception as exc:
         update_job(job_id, status="failed", error=str(exc))
 
@@ -318,6 +344,20 @@ def get_job_status(job_id: str) -> JobStatusResponse:
         updated_at=job.updated_at,
         result=result,
         error=job.error,
+        error_code=job.error_code.value if job.error_code is not None else None,
+        error_retryable=job.error_retryable,
+        error_details=job.error_details,
+        revision=job.revision,
+        scheduled_for=job.scheduled_for,
+        progress={
+            "total": job.progress.total,
+            "completed": job.progress.completed,
+            "failed": job.progress.failed,
+            "skipped": job.progress.skipped,
+            "percent": job.progress.percent,
+        },
+        transaction_id=job.transaction_id,
+        recovery_action=job.recovery_action,
     )
 
 

--- a/src/file_organizer/client/models.py
+++ b/src/file_organizer/client/models.py
@@ -143,6 +143,7 @@ class OrganizationResultResponse(BaseModel):
     organized_structure: dict[str, list[str]]
     errors: list[OrganizationError]
     plan: OrganizationPlanPayload | None = None
+    transaction_id: str | None = None
 
 
 class OrganizeExecuteResponse(BaseModel):
@@ -158,11 +159,30 @@ class JobStatusResponse(BaseModel):
     """Status of a background job."""
 
     job_id: str
-    status: str
+    status: Literal[
+        "scheduled",
+        "queued",
+        "running",
+        "completed",
+        "partial",
+        "failed",
+        "cancelled",
+        "recovery_required",
+        "rolling_back",
+        "rolled_back",
+    ]
     created_at: datetime
     updated_at: datetime
     result: OrganizationResultResponse | None = None
     error: str | None = None
+    error_code: str | None = None
+    error_retryable: bool = False
+    error_details: dict[str, Any] | None = None
+    revision: int = 0
+    scheduled_for: datetime | None = None
+    progress: dict[str, int | float] = Field(default_factory=dict)
+    transaction_id: str | None = None
+    recovery_action: Literal["none", "retry", "rollback", "manual"] = "none"
 
 
 class TokenResponse(BaseModel):

--- a/src/file_organizer/client/typescript/types.ts
+++ b/src/file_organizer/client/typescript/types.ts
@@ -167,6 +167,7 @@ export interface OrganizationResultResponse {
   organized_structure: Record<string, string[]>;
   errors: OrganizationError[];
   plan: OrganizationPlanPayload | null;
+  transaction_id: string | null;
 }
 
 export interface OrganizeRequest {
@@ -188,11 +189,35 @@ export interface OrganizeExecuteResponse {
 
 export interface JobStatusResponse {
   job_id: string;
-  status: "queued" | "running" | "completed" | "failed";
+  status:
+    | "scheduled"
+    | "queued"
+    | "running"
+    | "completed"
+    | "partial"
+    | "failed"
+    | "cancelled"
+    | "recovery_required"
+    | "rolling_back"
+    | "rolled_back";
   created_at: string;
   updated_at: string;
   result: OrganizationResultResponse | null;
   error: string | null;
+  error_code: string | null;
+  error_retryable: boolean;
+  error_details: Record<string, unknown> | null;
+  revision: number;
+  scheduled_for: string | null;
+  progress: {
+    total: number;
+    completed: number;
+    failed: number;
+    skipped: number;
+    percent: number;
+  };
+  transaction_id: string | null;
+  recovery_action: "none" | "retry" | "rollback" | "manual";
 }
 
 // -- System -----------------------------------------------------------------

--- a/src/file_organizer/core/errors.py
+++ b/src/file_organizer/core/errors.py
@@ -1,0 +1,70 @@
+"""Transport-neutral errors shared by organization adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from file_organizer._compat import StrEnum
+
+
+class DomainErrorCode(StrEnum):
+    """Stable error identifiers that presentation layers may translate."""
+
+    INVALID_REQUEST = "invalid_request"
+    NOT_FOUND = "not_found"
+    CONFLICT = "conflict"
+    OPTIONAL_FEATURE_UNAVAILABLE = "optional_feature_unavailable"
+    PLAN_MISMATCH = "plan_mismatch"
+    INVALID_JOB_TRANSITION = "invalid_job_transition"
+    STALE_JOB_REVISION = "stale_job_revision"
+    EXECUTION_FAILED = "execution_failed"
+    RECOVERY_REQUIRED = "recovery_required"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class DomainError(Exception):
+    """A stable domain failure independent of HTTP, CLI, or UI semantics."""
+
+    code: DomainErrorCode
+    message: str
+    retryable: bool = False
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Initialize the exception message after validating its public fields."""
+        if not self.message.strip():
+            raise ValueError("Domain error message must not be empty")
+        super().__init__(f"{self.code.value}: {self.message}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable adapter-facing error payload."""
+        payload: dict[str, Any] = {
+            "code": self.code.value,
+            "message": self.message,
+            "retryable": self.retryable,
+        }
+        if self.details:
+            payload["details"] = dict(self.details)
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DomainError:
+        """Restore a domain error from its stable payload."""
+        return cls(
+            code=DomainErrorCode(data["code"]),
+            message=str(data["message"]),
+            retryable=bool(data.get("retryable", False)),
+            details=dict(data.get("details", {})),
+        )
+
+
+def optional_feature_unavailable(feature: str, message: str) -> DomainError:
+    """Build the canonical result for an unavailable optional feature."""
+    return DomainError(
+        DomainErrorCode.OPTIONAL_FEATURE_UNAVAILABLE,
+        message,
+        retryable=False,
+        details={"feature": feature},
+    )

--- a/src/file_organizer/core/lifecycle.py
+++ b/src/file_organizer/core/lifecycle.py
@@ -34,6 +34,8 @@ class RecoveryAction(StrEnum):
     MANUAL = "manual"
 
 
+# These states end one execution attempt. Some still permit an explicit retry
+# or recovery transition; only CANCELLED and ROLLED_BACK are graph-terminal.
 TERMINAL_JOB_STATUSES = frozenset(
     {
         JobStatus.COMPLETED,
@@ -284,6 +286,13 @@ def transition_job(
         if recovery_action is not None
         else _default_recovery_action(target_status)
     )
+    next_error = error
+    if next_error is None and target_status in {
+        JobStatus.ROLLING_BACK,
+        JobStatus.ROLLED_BACK,
+        JobStatus.RECOVERY_REQUIRED,
+    }:
+        next_error = job.error
     return replace(
         job,
         status=target_status,
@@ -293,7 +302,7 @@ def transition_job(
         transaction_id=transaction_id or job.transaction_id,
         recovery_action=next_recovery,
         result=result if result is not None else job.result,
-        error=error,
+        error=next_error,
     )
 
 

--- a/src/file_organizer/core/lifecycle.py
+++ b/src/file_organizer/core/lifecycle.py
@@ -1,0 +1,306 @@
+"""Canonical job, scheduling, cancellation, and recovery contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from typing import Any
+
+from file_organizer._compat import StrEnum
+from file_organizer.core.errors import DomainError, DomainErrorCode
+
+
+class JobStatus(StrEnum):
+    """Stable lifecycle states exposed by every organization adapter."""
+
+    SCHEDULED = "scheduled"
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    RECOVERY_REQUIRED = "recovery_required"
+    ROLLING_BACK = "rolling_back"
+    ROLLED_BACK = "rolled_back"
+
+
+class RecoveryAction(StrEnum):
+    """Canonical next action after incomplete or failed work."""
+
+    NONE = "none"
+    RETRY = "retry"
+    ROLLBACK = "rollback"
+    MANUAL = "manual"
+
+
+TERMINAL_JOB_STATUSES = frozenset(
+    {
+        JobStatus.COMPLETED,
+        JobStatus.PARTIAL,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+        JobStatus.RECOVERY_REQUIRED,
+        JobStatus.ROLLED_BACK,
+    }
+)
+
+ACTIVE_JOB_STATUSES = frozenset(
+    {
+        JobStatus.SCHEDULED,
+        JobStatus.QUEUED,
+        JobStatus.RUNNING,
+        JobStatus.ROLLING_BACK,
+    }
+)
+
+LEGAL_JOB_TRANSITIONS: dict[JobStatus, frozenset[JobStatus]] = {
+    JobStatus.SCHEDULED: frozenset({JobStatus.RUNNING, JobStatus.CANCELLED, JobStatus.FAILED}),
+    JobStatus.QUEUED: frozenset(
+        {
+            JobStatus.RUNNING,
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+        }
+    ),
+    JobStatus.RUNNING: frozenset(
+        {
+            JobStatus.COMPLETED,
+            JobStatus.PARTIAL,
+            JobStatus.FAILED,
+            JobStatus.RECOVERY_REQUIRED,
+        }
+    ),
+    JobStatus.PARTIAL: frozenset(
+        {JobStatus.QUEUED, JobStatus.ROLLING_BACK, JobStatus.RECOVERY_REQUIRED}
+    ),
+    JobStatus.FAILED: frozenset(
+        {JobStatus.QUEUED, JobStatus.ROLLING_BACK, JobStatus.RECOVERY_REQUIRED}
+    ),
+    JobStatus.RECOVERY_REQUIRED: frozenset(
+        {JobStatus.QUEUED, JobStatus.ROLLING_BACK, JobStatus.FAILED}
+    ),
+    JobStatus.COMPLETED: frozenset({JobStatus.ROLLING_BACK}),
+    JobStatus.ROLLING_BACK: frozenset(
+        {JobStatus.ROLLED_BACK, JobStatus.RECOVERY_REQUIRED, JobStatus.FAILED}
+    ),
+    JobStatus.CANCELLED: frozenset(),
+    JobStatus.ROLLED_BACK: frozenset(),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class JobProgress:
+    """Monotonic progress counters for one job revision."""
+
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    skipped: int = 0
+
+    def __post_init__(self) -> None:
+        """Reject negative or internally inconsistent counters."""
+        counters = (self.total, self.completed, self.failed, self.skipped)
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in counters
+        ):
+            raise ValueError("Job progress counters must be non-negative integers")
+        if self.completed + self.failed + self.skipped > self.total:
+            raise ValueError("Job progress counters exceed total")
+
+    @property
+    def percent(self) -> float:
+        """Return completion progress as a stable percentage."""
+        if self.total == 0:
+            return 0.0
+        done = self.completed + self.failed + self.skipped
+        return round((done / self.total) * 100.0, 1)
+
+
+@dataclass(frozen=True, slots=True)
+class JobSnapshot:
+    """Immutable serialized state for background organization work."""
+
+    job_id: str
+    job_type: str
+    status: JobStatus
+    created_at: datetime
+    updated_at: datetime
+    revision: int = 0
+    idempotency_key: str | None = None
+    scheduled_for: datetime | None = None
+    progress: JobProgress = field(default_factory=JobProgress)
+    transaction_id: str | None = None
+    recovery_action: RecoveryAction = RecoveryAction.NONE
+    result: dict[str, Any] | None = None
+    error: DomainError | None = None
+
+    def __post_init__(self) -> None:
+        """Validate scheduling and timestamp invariants."""
+        if not self.job_id or not self.job_type:
+            raise ValueError("job_id and job_type must not be empty")
+        if self.revision < 0:
+            raise ValueError("revision must be non-negative")
+        if self.created_at.tzinfo is None or self.updated_at.tzinfo is None:
+            raise ValueError("job timestamps must be timezone-aware")
+        if self.scheduled_for is not None and self.scheduled_for.tzinfo is None:
+            raise ValueError("scheduled_for must be timezone-aware")
+        if self.status == JobStatus.SCHEDULED and self.scheduled_for is None:
+            raise ValueError("scheduled jobs require scheduled_for")
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must not precede created_at")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the lifecycle snapshot for persistence or transport."""
+        return {
+            "job_id": self.job_id,
+            "job_type": self.job_type,
+            "status": self.status.value,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "revision": self.revision,
+            "idempotency_key": self.idempotency_key,
+            "scheduled_for": (
+                self.scheduled_for.isoformat() if self.scheduled_for is not None else None
+            ),
+            "progress": {
+                "total": self.progress.total,
+                "completed": self.progress.completed,
+                "failed": self.progress.failed,
+                "skipped": self.progress.skipped,
+                "percent": self.progress.percent,
+            },
+            "transaction_id": self.transaction_id,
+            "recovery_action": self.recovery_action.value,
+            "result": self.result,
+            "error": self.error.to_dict() if self.error is not None else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> JobSnapshot:
+        """Restore a validated snapshot from persisted canonical state."""
+        progress = dict(data.get("progress", {}))
+        raw_error = data.get("error")
+        return cls(
+            job_id=str(data["job_id"]),
+            job_type=str(data["job_type"]),
+            status=JobStatus(data["status"]),
+            created_at=datetime.fromisoformat(str(data["created_at"])),
+            updated_at=datetime.fromisoformat(str(data["updated_at"])),
+            revision=int(data.get("revision", 0)),
+            idempotency_key=(
+                str(data["idempotency_key"]) if data.get("idempotency_key") is not None else None
+            ),
+            scheduled_for=(
+                datetime.fromisoformat(str(data["scheduled_for"]))
+                if data.get("scheduled_for") is not None
+                else None
+            ),
+            progress=JobProgress(
+                total=int(progress.get("total", 0)),
+                completed=int(progress.get("completed", 0)),
+                failed=int(progress.get("failed", 0)),
+                skipped=int(progress.get("skipped", 0)),
+            ),
+            transaction_id=(
+                str(data["transaction_id"]) if data.get("transaction_id") is not None else None
+            ),
+            recovery_action=RecoveryAction(data.get("recovery_action", "none")),
+            result=dict(data["result"]) if data.get("result") is not None else None,
+            error=DomainError.from_dict(dict(raw_error)) if raw_error is not None else None,
+        )
+
+
+def create_job_snapshot(
+    *,
+    job_id: str,
+    job_type: str,
+    now: datetime | None = None,
+    idempotency_key: str | None = None,
+    scheduled_for: datetime | None = None,
+) -> JobSnapshot:
+    """Create a queued or one-shot scheduled lifecycle snapshot."""
+    timestamp = now or datetime.now(UTC)
+    if scheduled_for is not None and scheduled_for.tzinfo is None:
+        raise ValueError("scheduled_for must be timezone-aware")
+    status = JobStatus.SCHEDULED if scheduled_for is not None else JobStatus.QUEUED
+    return JobSnapshot(
+        job_id=job_id,
+        job_type=job_type,
+        status=status,
+        created_at=timestamp,
+        updated_at=timestamp,
+        idempotency_key=idempotency_key,
+        scheduled_for=scheduled_for,
+    )
+
+
+def transition_job(
+    job: JobSnapshot,
+    target: JobStatus | str,
+    *,
+    now: datetime | None = None,
+    expected_revision: int | None = None,
+    progress: JobProgress | None = None,
+    transaction_id: str | None = None,
+    recovery_action: RecoveryAction | str | None = None,
+    result: dict[str, Any] | None = None,
+    error: DomainError | None = None,
+) -> JobSnapshot:
+    """Apply one legal compare-and-swap lifecycle transition."""
+    target_status = JobStatus(target)
+    if expected_revision is not None and expected_revision != job.revision:
+        raise DomainError(
+            DomainErrorCode.STALE_JOB_REVISION,
+            "Job state changed before this mutation could be applied.",
+            retryable=True,
+            details={"expected": expected_revision, "actual": job.revision},
+        )
+    if target_status == job.status:
+        raise DomainError(
+            DomainErrorCode.INVALID_JOB_TRANSITION,
+            f"Duplicate job transition to {target_status.value} is not allowed.",
+            details={"from": job.status.value, "to": target_status.value},
+        )
+    if target_status not in LEGAL_JOB_TRANSITIONS[job.status]:
+        raise DomainError(
+            DomainErrorCode.INVALID_JOB_TRANSITION,
+            f"Cannot transition job from {job.status.value} to {target_status.value}.",
+            details={"from": job.status.value, "to": target_status.value},
+        )
+    next_progress = progress or job.progress
+    if (
+        next_progress.completed < job.progress.completed
+        or next_progress.failed < job.progress.failed
+        or next_progress.skipped < job.progress.skipped
+    ):
+        raise DomainError(
+            DomainErrorCode.CONFLICT,
+            "Job progress cannot move backwards.",
+        )
+    next_recovery = (
+        RecoveryAction(recovery_action)
+        if recovery_action is not None
+        else _default_recovery_action(target_status)
+    )
+    return replace(
+        job,
+        status=target_status,
+        updated_at=now or datetime.now(UTC),
+        revision=job.revision + 1,
+        progress=next_progress,
+        transaction_id=transaction_id or job.transaction_id,
+        recovery_action=next_recovery,
+        result=result if result is not None else job.result,
+        error=error,
+    )
+
+
+def _default_recovery_action(status: JobStatus) -> RecoveryAction:
+    """Return the default recovery directive for a lifecycle state."""
+    if status in {JobStatus.PARTIAL, JobStatus.FAILED}:
+        return RecoveryAction.RETRY
+    if status == JobStatus.RECOVERY_REQUIRED:
+        return RecoveryAction.MANUAL
+    return RecoveryAction.NONE

--- a/src/file_organizer/core/organization_service.py
+++ b/src/file_organizer/core/organization_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from file_organizer.core import file_ops
+from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.organize_options import (
     OrganizeOptions,
     OrganizeRequest,
@@ -66,7 +67,11 @@ class OrganizationService:
     def scan(self, request: OrganizeRequest) -> OrganizationScan:
         """Collect exactly the files that preview and execution will consume."""
         if not request.input_path.exists():
-            raise ValueError(f"Input path does not exist: {request.input_path}")
+            raise DomainError(
+                DomainErrorCode.NOT_FOUND,
+                f"Input path does not exist: {request.input_path}",
+                details={"path": str(request.input_path)},
+            )
         files = tuple(
             file_ops.collect_files(
                 request.input_path,
@@ -109,13 +114,24 @@ class OrganizationService:
         if plan is None:
             preview = self.preview(request)
             if not isinstance(preview.plan, OrganizationPlan):
-                raise RuntimeError("Organization preview did not produce an executable plan.")
+                raise DomainError(
+                    DomainErrorCode.EXECUTION_FAILED,
+                    "Organization preview did not produce an executable plan.",
+                )
             plan = preview.plan
         if not plan.roots_match(request.input_path, request.output_path):
-            raise ValueError("Organization plan roots do not match request paths.")
+            raise DomainError(
+                DomainErrorCode.PLAN_MISMATCH,
+                "Organization plan roots do not match request paths.",
+                details={"plan_id": getattr(plan, "plan_id", "unknown")},
+            )
         resolved_options = self._resolve_options(request.options)
         if plan.options != resolved_options:
-            raise ValueError("Organization plan options do not match request options.")
+            raise DomainError(
+                DomainErrorCode.PLAN_MISMATCH,
+                "Organization plan options do not match request options.",
+                details={"plan_id": getattr(plan, "plan_id", "unknown")},
+            )
         return self._create_organizer(resolved_options, dry_run=False).execute_plan(plan)
 
     def _resolve_options(self, options: OrganizeOptions) -> OrganizeOptions:

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -667,6 +667,7 @@ class FileOrganizer:
             organized_structure=organized,
             errors=[*plan.errors, *errors],
             plan=plan,
+            transaction_id=transaction_id,
         )
         display.show_summary(self.console, result, Path(plan.output_path), dry_run=False)
         return result

--- a/src/file_organizer/core/types.py
+++ b/src/file_organizer/core/types.py
@@ -25,6 +25,7 @@ class OrganizationResult:
         processing_time: Total time taken in seconds
         organized_structure: Dictionary mapping folder names to file lists
         errors: List of (file_path, error_message) tuples
+        transaction_id: History transaction used for execution and recovery
 
     Invariant:
         processed_files + skipped_files + failed_files + deduplicated_files == total_files
@@ -39,6 +40,7 @@ class OrganizationResult:
     organized_structure: dict[str, list[str]] = field(default_factory=dict)
     errors: list[tuple[str, str]] = field(default_factory=list)  # (file, error)
     plan: OrganizationPlan | None = None
+    transaction_id: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/file_organizer/history/database.py
+++ b/src/file_organizer/history/database.py
@@ -11,7 +11,7 @@ import sqlite3
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from threading import Lock
+from threading import RLock
 from typing import cast
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,9 @@ class DatabaseManager:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._connection: sqlite3.Connection | None = None
-        self._lock = Lock()
+        # One re-entrant lock covers connection creation, cursor consumption,
+        # and commit/rollback boundaries for all threads sharing this manager.
+        self._lock = RLock()
         self._initialized = False
 
         logger.info(f"Database manager initialized with path: {self.db_path}")
@@ -158,14 +160,15 @@ class DatabaseManager:
         Returns:
             SQLite database connection
         """
-        if self._connection is None:
-            self._connection = sqlite3.connect(
-                str(self.db_path), check_same_thread=False, timeout=30.0
-            )
-            # Enable row factory for easier data access
-            self._connection.row_factory = sqlite3.Row
+        with self._lock:
+            if self._connection is None:
+                self._connection = sqlite3.connect(
+                    str(self.db_path), check_same_thread=False, timeout=30.0
+                )
+                # Enable row factory for easier data access
+                self._connection.row_factory = sqlite3.Row
 
-        return self._connection
+            return self._connection
 
     @contextmanager
     def transaction(self) -> Generator[sqlite3.Connection, None, None]:
@@ -225,8 +228,9 @@ class DatabaseManager:
         Returns:
             Single row result or None
         """
-        cursor = self.execute_query(query, params)
-        return cast("sqlite3.Row | None", cursor.fetchone())
+        with self._lock:
+            cursor = self.execute_query(query, params)
+            return cast("sqlite3.Row | None", cursor.fetchone())
 
     def fetch_all(self, query: str, params: tuple[object, ...] | None = None) -> list[sqlite3.Row]:
         """Execute query and fetch all results.
@@ -238,8 +242,9 @@ class DatabaseManager:
         Returns:
             List of row results
         """
-        cursor = self.execute_query(query, params)
-        return cursor.fetchall()
+        with self._lock:
+            cursor = self.execute_query(query, params)
+            return cursor.fetchall()
 
     def get_database_size(self) -> int:
         """Get current database file size in bytes.
@@ -263,19 +268,21 @@ class DatabaseManager:
     def vacuum(self) -> None:
         """Vacuum the database to reclaim space and optimize performance."""
         logger.info("Vacuuming database...")
-        conn = self.get_connection()
-        conn.execute("VACUUM")
+        with self._lock:
+            conn = self.get_connection()
+            conn.execute("VACUUM")
         logger.info("Database vacuum complete")
 
     def close(self) -> None:
         """Close database connection."""
-        if self._connection is not None:
-            try:
-                self._connection.close()
-                self._connection = None
-                logger.info("Database connection closed")
-            except Exception as e:
-                logger.error(f"Error closing database connection: {e}")
+        with self._lock:
+            if self._connection is not None:
+                try:
+                    self._connection.close()
+                    self._connection = None
+                    logger.info("Database connection closed")
+                except Exception:
+                    logger.exception("Error closing database connection")
 
     def __enter__(self) -> DatabaseManager:
         """Context manager entry."""

--- a/src/file_organizer/history/tracker.py
+++ b/src/file_organizer/history/tracker.py
@@ -158,8 +158,8 @@ class OperationHistory:
             metadata_json,
         )
 
-        self.db.execute_query(query, params)
-        self.db.get_connection().commit()
+        with self.db.transaction() as conn:
+            conn.execute(query, params)
 
         logger.info(f"Started transaction {transaction_id}")
         return transaction_id
@@ -188,8 +188,10 @@ class OperationHistory:
         )
 
         try:
-            self.db.execute_query(query, params)
-            self.db.get_connection().commit()
+            with self.db.transaction() as conn:
+                cursor = conn.execute(query, params)
+                if cursor.rowcount == 0:
+                    return False
             logger.info(f"Committed transaction {transaction_id}")
             return True
         except Exception as e:

--- a/src/file_organizer/undo/undo_manager.py
+++ b/src/file_organizer/undo/undo_manager.py
@@ -109,15 +109,15 @@ class UndoManager:
             # prior status; a re-undo then fails safely via validate_undo's
             # file-missing check. Full journal-backed crash recovery is WP-1.2b,
             # #1248.)
-            cursor = self.history.db.execute_query(
-                "UPDATE operations SET status = ? WHERE id = ? AND status != ?",
-                (
-                    OperationStatus.ROLLED_BACK.value,
-                    operation_id,
-                    OperationStatus.ROLLED_BACK.value,
-                ),
-            )
-            self.history.db.get_connection().commit()
+            with self.history.db.transaction() as conn:
+                cursor = conn.execute(
+                    "UPDATE operations SET status = ? WHERE id = ? AND status != ?",
+                    (
+                        OperationStatus.ROLLED_BACK.value,
+                        operation_id,
+                        OperationStatus.ROLLED_BACK.value,
+                    ),
+                )
             if cursor.rowcount == 0:
                 logger.warning(
                     "Operation %s was already rolled back concurrently; "
@@ -176,12 +176,12 @@ class UndoManager:
 
         if result.success:
             # Update all rolled-back operations to ROLLED_BACK status in DB
-            for operation in operations:
-                self.history.db.execute_query(
-                    "UPDATE operations SET status = ? WHERE id = ?",
-                    (OperationStatus.ROLLED_BACK.value, operation.id),
-                )
-            self.history.db.get_connection().commit()
+            with self.history.db.transaction() as conn:
+                for operation in operations:
+                    conn.execute(
+                        "UPDATE operations SET status = ? WHERE id = ?",
+                        (OperationStatus.ROLLED_BACK.value, operation.id),
+                    )
 
             logger.info(
                 f"Successfully undid transaction {transaction_id}: "
@@ -230,29 +230,29 @@ class UndoManager:
                 )
                 return False
 
-        # Execute redo in chronological (forward) order as a single DB transaction
-        conn = self.history.db.get_connection()
+        # Apply filesystem operations first. Persist their statuses together only
+        # after every operation succeeds, so other threads never observe a
+        # partially updated transaction.
         try:
             for operation in forward_ops:
                 success = self.executor.redo_operation(operation)
                 if success:
-                    self.history.db.execute_query(
-                        "UPDATE operations SET status = ? WHERE id = ?",
-                        (OperationStatus.COMPLETED.value, operation.id),
-                    )
                     logger.info(f"Successfully redid operation {operation.id}")
                 else:
                     logger.error(
                         f"Failed to redo operation {operation.id} in transaction {transaction_id}"
                     )
-                    conn.rollback()
                     return False
         except Exception:
             logger.exception(f"Unexpected error while redoing transaction {transaction_id}")
-            conn.rollback()
             return False
 
-        conn.commit()
+        with self.history.db.transaction() as conn:
+            for operation in forward_ops:
+                conn.execute(
+                    "UPDATE operations SET status = ? WHERE id = ?",
+                    (OperationStatus.COMPLETED.value, operation.id),
+                )
         logger.info(
             f"Successfully redid transaction {transaction_id}: {len(forward_ops)} operations"
         )
@@ -318,15 +318,15 @@ class UndoManager:
             # Transactional status flip (race B3): flip ROLLED_BACK → COMPLETED
             # only if it is still rolled back, via a single conditional UPDATE +
             # commit. rowcount == 0 means a concurrent redo already flipped it.
-            cursor = self.history.db.execute_query(
-                "UPDATE operations SET status = ? WHERE id = ? AND status = ?",
-                (
-                    OperationStatus.COMPLETED.value,
-                    operation_id,
-                    OperationStatus.ROLLED_BACK.value,
-                ),
-            )
-            self.history.db.get_connection().commit()
+            with self.history.db.transaction() as conn:
+                cursor = conn.execute(
+                    "UPDATE operations SET status = ? WHERE id = ? AND status = ?",
+                    (
+                        OperationStatus.COMPLETED.value,
+                        operation_id,
+                        OperationStatus.ROLLED_BACK.value,
+                    ),
+                )
             if cursor.rowcount == 0:
                 logger.warning(
                     "Operation %s was already redone concurrently; skipping duplicate status flip",

--- a/src/file_organizer/web/organize_routes.py
+++ b/src/file_organizer/web/organize_routes.py
@@ -24,6 +24,13 @@ from file_organizer.api.utils import resolve_path
 from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.config.methodology import LABELS as ORGANIZE_METHODOLOGIES
 from file_organizer.config.methodology import normalize as _normalize_methodology
+from file_organizer.core.errors import DomainError
+from file_organizer.core.lifecycle import (
+    TERMINAL_JOB_STATUSES,
+    JobProgress,
+    JobStatus,
+    RecoveryAction,
+)
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.plan import OrganizationPlan
 from file_organizer.core.types import OrganizationResult
@@ -133,11 +140,18 @@ def _get_job_metadata(job_id: str) -> dict[str, Any]:
 
 def _status_progress(status: str) -> int:
     """Map a job status string to an approximate progress percentage."""
-    if status == "queued":
+    if status in {"scheduled", "queued"}:
         return 5
-    if status == "running":
+    if status in {"running", "rolling_back"}:
         return 65
-    if status in {"completed", "failed"}:
+    if status in {
+        "completed",
+        "partial",
+        "failed",
+        "cancelled",
+        "recovery_required",
+        "rolled_back",
+    }:
         return 100
     return 0
 
@@ -155,8 +169,8 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
     metadata = _get_job_metadata(job_id)
     result = job.result or {}
     schedule_delay_minutes = int(metadata.get("schedule_delay_minutes", 0) or 0)
-    scheduled_for = str(metadata.get("scheduled_for", ""))
-    is_scheduled = job.status == "queued" and bool(scheduled_for) and schedule_delay_minutes > 0
+    scheduled_for = format_timestamp(job.scheduled_for) if job.scheduled_for is not None else ""
+    is_scheduled = job.status == JobStatus.SCHEDULED
     processed_files = int(result.get("processed_files", 0) or 0)
     total_files = int(result.get("total_files", 0) or 0)
     failed_files = int(result.get("failed_files", 0) or 0)
@@ -177,6 +191,9 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
         "created_at": format_timestamp(job.created_at),
         "updated_at": format_timestamp(job.updated_at),
         "error": job.error,
+        "error_code": job.error_code.value if job.error_code is not None else None,
+        "error_retryable": job.error_retryable,
+        "error_details": job.error_details,
         "processed_files": processed_files,
         "total_files": total_files,
         "failed_files": failed_files,
@@ -190,8 +207,15 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
         "schedule_delay_minutes": schedule_delay_minutes,
         "scheduled_for": scheduled_for,
         "can_cancel": is_scheduled,
-        "can_rollback": job.status == "completed" and not bool(metadata.get("dry_run", False)),
-        "is_terminal": job.status in {"completed", "failed"},
+        "transaction_id": job.transaction_id,
+        "recovery_action": job.recovery_action.value,
+        "revision": job.revision,
+        "can_rollback": (
+            job.status in {JobStatus.COMPLETED, JobStatus.PARTIAL}
+            and job.transaction_id is not None
+            and not bool(metadata.get("dry_run", False))
+        ),
+        "is_terminal": job.status in TERMINAL_JOB_STATUSES,
     }
 
 
@@ -226,7 +250,9 @@ def _build_organize_stats() -> dict[str, Any]:
     total_jobs = len(jobs)
     completed_jobs = sum(1 for job in jobs if job["status"] == "completed")
     failed_jobs = sum(1 for job in jobs if job["status"] == "failed")
-    active_jobs = sum(1 for job in jobs if job["status"] in {"queued", "running"})
+    active_jobs = sum(
+        1 for job in jobs if job["status"] in {"scheduled", "queued", "running", "rolling_back"}
+    )
     total_files = sum(int(job["processed_files"]) for job in jobs if job["status"] == "completed")
     success_rate = 0.0
     if total_jobs:
@@ -262,7 +288,16 @@ def _run_organize_job(job_id: str, organize_request: OrganizeRequest) -> None:
             skip_existing=organize_request.skip_existing,
         )
         response = _result_to_response(result).model_dump()
-        update_job(job_id, status="completed", result=response, error=None)
+        _complete_job_from_result(job_id, result, response)
+    except DomainError as exc:
+        update_job(
+            job_id,
+            status=JobStatus.FAILED,
+            error=exc.message,
+            error_code=exc.code,
+            error_retryable=exc.retryable,
+            error_details=exc.details,
+        )
     except Exception as exc:
         update_job(job_id, status="failed", error=str(exc))
 
@@ -292,7 +327,16 @@ def _run_organize_plan_job(job_id: str, plan_data: dict[str, Any], *, dry_run: b
             organizer = FileOrganizer(dry_run=False, use_hardlinks=plan.use_hardlinks)
             result = organizer.execute_plan(plan)
         response = _result_to_response(result).model_dump()
-        update_job(job_id, status="completed", result=response, error=None)
+        _complete_job_from_result(job_id, result, response)
+    except DomainError as exc:
+        update_job(
+            job_id,
+            status=JobStatus.FAILED,
+            error=exc.message,
+            error_code=exc.code,
+            error_retryable=exc.retryable,
+            error_details=exc.details,
+        )
     except Exception as exc:
         update_job(job_id, status="failed", error=str(exc))
 
@@ -359,8 +403,37 @@ def _cancel_scheduled_job(job_id: str) -> bool:
     if timer is None:
         return False
     timer.cancel()
-    update_job(job_id, status="failed", error="Cancelled before execution.")
+    update_job(
+        job_id,
+        status=JobStatus.CANCELLED,
+        error="Cancelled before execution.",
+        error_code="cancelled",
+    )
     return True
+
+
+def _complete_job_from_result(
+    job_id: str,
+    result: OrganizationResult,
+    response: dict[str, Any],
+) -> None:
+    """Record complete or partial execution with recovery metadata."""
+    progress = JobProgress(
+        total=result.total_files,
+        completed=result.processed_files,
+        failed=result.failed_files,
+        skipped=result.skipped_files + result.deduplicated_files,
+    )
+    status = JobStatus.PARTIAL if result.failed_files else JobStatus.COMPLETED
+    update_job(
+        job_id,
+        status=status,
+        result=response,
+        error=None,
+        progress=progress,
+        transaction_id=result.transaction_id,
+        recovery_action=(RecoveryAction.ROLLBACK if result.transaction_id else None),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -531,11 +604,13 @@ def organize_execute(
             run_in_background=True,
         )
 
-        job = create_job(ORGANIZE_JOB_TYPE)
+        scheduled_at_datetime: datetime | None = None
         scheduled_for = ""
         if delay_minutes > 0:
             scheduled_at = datetime.now(UTC).timestamp() + (delay_minutes * 60)
-            scheduled_for = format_timestamp(datetime.fromtimestamp(scheduled_at, tz=UTC))
+            scheduled_at_datetime = datetime.fromtimestamp(scheduled_at, tz=UTC)
+            scheduled_for = format_timestamp(scheduled_at_datetime)
+        job = create_job(ORGANIZE_JOB_TYPE, scheduled_for=scheduled_at_datetime)
         _set_job_metadata(
             job.job_id,
             {
@@ -809,15 +884,33 @@ def organize_job_rollback(request: Request, job_id: str) -> HTMLResponse:
         try:
             from file_organizer.undo.undo_manager import UndoManager
 
+            transaction_id = str(job["transaction_id"])
+            update_job(job_id, status=JobStatus.ROLLING_BACK)
             manager = UndoManager()
-            success = manager.undo_last_operation()
+            success = manager.undo_transaction(transaction_id)
+            update_job(
+                job_id,
+                status=(JobStatus.ROLLED_BACK if success else JobStatus.RECOVERY_REQUIRED),
+                error=(None if success else "Rollback did not complete."),
+                error_code=(None if success else "recovery_required"),
+                recovery_action=(RecoveryAction.NONE if success else RecoveryAction.MANUAL),
+            )
             rollback_message = (
-                "Rollback completed for the latest tracked operation."
+                "Rollback completed for this job's transaction."
                 if success
-                else "No rollback candidates were available."
+                else "Rollback requires manual recovery."
             )
         except Exception:
             logger.exception("Rollback execution failed for job {}", job_id)
+            current = get_job(job_id)
+            if current is not None and current.status == JobStatus.ROLLING_BACK:
+                update_job(
+                    job_id,
+                    status=JobStatus.RECOVERY_REQUIRED,
+                    error="Rollback failed.",
+                    error_code="recovery_required",
+                    recovery_action=RecoveryAction.MANUAL,
+                )
             error_message = "Rollback failed."
 
     refreshed_job = _build_job_view(job_id)

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -108,6 +108,7 @@ def _result_to_response(result: OrganizationResult) -> OrganizationResultRespons
         errors=[
             OrganizationError(file=file_name, error=error) for file_name, error in result.errors
         ],
+        transaction_id=result.transaction_id,
     )
 
 

--- a/tests/api/test_exceptions.py
+++ b/tests/api/test_exceptions.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
-from file_organizer.api.exceptions import ApiError
+from file_organizer.api.exceptions import ApiError, setup_exception_handlers
+from file_organizer.core.errors import optional_feature_unavailable
 
 
 class TestApiErrorInit:
@@ -85,3 +88,23 @@ class TestApiErrorRaiseCatch:
         assert isinstance(exc_info.value, ApiError)
         assert exc_info.value.status_code == 418
         assert exc_info.value.details == {"brew": "earl_grey"}
+
+
+def test_domain_error_handler_preserves_stable_contract() -> None:
+    app = FastAPI()
+    setup_exception_handlers(app)
+
+    @app.get("/optional")
+    def optional_route() -> None:
+        raise optional_feature_unavailable("transcription", "Install the audio extra.")
+
+    response = TestClient(app).get("/optional")
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": "optional_feature_unavailable",
+        "code": "optional_feature_unavailable",
+        "message": "Install the audio extra.",
+        "retryable": False,
+        "details": {"feature": "transcription"},
+    }

--- a/tests/api/test_job_repo.py
+++ b/tests/api/test_job_repo.py
@@ -61,6 +61,9 @@ class TestJobRepositoryGetById:
     def test_get_existing_job(self):
         session = MagicMock(spec=Session)
         job = MagicMock(spec=OrganizationJob)
+        job.status = "queued"
+        job.revision = 0
+        job.transaction_id = None
         session.get.return_value = job
 
         result = JobRepository.get_by_id(session, "job-1")
@@ -118,6 +121,9 @@ class TestJobRepositoryUpdateStatus:
     def test_update_status_existing_job(self):
         session = MagicMock(spec=Session)
         job = MagicMock(spec=OrganizationJob)
+        job.status = "queued"
+        job.revision = 0
+        job.transaction_id = None
         session.get.return_value = job
 
         result = JobRepository.update_status(session, "job-1", "running")
@@ -129,6 +135,9 @@ class TestJobRepositoryUpdateStatus:
     def test_update_status_with_error(self):
         session = MagicMock(spec=Session)
         job = MagicMock(spec=OrganizationJob)
+        job.status = "queued"
+        job.revision = 0
+        job.transaction_id = None
         session.get.return_value = job
 
         JobRepository.update_status(session, "job-1", "failed", error="OOM")

--- a/tests/api/test_job_repo.py
+++ b/tests/api/test_job_repo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from file_organizer.api.db_models import OrganizationJob
@@ -53,6 +54,29 @@ class TestJobRepositoryCreate:
         assert added.job_type == "dedupe"
         assert added.methodology == "para"
         assert added.dry_run is True
+
+    def test_concurrent_idempotency_conflict_returns_winner(self):
+        session = MagicMock(spec=Session)
+        winner = MagicMock(spec=OrganizationJob)
+        query = session.query.return_value
+        query.filter.return_value = query
+        query.one_or_none.side_effect = [None, winner]
+        session.flush.side_effect = IntegrityError(
+            "INSERT INTO organization_jobs",
+            {"idempotency_key": "request-1"},
+            Exception("unique constraint"),
+        )
+
+        result = JobRepository.create(
+            session,
+            "/input",
+            "/output",
+            idempotency_key="request-1",
+        )
+
+        assert result is winner
+        session.begin_nested.assert_called_once_with()
+        assert query.one_or_none.call_count == 2
 
 
 class TestJobRepositoryGetById:

--- a/tests/api/test_organize_router.py
+++ b/tests/api/test_organize_router.py
@@ -567,6 +567,18 @@ class TestGetJobStatus:
             "errors": [],
         }
         mock_job.error = None
+        mock_job.error_code = None
+        mock_job.error_retryable = False
+        mock_job.error_details = None
+        mock_job.revision = 1
+        mock_job.scheduled_for = None
+        mock_job.progress.total = 5
+        mock_job.progress.completed = 5
+        mock_job.progress.failed = 0
+        mock_job.progress.skipped = 0
+        mock_job.progress.percent = 100.0
+        mock_job.transaction_id = "txn-1"
+        mock_job.recovery_action = "none"
         mock_get_job.return_value = mock_job
         _, client, _ = _build_app(tmp_path)
 
@@ -596,6 +608,18 @@ class TestGetJobStatus:
         mock_job.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
         mock_job.result = None
         mock_job.error = None
+        mock_job.error_code = None
+        mock_job.error_retryable = False
+        mock_job.error_details = None
+        mock_job.revision = 1
+        mock_job.scheduled_for = None
+        mock_job.progress.total = 5
+        mock_job.progress.completed = 2
+        mock_job.progress.failed = 0
+        mock_job.progress.skipped = 0
+        mock_job.progress.percent = 40.0
+        mock_job.transaction_id = None
+        mock_job.recovery_action = "none"
         mock_get_job.return_value = mock_job
         _, client, _ = _build_app(tmp_path)
 
@@ -615,6 +639,18 @@ class TestGetJobStatus:
         mock_job.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
         mock_job.result = None
         mock_job.error = "Something went wrong"
+        mock_job.error_code.value = "execution_failed"
+        mock_job.error_retryable = True
+        mock_job.error_details = {"phase": "execution"}
+        mock_job.revision = 2
+        mock_job.scheduled_for = None
+        mock_job.progress.total = 1
+        mock_job.progress.completed = 0
+        mock_job.progress.failed = 1
+        mock_job.progress.skipped = 0
+        mock_job.progress.percent = 100.0
+        mock_job.transaction_id = None
+        mock_job.recovery_action = "retry"
         mock_get_job.return_value = mock_job
         _, client, _ = _build_app(tmp_path)
 

--- a/tests/client/test_client_models.py
+++ b/tests/client/test_client_models.py
@@ -396,6 +396,26 @@ class TestJobStatusResponse:
         assert resp.result is not None
         assert resp.error == "partial failure"
 
+    def test_canonical_recovery_fields(self):
+        resp = JobStatusResponse(
+            job_id="j-3",
+            status="recovery_required",
+            created_at=_NOW_STR,
+            updated_at=_NOW_STR,
+            error_code="recovery_required",
+            error_retryable=False,
+            error_details={"transaction_id": "txn-3"},
+            revision=4,
+            progress={"total": 2, "completed": 1, "failed": 1, "skipped": 0},
+            transaction_id="txn-3",
+            recovery_action="manual",
+        )
+        assert resp.status == "recovery_required"
+        assert resp.revision == 4
+        assert resp.transaction_id == "txn-3"
+        assert resp.recovery_action == "manual"
+        assert resp.error_details == {"transaction_id": "txn-3"}
+
 
 # ===================================================================
 # TokenResponse

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from file_organizer.core import dispatcher
+from file_organizer.core.errors import DomainError
 from file_organizer.core.organization_service import OrganizationService
 from file_organizer.core.organize_options import OrganizeRequest
 from file_organizer.core.organizer import FileOrganizer
@@ -222,7 +223,7 @@ class DirectServiceDriver:
         roots = (request.input_path, request.output_path)
         try:
             scan = self._service.scan(request)
-        except (ValueError, RuntimeError, OSError) as exc:
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
             return {"outcome": "error", "error": normalize_error(exc, *roots)}
         return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
 
@@ -231,7 +232,7 @@ class DirectServiceDriver:
         roots = (request.input_path, request.output_path)
         try:
             result = self._service.preview(request)
-        except (ValueError, RuntimeError, OSError) as exc:
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
             return {"outcome": "error", "error": normalize_error(exc, *roots)}
         if not isinstance(result.plan, OrganizationPlan):
             raise AssertionError("Canonical preview must produce an executable plan.")
@@ -250,7 +251,7 @@ class DirectServiceDriver:
         try:
             plan = OrganizationPlan.from_dict(plan_payload) if plan_payload is not None else None
             result = self._service.execute(request, plan)
-        except (ValueError, RuntimeError, OSError) as exc:
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
             return {"outcome": "error", "error": normalize_error(exc, *roots)}
         if not isinstance(result.plan, OrganizationPlan):
             raise AssertionError("Canonical execution must retain its executable plan.")

--- a/tests/conformance/normalize.py
+++ b/tests/conformance/normalize.py
@@ -13,6 +13,7 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.errors import DomainError
 from file_organizer.core.organization_service import OrganizationScan
 from file_organizer.core.plan import (
     OrganizationOperation,
@@ -27,7 +28,7 @@ INPUT_ROOT_TOKEN = "<input>"
 OUTPUT_ROOT_TOKEN = "<output>"
 EXTERNAL_TOKEN = "<external>"
 
-#: Job-event keys treated as volatile until #1604 finalizes job semantics.
+#: Volatile job-event keys excluded from cross-surface comparisons.
 VOLATILE_JOB_KEYS = frozenset({"job_id", "timestamp", "created_at", "updated_at", "duration"})
 
 
@@ -176,10 +177,23 @@ def normalize_result(
 
 def normalize_error(exc: BaseException, input_root: Path, output_root: Path) -> dict[str, Any]:
     """Normalize a raised error into a surface-neutral envelope payload."""
-    normalized: dict[str, Any] = {
-        "error_type": type(exc).__name__,
-        "message": redact_roots(str(exc), input_root, output_root),
-    }
+    if isinstance(exc, DomainError):
+        normalized: dict[str, Any] = {
+            "code": exc.code.value,
+            "message": redact_roots(exc.message, input_root, output_root),
+            "retryable": exc.retryable,
+            "details": {
+                key: redact_roots(value, input_root, output_root)
+                if isinstance(value, str)
+                else value
+                for key, value in exc.details.items()
+            },
+        }
+    else:
+        normalized = {
+            "error_type": type(exc).__name__,
+            "message": redact_roots(str(exc), input_root, output_root),
+        }
     if isinstance(exc, PlanValidationError):
         normalized["conflicts"] = sorted(
             (
@@ -224,13 +238,7 @@ def normalize_audit_events(
 
 
 def normalize_job_events(events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    """Normalize job lifecycle events (provisional until #1604 lands).
-
-    Drops volatile identifiers/timestamps and preserves ordering, which is the
-    part of the lifecycle contract already observable today.  #1604 replaces
-    this with the canonical job/recovery event schema; keeping the seam here
-    lets adapter drivers adopt it without changing the oracle.
-    """
+    """Normalize canonical lifecycle events while preserving transition order."""
     return [
         {key: value for key, value in sorted(event.items()) if key not in VOLATILE_JOB_KEYS}
         for event in events

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -519,7 +519,8 @@ def test_plan_roots_mismatch_rejected(conformance: ConformanceContext, tmp_path:
     )
 
     assert envelope["outcome"] == "error"
-    assert envelope["error"]["error_type"] == "ValueError"
+    assert envelope["error"]["code"] == "plan_mismatch"
+    assert envelope["error"]["retryable"] is False
     assert "roots do not match" in envelope["error"]["message"]
 
 
@@ -533,7 +534,8 @@ def test_plan_options_mismatch_rejected(conformance: ConformanceContext) -> None
     )
 
     assert envelope["outcome"] == "error"
-    assert envelope["error"]["error_type"] == "ValueError"
+    assert envelope["error"]["code"] == "plan_mismatch"
+    assert envelope["error"]["retryable"] is False
     assert "options do not match" in envelope["error"]["message"]
 
 
@@ -561,7 +563,8 @@ def test_missing_input_is_rejected(conformance: ConformanceContext) -> None:
     envelope = conformance.driver.scan(conformance.request())
 
     assert envelope["outcome"] == "error"
-    assert envelope["error"]["error_type"] == "ValueError"
+    assert envelope["error"]["code"] == "not_found"
+    assert envelope["error"]["retryable"] is False
     assert envelope["error"]["message"] == "Input path does not exist: <input>"
 
 
@@ -610,25 +613,27 @@ def test_methodology_seed_golden(
 
 
 def test_job_event_normalization_is_stable() -> None:
-    """Provisional job-event contract: order preserved, volatile keys dropped.
-
-    #1604 replaces this with the canonical job/recovery lifecycle schema.
-    """
+    """Canonical job-event order and recovery fields survive normalization."""
     events = [
         {"state": "queued", "job_id": "abc", "timestamp": "2026-01-01T00:00:00Z"},
-        {"state": "running", "job_id": "abc", "duration": 1.5},
+        {"state": "running", "job_id": "abc", "duration": 1.5, "revision": 1},
         {
             "state": "completed",
             "job_id": "abc",
             "created_at": "x",
             "capability": "organize",
+            "recovery_action": "rollback",
         },
     ]
 
     assert normalize_job_events(events) == [
         {"state": "queued"},
-        {"state": "running"},
-        {"capability": "organize", "state": "completed"},
+        {"revision": 1, "state": "running"},
+        {
+            "capability": "organize",
+            "recovery_action": "rollback",
+            "state": "completed",
+        },
     ]
 
 

--- a/tests/core/test_lifecycle.py
+++ b/tests/core/test_lifecycle.py
@@ -1,0 +1,166 @@
+"""Tests for canonical errors and organization job lifecycle semantics."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from file_organizer.api import jobs as api_jobs
+from file_organizer.core.errors import (
+    DomainError,
+    DomainErrorCode,
+    optional_feature_unavailable,
+)
+from file_organizer.core.lifecycle import (
+    JobProgress,
+    JobSnapshot,
+    JobStatus,
+    RecoveryAction,
+    create_job_snapshot,
+    transition_job,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def _now() -> datetime:
+    return datetime(2026, 7, 21, 12, tzinfo=UTC)
+
+
+def test_scheduled_partial_recovery_lifecycle_round_trips() -> None:
+    scheduled_for = _now() + timedelta(hours=1)
+    scheduled = create_job_snapshot(
+        job_id="job-1",
+        job_type="organize",
+        now=_now(),
+        scheduled_for=scheduled_for,
+    )
+    running = transition_job(scheduled, JobStatus.RUNNING, now=scheduled_for)
+    partial = transition_job(
+        running,
+        JobStatus.PARTIAL,
+        now=scheduled_for + timedelta(minutes=1),
+        progress=JobProgress(total=2, completed=1, failed=1),
+        transaction_id="txn-1",
+        recovery_action=RecoveryAction.ROLLBACK,
+        result={"processed_files": 1, "failed_files": 1},
+    )
+    rolling_back = transition_job(partial, JobStatus.ROLLING_BACK)
+    rolled_back = transition_job(rolling_back, JobStatus.ROLLED_BACK)
+
+    assert rolled_back.revision == 4
+    assert rolled_back.transaction_id == "txn-1"
+    assert rolled_back.progress.percent == 100.0
+    assert JobSnapshot.from_dict(rolled_back.to_dict()) == rolled_back
+
+
+def test_duplicate_and_illegal_transitions_have_stable_errors() -> None:
+    queued = create_job_snapshot(job_id="job-1", job_type="organize", now=_now())
+
+    with pytest.raises(DomainError) as duplicate:
+        transition_job(queued, JobStatus.QUEUED)
+    assert duplicate.value.code == DomainErrorCode.INVALID_JOB_TRANSITION
+
+    completed = transition_job(queued, JobStatus.COMPLETED)
+    with pytest.raises(DomainError) as illegal:
+        transition_job(completed, JobStatus.RUNNING)
+    assert illegal.value.to_dict() == {
+        "code": "invalid_job_transition",
+        "message": "Cannot transition job from completed to running.",
+        "retryable": False,
+        "details": {"from": "completed", "to": "running"},
+    }
+
+
+def test_stale_revision_and_progress_regression_are_rejected() -> None:
+    queued = create_job_snapshot(job_id="job-1", job_type="organize", now=_now())
+    running = transition_job(
+        queued,
+        JobStatus.RUNNING,
+        progress=JobProgress(total=2, completed=1),
+    )
+
+    with pytest.raises(DomainError) as stale:
+        transition_job(running, JobStatus.COMPLETED, expected_revision=0)
+    assert stale.value.code == DomainErrorCode.STALE_JOB_REVISION
+    assert stale.value.retryable is True
+
+    with pytest.raises(DomainError, match="cannot move backwards"):
+        transition_job(
+            running,
+            JobStatus.COMPLETED,
+            progress=JobProgress(total=2, completed=0),
+        )
+
+
+def test_optional_feature_error_is_transport_neutral() -> None:
+    error = optional_feature_unavailable("transcription", "Install the audio extra.")
+
+    assert DomainError.from_dict(error.to_dict()).to_dict() == {
+        "code": "optional_feature_unavailable",
+        "message": "Install the audio extra.",
+        "retryable": False,
+        "details": {"feature": "transcription"},
+    }
+
+
+def test_api_job_idempotency_is_safe_under_concurrent_creation() -> None:
+    with api_jobs._JOB_STORE_LOCK:
+        api_jobs._JOB_STORE.clear()
+        api_jobs._IDEMPOTENCY_INDEX.clear()
+
+    def create() -> str:
+        return api_jobs.create_job("organize", idempotency_key="request-1").job_id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        job_ids = list(executor.map(lambda _: create(), range(32)))
+
+    assert len(set(job_ids)) == 1
+    assert len(api_jobs.list_jobs(job_type="organize")) == 1
+
+
+def test_api_job_compare_and_swap_rejects_lost_update() -> None:
+    with api_jobs._JOB_STORE_LOCK:
+        api_jobs._JOB_STORE.clear()
+        api_jobs._IDEMPOTENCY_INDEX.clear()
+    job = api_jobs.create_job("organize")
+    running = api_jobs.update_job(
+        job.job_id,
+        status=JobStatus.RUNNING,
+        expected_revision=job.revision,
+    )
+
+    assert running is not None
+    with pytest.raises(DomainError) as stale:
+        api_jobs.update_job(
+            job.job_id,
+            status=JobStatus.FAILED,
+            error="late failure",
+            expected_revision=job.revision,
+        )
+    assert stale.value.code == DomainErrorCode.STALE_JOB_REVISION
+
+
+def test_api_job_preserves_domain_error_evidence() -> None:
+    with api_jobs._JOB_STORE_LOCK:
+        api_jobs._JOB_STORE.clear()
+        api_jobs._IDEMPOTENCY_INDEX.clear()
+    job = api_jobs.create_job("organize")
+
+    failed = api_jobs.update_job(
+        job.job_id,
+        status=JobStatus.FAILED,
+        error="Install the audio extra.",
+        error_code=DomainErrorCode.OPTIONAL_FEATURE_UNAVAILABLE,
+        error_retryable=False,
+        error_details={"feature": "transcription"},
+    )
+
+    assert failed is not None
+    assert failed.to_snapshot().error is not None
+    assert failed.to_snapshot().error.to_dict() == {
+        "code": "optional_feature_unavailable",
+        "message": "Install the audio extra.",
+        "retryable": False,
+        "details": {"feature": "transcription"},
+    }

--- a/tests/core/test_lifecycle.py
+++ b/tests/core/test_lifecycle.py
@@ -54,6 +54,25 @@ def test_scheduled_partial_recovery_lifecycle_round_trips() -> None:
     assert JobSnapshot.from_dict(rolled_back.to_dict()) == rolled_back
 
 
+def test_rollback_preserves_original_failure_evidence() -> None:
+    queued = create_job_snapshot(job_id="job-1", job_type="organize", now=_now())
+    running = transition_job(queued, JobStatus.RUNNING)
+    failure = DomainError(
+        DomainErrorCode.EXECUTION_FAILED,
+        "Destination write failed.",
+        details={"path": "/output/report.txt"},
+    )
+    failed = transition_job(running, JobStatus.FAILED, error=failure)
+
+    rolling_back = transition_job(failed, JobStatus.ROLLING_BACK)
+    rolled_back = transition_job(rolling_back, JobStatus.ROLLED_BACK)
+
+    assert rolling_back.error is failure
+    assert rolled_back.error is failure
+    assert rolled_back.error.to_dict()["details"] == {"path": "/output/report.txt"}
+    assert transition_job(failed, JobStatus.QUEUED).error is None
+
+
 def test_duplicate_and_illegal_transitions_have_stable_errors() -> None:
     queued = create_job_snapshot(job_id="job-1", job_type="organize", now=_now())
 

--- a/tests/core/test_organization_service.py
+++ b/tests/core/test_organization_service.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.organization_service import OrganizationService
 from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from file_organizer.core.organizer import FileOrganizer
@@ -114,8 +115,9 @@ def test_scan_excludes_direct_hidden_file_unless_requested(tmp_path: Path) -> No
 
 
 def test_scan_rejects_missing_input(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="Input path does not exist"):
+    with pytest.raises(DomainError, match="Input path does not exist") as exc_info:
         _service().scan(OrganizeRequest(tmp_path / "missing", tmp_path / "out"))
+    assert exc_info.value.code == DomainErrorCode.NOT_FOUND
 
 
 def test_preview_persists_resolved_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -191,8 +193,9 @@ def test_execute_rejects_plan_from_different_options(tmp_path: Path) -> None:
     plan.roots_match.return_value = True
     plan.options = OrganizeOptions(use_hardlinks=True)
 
-    with pytest.raises(ValueError, match="options do not match"):
+    with pytest.raises(DomainError, match="options do not match") as exc_info:
         service.execute(request, plan)
+    assert exc_info.value.code == DomainErrorCode.PLAN_MISMATCH
 
 
 def test_execute_applies_reviewed_plan_with_resolved_options(tmp_path: Path) -> None:
@@ -240,15 +243,17 @@ def test_execute_rejects_missing_preview_plan(tmp_path: Path) -> None:
     service = _service(organizer_factory=MagicMock(return_value=organizer))
     request = OrganizeRequest(tmp_path, tmp_path / "out")
 
-    with pytest.raises(RuntimeError, match="did not produce an executable plan"):
+    with pytest.raises(DomainError, match="did not produce an executable plan") as exc_info:
         service.execute(request)
+    assert exc_info.value.code == DomainErrorCode.EXECUTION_FAILED
 
 
 def test_execute_rejects_plan_from_different_roots(tmp_path: Path) -> None:
     plan = _empty_plan(tmp_path, _resolved_options())
 
-    with pytest.raises(ValueError, match="roots do not match"):
+    with pytest.raises(DomainError, match="roots do not match") as exc_info:
         _service().execute(OrganizeRequest(tmp_path / "other", tmp_path / "out"), plan)
+    assert exc_info.value.code == DomainErrorCode.PLAN_MISMATCH
 
 
 def test_service_resolves_missing_model_dependencies() -> None:

--- a/tests/history/test_concurrent_history.py
+++ b/tests/history/test_concurrent_history.py
@@ -1,0 +1,39 @@
+"""Concurrency contracts for shared history persistence."""
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from file_organizer.history.models import OperationType, TransactionStatus
+from file_organizer.history.tracker import OperationHistory
+
+pytestmark = [pytest.mark.integration, pytest.mark.ci]
+
+
+def test_shared_history_serializes_transaction_mutations(tmp_path: Path) -> None:
+    history = OperationHistory(tmp_path / "history.db")
+    source = tmp_path / "source.txt"
+    source.write_text("content")
+
+    def record(index: int) -> str:
+        transaction_id = history.start_transaction({"worker": index})
+        history.log_operation(
+            OperationType.COPY,
+            source,
+            tmp_path / f"destination-{index}.txt",
+            transaction_id=transaction_id,
+        )
+        assert history.commit_transaction(transaction_id)
+        return transaction_id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        transaction_ids = list(executor.map(record, range(32)))
+
+    assert len(set(transaction_ids)) == 32
+    assert history.db.get_operation_count() == 32
+    for transaction_id in transaction_ids:
+        transaction = history.get_transaction(transaction_id)
+        assert transaction is not None
+        assert transaction.status == TransactionStatus.COMPLETED
+        assert transaction.operation_count == 1

--- a/tests/integration/test_executable_plan_review_regressions.py
+++ b/tests/integration/test_executable_plan_review_regressions.py
@@ -165,6 +165,7 @@ def test_api_preview_plan_executes_round_trip(tmp_path: Path) -> None:
             organized_structure=plan.organized_structure(),
             errors=[],
             plan=plan,
+            transaction_id=None,
         )
         organizer.execute_plan.return_value = organizer.organize.return_value
 

--- a/tests/integration/test_history_branches.py
+++ b/tests/integration/test_history_branches.py
@@ -237,13 +237,13 @@ class TestOperationHistoryBranches:
         assert op_id > 0
 
     def test_commit_transaction_failure_returns_false(self, tmp_path: Path) -> None:
-        """commit_transaction returns False when db.execute_query raises (lines 195-197)."""
+        """commit_transaction returns False when the DB transaction fails."""
         from file_organizer.history.tracker import OperationHistory
 
         tracker = OperationHistory(tmp_path / "h3.db")
         txn_id = tracker.start_transaction()
 
-        with patch.object(tracker.db, "execute_query", side_effect=Exception("write error")):
+        with patch.object(tracker.db, "transaction", side_effect=Exception("write error")):
             result = tracker.commit_transaction(txn_id)
 
         assert result is False

--- a/tests/integration/test_job_repo_integration.py
+++ b/tests/integration/test_job_repo_integration.py
@@ -12,6 +12,7 @@ from sqlalchemy.pool import StaticPool
 import file_organizer.api.db_models  # noqa: F401 — registers models with Base
 from file_organizer.api.auth_models import Base
 from file_organizer.api.repositories.job_repo import JobRepository
+from file_organizer.core.errors import DomainError, DomainErrorCode
 
 pytestmark = [pytest.mark.integration, pytest.mark.ci]
 
@@ -65,6 +66,23 @@ class TestJobRepositoryCreate:
         j2 = JobRepository.create(db_session, "/c", "/d")
         db_session.flush()
         assert j1.id != j2.id
+
+    def test_idempotency_key_returns_existing_job(self, db_session: Session) -> None:
+        first = JobRepository.create(
+            db_session,
+            "/a",
+            "/b",
+            idempotency_key="request-1",
+        )
+        second = JobRepository.create(
+            db_session,
+            "/different",
+            "/different-output",
+            idempotency_key="request-1",
+        )
+
+        assert second.id == first.id
+        assert second.input_dir == "/a"
 
 
 class TestJobRepositoryGetById:
@@ -130,15 +148,52 @@ class TestJobRepositoryUpdateStatus:
     def test_sets_error_on_failure(self, db_session: Session) -> None:
         job = JobRepository.create(db_session, "/in", "/out")
         db_session.flush()
-        updated = JobRepository.update_status(db_session, job.id, "failed", error="disk full")
+        updated = JobRepository.update_status(
+            db_session,
+            job.id,
+            "failed",
+            error="disk full",
+            error_code="execution_failed",
+            error_retryable=True,
+            error_details={"device": "output"},
+        )
         db_session.flush()
         assert updated is not None
         assert updated.status == "failed"
         assert updated.error == "disk full"
+        assert updated.error_code == "execution_failed"
+        assert updated.error_retryable is True
+        assert updated.error_details_json == '{"device": "output"}'
 
     def test_returns_none_for_unknown_id(self, db_session: Session) -> None:
         result = JobRepository.update_status(db_session, "ghost-id", "running")
         assert result is None
+
+    def test_stale_session_cannot_overwrite_newer_revision(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        with Session(engine) as setup:
+            job = JobRepository.create(setup, "/in", "/out")
+            setup.commit()
+            job_id = job.id
+
+        with Session(engine) as winner, Session(engine) as stale:
+            winner_job = JobRepository.get_by_id(winner, job_id)
+            stale_job = JobRepository.get_by_id(stale, job_id)
+            assert winner_job is not None and stale_job is not None
+
+            JobRepository.update_status(winner, job_id, "running")
+            winner.commit()
+
+            with pytest.raises(DomainError) as exc_info:
+                JobRepository.update_status(stale, job_id, "failed")
+
+        assert exc_info.value.code == DomainErrorCode.STALE_JOB_REVISION
+        Base.metadata.drop_all(engine)
 
 
 class TestJobRepositoryUpdateResult:

--- a/tests/integration/test_web_organize_routes_extended.py
+++ b/tests/integration/test_web_organize_routes_extended.py
@@ -34,6 +34,7 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_settings
 from file_organizer.api.exceptions import ApiError, setup_exception_handlers
 from file_organizer.api.test_utils import csrf_headers, seed_csrf_token
+from file_organizer.core.lifecycle import JobStatus, RecoveryAction
 from file_organizer.core.plan import OrganizationPlan, build_plan_from_processed
 from file_organizer.core.types import OrganizationResult
 from file_organizer.services.text_processor import ProcessedFile
@@ -77,8 +78,15 @@ def _mock_job(
         "organized_structure": {"docs": ["a.txt"], "images": ["b.jpg"]},
     }
     job.error = None
+    job.error_code = None
+    job.error_retryable = False
+    job.error_details = {}
     job.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     job.updated_at = datetime(2026, 1, 1, 0, 1, tzinfo=UTC)
+    job.scheduled_for = None
+    job.transaction_id = "txn-1" if status in {"completed", "partial"} else None
+    job.recovery_action = RecoveryAction.NONE
+    job.revision = 0
     return job
 
 
@@ -462,7 +470,8 @@ class TestBuildJobView:
         assert view["progress_percent"] == 65
 
     def test_scheduled_job_can_cancel(self) -> None:
-        mock = _mock_job("j3", status="queued")
+        mock = _mock_job("j3", status=JobStatus.SCHEDULED)
+        mock.scheduled_for = datetime(2026, 1, 1, 1, tzinfo=UTC)
         with patch("file_organizer.web.organize_routes.get_job", return_value=mock):
             _set_job_metadata(
                 "j3", {"schedule_delay_minutes": 30, "scheduled_for": "2026-01-01T01:00:00"}

--- a/tests/web/test_organize_routes.py
+++ b/tests/web/test_organize_routes.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from file_organizer.api.exceptions import ApiError
+from file_organizer.core.lifecycle import RecoveryAction
 from file_organizer.web.organize_routes import (
     ORGANIZE_MAX_DELAY_MIN,
     ORGANIZE_METHODOLOGIES,
@@ -527,6 +528,10 @@ class TestBuildJobView:
         mock_job.created_at = datetime(2025, 1, 1, tzinfo=UTC)
         mock_job.updated_at = datetime(2025, 1, 2, tzinfo=UTC)
         mock_job.error = None
+        mock_job.scheduled_for = None
+        mock_job.transaction_id = "txn-1"
+        mock_job.recovery_action = RecoveryAction.ROLLBACK
+        mock_job.revision = 1
 
         with (
             patch("file_organizer.web.organize_routes.get_job", return_value=mock_job),
@@ -566,6 +571,10 @@ class TestBuildJobView:
         mock_job.created_at = datetime(2025, 1, 1, tzinfo=UTC)
         mock_job.updated_at = datetime(2025, 1, 2, tzinfo=UTC)
         mock_job.error = None
+        mock_job.scheduled_for = None
+        mock_job.transaction_id = None
+        mock_job.recovery_action = RecoveryAction.NONE
+        mock_job.revision = 1
 
         with (
             patch("file_organizer.web.organize_routes.get_job", return_value=mock_job),
@@ -584,11 +593,15 @@ class TestBuildJobView:
 
         mock_job = MagicMock()
         mock_job.job_id = "job-3"
-        mock_job.status = "queued"
+        mock_job.status = "scheduled"
         mock_job.result = None
         mock_job.created_at = datetime(2025, 1, 1, tzinfo=UTC)
         mock_job.updated_at = datetime(2025, 1, 2, tzinfo=UTC)
         mock_job.error = None
+        mock_job.scheduled_for = datetime(2025, 1, 1, 1, tzinfo=UTC)
+        mock_job.transaction_id = None
+        mock_job.recovery_action = RecoveryAction.NONE
+        mock_job.revision = 0
 
         with (
             patch("file_organizer.web.organize_routes.get_job", return_value=mock_job),
@@ -721,11 +734,12 @@ class TestCancelScheduledJob:
         mock_timer = MagicMock(spec=Timer)
         _SCHEDULED_TIMERS["cancel-test"] = mock_timer
 
-        with patch("file_organizer.web.organize_routes.update_job"):
+        with patch("file_organizer.web.organize_routes.update_job") as update:
             result = _cancel_scheduled_job("cancel-test")
 
         assert result is True
         mock_timer.cancel.assert_called_once()
+        assert update.call_args.kwargs["status"] == "cancelled"
         assert "cancel-test" not in _SCHEDULED_TIMERS
 
     def test_cancel_nonexistent_timer(self):

--- a/tests/web/test_organize_routes_coverage.py
+++ b/tests/web/test_organize_routes_coverage.py
@@ -396,15 +396,17 @@ class TestOrganizeJobRollbackRoute:
             "job_id": "j1",
             "status": "completed",
             "can_rollback": True,
+            "transaction_id": "txn-1",
         }
         request = MagicMock()
         mock_manager = MagicMock()
-        mock_manager.undo_last_operation.return_value = True
+        mock_manager.undo_transaction.return_value = True
         with (
             patch("file_organizer.web.organize_routes._build_job_view", return_value=job_view),
             patch("file_organizer.undo.undo_manager.UndoManager", return_value=mock_manager),
         ):
             organize_job_rollback(request, "j1")
+        mock_manager.undo_transaction.assert_called_once_with("txn-1")
         mock_templates.TemplateResponse.assert_called_once()
 
     def test_rollback_exception(self, mock_templates) -> None:
@@ -414,6 +416,7 @@ class TestOrganizeJobRollbackRoute:
             "job_id": "j1",
             "status": "completed",
             "can_rollback": True,
+            "transaction_id": "txn-1",
         }
         request = MagicMock()
         with (

--- a/tests/web/test_organize_routes_http.py
+++ b/tests/web/test_organize_routes_http.py
@@ -18,6 +18,7 @@ from starlette.testclient import TestClient
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
+from file_organizer.core.lifecycle import RecoveryAction
 from file_organizer.web.organize_routes import organize_router
 
 pytestmark = [pytest.mark.unit]
@@ -76,6 +77,13 @@ def _mock_job(
     job.created_at = datetime(2025, 6, 1, tzinfo=UTC)
     job.updated_at = datetime(2025, 6, 1, 0, 5, tzinfo=UTC)
     job.error = error
+    job.error_code = None
+    job.error_retryable = False
+    job.error_details = None
+    job.scheduled_for = None
+    job.transaction_id = "txn-1" if status == "completed" else None
+    job.recovery_action = RecoveryAction.NONE
+    job.revision = 0
     return job
 
 
@@ -351,12 +359,13 @@ class TestOrganizeJobRollback:
             ),
             patch("file_organizer.undo.undo_manager.UndoManager") as mock_undo_cls,
         ):
-            mock_undo_cls.return_value.undo_last_operation.return_value = True
+            mock_undo_cls.return_value.undo_transaction.return_value = True
             mock_tpl.TemplateResponse.return_value = HTMLResponse("<div>rolled back</div>")
             response = client.post("/ui/organize/jobs/test-job-1/rollback")
         assert response.status_code == 200
         trigger = json.loads(response.headers["HX-Trigger"])
         assert trigger == {"refreshHistory": True, "refreshStats": True}
+        mock_undo_cls.return_value.undo_transaction.assert_called_once_with("txn-1")
 
     def test_rollback_not_found(self, client):
         with patch(

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -36,6 +36,7 @@ def _preview_result(structure: dict[str, list[str]]) -> MagicMock:
     result.processing_time = 0.01
     result.organized_structure = structure
     result.errors = []
+    result.transaction_id = None
     return result
 
 


### PR DESCRIPTION
## Summary

- add transport-neutral domain errors and a canonical job lifecycle state machine
- unify scheduling, cancellation, progress, idempotency, recovery, and transaction-specific rollback semantics across direct, REST, SDK, and Web surfaces
- harden in-memory, SQL, and history persistence with immutable snapshots, revisions, optimistic locking, and atomic history status changes
- persist structured error evidence and lifecycle metadata, including an Alembic migration
- document the canonical lifecycle, scheduling ownership, daemon/watcher boundary, and recovery behavior

## User-visible behavior

Scheduled work now has an explicit `scheduled` state and pre-start cancellation ends as `cancelled`, not `failed`. Partial work records its exact history transaction and Web rollback targets that transaction instead of the globally latest operation. REST and SDK job payloads expose stable error codes, retryability, progress, revision, schedule, transaction, and recovery fields.

## Validation

- 341 focused lifecycle, API, Web, SDK, history, repository, and conformance tests passed
- 109-test replay covering every failure from the first full run passed
- SQL migration upgraded and downgraded cleanly on fresh SQLite databases
- Ruff and targeted mypy checks passed
- pre-commit smoke, CI guardrail, WebSocket, Web UI, codespell, mypy, interrogate, link, dependency, CI-rail, and Markdown hooks passed
- diff-cover changed-line gate passed
- full suite: 22,083 passed, 34 skipped; four unrelated suite-order/environment tests failed in aggregate and all four passed immediately together in isolation (path-manager environment leakage, TUI timing, and logger capture state)

## Risk

- Lifecycle consumers must handle the expanded state set, especially `scheduled`, `partial`, `cancelled`, `recovery_required`, `rolling_back`, and `rolled_back`.
- The organization job table gains lifecycle columns and a unique `(job_type, idempotency_key)` constraint; the migration was verified in both directions.
- Running jobs remain non-cancellable until cooperative cancellation boundaries are introduced; only queued or scheduled cancellation is claimed.

Closes #1604
Part of #1593