### PR TITLE
feat(cli): use canonical organization service

### DIFF
--- a/docs/architecture/cli-organization-adapter.md
+++ b/docs/architecture/cli-organization-adapter.md
@@ -20,9 +20,10 @@ fo organize INPUT OUTPUT --plan plan.json
 
 The plan's roots and resolved `OrganizeOptions` are validated again before any
 operation runs. When `--plan` is supplied without behavior flags, its embedded
-options are authoritative. Supplying behavior flags explicitly causes the
-service to compare them with the reviewed plan and reject a mismatch. Schema-1
-plans remain load/inspect-only; create a new preview before execution.
+options are authoritative. Explicit behavior flags overlay only their matching
+plan fields; the service rejects the request before mutation if that result no
+longer equals the reviewed plan. Schema-1 plans remain load/inspect-only; create
+a new preview before execution.
 
 The legacy `fo preview INPUT` invocation remains supported and uses `INPUT` as
 the display-only destination root. Use `--output-dir` for a plan intended to be

--- a/docs/architecture/cli-organization-adapter.md
+++ b/docs/architecture/cli-organization-adapter.md
@@ -1,0 +1,62 @@
+# CLI organization adapter
+
+`fo organize` and `fo preview` are presentation adapters over the canonical
+`OrganizationService`. They do not construct `FileOrganizer` or define traversal,
+classification, collision, transfer, or methodology policy themselves.
+
+## Reviewed-plan flow
+
+Create and inspect a plan without applying files:
+
+```console
+fo preview INPUT --output-dir OUTPUT --save-plan plan.json
+```
+
+Apply that exact plan later:
+
+```console
+fo organize INPUT OUTPUT --plan plan.json
+```
+
+The plan's roots and resolved `OrganizeOptions` are validated again before any
+operation runs. When `--plan` is supplied without behavior flags, its embedded
+options are authoritative. Supplying behavior flags explicitly causes the
+service to compare them with the reviewed plan and reject a mismatch. Schema-1
+plans remain load/inspect-only; create a new preview before execution.
+
+The legacy `fo preview INPUT` invocation remains supported and uses `INPUT` as
+the display-only destination root. Use `--output-dir` for a plan intended to be
+applied.
+
+## Canonical options
+
+Both commands map the same controls into `OrganizeOptions`: recursion, hidden
+files, existing-target policy, transfer mode, methodology, vision and audio
+processing, worker/prefetch tuning, and model/provider identity. `--text-only`
+and `--no-prefetch` remain compatibility aliases. A transcription duration of
+`0` means no cap.
+
+## JSON contract
+
+Place global `--json` before the command or use the command-local `--json` flag.
+Successful output is one JSON object with `schema_version: 1`, `outcome: "ok"`,
+`command`, `mode`, canonical `request`, `result`, and serialized `plan`. Preview
+also includes `scan`; fields not produced for a mode are `null` rather than
+omitted.
+
+Errors use the same envelope with `outcome: "error"` and a stable domain error
+(`code`, `message`, `retryable`, optional `details`) or an unexpected-error
+shape (`error_type`, `message`, and plan conflicts when applicable). Domain and
+organizer progress rendering is suppressed in JSON mode, so stdout contains
+exactly one scriptable JSON document.
+
+Exit codes are:
+
+- `0`: success
+- `1`: execution or optional-feature failure
+- `2`: invalid request or missing input
+- `3`: conflict, reviewed-plan mismatch, or recovery-required state
+
+The CLI driver runs the shared conformance corpus alongside the direct-service
+driver. Registry entries for CLI organization and methodology are marked
+verified only while that suite remains green.

--- a/src/file_organizer/cli/lazy.py
+++ b/src/file_organizer/cli/lazy.py
@@ -176,7 +176,7 @@ class LazyTyperGroup(typer.core.TyperGroup):
     """A TyperGroup that integrates with LazyCommandProxy for deferred loading."""
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        """Stash help-flag presence in ctx.meta before Click consumes the args.
+        """Stash presentation-flag presence in ctx.meta before Click consumes args.
 
         Click's ``Group.parse_args`` calls ``resolve_command``, which removes
         ``--help`` / ``-h`` from ``ctx.args`` before the group callback fires.
@@ -203,6 +203,12 @@ class LazyTyperGroup(typer.core.TyperGroup):
         # option (e.g. ``--type -h``) and must not trigger a gate bypass.
         args_before_terminator = args[: args.index("--")] if "--" in args else args
         ctx.meta["help_requested"] = "--help" in args_before_terminator
+        # Command-local ``--json`` is parsed only after the root callback, but
+        # the first-run setup gate executes inside that callback. Preserve the
+        # raw intent so even setup-gate failures honor the JSON-only stdout
+        # contract. The root ``--json`` option remains the canonical source
+        # for normal command execution.
+        ctx.meta["json_requested"] = "--json" in args_before_terminator
         return super().parse_args(ctx, args)
 
     def list_commands(self, ctx: click.Context) -> list[str]:

--- a/src/file_organizer/cli/main.py
+++ b/src/file_organizer/cli/main.py
@@ -123,10 +123,11 @@ def main_callback(
         version_flag (bool): Eager version callback value (accepted and ignored here).
     """
     _ = version_flag
+    effective_json_output = json_output or bool(ctx.meta.get("json_requested", False))
     ctx.obj = CLIState(
         verbose=verbose,
         dry_run=dry_run,
-        json_output=json_output,
+        json_output=effective_json_output,
         yes=yes,
         no_interactive=not interactive,
         debug=debug,

--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -1,34 +1,40 @@
-"""Organize and preview CLI commands."""
+"""Thin CLI adapters for canonical organization preview and execution."""
 
 from __future__ import annotations
 
+import json
+from contextlib import nullcontext, redirect_stdout
+from io import StringIO
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
+from click.core import ParameterSource
 from rich.console import Console
 from rich.panel import Panel
 
-from file_organizer.cli.path_validation import resolve_cli_path, validate_pair
+from file_organizer.cli.path_validation import (
+    resolve_cli_path,
+    validate_pair,
+    validate_regular_file,
+)
 from file_organizer.cli.state import _get_state
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.organization_service import OrganizationScan, OrganizationService
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
+from file_organizer.core.plan import OrganizationPlan, PlanValidationError
+from file_organizer.core.types import OrganizationResult
+from file_organizer.utils.atomic_write import atomic_write_text
 
 console = Console()
+_JSON_SCHEMA_VERSION = 1
 
 
 def _check_setup_completed() -> bool:
-    """Check if the initial setup wizard has been completed.
-
-    Returns:
-        True if setup is complete, False otherwise.
-
-    Raises:
-        typer.Exit: With code 1 if setup is not completed.
-    """
+    """Check if the initial setup wizard has been completed."""
     from file_organizer.config.manager import ConfigManager
 
-    config_manager = ConfigManager()
-    config = config_manager.load()
-
+    config = ConfigManager().load()
     if not config.setup_completed:
         console.print()
         console.print(
@@ -44,8 +50,12 @@ def _check_setup_completed() -> bool:
         )
         console.print()
         raise typer.Exit(code=1)
-
     return True
+
+
+def _create_service() -> OrganizationService:
+    """Create the application service; kept as an adapter test seam."""
+    return OrganizationService()
 
 
 def _resolve_parallel_settings(
@@ -54,20 +64,7 @@ def _resolve_parallel_settings(
     prefetch_depth: int,
     no_prefetch: bool = False,
 ) -> tuple[int | None, int]:
-    """Validate and resolve parallel worker/prefetch settings.
-
-    Args:
-        sequential: Whether to force single-worker sequential processing.
-        max_workers: Requested worker count, or None for auto.
-        prefetch_depth: Requested prefetch queue depth.
-        no_prefetch: Backward-compatible alias for prefetch_depth=0.
-
-    Returns:
-        Tuple of (resolved_workers, resolved_prefetch_depth).
-
-    Raises:
-        typer.Exit: With code 2 if --sequential and --max-workers > 1 conflict.
-    """
+    """Validate and normalize CLI performance aliases."""
     if sequential and max_workers not in (None, 1):
         console.print("[red]Error: --sequential cannot be combined with --max-workers > 1[/red]")
         raise typer.Exit(code=2)
@@ -89,35 +86,244 @@ def _print_organize_advanced_help() -> None:
             [
                 "[bold]`--max-workers INTEGER`[/bold] — Cap parallel worker count.",
                 "[bold]`--sequential`[/bold] — Force single-worker sequential processing.",
-                "[bold]`--prefetch-depth INTEGER`[/bold] — Tune queue-ahead depth per worker (`0` disables prefetch).",
+                "[bold]`--prefetch-depth INTEGER`[/bold] — Tune queue-ahead depth per worker.",
                 "[bold]`--no-prefetch`[/bold] — Backward-compatible alias for `--prefetch-depth 0`.",
-                "[bold]`--no-vision`, `--text-only`[/bold] — Disable vision model processing for images.",
-                "[bold]`--transcribe-audio`[/bold] — Enable transcription-based audio categorization.",
-                "[bold]`--max-transcribe-seconds FLOAT`[/bold] — Skip transcription for long audio files (`0` disables cap).",
+                "[bold]`--no-vision`, `--text-only`[/bold] — Disable image vision processing.",
+                "[bold]`--transcribe-audio`[/bold] — Enable audio transcription.",
+                "[bold]`--max-transcribe-seconds FLOAT`[/bold] — Set `0` for no cap.",
             ]
         )
-    )
-    console.print(
-        "\n[bold]Example:[/bold] [cyan]fo organize INPUT_DIR OUTPUT_DIR "
-        "--max-workers 2 --prefetch-depth 1[/cyan]"
     )
 
 
 def _advanced_help_callback(value: bool) -> None:
-    """Eager callback for ``--advanced-help``."""
-    if not value:
-        return
-    _print_organize_advanced_help()
-    raise typer.Exit()
+    """Print advanced help and stop eager option processing when requested."""
+    if value:
+        _print_organize_advanced_help()
+        raise typer.Exit()
+
+
+def _build_options(
+    *,
+    recursive: bool,
+    include_hidden: bool,
+    skip_existing: bool,
+    transfer_mode: str,
+    methodology: str,
+    no_vision: bool,
+    transcribe_audio: bool,
+    max_transcribe_seconds: float,
+    whisper_model: str,
+    sequential: bool,
+    max_workers: int | None,
+    prefetch_depth: int,
+    no_prefetch: bool,
+    text_model: str | None,
+    vision_model: str | None,
+    text_provider: str | None,
+    vision_provider: str | None,
+) -> OrganizeOptions:
+    """Map every behavior-affecting CLI flag to the canonical contract."""
+    workers, resolved_prefetch = _resolve_parallel_settings(
+        sequential, max_workers, prefetch_depth, no_prefetch
+    )
+    try:
+        return OrganizeOptions(
+            recursive=recursive,
+            include_hidden=include_hidden,
+            skip_existing=skip_existing,
+            transfer_mode=transfer_mode,
+            methodology=methodology,
+            enable_vision=not no_vision,
+            transcribe_audio=transcribe_audio,
+            max_transcribe_seconds=(max_transcribe_seconds if max_transcribe_seconds > 0 else None),
+            whisper_model=whisper_model,
+            parallel_workers=workers,
+            prefetch_depth=resolved_prefetch,
+            text_model=text_model,
+            vision_model=vision_model,
+            text_provider=text_provider,  # type: ignore[arg-type]
+            vision_provider=vision_provider,  # type: ignore[arg-type]
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def _result_payload(result: OrganizationResult) -> dict[str, Any]:
+    """Serialize an organization result without its separately emitted plan."""
+    return {
+        "total_files": result.total_files,
+        "processed_files": result.processed_files,
+        "skipped_files": result.skipped_files,
+        "failed_files": result.failed_files,
+        "deduplicated_files": result.deduplicated_files,
+        "processing_time": result.processing_time,
+        "organized_structure": result.organized_structure,
+        "errors": [list(error) for error in result.errors],
+        "transaction_id": result.transaction_id,
+    }
+
+
+def _scan_payload(scan: OrganizationScan) -> dict[str, Any]:
+    """Serialize a canonical scan into JSON-compatible primitives."""
+    return {
+        "input_path": str(scan.input_path),
+        "files": [str(path) for path in scan.files],
+        "counts": scan.counts,
+        "total_files": scan.total_files,
+    }
+
+
+def _success_payload(
+    command: str,
+    request: OrganizeRequest,
+    result: OrganizationResult,
+    *,
+    mode: str,
+    scan: OrganizationScan | None = None,
+) -> dict[str, Any]:
+    """Build the versioned success envelope shared by both CLI commands."""
+    return {
+        "schema_version": _JSON_SCHEMA_VERSION,
+        "outcome": "ok",
+        "command": command,
+        "mode": mode,
+        "request": {
+            "input_path": str(request.input_path),
+            "output_path": str(request.output_path),
+            "options": request.options.to_dict(),
+        },
+        "scan": _scan_payload(scan) if scan is not None else None,
+        "result": _result_payload(result),
+        "plan": result.plan.to_dict() if isinstance(result.plan, OrganizationPlan) else None,
+    }
+
+
+def _emit_json(payload: dict[str, Any]) -> None:
+    """Emit exactly one deterministic compact JSON document to stdout."""
+    typer.echo(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def _save_plan(path: Path, plan: OrganizationPlan) -> Path:
+    """Atomically persist a canonical reviewed plan and return its resolved path."""
+    resolved = resolve_cli_path(path, must_exist=False, must_be_dir=False)
+    validate_regular_file(resolved, "plan output")
+    if not resolved.parent.is_dir():
+        raise typer.BadParameter(f"Plan output parent does not exist: {resolved.parent}")
+    atomic_write_text(resolved, json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n")
+    return resolved
+
+
+def _load_plan(path: Path) -> OrganizationPlan:
+    """Load and validate a canonical serialized plan from the CLI boundary."""
+    resolved = resolve_cli_path(path, must_exist=True, must_be_dir=False)
+    validate_regular_file(resolved, "plan")
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("plan document must be a JSON object")
+        return OrganizationPlan.from_dict(payload)
+    except (OSError, json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
+        raise typer.BadParameter(f"Invalid organization plan {resolved}: {exc}") from exc
+
+
+def _error_exit_code(exc: Exception) -> int:
+    """Map stable domain failure categories onto documented CLI exit codes."""
+    if isinstance(exc, DomainError) and exc.code in {
+        DomainErrorCode.INVALID_REQUEST,
+        DomainErrorCode.NOT_FOUND,
+    }:
+        return 2
+    if isinstance(exc, DomainError) and exc.code in {
+        DomainErrorCode.CONFLICT,
+        DomainErrorCode.PLAN_MISMATCH,
+        DomainErrorCode.RECOVERY_REQUIRED,
+    }:
+        return 3
+    return 1
+
+
+def _raise_cli_error(command: str, exc: Exception, *, json_output: bool) -> None:
+    """Render one normalized failure and terminate with its stable exit code."""
+    code = _error_exit_code(exc)
+    if isinstance(exc, DomainError):
+        error = exc.to_dict()
+    elif isinstance(exc, PlanValidationError):
+        error = {
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+            "conflicts": [
+                {"conflict_type": conflict.conflict_type.value, "path": conflict.path}
+                for conflict in exc.validation.conflicts
+            ],
+        }
+    else:
+        error = {
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+    if json_output:
+        _emit_json(
+            {
+                "schema_version": _JSON_SCHEMA_VERSION,
+                "outcome": "error",
+                "command": command,
+                "error": error,
+            }
+        )
+    else:
+        console.print(f"[red]Error: {error['message']}[/red]")
+        if _get_state().debug:
+            console.print_exception(show_locals=False)
+    raise typer.Exit(code=code) from exc
+
+
+def _raise_usage_error(command: str, exc: typer.BadParameter, *, json_output: bool) -> None:
+    """Keep Typer usage rendering for humans and normalize JSON-mode errors."""
+    if json_output:
+        code = (
+            DomainErrorCode.NOT_FOUND
+            if str(exc).startswith("Path does not exist:")
+            else DomainErrorCode.INVALID_REQUEST
+        )
+        _raise_cli_error(
+            command,
+            DomainError(code, str(exc)),
+            json_output=True,
+        )
+    raise exc
 
 
 def organize(
+    ctx: typer.Context,
     input_dir: Annotated[Path, typer.Argument(help="Directory containing files to organize.")],
     output_dir: Annotated[Path, typer.Argument(help="Destination directory for organized files.")],
     dry_run: Annotated[
-        bool, typer.Option("--dry-run", help="Preview without moving files.")
+        bool, typer.Option("--dry-run", help="Preview without applying files.")
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit stable JSON output.")] = False,
+    plan_path: Annotated[
+        Path | None, typer.Option("--plan", help="Apply a canonical plan JSON file.")
+    ] = None,
+    save_plan: Annotated[
+        Path | None, typer.Option("--save-plan", help="Write the generated plan as JSON.")
+    ] = None,
+    recursive: Annotated[
+        bool, typer.Option("--recursive/--no-recursive", help="Recurse into subdirectories.")
+    ] = True,
+    include_hidden: Annotated[
+        bool, typer.Option("--include-hidden/--exclude-hidden", help="Include hidden files.")
+    ] = False,
+    skip_existing: Annotated[
+        bool, typer.Option("--skip-existing/--overwrite-existing", help="Skip existing targets.")
+    ] = True,
+    transfer_mode: Annotated[
+        str, typer.Option("--transfer-mode", help="Transfer mode: copy or hardlink.")
+    ] = "hardlink",
+    methodology: Annotated[
+        str, typer.Option("--methodology", help="Layout policy: none, para, or jd.")
+    ] = "none",
     advanced_help: Annotated[
         bool,
         typer.Option(
@@ -127,236 +333,225 @@ def organize(
             help="Show advanced tuning options and exit.",
         ),
     ] = False,
-    max_workers: Annotated[
-        int | None,
-        typer.Option(
-            "--max-workers",
-            min=1,
-            help="Maximum number of parallel workers for file processing.",
-            hidden=True,
-        ),
-    ] = None,
-    sequential: Annotated[
-        bool,
-        typer.Option(
-            "--sequential", help="Force single-worker sequential processing.", hidden=True
-        ),
-    ] = False,
-    no_vision: Annotated[
-        bool,
-        typer.Option(
-            "--no-vision",
-            "--text-only",
-            help="Disable vision model usage and organize images by extension fallback.",
-            hidden=True,
-        ),
-    ] = False,
-    prefetch_depth: Annotated[
-        int,
-        typer.Option(
-            "--prefetch-depth",
-            min=0,
-            help=(
-                "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
-                "uses strictly sequential submission)."
-            ),
-            hidden=True,
-        ),
-    ] = 2,
-    no_prefetch: Annotated[
-        bool,
-        typer.Option(
-            "--no-prefetch",
-            help="Backward-compatible alias for --prefetch-depth 0.",
-            hidden=True,
-        ),
-    ] = False,
-    transcribe_audio: Annotated[
-        bool,
-        typer.Option(
-            "--transcribe-audio",
-            help=(
-                "Transcribe audio files (requires the [audio] extra) and use the "
-                "transcript for content-aware categorization. Off by default — "
-                "transcription is the expensive operation in the audio pipeline."
-            ),
-            hidden=True,
-        ),
-    ] = False,
+    max_workers: Annotated[int | None, typer.Option("--max-workers", min=1, hidden=True)] = None,
+    sequential: Annotated[bool, typer.Option("--sequential", hidden=True)] = False,
+    no_vision: Annotated[bool, typer.Option("--no-vision", "--text-only", hidden=True)] = False,
+    prefetch_depth: Annotated[int, typer.Option("--prefetch-depth", min=0, hidden=True)] = 2,
+    no_prefetch: Annotated[bool, typer.Option("--no-prefetch", hidden=True)] = False,
+    transcribe_audio: Annotated[bool, typer.Option("--transcribe-audio", hidden=True)] = False,
     max_transcribe_seconds: Annotated[
-        float,
-        typer.Option(
-            "--max-transcribe-seconds",
-            min=0.0,
-            help=(
-                "Skip transcription for audio files longer than this (seconds). "
-                "Default: 600 (10 min). Set to 0 to disable the cap entirely."
-            ),
-            hidden=True,
-        ),
+        float, typer.Option("--max-transcribe-seconds", min=0.0, hidden=True)
     ] = 600.0,
-    whisper_model: Annotated[
-        str,
-        typer.Option(
-            "--whisper-model",
-            help=(
-                "Whisper model size for --transcribe-audio: tiny, base, small, "
-                "medium, large-v2, or large-v3. Larger models transcribe more "
-                "accurately but are slower and need a bigger download."
-            ),
-            hidden=True,
-        ),
-    ] = "tiny",
+    whisper_model: Annotated[str, typer.Option("--whisper-model", hidden=True)] = "tiny",
+    text_model: Annotated[str | None, typer.Option("--text-model", hidden=True)] = None,
+    vision_model: Annotated[str | None, typer.Option("--vision-model", hidden=True)] = None,
+    text_provider: Annotated[str | None, typer.Option("--text-provider", hidden=True)] = None,
+    vision_provider: Annotated[str | None, typer.Option("--vision-provider", hidden=True)] = None,
 ) -> None:
-    """Organize files in a directory using AI models."""
-    _ = advanced_help
-    # First-run setup gate now lives in `cli.main.main_callback` and runs
-    # for every non-allowlisted command. The previous inline call here
-    # is removed (Step 3); leaving both would double-print the panel.
-
-    # A.cli: resolve + validate both path args before any filesystem work.
-    # Input must exist and be a dir; output may not exist yet (the
-    # organizer creates it), but when it does exist it must be a dir.
-    input_dir = resolve_cli_path(input_dir, must_exist=True, must_be_dir=True, reject_symlink=True)
-    output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
-    validate_pair(input_dir, output_dir)
-
-    console.print(f"[bold]Organizing[/bold] {input_dir} -> {output_dir}")
-    if dry_run or _get_state().dry_run:
-        console.print("[yellow]Dry run mode — no files will be moved.[/yellow]")
-    resolved_workers, resolved_prefetch_depth = _resolve_parallel_settings(
-        sequential, max_workers, prefetch_depth, no_prefetch
-    )
+    """Preview or apply organization through the canonical application service."""
+    _ = (advanced_help, verbose)
+    json_output = json_output or _get_state().json_output
+    is_preview = dry_run or _get_state().dry_run
 
     try:
-        from file_organizer.core.organizer import FileOrganizer
-
-        organizer = FileOrganizer(
-            dry_run=dry_run or _get_state().dry_run,
-            parallel_workers=resolved_workers,
-            prefetch_depth=resolved_prefetch_depth,
-            enable_vision=not no_vision,
-            no_prefetch=no_prefetch,
-            transcribe_audio=transcribe_audio,
-            # `--max-transcribe-seconds 0` is the documented "disable the cap"
-            # value; convert to None for the organizer (None means uncapped).
-            max_transcribe_seconds=max_transcribe_seconds if max_transcribe_seconds > 0 else None,
-            whisper_model=whisper_model,
+        input_dir = resolve_cli_path(
+            input_dir, must_exist=False, must_be_dir=True, reject_symlink=True
         )
-        result = organizer.organize(input_dir, output_dir)
+        if not input_dir.exists():
+            raise DomainError(
+                DomainErrorCode.NOT_FOUND,
+                f"Input path does not exist: {input_dir}",
+                details={"path": str(input_dir)},
+            )
+        output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
+        validate_pair(input_dir, output_dir)
+        plan = _load_plan(plan_path) if plan_path is not None else None
+        if plan is not None and is_preview:
+            raise typer.BadParameter(
+                "--plan applies a reviewed plan and cannot be used with --dry-run"
+            )
+        behavior_parameters = {
+            "recursive",
+            "include_hidden",
+            "skip_existing",
+            "transfer_mode",
+            "methodology",
+            "max_workers",
+            "sequential",
+            "no_vision",
+            "prefetch_depth",
+            "no_prefetch",
+            "transcribe_audio",
+            "max_transcribe_seconds",
+            "whisper_model",
+            "text_model",
+            "vision_model",
+            "text_provider",
+            "vision_provider",
+        }
+        has_explicit_options = any(
+            ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+            for name in behavior_parameters
+        )
+        options = (
+            plan.options
+            if plan is not None and not has_explicit_options
+            else _build_options(
+                recursive=recursive,
+                include_hidden=include_hidden,
+                skip_existing=skip_existing,
+                transfer_mode=transfer_mode,
+                methodology=methodology,
+                no_vision=no_vision,
+                transcribe_audio=transcribe_audio,
+                max_transcribe_seconds=max_transcribe_seconds,
+                whisper_model=whisper_model,
+                sequential=sequential,
+                max_workers=max_workers,
+                prefetch_depth=prefetch_depth,
+                no_prefetch=no_prefetch,
+                text_model=text_model,
+                vision_model=vision_model,
+                text_provider=text_provider,
+                vision_provider=vision_provider,
+            )
+        )
+        request = OrganizeRequest(input_dir, output_dir, options)
+        if not json_output:
+            console.print(f"[bold]Organizing[/bold] {input_dir} -> {output_dir}")
+            if is_preview:
+                console.print("[yellow]Dry run mode — no files will be applied.[/yellow]")
+        service = _create_service()
+        output_guard = redirect_stdout(StringIO()) if json_output else nullcontext()
+        with output_guard:
+            result = service.preview(request) if is_preview else service.execute(request, plan)
+        if save_plan is not None:
+            if not isinstance(result.plan, OrganizationPlan):
+                raise DomainError(
+                    DomainErrorCode.EXECUTION_FAILED,
+                    "Organization result did not include a serializable plan.",
+                )
+            saved_path = _save_plan(save_plan, result.plan)
+        else:
+            saved_path = None
+    except typer.BadParameter as exc:
+        _raise_usage_error("organize", exc, json_output=json_output)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        _raise_cli_error("organize", exc, json_output=json_output)
+
+    if json_output:
+        _emit_json(
+            _success_payload(
+                "organize", request, result, mode="preview" if is_preview else "execute"
+            )
+        )
+        return
+    if is_preview:
+        console.print(f"[green]Preview:[/green] {result.total_files} files would be organized")
+    else:
         console.print(
             f"[green]Done:[/green] {result.processed_files} processed, "
             f"{result.skipped_files} skipped, {result.failed_files} failed"
         )
-    except Exception as exc:
-        console.print(f"[red]Error: {exc}[/red]")
-        # Step 3: surface the full Rich traceback when --debug is set so
-        # beta testers can attach actionable repro info to bug reports.
-        # Without --debug, only the red one-liner shows (current behavior).
-        if _get_state().debug:
-            console.print_exception(show_locals=False)
-        raise typer.Exit(code=1) from exc
+    if saved_path is not None:
+        console.print(f"[green]Plan saved:[/green] {saved_path}")
 
 
 def preview(
     input_dir: Annotated[Path, typer.Argument(help="Directory to preview.")],
-    max_workers: Annotated[
-        int | None,
-        typer.Option(
-            "--max-workers",
-            min=1,
-            help="Maximum number of parallel workers for file processing.",
-        ),
+    output_dir: Annotated[
+        Path | None,
+        typer.Option("--output-dir", help="Destination root represented by the plan."),
     ] = None,
-    sequential: Annotated[
-        bool,
-        typer.Option("--sequential", help="Force single-worker sequential processing."),
-    ] = False,
-    no_vision: Annotated[
-        bool,
-        typer.Option(
-            "--no-vision",
-            "--text-only",
-            help="Disable vision model usage and organize images by extension fallback.",
-        ),
-    ] = False,
-    prefetch_depth: Annotated[
-        int,
-        typer.Option(
-            "--prefetch-depth",
-            min=0,
-            help=(
-                "Task scheduling prefetch depth per worker (0 disables queue-ahead and "
-                "uses strictly sequential submission)."
-            ),
-        ),
-    ] = 2,
-    no_prefetch: Annotated[
-        bool,
-        typer.Option("--no-prefetch", help="Backward-compatible alias for --prefetch-depth 0."),
-    ] = False,
-    transcribe_audio: Annotated[
-        bool,
-        typer.Option(
-            "--transcribe-audio",
-            help=(
-                "Transcribe audio files (requires the [audio] extra) and use the "
-                "transcript for content-aware categorization. Off by default."
-            ),
-        ),
-    ] = False,
+    save_plan: Annotated[Path | None, typer.Option("--save-plan", help="Write plan JSON.")] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit stable JSON output.")] = False,
+    recursive: Annotated[bool, typer.Option("--recursive/--no-recursive")] = True,
+    include_hidden: Annotated[bool, typer.Option("--include-hidden/--exclude-hidden")] = False,
+    skip_existing: Annotated[bool, typer.Option("--skip-existing/--overwrite-existing")] = True,
+    transfer_mode: Annotated[str, typer.Option("--transfer-mode")] = "hardlink",
+    methodology: Annotated[str, typer.Option("--methodology")] = "none",
+    max_workers: Annotated[int | None, typer.Option("--max-workers", min=1)] = None,
+    sequential: Annotated[bool, typer.Option("--sequential")] = False,
+    no_vision: Annotated[bool, typer.Option("--no-vision", "--text-only")] = False,
+    prefetch_depth: Annotated[int, typer.Option("--prefetch-depth", min=0)] = 2,
+    no_prefetch: Annotated[bool, typer.Option("--no-prefetch")] = False,
+    transcribe_audio: Annotated[bool, typer.Option("--transcribe-audio")] = False,
     max_transcribe_seconds: Annotated[
-        float,
-        typer.Option(
-            "--max-transcribe-seconds",
-            min=0.0,
-            help=(
-                "Skip transcription for audio files longer than this (seconds). "
-                "Default: 600 (10 min). Set to 0 to disable the cap entirely."
-            ),
-        ),
+        float, typer.Option("--max-transcribe-seconds", min=0.0)
     ] = 600.0,
-    whisper_model: Annotated[
-        str,
-        typer.Option(
-            "--whisper-model",
-            help=(
-                "Whisper model size for --transcribe-audio: tiny, base, small, "
-                "medium, large-v2, or large-v3. Larger models transcribe more "
-                "accurately but are slower and need a bigger download."
-            ),
-        ),
-    ] = "tiny",
+    whisper_model: Annotated[str, typer.Option("--whisper-model")] = "tiny",
+    text_model: Annotated[str | None, typer.Option("--text-model")] = None,
+    vision_model: Annotated[str | None, typer.Option("--vision-model")] = None,
+    text_provider: Annotated[str | None, typer.Option("--text-provider")] = None,
+    vision_provider: Annotated[str | None, typer.Option("--vision-provider")] = None,
 ) -> None:
-    """Preview how files would be organized (dry-run)."""
-    # Setup gate moved to `cli.main.main_callback` (Step 3).
-
-    # A.cli: single-path validation — preview never writes, so no
-    # output-dir pair check needed.
-    input_dir = resolve_cli_path(input_dir, must_exist=True, must_be_dir=True, reject_symlink=True)
-
-    console.print(f"[bold]Previewing[/bold] {input_dir}")
-    resolved_workers, resolved_prefetch_depth = _resolve_parallel_settings(
-        sequential, max_workers, prefetch_depth, no_prefetch
-    )
-
+    """Build a canonical plan without applying filesystem changes."""
+    json_output = json_output or _get_state().json_output
     try:
-        from file_organizer.core.organizer import FileOrganizer
-
-        organizer = FileOrganizer(
-            dry_run=True,
-            parallel_workers=resolved_workers,
-            prefetch_depth=resolved_prefetch_depth,
-            enable_vision=not no_vision,
-            no_prefetch=no_prefetch,
-            transcribe_audio=transcribe_audio,
-            max_transcribe_seconds=max_transcribe_seconds if max_transcribe_seconds > 0 else None,
-            whisper_model=whisper_model,
+        input_dir = resolve_cli_path(
+            input_dir, must_exist=False, must_be_dir=True, reject_symlink=True
         )
-        result = organizer.organize(input_dir, input_dir)
-        console.print(f"[green]Preview:[/green] {result.total_files} files would be organized")
+        if not input_dir.exists():
+            raise DomainError(
+                DomainErrorCode.NOT_FOUND,
+                f"Input path does not exist: {input_dir}",
+                details={"path": str(input_dir)},
+            )
+        output_dir = (
+            resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
+            if output_dir is not None
+            else input_dir
+        )
+        if output_dir != input_dir:
+            validate_pair(input_dir, output_dir)
+        options = _build_options(
+            recursive=recursive,
+            include_hidden=include_hidden,
+            skip_existing=skip_existing,
+            transfer_mode=transfer_mode,
+            methodology=methodology,
+            no_vision=no_vision,
+            transcribe_audio=transcribe_audio,
+            max_transcribe_seconds=max_transcribe_seconds,
+            whisper_model=whisper_model,
+            sequential=sequential,
+            max_workers=max_workers,
+            prefetch_depth=prefetch_depth,
+            no_prefetch=no_prefetch,
+            text_model=text_model,
+            vision_model=vision_model,
+            text_provider=text_provider,
+            vision_provider=vision_provider,
+        )
+        request = OrganizeRequest(input_dir, output_dir, options)
+        if not json_output:
+            console.print(f"[bold]Previewing[/bold] {input_dir} -> {output_dir}")
+        service = _create_service()
+        output_guard = redirect_stdout(StringIO()) if json_output else nullcontext()
+        with output_guard:
+            scan = service.scan(request)
+            result = service.preview(request)
+        if save_plan is not None:
+            if not isinstance(result.plan, OrganizationPlan):
+                raise DomainError(
+                    DomainErrorCode.EXECUTION_FAILED,
+                    "Organization preview did not include a serializable plan.",
+                )
+            saved_path = _save_plan(save_plan, result.plan)
+        else:
+            saved_path = None
+    except typer.BadParameter as exc:
+        _raise_usage_error("preview", exc, json_output=json_output)
+    except typer.Exit:
+        raise
     except Exception as exc:
-        console.print(f"[red]Error: {exc}[/red]")
-        if _get_state().debug:
-            console.print_exception(show_locals=False)
-        raise typer.Exit(code=1) from exc
+        _raise_cli_error("preview", exc, json_output=json_output)
+
+    if json_output:
+        _emit_json(_success_payload("preview", request, result, mode="preview", scan=scan))
+        return
+    console.print(f"[green]Preview:[/green] {result.total_files} files would be organized")
+    if saved_path is not None:
+        console.print(f"[green]Plan saved:[/green] {saved_path}")

--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -8,6 +8,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Annotated, Any
 
+import click
 import typer
 from click.core import ParameterSource
 from rich.console import Console
@@ -28,6 +29,25 @@ from file_organizer.utils.atomic_write import atomic_write_text
 
 console = Console()
 _JSON_SCHEMA_VERSION = 1
+_PLAN_PARAMETER_FIELDS: dict[str, tuple[str, ...]] = {
+    "recursive": ("recursive",),
+    "include_hidden": ("include_hidden",),
+    "skip_existing": ("skip_existing",),
+    "transfer_mode": ("transfer_mode",),
+    "methodology": ("methodology",),
+    "max_workers": ("parallel_workers",),
+    "sequential": ("parallel_workers", "prefetch_depth"),
+    "no_vision": ("enable_vision",),
+    "prefetch_depth": ("prefetch_depth",),
+    "no_prefetch": ("prefetch_depth",),
+    "transcribe_audio": ("transcribe_audio",),
+    "max_transcribe_seconds": ("max_transcribe_seconds",),
+    "whisper_model": ("whisper_model",),
+    "text_model": ("text_model",),
+    "vision_model": ("vision_model",),
+    "text_provider": ("text_provider",),
+    "vision_provider": ("vision_provider",),
+}
 
 
 def _check_setup_completed() -> bool:
@@ -36,6 +56,22 @@ def _check_setup_completed() -> bool:
 
     config = ConfigManager().load()
     if not config.setup_completed:
+        if _get_state().json_output:
+            context = click.get_current_context(silent=True)
+            _emit_json(
+                {
+                    "schema_version": _JSON_SCHEMA_VERSION,
+                    "outcome": "error",
+                    "command": context.invoked_subcommand if context is not None else None,
+                    "error": {
+                        "code": "setup_required",
+                        "message": "First-time setup is required. Run `fo setup` to continue.",
+                        "retryable": False,
+                        "details": {"action": "fo setup"},
+                    },
+                }
+            )
+            raise typer.Exit(code=1)
         console.print()
         console.print(
             Panel.fit(
@@ -66,8 +102,7 @@ def _resolve_parallel_settings(
 ) -> tuple[int | None, int]:
     """Validate and normalize CLI performance aliases."""
     if sequential and max_workers not in (None, 1):
-        console.print("[red]Error: --sequential cannot be combined with --max-workers > 1[/red]")
-        raise typer.Exit(code=2)
+        raise typer.BadParameter("--sequential cannot be combined with --max-workers > 1")
     return (1 if sequential else max_workers, 0 if (sequential or no_prefetch) else prefetch_depth)
 
 
@@ -147,6 +182,22 @@ def _build_options(
         )
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+
+
+def _merge_explicit_plan_options(
+    ctx: typer.Context,
+    plan_options: OrganizeOptions,
+    cli_options: OrganizeOptions,
+) -> OrganizeOptions:
+    """Overlay only explicit CLI option fields onto reviewed plan options."""
+    merged = plan_options.to_dict()
+    explicit = cli_options.to_dict()
+    for parameter, fields in _PLAN_PARAMETER_FIELDS.items():
+        if ctx.get_parameter_source(parameter) != ParameterSource.COMMANDLINE:
+            continue
+        for field in fields:
+            merged[field] = explicit[field]
+    return OrganizeOptions.from_dict(merged)
 
 
 def _result_payload(result: OrganizationResult) -> dict[str, Any]:
@@ -301,7 +352,14 @@ def organize(
     dry_run: Annotated[
         bool, typer.Option("--dry-run", help="Preview without applying files.")
     ] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Verbose output.")] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Compatibility flag; canonical organization progress is already detailed.",
+        ),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit stable JSON output.")] = False,
     plan_path: Annotated[
         Path | None, typer.Option("--plan", help="Apply a canonical plan JSON file.")
@@ -370,33 +428,14 @@ def organize(
             raise typer.BadParameter(
                 "--plan applies a reviewed plan and cannot be used with --dry-run"
             )
-        behavior_parameters = {
-            "recursive",
-            "include_hidden",
-            "skip_existing",
-            "transfer_mode",
-            "methodology",
-            "max_workers",
-            "sequential",
-            "no_vision",
-            "prefetch_depth",
-            "no_prefetch",
-            "transcribe_audio",
-            "max_transcribe_seconds",
-            "whisper_model",
-            "text_model",
-            "vision_model",
-            "text_provider",
-            "vision_provider",
-        }
         has_explicit_options = any(
             ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
-            for name in behavior_parameters
+            for name in _PLAN_PARAMETER_FIELDS
         )
-        options = (
-            plan.options
-            if plan is not None and not has_explicit_options
-            else _build_options(
+        if plan is not None and not has_explicit_options:
+            options = plan.options
+        else:
+            cli_options = _build_options(
                 recursive=recursive,
                 include_hidden=include_hidden,
                 skip_existing=skip_existing,
@@ -415,7 +454,11 @@ def organize(
                 text_provider=text_provider,
                 vision_provider=vision_provider,
             )
-        )
+            options = (
+                _merge_explicit_plan_options(ctx, plan.options, cli_options)
+                if plan is not None
+                else cli_options
+            )
         request = OrganizeRequest(input_dir, output_dir, options)
         if not json_output:
             console.print(f"[bold]Organizing[/bold] {input_dir} -> {output_dir}")

--- a/src/file_organizer/core/capability_registry.json
+++ b/src/file_organizer/core/capability_registry.json
@@ -1465,11 +1465,13 @@
       ],
       "surfaces": {
         "cli": {
-          "conformance_status": "unverified",
+          "conformance_status": "verified",
           "entry_points": [
-            "fo config edit"
+            "fo config edit",
+            "fo organize --methodology",
+            "fo preview --methodology"
           ],
-          "implementation_status": "partial",
+          "implementation_status": "implemented",
           "target_support": "full"
         },
         "python-sdk": {
@@ -1607,7 +1609,7 @@
       ],
       "surfaces": {
         "cli": {
-          "conformance_status": "unverified",
+          "conformance_status": "verified",
           "entry_points": [
             "fo organize"
           ],
@@ -1750,7 +1752,7 @@
       ],
       "surfaces": {
         "cli": {
-          "conformance_status": "unverified",
+          "conformance_status": "verified",
           "entry_points": [
             "fo preview",
             "fo organize --dry-run"

--- a/tests/cli/test_cli_organize.py
+++ b/tests/cli/test_cli_organize.py
@@ -1,11 +1,8 @@
-"""Tests for the organize CLI commands (organize.py).
-
-Tests the ``organize`` and ``preview`` top-level commands with mocked
-FileOrganizer service.
-"""
+"""Contract tests for the local organization CLI adapter."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,514 +11,286 @@ import typer
 from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.organization_service import OrganizationScan, OrganizationService
+from file_organizer.core.organize_options import (
+    OrganizationMethodology,
+    OrganizeOptions,
+    TransferMode,
+)
+from file_organizer.core.plan import PLAN_SCHEMA_VERSION, OrganizationPlan
+from file_organizer.core.types import OrganizationResult
 
 pytestmark = [pytest.mark.unit]
-
 runner = CliRunner()
-
-# Auto-mock the setup gate so tests don't require a completed setup wizard.
 _SETUP_PATCH = "file_organizer.cli.organize._check_setup_completed"
 
 
 def _fake_check_setup() -> None:
-    """Mimic ``_check_setup_completed`` when setup is not done."""
-    from rich.console import Console
-    from rich.panel import Panel
-
-    console = Console()
-    console.print()
-    console.print(
-        Panel.fit(
-            "[bold yellow]First-time setup required[/bold yellow]\n\n"
-            "File Organizer needs to be configured before use.\n"
-            "Run the setup wizard to get started:\n\n"
-            "  [bold cyan]fo setup[/bold cyan]\n\n"
-            "This will detect your system capabilities and configure\n"
-            "the optimal AI models for your hardware.",
-            border_style="yellow",
-        )
-    )
-    console.print()
     raise typer.Exit(code=1)
 
 
+@pytest.fixture
+def service() -> MagicMock:
+    mock = MagicMock(spec=OrganizationService)
+    mock.scan.return_value = OrganizationScan(Path("input"), (), {"text": 0})
+    mock.preview.return_value = OrganizationResult(total_files=5)
+    mock.execute.return_value = OrganizationResult(
+        total_files=10, processed_files=8, skipped_files=1, failed_files=1
+    )
+    return mock
+
+
 @pytest.fixture(autouse=True)
-def _bypass_setup_check():
-    """Bypass the setup-completed gate for all tests in this module."""
-    with patch(_SETUP_PATCH, return_value=True):
+def _adapter_seams(service: MagicMock):
+    with (
+        patch(_SETUP_PATCH, return_value=True),
+        patch("file_organizer.cli.organize._create_service", return_value=service),
+    ):
         yield
 
 
-def _mock_result(
-    total: int = 10,
-    processed: int = 8,
-    skipped: int = 1,
-    failed: int = 1,
-) -> MagicMock:
-    """Create a mock organize result."""
-    result = MagicMock()
-    result.total_files = total
-    result.processed_files = processed
-    result.skipped_files = skipped
-    result.failed_files = failed
-    return result
+def _roots(tmp_path: Path) -> tuple[Path, Path]:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    return input_dir, output_dir
 
 
-# ---------------------------------------------------------------------------
-# organize
-# ---------------------------------------------------------------------------
-
-
-class TestOrganize:
-    """Tests for the ``organize`` command."""
-
-    def test_organize_fails_when_setup_not_completed(self, tmp_path: Path) -> None:
-        """When setup is not completed, organize should exit with code 1 and show guidance."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        with patch(_SETUP_PATCH, side_effect=_fake_check_setup):
-            result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
-
-        assert result.exit_code == 1
-        assert "First-time setup required" in result.output
-        assert "fo setup" in result.output
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_basic(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
-        assert result.exit_code == 0
-        assert "8 processed" in result.output
-        assert "1 skipped" in result.output
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_dry_run(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(app, ["organize", str(input_dir), str(output_dir), "--dry-run"])
-        assert result.exit_code == 0
-        assert "dry run" in result.output.lower() or "Dry run" in result.output
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_parallel_controls(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        """CLI parallel controls should be wired into runtime config."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(
-            app,
-            [
-                "organize",
-                str(input_dir),
-                str(output_dir),
-                "--max-workers",
-                "3",
-                "--prefetch-depth",
-                "1",
-                "--no-vision",
-            ],
-        )
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=3,
-            prefetch_depth=1,
-            enable_vision=False,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_sequential_forces_single_worker(
-        self, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        """--sequential should force one worker and disable queue-ahead."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(
-            app,
-            ["organize", str(input_dir), str(output_dir), "--sequential"],
-        )
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=1,
-            prefetch_depth=0,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_rejects_incompatible_worker_flags(
-        self, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        """--sequential and --max-workers>1 should fail fast."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        result = runner.invoke(
-            app,
-            [
-                "organize",
-                str(input_dir),
-                str(output_dir),
-                "--sequential",
-                "--max-workers",
-                "4",
-            ],
-        )
-        assert result.exit_code == 2
-        assert "--sequential cannot be combined with --max-workers > 1" in result.output
-        mock_cls.assert_not_called()
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_text_only_alias_for_no_vision(
-        self, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        """--text-only should route as --no-vision (enable_vision=False)."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(
-            app,
-            ["organize", str(input_dir), str(output_dir), "--text-only"],
-        )
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=False,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_no_prefetch_flag_passes_through(
-        self, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        """--no-prefetch should be forwarded as no_prefetch=True."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(
-            app,
-            ["organize", str(input_dir), str(output_dir), "--no-prefetch"],
-        )
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=None,
-            prefetch_depth=0,
-            enable_vision=True,
-            no_prefetch=True,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_sequential_with_max_workers_one_is_valid(
-        self, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        """--sequential with --max-workers 1 should succeed."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(
-            app,
-            [
-                "organize",
-                str(input_dir),
-                str(output_dir),
-                "--sequential",
-                "--max-workers",
-                "1",
-            ],
-        )
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=1,
-            prefetch_depth=0,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_organize_prefetch_depth_zero_explicit(
-        self, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        """Explicit --prefetch-depth 0 should be forwarded unchanged."""
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
-
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result()
-
-        result = runner.invoke(
-            app,
-            ["organize", str(input_dir), str(output_dir), "--prefetch-depth", "0"],
-        )
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=None,
-            prefetch_depth=0,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch(
-        "file_organizer.core.organizer.FileOrganizer",
-        side_effect=RuntimeError("Ollama not running"),
+def _plan(input_dir: Path, output_dir: Path) -> OrganizationPlan:
+    options = OrganizeOptions(recursive=False, transfer_mode="copy", methodology="para")
+    return OrganizationPlan(
+        plan_id="plan-1",
+        schema_version=PLAN_SCHEMA_VERSION,
+        input_path=str(input_dir.resolve()),
+        output_path=str(output_dir.resolve()),
+        created_at="2026-01-01T00:00:00Z",
+        skip_existing=options.skip_existing,
+        use_hardlinks=options.use_hardlinks,
+        total_files=0,
+        processed_files=0,
+        skipped_files=0,
+        failed_files=0,
+        deduplicated_files=0,
+        options=options,
     )
-    def test_organize_error(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        input_dir = tmp_path / "input"
-        output_dir = tmp_path / "output"
-        input_dir.mkdir()
-        output_dir.mkdir()
 
+
+def test_organize_fails_when_setup_not_completed(tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    with patch(_SETUP_PATCH, side_effect=_fake_check_setup):
         result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
-        assert result.exit_code == 1
-        assert "Ollama not running" in result.output
+    assert result.exit_code == 1
 
 
-# ---------------------------------------------------------------------------
-# preview
-# ---------------------------------------------------------------------------
+def test_organize_executes_through_application_service(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
+    assert result.exit_code == 0, result.output
+    assert "8 processed" in result.output
+    request, plan = service.execute.call_args.args
+    assert plan is None
+    assert request.input_path == input_dir.resolve()
+    assert request.output_path == output_dir.resolve()
+    assert request.options.transfer_mode == TransferMode.HARDLINK
 
 
-class TestPreview:
-    """Tests for the ``preview`` command."""
+@pytest.mark.parametrize("flag", ["--dry-run"])
+def test_organize_dry_run_uses_preview(flag: str, service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(app, ["organize", str(input_dir), str(output_dir), flag])
+    assert result.exit_code == 0, result.output
+    service.preview.assert_called_once()
+    service.execute.assert_not_called()
+    assert "no files will be applied" in result.output
 
-    def test_preview_fails_when_setup_not_completed(self, tmp_path: Path) -> None:
-        """When setup is not completed, preview should exit with code 1 and show guidance."""
-        input_dir = tmp_path / "input"
-        input_dir.mkdir()
 
-        with patch(_SETUP_PATCH, side_effect=_fake_check_setup):
-            result = runner.invoke(app, ["preview", str(input_dir)])
-
-        assert result.exit_code == 1
-        assert "First-time setup required" in result.output
-        assert "fo setup" in result.output
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_preview_basic(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result(total=15)
-
-        result = runner.invoke(app, ["preview", str(tmp_path)])
-        assert result.exit_code == 0
-        assert "15" in result.output
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_preview_max_workers(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result(total=5)
-
-        result = runner.invoke(app, ["preview", str(tmp_path), "--max-workers", "4"])
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=4,
-            prefetch_depth=2,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_preview_sequential(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result(total=5)
-
-        result = runner.invoke(app, ["preview", str(tmp_path), "--sequential"])
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=1,
-            prefetch_depth=0,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_preview_no_vision(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result(total=5)
-
-        result = runner.invoke(app, ["preview", str(tmp_path), "--no-vision"])
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=False,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_preview_text_only_alias(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result(total=5)
-
-        result = runner.invoke(app, ["preview", str(tmp_path), "--text-only"])
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=False,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    @patch("file_organizer.core.organizer.FileOrganizer")
-    def test_preview_no_prefetch(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        mock_org.organize.return_value = _mock_result(total=5)
-
-        result = runner.invoke(app, ["preview", str(tmp_path), "--no-prefetch"])
-        assert result.exit_code == 0
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=None,
-            prefetch_depth=0,
-            enable_vision=True,
-            no_prefetch=True,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
-
-    def test_preview_sequential_conflicts_with_max_workers(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app, ["preview", str(tmp_path), "--sequential", "--max-workers", "4"]
-        )
-        assert result.exit_code == 2
-        assert "--sequential" in result.output
-
-    @patch(
-        "file_organizer.core.organizer.FileOrganizer",
-        side_effect=ValueError("Invalid directory"),
+def test_all_behavior_flags_map_losslessly(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "organize",
+            str(input_dir),
+            str(output_dir),
+            "--no-recursive",
+            "--include-hidden",
+            "--overwrite-existing",
+            "--transfer-mode",
+            "copy",
+            "--methodology",
+            "para",
+            "--max-workers",
+            "3",
+            "--prefetch-depth",
+            "1",
+            "--no-vision",
+            "--transcribe-audio",
+            "--max-transcribe-seconds",
+            "300",
+            "--whisper-model",
+            "small",
+            "--text-model",
+            "text-v1",
+            "--vision-model",
+            "vision-v1",
+            "--text-provider",
+            "openai",
+            "--vision-provider",
+            "claude",
+        ],
     )
-    def test_preview_error(self, mock_cls: MagicMock, tmp_path: Path) -> None:
-        result = runner.invoke(app, ["preview", str(tmp_path)])
-        assert result.exit_code == 1
+    assert result.exit_code == 0, result.output
+    options = service.execute.call_args.args[0].options
+    assert options.to_dict() == {
+        "recursive": False,
+        "include_hidden": True,
+        "skip_existing": False,
+        "transfer_mode": "copy",
+        "methodology": "para",
+        "enable_vision": False,
+        "transcribe_audio": True,
+        "max_transcribe_seconds": 300.0,
+        "whisper_model": "small",
+        "parallel_workers": 3,
+        "prefetch_depth": 1,
+        "text_model": "text-v1",
+        "vision_model": "vision-v1",
+        "text_provider": "openai",
+        "vision_provider": "claude",
+    }
 
-        assert "Invalid directory" in result.output
+
+def test_compatibility_aliases_normalize(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(
+        app,
+        ["organize", str(input_dir), str(output_dir), "--text-only", "--no-prefetch"],
+    )
+    assert result.exit_code == 0, result.output
+    options = service.execute.call_args.args[0].options
+    assert options.enable_vision is False
+    assert options.prefetch_depth == 0
+
+
+def test_sequential_normalizes_workers_and_prefetch(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(app, ["organize", str(input_dir), str(output_dir), "--sequential"])
+    assert result.exit_code == 0, result.output
+    options = service.execute.call_args.args[0].options
+    assert options.parallel_workers == 1
+    assert options.prefetch_depth == 0
+
+
+def test_incompatible_worker_flags_exit_two(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(
+        app,
+        ["organize", str(input_dir), str(output_dir), "--sequential", "--max-workers", "4"],
+    )
+    assert result.exit_code == 2
+    assert "cannot be combined" in result.output
+    service.execute.assert_not_called()
+
+
+def test_invalid_canonical_option_is_usage_error(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(
+        app, ["organize", str(input_dir), str(output_dir), "--transfer-mode", "move"]
+    )
+    assert result.exit_code == 2
+    assert "not supported" in result.output
+    service.execute.assert_not_called()
+
+
+def test_preview_scans_and_previews_same_request(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(
+        app,
+        ["preview", str(input_dir), "--output-dir", str(output_dir), "--methodology", "jd"],
+    )
+    assert result.exit_code == 0, result.output
+    scan_request = service.scan.call_args.args[0]
+    preview_request = service.preview.call_args.args[0]
+    assert scan_request == preview_request
+    assert preview_request.options.methodology == OrganizationMethodology.JOHNNY_DECIMAL
+
+
+def test_preview_keeps_legacy_single_path_invocation(service: MagicMock, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["preview", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    request = service.preview.call_args.args[0]
+    assert request.input_path == request.output_path == tmp_path.resolve()
+
+
+def test_json_output_is_stable_and_scriptable(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(app, ["organize", str(input_dir), str(output_dir), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["outcome"] == "ok"
+    assert payload["mode"] == "execute"
+    assert payload["request"]["options"]["transfer_mode"] == "hardlink"
+    assert payload["result"]["processed_files"] == 8
+
+
+def test_preview_saves_canonical_plan(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    plan = _plan(input_dir, output_dir)
+    service.preview.return_value = OrganizationResult(plan=plan)
+    plan_path = tmp_path / "review.json"
+    result = runner.invoke(
+        app,
+        [
+            "preview",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--save-plan",
+            str(plan_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert OrganizationPlan.from_dict(json.loads(plan_path.read_text())) == plan
+
+
+def test_organize_applies_serialized_plan_with_embedded_options(
+    service: MagicMock, tmp_path: Path
+) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    plan = _plan(input_dir, output_dir)
+    plan_path = tmp_path / "review.json"
+    plan_path.write_text(json.dumps(plan.to_dict()))
+    result = runner.invoke(
+        app,
+        ["organize", str(input_dir), str(output_dir), "--plan", str(plan_path)],
+    )
+    assert result.exit_code == 0, result.output
+    request, applied_plan = service.execute.call_args.args
+    assert applied_plan == plan
+    assert request.options == plan.options
+
+
+def test_domain_errors_have_stable_json_and_exit_code(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    service.execute.side_effect = DomainError(
+        DomainErrorCode.PLAN_MISMATCH, "reviewed plan no longer matches"
+    )
+    result = runner.invoke(app, ["organize", str(input_dir), str(output_dir), "--json"])
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    assert payload["outcome"] == "error"
+    assert payload["error"] == {
+        "code": "plan_mismatch",
+        "message": "reviewed plan no longer matches",
+        "retryable": False,
+    }
+
+
+def test_unexpected_errors_remain_actionable(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    service.execute.side_effect = RuntimeError("Ollama not running")
+    result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
+    assert result.exit_code == 1
+    assert "Ollama not running" in result.output

--- a/tests/cli/test_cli_organize.py
+++ b/tests/cli/test_cli_organize.py
@@ -193,6 +193,30 @@ def test_incompatible_worker_flags_exit_two(service: MagicMock, tmp_path: Path) 
     service.execute.assert_not_called()
 
 
+def test_incompatible_worker_flags_preserve_json_contract(
+    service: MagicMock, tmp_path: Path
+) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "organize",
+            str(input_dir),
+            str(output_dir),
+            "--json",
+            "--sequential",
+            "--max-workers",
+            "2",
+        ],
+    )
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["outcome"] == "error"
+    assert payload["error"]["code"] == "invalid_request"
+    assert "--sequential cannot be combined" in payload["error"]["message"]
+    service.execute.assert_not_called()
+
+
 def test_invalid_canonical_option_is_usage_error(service: MagicMock, tmp_path: Path) -> None:
     input_dir, output_dir = _roots(tmp_path)
     result = runner.invoke(
@@ -270,6 +294,30 @@ def test_organize_applies_serialized_plan_with_embedded_options(
     request, applied_plan = service.execute.call_args.args
     assert applied_plan == plan
     assert request.options == plan.options
+
+
+def test_plan_overlays_only_explicit_behavior_fields(service: MagicMock, tmp_path: Path) -> None:
+    input_dir, output_dir = _roots(tmp_path)
+    plan = _plan(input_dir, output_dir)
+    plan_path = tmp_path / "review.json"
+    plan_path.write_text(json.dumps(plan.to_dict()))
+    result = runner.invoke(
+        app,
+        [
+            "organize",
+            str(input_dir),
+            str(output_dir),
+            "--plan",
+            str(plan_path),
+            "--recursive",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    request, _ = service.execute.call_args.args
+    assert request.options.recursive is True
+    assert request.options.transfer_mode == TransferMode.COPY
+    assert request.options.methodology == OrganizationMethodology.PARA
+    assert request.options.text_model == plan.options.text_model
 
 
 def test_domain_errors_have_stable_json_and_exit_code(service: MagicMock, tmp_path: Path) -> None:

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -12,6 +12,7 @@ import pytest
 from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
+from file_organizer.core.types import OrganizationResult
 
 pytestmark = [pytest.mark.smoke, pytest.mark.ci, pytest.mark.unit]
 runner = CliRunner()
@@ -21,12 +22,12 @@ _SETUP_PATCH = "file_organizer.cli.organize._check_setup_completed"
 class TestOrganizeSmoke:
     """fo organize --dry-run exits 0 and reports processed count."""
 
-    # FileOrganizer is lazy-imported inside organize(); patching at definition
-    # site because cli.organize holds no module-level reference to the class.
     # _SETUP_PATCH uses new= so its mock is not injected as a parameter (PT019).
-    @patch("file_organizer.core.organizer.FileOrganizer")
+    @patch("file_organizer.cli.organize._create_service")
     @patch(_SETUP_PATCH, new=MagicMock(return_value=True))
-    def test_organize_dry_run_exits_zero(self, mock_cls: MagicMock, tmp_path: Path) -> None:
+    def test_organize_dry_run_exits_zero(
+        self, mock_create_service: MagicMock, tmp_path: Path
+    ) -> None:
         input_dir = tmp_path / "input"
         output_dir = tmp_path / "output"
         input_dir.mkdir()
@@ -34,14 +35,8 @@ class TestOrganizeSmoke:
         for name in ("a.txt", "b.md", "c.csv"):
             (input_dir / name).write_text("x")
 
-        mock_org = MagicMock()
-        mock_cls.return_value = mock_org
-        result_obj = MagicMock()
-        result_obj.total_files = 3
-        result_obj.processed_files = 3
-        result_obj.skipped_files = 0
-        result_obj.failed_files = 0
-        mock_org.organize.return_value = result_obj
+        service = mock_create_service.return_value
+        service.preview.return_value = OrganizationResult(total_files=3, processed_files=3)
 
         result = runner.invoke(
             app,
@@ -49,16 +44,7 @@ class TestOrganizeSmoke:
         )
 
         assert result.exit_code == 0, result.output
-        mock_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=None,
-            prefetch_depth=2,
-            enable_vision=True,
-            no_prefetch=False,
-            transcribe_audio=False,
-            max_transcribe_seconds=600.0,
-            whisper_model="tiny",
-        )
+        service.preview.assert_called_once()
 
 
 class TestSearchSmoke:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
+from file_organizer.core.types import OrganizationResult
 
 runner = CliRunner()
 
@@ -108,13 +109,11 @@ def test_organize_advanced_help_lists_hidden_tuning_flags():
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)
-@patch("file_organizer.core.organizer.FileOrganizer")
-def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
-    """Test organize command executes FileOrganizer correctly."""
-    mock_instance = MagicMock()
-    mock_result = MagicMock(processed_files=5, skipped_files=1, failed_files=0)
-    mock_instance.organize.return_value = mock_result
-    mock_organizer_cls.return_value = mock_instance
+@patch("file_organizer.cli.organize._create_service")
+def test_organize_command_live(mock_create_service, _mock_setup, tmp_path):
+    """Test organize command executes the canonical service."""
+    service = mock_create_service.return_value
+    service.execute.return_value = OrganizationResult(processed_files=5, skipped_files=1)
 
     in_dir = tmp_path / "in"
     out_dir = tmp_path / "out"
@@ -125,27 +124,18 @@ def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
 
     assert result.exit_code == 0
     assert "Organizing" in result.stdout
-    mock_organizer_cls.assert_called_once_with(
-        dry_run=False,
-        parallel_workers=None,
-        prefetch_depth=2,
-        enable_vision=True,
-        no_prefetch=False,
-        transcribe_audio=False,
-        max_transcribe_seconds=600.0,
-        whisper_model="tiny",
-    )
-    mock_instance.organize.assert_called_once_with(in_dir, out_dir)
+    request, plan = service.execute.call_args.args
+    assert plan is None
+    assert request.input_path == in_dir.resolve()
+    assert request.output_path == out_dir.resolve()
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)
-@patch("file_organizer.core.organizer.FileOrganizer")
-def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
+@patch("file_organizer.cli.organize._create_service")
+def test_organize_command_dry_run(mock_create_service, _mock_setup, tmp_path):
     """Test organize command processes dry-run flag."""
-    mock_instance = MagicMock()
-    mock_result = MagicMock(processed_files=3, skipped_files=0, failed_files=0)
-    mock_instance.organize.return_value = mock_result
-    mock_organizer_cls.return_value = mock_instance
+    service = mock_create_service.return_value
+    service.preview.return_value = OrganizationResult(total_files=3, processed_files=3)
 
     in_dir = tmp_path / "in"
     out_dir = tmp_path / "out"
@@ -156,28 +146,16 @@ def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
 
     assert result.exit_code == 0
     assert "Dry run mode" in result.stdout
-    mock_organizer_cls.assert_called_once_with(
-        dry_run=True,
-        parallel_workers=None,
-        prefetch_depth=2,
-        enable_vision=True,
-        no_prefetch=False,
-        transcribe_audio=False,
-        max_transcribe_seconds=600.0,
-        whisper_model="tiny",
-    )
-    # A.cli resolves the path args before dispatching; the service sees
-    # the canonical absolute form.
-    mock_instance.organize.assert_called_once_with(in_dir.resolve(), out_dir.resolve())
+    request = service.preview.call_args.args[0]
+    assert request.input_path == in_dir.resolve()
+    assert request.output_path == out_dir.resolve()
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)
-@patch("file_organizer.core.organizer.FileOrganizer")
-def test_organize_command_error(mock_organizer_cls, _mock_setup, tmp_path):
+@patch("file_organizer.cli.organize._create_service")
+def test_organize_command_error(mock_create_service, _mock_setup, tmp_path):
     """Test organize command handles exceptions gracefully."""
-    mock_instance = MagicMock()
-    mock_instance.organize.side_effect = RuntimeError("Something broke")
-    mock_organizer_cls.return_value = mock_instance
+    mock_create_service.return_value.execute.side_effect = RuntimeError("Something broke")
 
     # A.cli: real directories required so the service-layer error path
     # (not CLI-arg-validation path) is exercised.
@@ -191,13 +169,11 @@ def test_organize_command_error(mock_organizer_cls, _mock_setup, tmp_path):
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)
-@patch("file_organizer.core.organizer.FileOrganizer")
-def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
-    """Test preview command runs organizer in dry_run mode."""
-    mock_instance = MagicMock()
-    mock_result = MagicMock(total_files=10)
-    mock_instance.organize.return_value = mock_result
-    mock_organizer_cls.return_value = mock_instance
+@patch("file_organizer.cli.organize._create_service")
+def test_preview_command(mock_create_service, _mock_setup, tmp_path):
+    """Test preview command uses canonical scan and preview calls."""
+    service = mock_create_service.return_value
+    service.preview.return_value = OrganizationResult(total_files=10)
 
     in_dir = tmp_path / "in_dir"
     in_dir.mkdir()
@@ -205,27 +181,17 @@ def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
 
     assert result.exit_code == 0
     assert "Previewing" in result.stdout
-    mock_organizer_cls.assert_called_once_with(
-        dry_run=True,
-        parallel_workers=None,
-        prefetch_depth=2,
-        enable_vision=True,
-        no_prefetch=False,
-        transcribe_audio=False,
-        max_transcribe_seconds=600.0,
-        whisper_model="tiny",
-    )
     resolved = in_dir.resolve()
-    mock_instance.organize.assert_called_once_with(resolved, resolved)
+    request = service.preview.call_args.args[0]
+    assert request.input_path == request.output_path == resolved
+    service.scan.assert_called_once_with(request)
 
 
 @patch("file_organizer.cli.organize._check_setup_completed", return_value=True)
-@patch("file_organizer.core.organizer.FileOrganizer")
-def test_preview_command_error(mock_organizer_cls, _mock_setup, tmp_path):
+@patch("file_organizer.cli.organize._create_service")
+def test_preview_command_error(mock_create_service, _mock_setup, tmp_path):
     """Test preview command handles exceptions."""
-    mock_instance = MagicMock()
-    mock_instance.organize.side_effect = ValueError("Bad input")
-    mock_organizer_cls.return_value = mock_instance
+    mock_create_service.return_value.preview.side_effect = ValueError("Bad input")
 
     in_dir = tmp_path / "in_dir"
     in_dir.mkdir()

--- a/tests/cli/test_organize_transcribe_flag.py
+++ b/tests/cli/test_organize_transcribe_flag.py
@@ -1,9 +1,4 @@
-"""Tests that --transcribe-audio and --max-transcribe-seconds reach FileOrganizer.
-
-Pins the CLI wiring contract end-to-end: the flags parse, get threaded
-through, and convert the documented "0 disables cap" boundary to None
-(the organizer's representation of uncapped).
-"""
+"""Compatibility tests for CLI transcription flags at the canonical boundary."""
 
 from __future__ import annotations
 
@@ -14,184 +9,77 @@ import pytest
 from typer.testing import CliRunner
 
 from file_organizer.cli.main import app
+from file_organizer.core.organization_service import OrganizationScan, OrganizationService
+from file_organizer.core.types import OrganizationResult
+
+
+@pytest.fixture
+def service() -> MagicMock:
+    mock = MagicMock(spec=OrganizationService)
+    mock.scan.return_value = OrganizationScan(Path("input"), (), {})
+    mock.preview.return_value = OrganizationResult()
+    mock.execute.return_value = OrganizationResult()
+    return mock
 
 
 @pytest.mark.unit
 @pytest.mark.ci
-class TestOrganizeTranscribeFlag:
-    def test_transcribe_audio_flag_threads_to_organizer(self, tmp_path: Path) -> None:
-        input_dir = tmp_path / "in"
-        input_dir.mkdir()
-        output_dir = tmp_path / "out"
+@pytest.mark.parametrize(
+    ("command", "expected_seconds", "expected_model"),
+    [
+        ("organize", 300.0, "base"),
+        ("preview", 120.0, "small"),
+        ("organize", None, "tiny"),
+    ],
+)
+def test_transcription_flags_reach_canonical_options(
+    command: str,
+    expected_seconds: float | None,
+    expected_model: str,
+    service: MagicMock,
+    tmp_path: Path,
+) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    args = [command, str(input_dir)]
+    if command == "organize":
+        args.append(str(output_dir))
+    seconds = "0" if expected_seconds is None else str(expected_seconds)
+    args.extend(
+        [
+            "--transcribe-audio",
+            "--max-transcribe-seconds",
+            seconds,
+            "--whisper-model",
+            expected_model,
+        ]
+    )
+    with (
+        patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
+        patch("file_organizer.cli.organize._create_service", return_value=service),
+    ):
+        result = CliRunner().invoke(app, args)
+    assert result.exit_code == 0, result.output
+    call = service.execute.call_args or service.preview.call_args
+    options = call.args[0].options
+    assert options.transcribe_audio is True
+    assert options.max_transcribe_seconds == expected_seconds
+    assert options.whisper_model == expected_model
 
-        runner = CliRunner()
-        with (
-            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org_cls,
-        ):
-            mock_org = MagicMock()
-            mock_org_cls.return_value = mock_org
-            mock_org.organize.return_value = MagicMock(
-                processed_files=0, skipped_files=0, failed_files=0, total_files=0
-            )
 
-            result = runner.invoke(
-                app,
-                [
-                    "organize",
-                    str(input_dir),
-                    str(output_dir),
-                    "--transcribe-audio",
-                    "--max-transcribe-seconds",
-                    "300",
-                ],
-            )
-
-        assert result.exit_code == 0, result.output
-        kwargs = mock_org_cls.call_args.kwargs
-        assert kwargs.get("transcribe_audio") is True
-        assert kwargs.get("max_transcribe_seconds") == 300.0
-
-    def test_transcribe_audio_default_off(self, tmp_path: Path) -> None:
-        # Without the flag, FileOrganizer must receive transcribe_audio=False.
-        # Default ON would silently slow `fo organize` for every audio file
-        # and break beta testers without the [audio] extra.
-        input_dir = tmp_path / "in"
-        input_dir.mkdir()
-        output_dir = tmp_path / "out"
-
-        runner = CliRunner()
-        with (
-            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org_cls,
-        ):
-            mock_org_cls.return_value = MagicMock()
-            mock_org_cls.return_value.organize.return_value = MagicMock(
-                processed_files=0, skipped_files=0, failed_files=0, total_files=0
-            )
-
-            result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
-
-        assert result.exit_code == 0, result.output
-        kwargs = mock_org_cls.call_args.kwargs
-        assert kwargs.get("transcribe_audio") is False
-
-    def test_max_transcribe_seconds_zero_means_no_cap(self, tmp_path: Path) -> None:
-        # The documented "0 disables the cap entirely" boundary maps to
-        # `max_transcribe_seconds=None` in the organizer (None = uncapped).
-        # Without this conversion, `--max-transcribe-seconds 0` would skip
-        # every audio file because every duration > 0.
-        input_dir = tmp_path / "in"
-        input_dir.mkdir()
-        output_dir = tmp_path / "out"
-
-        runner = CliRunner()
-        with (
-            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org_cls,
-        ):
-            mock_org_cls.return_value = MagicMock()
-            mock_org_cls.return_value.organize.return_value = MagicMock(
-                processed_files=0, skipped_files=0, failed_files=0, total_files=0
-            )
-
-            result = runner.invoke(
-                app,
-                [
-                    "organize",
-                    str(input_dir),
-                    str(output_dir),
-                    "--transcribe-audio",
-                    "--max-transcribe-seconds",
-                    "0",
-                ],
-            )
-
-        assert result.exit_code == 0, result.output
-        kwargs = mock_org_cls.call_args.kwargs
-        assert kwargs.get("max_transcribe_seconds") is None
-
-    def test_preview_supports_same_flags(self, tmp_path: Path) -> None:
-        input_dir = tmp_path / "in"
-        input_dir.mkdir()
-
-        runner = CliRunner()
-        with (
-            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org_cls,
-        ):
-            mock_org_cls.return_value = MagicMock()
-            mock_org_cls.return_value.organize.return_value = MagicMock(total_files=0)
-
-            result = runner.invoke(
-                app,
-                [
-                    "preview",
-                    str(input_dir),
-                    "--transcribe-audio",
-                    "--max-transcribe-seconds",
-                    "120",
-                    "--whisper-model",
-                    "small",
-                ],
-            )
-
-        assert result.exit_code == 0, result.output
-        kwargs = mock_org_cls.call_args.kwargs
-        assert kwargs.get("transcribe_audio") is True
-        assert kwargs.get("max_transcribe_seconds") == 120.0
-        assert kwargs.get("whisper_model") == "small"
-
-    def test_whisper_model_flag_threads_to_organizer(self, tmp_path: Path) -> None:
-        input_dir = tmp_path / "in"
-        input_dir.mkdir()
-        output_dir = tmp_path / "out"
-
-        runner = CliRunner()
-        with (
-            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org_cls,
-        ):
-            mock_org_cls.return_value = MagicMock()
-            mock_org_cls.return_value.organize.return_value = MagicMock(
-                processed_files=0, skipped_files=0, failed_files=0, total_files=0
-            )
-
-            result = runner.invoke(
-                app,
-                [
-                    "organize",
-                    str(input_dir),
-                    str(output_dir),
-                    "--transcribe-audio",
-                    "--whisper-model",
-                    "base",
-                ],
-            )
-
-        assert result.exit_code == 0, result.output
-        kwargs = mock_org_cls.call_args.kwargs
-        assert kwargs.get("whisper_model") == "base"
-
-    def test_whisper_model_defaults_to_tiny(self, tmp_path: Path) -> None:
-        # "tiny" keeps the default transcription path fast; larger models
-        # must be an explicit opt-in via --whisper-model.
-        input_dir = tmp_path / "in"
-        input_dir.mkdir()
-        output_dir = tmp_path / "out"
-
-        runner = CliRunner()
-        with (
-            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org_cls,
-        ):
-            mock_org_cls.return_value = MagicMock()
-            mock_org_cls.return_value.organize.return_value = MagicMock(
-                processed_files=0, skipped_files=0, failed_files=0, total_files=0
-            )
-
-            result = runner.invoke(app, ["organize", str(input_dir), str(output_dir)])
-
-        assert result.exit_code == 0, result.output
-        kwargs = mock_org_cls.call_args.kwargs
-        assert kwargs.get("whisper_model") == "tiny"
+@pytest.mark.unit
+@pytest.mark.ci
+def test_transcription_remains_opt_in(service: MagicMock, tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    with (
+        patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
+        patch("file_organizer.cli.organize._create_service", return_value=service),
+    ):
+        result = CliRunner().invoke(app, ["organize", str(input_dir), str(output_dir)])
+    assert result.exit_code == 0, result.output
+    options = service.execute.call_args.args[0].options
+    assert options.transcribe_audio is False
+    assert options.whisper_model == "tiny"

--- a/tests/cli/test_setup_gate.py
+++ b/tests/cli/test_setup_gate.py
@@ -14,6 +14,7 @@ non-organize command crashes pre-setup with a cryptic stack trace.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -102,6 +103,40 @@ def test_organize_blocked_pre_setup(fresh_config: Path, tmp_path: Path) -> None:
     result = runner.invoke(app, ["organize", str(in_dir), str(out_dir)])
     # The gate exits the process; result.output carries the panel.
     assert "First-time setup required" in result.output
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+@pytest.mark.uses_setup_gate
+@pytest.mark.parametrize("local_json", [False, True], ids=["global", "command-local"])
+def test_organize_setup_gate_honors_json_contract(
+    local_json: bool, fresh_config: Path, tmp_path: Path
+) -> None:
+    """Both global and command-local JSON modes emit one setup error object."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    args = ["organize", str(input_dir), str(output_dir)]
+    if local_json:
+        args.append("--json")
+    else:
+        args.insert(0, "--json")
+
+    result = CliRunner().invoke(app, args)
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload == {
+        "command": "organize",
+        "error": {
+            "code": "setup_required",
+            "details": {"action": "fo setup"},
+            "message": "First-time setup is required. Run `fo setup` to continue.",
+            "retryable": False,
+        },
+        "outcome": "error",
+        "schema_version": 1,
+    }
 
 
 @pytest.mark.integration

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -9,7 +9,11 @@ import pytest
 
 from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from tests.conformance.corpus import CorpusCase, get_case, materialize_case
-from tests.conformance.driver import DirectServiceDriver, OrganizationConformanceDriver
+from tests.conformance.driver import (
+    CLIConformanceDriver,
+    DirectServiceDriver,
+    OrganizationConformanceDriver,
+)
 
 
 @dataclass
@@ -35,11 +39,12 @@ class ConformanceContext:
         )
 
 
-@pytest.fixture
-def conformance(tmp_path: Path) -> ConformanceContext:
-    """Fully isolated conformance context: fresh roots, fresh audit workspace."""
+@pytest.fixture(params=(DirectServiceDriver, CLIConformanceDriver), ids=("direct", "cli"))
+def conformance(tmp_path: Path, request: pytest.FixtureRequest) -> ConformanceContext:
+    """Run the golden corpus against the oracle and each migrated adapter."""
+    driver_type = request.param
     return ConformanceContext(
         input_root=tmp_path / "input",
         output_root=tmp_path / "output",
-        driver=DirectServiceDriver(tmp_path / "workspace"),
+        driver=driver_type(tmp_path / "workspace"),
     )

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -25,16 +25,22 @@ identical inputs.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+from unittest.mock import patch
 
+from typer.testing import CliRunner
+
+from file_organizer.cli.main import app
 from file_organizer.core import dispatcher
 from file_organizer.core.errors import DomainError
-from file_organizer.core.organization_service import OrganizationService
+from file_organizer.core.organization_service import OrganizationScan, OrganizationService
 from file_organizer.core.organize_options import OrganizeRequest
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.plan import OrganizationPlan
+from file_organizer.core.types import OrganizationResult
 from file_organizer.history.tracker import OperationHistory
 from file_organizer.models.base import ModelConfig, ModelType
 from file_organizer.services.audio.metadata_extractor import (
@@ -46,9 +52,11 @@ from file_organizer.services.video.metadata_extractor import (
     VideoMetadataExtractor,
 )
 from file_organizer.undo import UndoManager
+from file_organizer.utils.atomic_write import atomic_write_text
 from tests.conformance.normalize import (
     normalize_audit_events,
     normalize_error,
+    normalize_path,
     normalize_plan,
     normalize_result,
     normalize_scan,
@@ -268,4 +276,180 @@ class DirectServiceDriver:
             "plan": normalize_plan(result.plan, *roots),
             "result": normalize_result(result, *roots),
             "audit_events": events,
+        }
+
+
+class CLIConformanceDriver:
+    """Drive the local CLI through JSON, with the direct service as its oracle seam."""
+
+    name = "cli"
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+        self._workspace.mkdir(parents=True, exist_ok=True)
+        self._oracle = DirectServiceDriver(workspace / "service")
+        self._invocations = 0
+
+    @staticmethod
+    def _option_args(request: OrganizeRequest) -> list[str]:
+        options = request.options
+        args = [
+            "--recursive" if options.recursive else "--no-recursive",
+            "--include-hidden" if options.include_hidden else "--exclude-hidden",
+            "--skip-existing" if options.skip_existing else "--overwrite-existing",
+            "--transfer-mode",
+            options.effective_transfer_mode.value,
+            "--methodology",
+            options.effective_methodology.value,
+            "--prefetch-depth",
+            str(options.prefetch_depth),
+            "--whisper-model",
+            options.whisper_model,
+            "--max-transcribe-seconds",
+            str(options.max_transcribe_seconds or 0),
+        ]
+        if not options.enable_vision:
+            args.append("--no-vision")
+        if options.transcribe_audio:
+            args.append("--transcribe-audio")
+        if options.parallel_workers is not None:
+            args.extend(("--max-workers", str(options.parallel_workers)))
+        for flag, value in (
+            ("--text-model", options.text_model),
+            ("--vision-model", options.vision_model),
+            ("--text-provider", options.text_provider),
+            ("--vision-provider", options.vision_provider),
+        ):
+            if value is not None:
+                args.extend((flag, value))
+        return args
+
+    def _invoke(self, args: list[str]) -> dict[str, Any]:
+        self._invocations += 1
+        with (
+            patch("file_organizer.cli.organize._check_setup_completed", return_value=True),
+            patch(
+                "file_organizer.cli.organize._create_service",
+                return_value=self._oracle._service,
+            ),
+        ):
+            result = CliRunner().invoke(app, args)
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"CLI did not emit valid JSON (exit {result.exit_code}): {result.stdout}"
+            ) from exc
+        if result.exit_code == 0 and payload.get("outcome") != "ok":
+            raise AssertionError(f"CLI succeeded with a non-success envelope: {payload}")
+        return payload
+
+    @staticmethod
+    def _result(payload: dict[str, Any], plan: OrganizationPlan | None) -> OrganizationResult:
+        return OrganizationResult(
+            total_files=payload["total_files"],
+            processed_files=payload["processed_files"],
+            skipped_files=payload["skipped_files"],
+            failed_files=payload["failed_files"],
+            deduplicated_files=payload["deduplicated_files"],
+            processing_time=payload["processing_time"],
+            organized_structure=payload["organized_structure"],
+            errors=[tuple(error) for error in payload["errors"]],
+            plan=plan,
+            transaction_id=payload["transaction_id"],
+        )
+
+    @staticmethod
+    def _normalize_cli_error(
+        payload: dict[str, Any], input_root: Path, output_root: Path
+    ) -> dict[str, Any]:
+        error = dict(payload["error"])
+        if "code" in error:
+            error.setdefault("details", {})
+            return normalize_error(DomainError.from_dict(error), input_root, output_root)
+        error["message"] = (
+            error.get("message", "")
+            .replace(str(input_root.resolve(strict=False)), "<input>")
+            .replace(str(output_root.resolve(strict=False)), "<output>")
+        )
+        if "conflicts" in error:
+            for conflict in error["conflicts"]:
+                conflict["path"] = normalize_path(conflict["path"], input_root, output_root)
+            error["conflicts"].sort(
+                key=lambda conflict: (conflict["conflict_type"], conflict["path"])
+            )
+        return error
+
+    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        roots = (request.input_path, request.output_path)
+        payload = self._invoke(
+            [
+                "preview",
+                str(request.input_path),
+                "--output-dir",
+                str(request.output_path),
+                "--json",
+                *self._option_args(request),
+            ]
+        )
+        if payload["outcome"] == "error":
+            return {"outcome": "error", "error": self._normalize_cli_error(payload, *roots)}
+        raw = payload["scan"]
+        scan = OrganizationScan(
+            Path(raw["input_path"]), tuple(Path(path) for path in raw["files"]), raw["counts"]
+        )
+        return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
+
+    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        roots = (request.input_path, request.output_path)
+        payload = self._invoke(
+            [
+                "preview",
+                str(request.input_path),
+                "--output-dir",
+                str(request.output_path),
+                "--json",
+                *self._option_args(request),
+            ]
+        )
+        if payload["outcome"] == "error":
+            return {"outcome": "error", "error": self._normalize_cli_error(payload, *roots)}
+        plan = OrganizationPlan.from_dict(payload["plan"])
+        result = self._result(payload["result"], plan)
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(plan, *roots),
+            "result": normalize_result(result, *roots),
+            "plan_payload": payload["plan"],
+        }
+
+    def execute(
+        self, request: OrganizeRequest, plan_payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        roots = (request.input_path, request.output_path)
+        args = [
+            "organize",
+            str(request.input_path),
+            str(request.output_path),
+            "--json",
+            *self._option_args(request),
+        ]
+        if plan_payload is not None:
+            plan_path = self._workspace / f"plan-{self._invocations + 1}.json"
+            atomic_write_text(plan_path, json.dumps(plan_payload))
+            args.extend(("--plan", str(plan_path)))
+        payload = self._invoke(args)
+        if payload["outcome"] == "error":
+            return {"outcome": "error", "error": self._normalize_cli_error(payload, *roots)}
+        plan = OrganizationPlan.from_dict(payload["plan"])
+        result = self._result(payload["result"], plan)
+        history = self._oracle._last_history
+        assert history is not None
+        operations = history.get_operations()
+        operations.sort(key=lambda operation: operation.id if operation.id is not None else -1)
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(plan, *roots),
+            "result": normalize_result(result, *roots),
+            "audit_events": normalize_audit_events(operations, *roots),
         }

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -55,9 +55,9 @@ def _operation_routes(envelope: dict) -> list[tuple[str, str, str, str]]:
     ]
 
 
-def test_direct_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
+def test_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
     assert isinstance(conformance.driver, OrganizationConformanceDriver)
-    assert conformance.driver.name == "direct-service"
+    assert conformance.driver.name in {"direct-service", "cli"}
 
 
 def test_corpus_materialization_is_deterministic(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- migrate `fo organize` and `fo preview` from direct `FileOrganizer` construction to the canonical `OrganizationService`
- map recursion, hidden-file, collision, transfer, methodology, media, performance, model, and provider controls losslessly into `OrganizeOptions`
- add canonical plan save/apply flows and versioned, single-document JSON success/error envelopes
- run the shared golden conformance corpus against both the direct-service oracle and the CLI adapter
- mark the verified CLI organization and methodology capabilities in the registry and document the adapter contract

## User-visible behavior

- `fo organize` now supports `--recursive/--no-recursive`, `--include-hidden/--exclude-hidden`, `--skip-existing/--overwrite-existing`, `--transfer-mode`, and `--methodology`
- `fo preview INPUT --output-dir OUTPUT --save-plan plan.json` creates a reviewable canonical plan; `fo organize INPUT OUTPUT --plan plan.json` applies it
- both commands accept a local `--json` flag in addition to global `fo --json`; JSON stdout is exactly one stable document with no progress-rendering contamination
- existing `fo preview INPUT`, `--text-only`, `--no-prefetch`, transcription, worker, and dry-run invocations remain supported
- invalid requests, missing paths, plan conflicts, and execution failures have stable error shapes and exit codes
- setup preconditions and conflicting parallel flags also preserve the one-document JSON contract

## Internal implementation

- keep the CLI presentation-only; organization policy remains in the application/domain layer
- add an injectable service factory for adapter tests
- add a `CLIConformanceDriver` that exercises Typer parsing, JSON serialization, canonical service execution, reviewed-plan handoff, and audit normalization
- parameterize all shared organization conformance scenarios over direct service and CLI

## Validation

- `pytest -q -o addopts='' tests/cli tests/conformance tests/core/test_capabilities.py --disable-warnings --maxfail=3` — 1,171 passed
- `mypy src/file_organizer/` — 452 source files clean
- changed-file pre-commit suite — passed, including smoke, CI guardrails, WebSocket, Web UI, diff-cover, interrogate, docs links, CI rails, and PyMarkdown
- `git diff --check` — passed

## Risk

- Human-readable organization progress now flows through the canonical service, so presentation ordering can differ slightly from the former direct adapter.
- JSON output is a new versioned contract (`schema_version: 1`); future incompatible changes must increment it.
- Applying a serialized plan without behavior flags uses the reviewed plan's embedded options. Only explicitly supplied fields are overlaid; mismatches are rejected before mutation.

Part of #1593

Fixes #1607
