### PR TITLE
Align Web and Desktop with canonical organization workflows

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,6 +6,11 @@ language: en
 
 reviews:
   request_changes_workflow: false
+  pre_merge_checks:
+    # The repository's source-only interrogate gate enforces 95% coverage.
+    # CodeRabbit's PR-wide calculation also counts intentionally undocumented tests.
+    docstrings:
+      mode: "off"
   auto_review:
     enabled: true
   review_status: true

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -43,6 +43,12 @@ When you start the app, it does these steps:
 3. It waits for the server.
 4. It opens a native window to the local UI.
 
+The Desktop application does not implement a second organization workflow.
+It loads the same `/ui/organize` routes, canonical option mapping, reviewed
+plans, jobs, and results as a browser. Its only additions are native directory,
+file, and save dialogs plus reveal-in-file-manager behavior; those affordances
+select or display paths and do not alter organization semantics.
+
 ## Install
 
 ```bash
@@ -60,6 +66,7 @@ pip install -e ".[desktop]"
 Templates must use the helpers from `desktop_api.js`:
 
 - `window.desktopBrowseFile(inputId, fileTypes)`
+- `window.desktopBrowseDirectory(inputId)`
 - `window.desktopSaveFile(suggestedName, fileTypes)`
 - `window.desktopOpenPath(path)`
 

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -13,7 +13,7 @@ never from any adapter.
 | --- | --- |
 | `tests/conformance/corpus.py` | Deterministic fixture corpus: pinned bytes and mtimes, tagged cases |
 | `tests/conformance/normalize.py` | Strips presentation-only differences while preserving executable ordering and complete source fingerprints |
-| `tests/conformance/driver.py` | Driver protocol, direct-service oracle, and CLI/REST/Python SDK adapters |
+| `tests/conformance/driver.py` | Driver protocol, direct-service oracle, and CLI/REST/Python SDK/Web-Desktop adapters |
 | `tests/conformance/test_direct_service_conformance.py` | Golden expectations for canonical semantics |
 
 ## Fixture corpus
@@ -37,6 +37,14 @@ through in-process HTTP transports. This verifies traversal, complete option
 mapping, executable-plan round trips, stable errors, execution results, and
 audit effects against the direct-service oracle without relying on route
 construction alone.
+
+The Web/Desktop driver round-trips every canonical option through the Web form
+parser, builds the serialized plan rendered for review, and executes that plan
+through the same application-service seam. Desktop uses these exact `/ui`
+routes; its separate tests constrain the Python bridge to native path dialogs
+and reveal-in-file-manager affordances. Web/Desktop scan and preview therefore
+have executable corpus evidence. Execution remains unverified until the corpus
+also covers the surface's queued job, cancellation, and rollback lifecycle.
 
 ## Writing an adapter driver
 

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -13,7 +13,7 @@ never from any adapter.
 | --- | --- |
 | `tests/conformance/corpus.py` | Deterministic fixture corpus: pinned bytes and mtimes, tagged cases |
 | `tests/conformance/normalize.py` | Strips presentation-only differences while preserving executable ordering and complete source fingerprints |
-| `tests/conformance/driver.py` | Driver protocol, direct-service oracle, and CLI/REST/Python SDK/Web-Desktop adapters |
+| `tests/conformance/driver.py` | Driver protocol, direct-service oracle, and CLI/REST/Python SDK/Web-form adapters |
 | `tests/conformance/test_direct_service_conformance.py` | Golden expectations for canonical semantics |
 
 ## Fixture corpus
@@ -38,13 +38,17 @@ mapping, executable-plan round trips, stable errors, execution results, and
 audit effects against the direct-service oracle without relying on route
 construction alone.
 
-The Web/Desktop driver round-trips every canonical option through the Web form
-parser, builds the serialized plan rendered for review, and executes that plan
-through the same application-service seam. Desktop uses these exact `/ui`
-routes; its separate tests constrain the Python bridge to native path dialogs
-and reveal-in-file-manager affordances. Web/Desktop scan and preview therefore
+The Web form driver sends the corpus through the real `/ui/organize`,
+`/ui/organize/scan`, and `/ui/organize/plan/clear` routes. It round-trips every
+canonical option, reads the serialized plan rendered for review, and verifies
+that rejecting the plan evicts it. Those declared Web entry points therefore
 have executable corpus evidence. Execution remains unverified until the corpus
 also covers the surface's queued job, cancellation, and rollback lifecycle.
+
+Desktop loads these same `/ui` routes, so its organization behavior is
+equivalent by construction rather than independently corpus-driven. Focused
+Desktop tests constrain the additional Python bridge to native path dialogs
+and reveal-in-file-manager affordances.
 
 ## Writing an adapter driver
 

--- a/docs/web-ui/organization.md
+++ b/docs/web-ui/organization.md
@@ -14,7 +14,7 @@ The page is organized as:
 ## Quick workflow: plan, review, run, export
 
 1. Open `/ui/organize` and enter input/output directories.
-2. Select methodology (`content_based`, `johnny_decimal`, `para`, or `date_based`).
+2. Select methodology (`none`, `para`, or `jd`) and any canonical processing options.
 3. Generate the plan and review proposed output paths before execution.
 4. Start the run and watch live progress/status updates.
 5. Export run output/history as JSON/CSV for follow-up or audit.
@@ -27,15 +27,24 @@ Use the scan form to provide:
 - output directory
 - methodology
 - recursive scan toggle
+- hidden-file toggle
 - skip-existing toggle
-- hardlink toggle
+- copy or hardlink transfer mode
+- image analysis and audio transcription controls
+- text, vision, and transcription model settings
+- provider and performance settings
 
 Supported methodology options in the current UI:
 
-- `content_based`
-- `johnny_decimal`
+- `none`
 - `para`
-- `date_based`
+- `jd`
+
+The form maps directly to the shared `OrganizeOptions` contract. Scan counts,
+preview operations, and execution use the same recursion and hidden-file
+policy. The server stores the canonical serialized plan shown for review and
+executes that exact version; it does not recompute or rewrite destinations in
+the Web layer.
 
 ## Run and monitor
 
@@ -47,6 +56,12 @@ The page includes:
 - progress rendering
 - periodic history refresh
 - periodic stats refresh
+- queued and scheduled cancellation
+- transaction-specific rollback when a completed run supports it
+
+The capability-status panel is generated from the shared registry. It shows
+implemented, unverified, and unavailable organization workflows explicitly
+instead of inferring support from which buttons happen to be visible.
 
 ## History and exports
 

--- a/src/file_organizer/core/capability_registry.json
+++ b/src/file_organizer/core/capability_registry.json
@@ -1902,7 +1902,7 @@
           "target_support": "full"
         },
         "web-desktop": {
-          "conformance_status": "unverified",
+          "conformance_status": "verified",
           "entry_points": [
             "GET /ui/organize",
             "POST /ui/organize/scan",
@@ -1974,7 +1974,7 @@
           "target_support": "full"
         },
         "web-desktop": {
-          "conformance_status": "unverified",
+          "conformance_status": "verified",
           "entry_points": [
             "POST /ui/organize/scan"
           ],

--- a/src/file_organizer/core/organization_service.py
+++ b/src/file_organizer/core/organization_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -43,6 +43,26 @@ class OrganizationScan:
 OrganizerFactory = Callable[..., FileOrganizer]
 
 
+def count_files_by_type(files: Iterable[Path]) -> dict[str, int]:
+    """Count files using the canonical organization type buckets."""
+    counts = dict.fromkeys(("text", "image", "video", "audio", "cad", "other"), 0)
+    for path in files:
+        extension = path.suffix.lower()
+        if extension in TEXT_EXTENSIONS:
+            counts["text"] += 1
+        elif extension in IMAGE_EXTENSIONS:
+            counts["image"] += 1
+        elif extension in VIDEO_EXTENSIONS:
+            counts["video"] += 1
+        elif extension in AUDIO_EXTENSIONS:
+            counts["audio"] += 1
+        elif extension in CAD_EXTENSIONS:
+            counts["cad"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
 class OrganizationService:
     """Transport-neutral entry point for scan, preview, and execution."""
 
@@ -79,21 +99,7 @@ class OrganizationService:
                 include_hidden=request.options.include_hidden,
             )
         )
-        counts = dict.fromkeys(("text", "image", "video", "audio", "cad", "other"), 0)
-        for path in files:
-            extension = path.suffix.lower()
-            if extension in TEXT_EXTENSIONS:
-                counts["text"] += 1
-            elif extension in IMAGE_EXTENSIONS:
-                counts["image"] += 1
-            elif extension in VIDEO_EXTENSIONS:
-                counts["video"] += 1
-            elif extension in AUDIO_EXTENSIONS:
-                counts["audio"] += 1
-            elif extension in CAD_EXTENSIONS:
-                counts["cad"] += 1
-            else:
-                counts["other"] += 1
+        counts = count_files_by_type(files)
         return OrganizationScan(request.input_path, files, counts)
 
     def preview(self, request: OrganizeRequest) -> OrganizationResult:

--- a/src/file_organizer/web/organize_routes.py
+++ b/src/file_organizer/web/organize_routes.py
@@ -511,6 +511,7 @@ def organize_scan(
         HTMX partial showing the generated plan or an error message.
     """
     error_message: str | None = None
+    error_payload: dict[str, Any] | None = None
     info_message: str | None = None
     plan: dict[str, Any] | None = None
 
@@ -543,11 +544,24 @@ def organize_scan(
         info_message = "Plan generated. Review movements and execute when ready."
     except ApiError as exc:
         error_message = exc.message
+        error_payload = {
+            "code": exc.error,
+            "message": exc.message,
+            "retryable": False,
+            "details": exc.details or {},
+        }
     except DomainError as exc:
         error_message = exc.message
+        error_payload = {**exc.to_dict(), "details": exc.details}
     except Exception:
         logger.exception("Failed to generate organize plan")
         error_message = "Failed to generate plan."
+        error_payload = {
+            "code": "execution_failed",
+            "message": error_message,
+            "retryable": False,
+            "details": {},
+        }
 
     return templates.TemplateResponse(
         request,
@@ -555,6 +569,7 @@ def organize_scan(
         {
             "plan": plan,
             "error_message": error_message,
+            "error_payload": error_payload,
             "info_message": info_message,
             "methodology_options": ORGANIZE_METHODOLOGIES,
         },
@@ -580,6 +595,7 @@ def organize_clear_plan(
             "plan": None,
             "info_message": "Plan dismissed.",
             "error_message": None,
+            "error_payload": None,
             "methodology_options": ORGANIZE_METHODOLOGIES,
         },
     )

--- a/src/file_organizer/web/organize_routes.py
+++ b/src/file_organizer/web/organize_routes.py
@@ -16,14 +16,15 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingRes
 from loguru import logger
 
 from file_organizer.api.config import ApiSettings
-from file_organizer.api.dependencies import get_settings
+from file_organizer.api.dependencies import get_config_manager, get_settings
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.jobs import create_job, get_job, list_jobs, update_job
-from file_organizer.api.models import OrganizeRequest
 from file_organizer.api.utils import resolve_path
+from file_organizer.config.manager import ConfigManager
 from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.config.methodology import LABELS as ORGANIZE_METHODOLOGIES
 from file_organizer.config.methodology import normalize as _normalize_methodology
+from file_organizer.core.capabilities import Surface, get_capability_registry
 from file_organizer.core.errors import DomainError
 from file_organizer.core.lifecycle import (
     TERMINAL_JOB_STATUSES,
@@ -31,6 +32,8 @@ from file_organizer.core.lifecycle import (
     JobStatus,
     RecoveryAction,
 )
+from file_organizer.core.organization_service import OrganizationService
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.plan import OrganizationPlan
 from file_organizer.core.types import OrganizationResult
@@ -46,16 +49,14 @@ from file_organizer.web.organize_services import (
     ORGANIZE_DEFAULT_DELAY_MIN,
     ORGANIZE_MAX_DELAY_MIN,
     ORGANIZE_PLAN_LIMIT,
-    _build_plan_movements,
-    _counts_by_type,
     _delete_organize_plan,
     _get_organize_plan,
     _job_report_payload,
     _parse_delay_minutes,
     _result_to_response,
-    _scan_directory,
     _store_organize_plan,
     build_organize_plan,
+    parse_organize_options,
 )
 
 organize_router = APIRouter(tags=["web"])
@@ -71,9 +72,7 @@ __all__ = [
     "_ORGANIZE_PLAN_STORE",
     "_build_job_view",
     "_build_organize_stats",
-    "_build_plan_movements",
     "_cancel_scheduled_job",
-    "_counts_by_type",
     "_delete_organize_plan",
     "_get_job_metadata",
     "_get_organize_plan",
@@ -83,9 +82,6 @@ __all__ = [
     "_parse_delay_minutes",
     "_prune_job_metadata",
     "_result_to_response",
-    "_run_organize_job",
-    "_scan_directory",
-    "_schedule_job",
     "_set_job_metadata",
     "_status_progress",
     "_store_organize_plan",
@@ -94,7 +90,7 @@ __all__ = [
 
 ORGANIZE_EVENT_POLL_SECONDS = 1
 ORGANIZE_HISTORY_LIMIT = 50
-ORGANIZE_JOB_TYPE = "organize_web"
+ORGANIZE_JOB_TYPE = "organize"
 JOB_METADATA_PRUNE_THRESHOLD = 256
 JOB_METADATA_PRUNE_INTERVAL_SECONDS = 60.0
 
@@ -103,6 +99,38 @@ _SCHEDULED_TIMERS_LOCK = Lock()
 _JOB_METADATA: dict[str, dict[str, Any]] = {}
 _JOB_METADATA_LOCK = Lock()
 _LAST_JOB_METADATA_PRUNE_MONOTONIC = 0.0
+
+_ORGANIZATION_CAPABILITY_IDS = (
+    "organization.scan",
+    "organization.preview",
+    "organization.execute",
+    "organization.jobs-recovery",
+    "organization.suggest",
+)
+
+
+def get_web_organization_service() -> OrganizationService:
+    """Provide the canonical application service to Web adapter routes."""
+    return OrganizationService(organizer_factory=FileOrganizer)
+
+
+def _web_capability_views() -> list[dict[str, str]]:
+    """Return registry-backed organization support states for dashboard rendering."""
+    registry = get_capability_registry()
+    rows: list[dict[str, str]] = []
+    for capability_id in _ORGANIZATION_CAPABILITY_IDS:
+        capability = registry.get(capability_id)
+        support = capability.support_for(Surface.WEB_DESKTOP)
+        rows.append(
+            {
+                "id": capability.capability_id,
+                "name": capability.name,
+                "target_support": support.target_support.value,
+                "implementation_status": support.implementation_status.value,
+                "conformance_status": support.conformance_status.value,
+            }
+        )
+    return rows
 
 
 def _prune_job_metadata(*, force: bool = False) -> None:
@@ -170,7 +198,7 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
     result = job.result or {}
     schedule_delay_minutes = int(metadata.get("schedule_delay_minutes", 0) or 0)
     scheduled_for = format_timestamp(job.scheduled_for) if job.scheduled_for is not None else ""
-    is_scheduled = job.status == JobStatus.SCHEDULED
+    is_cancellable = job.status in {JobStatus.SCHEDULED, JobStatus.QUEUED}
     processed_files = int(result.get("processed_files", 0) or 0)
     total_files = int(result.get("total_files", 0) or 0)
     failed_files = int(result.get("failed_files", 0) or 0)
@@ -206,7 +234,7 @@ def _build_job_view(job_id: str) -> dict[str, Any] | None:
         "dry_run": bool(metadata.get("dry_run", False)),
         "schedule_delay_minutes": schedule_delay_minutes,
         "scheduled_for": scheduled_for,
-        "can_cancel": is_scheduled,
+        "can_cancel": is_cancellable,
         "transaction_id": job.transaction_id,
         "recovery_action": job.recovery_action.value,
         "revision": job.revision,
@@ -274,34 +302,6 @@ def _build_organize_stats() -> dict[str, Any]:
     }
 
 
-def _run_organize_job(job_id: str, organize_request: OrganizeRequest) -> None:
-    """Execute an organization job synchronously, updating job state on completion."""
-    update_job(job_id, status="running", error=None)
-    try:
-        organizer = FileOrganizer(
-            dry_run=organize_request.dry_run,
-            use_hardlinks=organize_request.use_hardlinks,
-        )
-        result = organizer.organize(
-            input_path=organize_request.input_dir,
-            output_path=organize_request.output_dir,
-            skip_existing=organize_request.skip_existing,
-        )
-        response = _result_to_response(result).model_dump()
-        _complete_job_from_result(job_id, result, response)
-    except DomainError as exc:
-        update_job(
-            job_id,
-            status=JobStatus.FAILED,
-            error=exc.message,
-            error_code=exc.code,
-            error_retryable=exc.retryable,
-            error_details=exc.details,
-        )
-    except Exception as exc:
-        update_job(job_id, status="failed", error=str(exc))
-
-
 def _result_from_plan_preview(plan: OrganizationPlan) -> OrganizationResult:
     """Build an OrganizationResult for a dry-run execution of a stored plan."""
     return OrganizationResult(
@@ -316,19 +316,42 @@ def _result_from_plan_preview(plan: OrganizationPlan) -> OrganizationResult:
     )
 
 
-def _run_organize_plan_job(job_id: str, plan_data: dict[str, Any], *, dry_run: bool) -> None:
+def _run_organize_plan_job(
+    job_id: str,
+    plan_data: dict[str, Any],
+    organization_service: OrganizationService,
+    *,
+    dry_run: bool,
+) -> None:
     """Execute a stored executable organization plan."""
-    update_job(job_id, status="running", error=None)
     try:
+        current = get_job(job_id)
+        if current is None or current.status == JobStatus.CANCELLED:
+            return
+        started = update_job(
+            job_id,
+            status=JobStatus.RUNNING,
+            error=None,
+            expected_revision=current.revision,
+        )
+        if started is None:
+            return
         plan = OrganizationPlan.from_dict(plan_data)
         if dry_run:
             result = _result_from_plan_preview(plan)
         else:
-            organizer = FileOrganizer(dry_run=False, use_hardlinks=plan.use_hardlinks)
-            result = organizer.execute_plan(plan)
+            organization_request = OrganizeRequest(
+                plan.input_path,
+                plan.output_path,
+                plan.options,
+            )
+            result = organization_service.execute(organization_request, plan)
         response = _result_to_response(result).model_dump()
         _complete_job_from_result(job_id, result, response)
     except DomainError as exc:
+        current = get_job(job_id)
+        if current is None or current.status == JobStatus.CANCELLED:
+            return
         update_job(
             job_id,
             status=JobStatus.FAILED,
@@ -341,33 +364,10 @@ def _run_organize_plan_job(job_id: str, plan_data: dict[str, Any], *, dry_run: b
         update_job(job_id, status="failed", error=str(exc))
 
 
-def _schedule_job(job_id: str, organize_request: OrganizeRequest, delay_minutes: int) -> None:
-    """Schedule an organization job to run after *delay_minutes*.
-
-    If *delay_minutes* is zero or negative the job runs immediately.
-    """
-    delay_seconds = delay_minutes * 60
-
-    def _runner() -> None:
-        """Execute the scheduled organization job."""
-        with _SCHEDULED_TIMERS_LOCK:
-            _SCHEDULED_TIMERS.pop(job_id, None)
-        _run_organize_job(job_id, organize_request)
-
-    if delay_seconds <= 0:
-        _runner()
-        return
-
-    timer = Timer(delay_seconds, _runner)
-    timer.daemon = True
-    with _SCHEDULED_TIMERS_LOCK:
-        _SCHEDULED_TIMERS[job_id] = timer
-    timer.start()
-
-
 def _schedule_plan_job(
     job_id: str,
     plan_data: dict[str, Any],
+    organization_service: OrganizationService,
     delay_minutes: int,
     *,
     dry_run: bool,
@@ -379,7 +379,12 @@ def _schedule_plan_job(
         """Execute the scheduled plan job."""
         with _SCHEDULED_TIMERS_LOCK:
             _SCHEDULED_TIMERS.pop(job_id, None)
-        _run_organize_plan_job(job_id, plan_data, dry_run=dry_run)
+        _run_organize_plan_job(
+            job_id,
+            plan_data,
+            organization_service,
+            dry_run=dry_run,
+        )
 
     if delay_seconds <= 0:
         _runner()
@@ -393,7 +398,7 @@ def _schedule_plan_job(
 
 
 def _cancel_scheduled_job(job_id: str) -> bool:
-    """Cancel a scheduled job timer if it exists.
+    """Cancel and remove a scheduled job timer if it exists.
 
     Returns:
         ``True`` if the job was successfully cancelled, ``False`` otherwise.
@@ -403,12 +408,6 @@ def _cancel_scheduled_job(job_id: str) -> bool:
     if timer is None:
         return False
     timer.cancel()
-    update_job(
-        job_id,
-        status=JobStatus.CANCELLED,
-        error="Cancelled before execution.",
-        error_code="cancelled",
-    )
     return True
 
 
@@ -443,7 +442,9 @@ def _complete_job_from_result(
 
 @organize_router.get("/organize", response_class=HTMLResponse)
 def organize_dashboard(
-    request: Request, settings: ApiSettings = Depends(get_settings)
+    request: Request,
+    settings: ApiSettings = Depends(get_settings),
+    manager: ConfigManager = Depends(get_config_manager),
 ) -> HTMLResponse:
     """Render the organization dashboard with defaults and aggregate stats.
 
@@ -453,8 +454,14 @@ def organize_dashboard(
     from file_organizer.web._helpers import base_context
 
     roots = allowed_roots(settings)
-    default_input = str(roots[0]) if roots else ""
-    default_output = str(roots[0] / "organized") if roots else ""
+    app_config = manager.load()
+    default_input = app_config.default_input_dir or (str(roots[0]) if roots else "")
+    default_output = app_config.default_output_dir or (str(roots[0] / "organized") if roots else "")
+    default_options = OrganizeOptions(
+        methodology=_normalize_methodology(app_config.default_methodology),
+        text_model=app_config.models.text_model,
+        vision_model=app_config.models.vision_model,
+    )
     stats = _build_organize_stats()
     context = base_context(
         request,
@@ -466,6 +473,8 @@ def organize_dashboard(
             "default_input_dir": default_input,
             "default_output_dir": default_output,
             "methodology_options": ORGANIZE_METHODOLOGIES,
+            "organization_defaults": default_options.to_dict(),
+            "organization_capabilities": _web_capability_views(),
             "stats": stats,
         },
     )
@@ -476,6 +485,7 @@ def organize_dashboard(
 def organize_scan(
     request: Request,
     settings: ApiSettings = Depends(get_settings),
+    organization_service: OrganizationService = Depends(get_web_organization_service),
     input_dir: str = Form(""),
     output_dir: str = Form(""),
     methodology: str = Form(_DEFAULT_METHODOLOGY),
@@ -483,6 +493,17 @@ def organize_scan(
     include_hidden: str = Form("0"),
     skip_existing: str = Form("1"),
     use_hardlinks: str = Form("1"),
+    transfer_mode: str = Form(""),
+    enable_vision: str = Form("1"),
+    transcribe_audio: str = Form("0"),
+    max_transcribe_seconds: str = Form("600"),
+    whisper_model: str = Form("tiny"),
+    parallel_workers: str = Form(""),
+    prefetch_depth: str = Form("2"),
+    text_model: str = Form(""),
+    vision_model: str = Form(""),
+    text_provider: str = Form(""),
+    vision_provider: str = Form(""),
 ) -> HTMLResponse:
     """Scan the input directory and generate a dry-run organization plan.
 
@@ -494,19 +515,35 @@ def organize_scan(
     plan: dict[str, Any] | None = None
 
     try:
-        plan = build_organize_plan(
-            input_dir=input_dir,
-            output_dir=output_dir,
+        options = parse_organize_options(
             methodology=methodology,
             recursive=recursive,
             include_hidden=include_hidden,
             skip_existing=skip_existing,
+            transfer_mode=transfer_mode,
             use_hardlinks=use_hardlinks,
+            enable_vision=enable_vision,
+            transcribe_audio=transcribe_audio,
+            max_transcribe_seconds=max_transcribe_seconds,
+            whisper_model=whisper_model,
+            parallel_workers=parallel_workers,
+            prefetch_depth=prefetch_depth,
+            text_model=text_model,
+            vision_model=vision_model,
+            text_provider=text_provider,
+            vision_provider=vision_provider,
+        )
+        plan = build_organize_plan(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            options=options,
             allowed_paths=settings.allowed_paths,
-            organizer_factory=FileOrganizer,
+            organization_service=organization_service,
         )
         info_message = "Plan generated. Review movements and execute when ready."
     except ApiError as exc:
+        error_message = exc.message
+    except DomainError as exc:
         error_message = exc.message
     except Exception:
         logger.exception("Failed to generate organize plan")
@@ -553,6 +590,7 @@ def organize_execute(
     request: Request,
     background_tasks: BackgroundTasks,
     settings: ApiSettings = Depends(get_settings),
+    organization_service: OrganizationService = Depends(get_web_organization_service),
     plan_id: str = Form(""),
     dry_run: str = Form("0"),
     schedule_delay_minutes: str = Form(str(ORGANIZE_DEFAULT_DELAY_MIN)),
@@ -595,15 +633,6 @@ def organize_execute(
                 message="Stored plan paths do not match the requested safe paths.",
             )
 
-        organize_request = OrganizeRequest(
-            input_dir=str(safe_input),
-            output_dir=str(safe_output),
-            skip_existing=bool(plan.get("skip_existing", True)),
-            dry_run=dry_run_enabled,
-            use_hardlinks=bool(plan.get("use_hardlinks", True)),
-            run_in_background=True,
-        )
-
         scheduled_at_datetime: datetime | None = None
         scheduled_for = ""
         if delay_minutes > 0:
@@ -615,10 +644,10 @@ def organize_execute(
             job.job_id,
             {
                 "plan_id": plan_id,
-                "input_dir": organize_request.input_dir,
-                "output_dir": organize_request.output_dir,
-                "methodology": _normalize_methodology(plan.get("methodology")),
-                "dry_run": organize_request.dry_run,
+                "input_dir": str(safe_input),
+                "output_dir": str(safe_output),
+                "methodology": executable_plan.options.effective_methodology.value,
+                "dry_run": dry_run_enabled,
                 "schedule_delay_minutes": delay_minutes,
                 "scheduled_for": scheduled_for,
                 "executable_plan_id": executable_plan.plan_id,
@@ -629,6 +658,7 @@ def organize_execute(
             _schedule_plan_job(
                 job.job_id,
                 executable_plan.to_dict(),
+                organization_service,
                 delay_minutes,
                 dry_run=dry_run_enabled,
             )
@@ -638,6 +668,7 @@ def organize_execute(
                 _run_organize_plan_job,
                 job.job_id,
                 executable_plan.to_dict(),
+                organization_service,
                 dry_run=dry_run_enabled,
             )
             info_message = "Organization job queued."
@@ -646,6 +677,8 @@ def organize_execute(
         if job_view is None:
             raise ApiError(status_code=500, error="job_error", message="Failed to queue job.")
     except ApiError as exc:
+        error_message = exc.message
+    except DomainError as exc:
         error_message = exc.message
     except Exception:
         logger.exception("Failed to queue organize job")
@@ -837,7 +870,7 @@ async def organize_history_events(
 
 @organize_router.post("/organize/jobs/{job_id}/cancel", response_class=HTMLResponse)
 def organize_job_cancel(request: Request, job_id: str) -> HTMLResponse:
-    """Cancel a scheduled organization job.
+    """Cancel a queued or scheduled organization job.
 
     Returns:
         Updated job status partial.
@@ -848,10 +881,19 @@ def organize_job_cancel(request: Request, job_id: str) -> HTMLResponse:
 
     info_message: str | None = None
     error_message: str | None = None
-    if _cancel_scheduled_job(job_id):
-        info_message = "Scheduled job cancelled."
+    if not job["can_cancel"]:
+        error_message = "Only queued or scheduled jobs can be cancelled."
     else:
-        error_message = "Only scheduled jobs can be cancelled."
+        if job["status"] == JobStatus.SCHEDULED:
+            _cancel_scheduled_job(job_id)
+        updated = update_job(
+            job_id,
+            status=JobStatus.CANCELLED,
+            expected_revision=job["revision"],
+        )
+        if updated is None:
+            raise ApiError(status_code=404, error="not_found", message="Job not found.")
+        info_message = "Organization job cancelled."
     refreshed_job = _build_job_view(job_id)
     return templates.TemplateResponse(
         request,
@@ -881,25 +923,18 @@ def organize_job_rollback(request: Request, job_id: str) -> HTMLResponse:
     if not job["can_rollback"]:
         error_message = "Rollback is only available for completed non-dry-run jobs."
     else:
-        try:
-            from file_organizer.undo.undo_manager import UndoManager
+        from file_organizer.undo.undo_manager import UndoManager
 
-            transaction_id = str(job["transaction_id"])
-            update_job(job_id, status=JobStatus.ROLLING_BACK)
-            manager = UndoManager()
-            success = manager.undo_transaction(transaction_id)
-            update_job(
-                job_id,
-                status=(JobStatus.ROLLED_BACK if success else JobStatus.RECOVERY_REQUIRED),
-                error=(None if success else "Rollback did not complete."),
-                error_code=(None if success else "recovery_required"),
-                recovery_action=(RecoveryAction.NONE if success else RecoveryAction.MANUAL),
-            )
-            rollback_message = (
-                "Rollback completed for this job's transaction."
-                if success
-                else "Rollback requires manual recovery."
-            )
+        transaction_id = str(job["transaction_id"])
+        rolling_back = update_job(
+            job_id,
+            status=JobStatus.ROLLING_BACK,
+            expected_revision=job["revision"],
+        )
+        if rolling_back is None:
+            raise ApiError(status_code=404, error="not_found", message="Job not found.")
+        try:
+            success = UndoManager().undo_transaction(transaction_id)
         except Exception:
             logger.exception("Rollback execution failed for job {}", job_id)
             current = get_job(job_id)
@@ -910,8 +945,25 @@ def organize_job_rollback(request: Request, job_id: str) -> HTMLResponse:
                     error="Rollback failed.",
                     error_code="recovery_required",
                     recovery_action=RecoveryAction.MANUAL,
+                    expected_revision=current.revision,
                 )
             error_message = "Rollback failed."
+        else:
+            updated = update_job(
+                job_id,
+                status=(JobStatus.ROLLED_BACK if success else JobStatus.RECOVERY_REQUIRED),
+                error=(None if success else "Rollback did not complete."),
+                error_code=(None if success else "recovery_required"),
+                recovery_action=(RecoveryAction.NONE if success else RecoveryAction.MANUAL),
+                expected_revision=rolling_back.revision,
+            )
+            if updated is None:
+                raise ApiError(status_code=404, error="not_found", message="Job not found.")
+            rollback_message = (
+                "Rollback completed for this job's transaction."
+                if success
+                else "Rollback requires manual recovery."
+            )
 
     refreshed_job = _build_job_view(job_id)
     response = templates.TemplateResponse(

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -227,9 +227,6 @@ def build_organize_plan(
 
     safe_input = resolve_path(input_dir, allowed_paths)
     safe_output = resolve_path(output_dir, allowed_paths)
-    if not safe_input.exists():
-        raise ApiError(status_code=404, error="not_found", message="Input directory not found.")
-
     if options is None:
         options = parse_organize_options(
             methodology=methodology,
@@ -279,6 +276,7 @@ def build_organize_plan(
             "use_hardlinks": plan.options.use_hardlinks,
             "transfer_mode": plan.options.effective_transfer_mode.value,
             "options": plan.options.to_dict(),
+            "scan_files": [str(path) for path in scan.files],
             "scan_counts": scan.counts,
             "scan_total_files": scan.total_files,
             "preview": preview.model_dump(),

--- a/src/file_organizer/web/organize_services.py
+++ b/src/file_organizer/web/organize_services.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
 from threading import Lock
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.models import OrganizationError, OrganizationResultResponse
-from file_organizer.api.utils import is_hidden, resolve_path
+from file_organizer.api.utils import resolve_path
 from file_organizer.config.methodology import (
     normalize as _normalize_methodology,
 )
-from file_organizer.core.organize_options import OrganizeOptions
+from file_organizer.core.organization_service import OrganizationService
+from file_organizer.core.organize_options import ModelProvider, OrganizeOptions, OrganizeRequest
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.plan import OrganizationPlan
 from file_organizer.core.types import OrganizationResult
@@ -50,51 +50,6 @@ def _parse_delay_minutes(value: str | None) -> int:
     return minutes
 
 
-def _scan_directory(path: Path, recursive: bool, include_hidden: bool) -> list[Path]:
-    """Collect files from *path*, optionally recursing and including hidden items."""
-    files: list[Path] = []
-    if path.is_file():
-        if include_hidden or not is_hidden(path):
-            files.append(path)
-        return files
-
-    iterator = path.rglob("*") if recursive else path.glob("*")
-    for entry in iterator:
-        if not entry.is_file():
-            continue
-        if not include_hidden and is_hidden(entry):
-            continue
-        files.append(entry)
-    return files
-
-
-def _counts_by_type(files: list[Path]) -> dict[str, int]:
-    """Tally files by broad type category (text, image, video, etc.)."""
-    counts = {
-        "text": 0,
-        "image": 0,
-        "video": 0,
-        "audio": 0,
-        "cad": 0,
-        "other": 0,
-    }
-    for path in files:
-        suffix = path.suffix.lower()
-        if suffix in FileOrganizer.TEXT_EXTENSIONS:
-            counts["text"] += 1
-        elif suffix in FileOrganizer.IMAGE_EXTENSIONS:
-            counts["image"] += 1
-        elif suffix in FileOrganizer.VIDEO_EXTENSIONS:
-            counts["video"] += 1
-        elif suffix in FileOrganizer.AUDIO_EXTENSIONS:
-            counts["audio"] += 1
-        elif suffix in FileOrganizer.CAD_EXTENSIONS:
-            counts["cad"] += 1
-        else:
-            counts["other"] += 1
-    return counts
-
-
 def _result_to_response(result: OrganizationResult) -> OrganizationResultResponse:
     """Convert an ``OrganizationResult`` to the API response model."""
     return OrganizationResultResponse(
@@ -110,35 +65,6 @@ def _result_to_response(result: OrganizationResult) -> OrganizationResultRespons
         ],
         transaction_id=result.transaction_id,
     )
-
-
-def _build_plan_movements(
-    files: list[Path],
-    output_dir: Path,
-    preview: OrganizationResultResponse,
-) -> list[dict[str, str]]:
-    """Build a list of planned source-to-destination movements from a dry-run preview."""
-    source_lookup: dict[str, list[str]] = {}
-    for file_path in sorted(files, key=lambda item: item.as_posix().lower()):
-        source_lookup.setdefault(file_path.name, []).append(str(file_path))
-
-    movements: list[dict[str, str]] = []
-    for bucket, names in sorted(
-        preview.organized_structure.items(), key=lambda item: item[0].lower()
-    ):
-        for name in sorted(names, key=str.lower):
-            sources = source_lookup.get(name, [])
-            source_path = sources.pop(0) if sources else name
-            destination = output_dir / bucket / name
-            movements.append(
-                {
-                    "file_name": name,
-                    "source": source_path,
-                    "destination": str(destination),
-                    "reason": f"Categorized into {bucket}",
-                }
-            )
-    return movements
 
 
 def _prune_plan_store() -> None:
@@ -180,19 +106,112 @@ def _delete_organize_plan(plan_id: str) -> None:
         _ORGANIZE_PLAN_STORE.pop(plan_id, None)
 
 
-def build_organize_plan(
+def _optional_int(value: str | None, field_name: str) -> int | None:
+    """Parse an optional integer form value into the canonical option shape."""
+    if value is None or not value.strip():
+        return None
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            error="invalid_organization_options",
+            message=f"{field_name} must be a whole number.",
+        ) from exc
+
+
+def _optional_float(value: str | None, field_name: str) -> float | None:
+    """Parse an optional numeric form value into the canonical option shape."""
+    if value is None or not value.strip():
+        return None
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            error="invalid_organization_options",
+            message=f"{field_name} must be a number.",
+        ) from exc
+
+
+def parse_organize_options(
     *,
-    input_dir: str,
-    output_dir: str,
     methodology: str,
     recursive: str,
     include_hidden: str,
     skip_existing: str,
+    transfer_mode: str,
     use_hardlinks: str,
+    enable_vision: str,
+    transcribe_audio: str,
+    max_transcribe_seconds: str,
+    whisper_model: str,
+    parallel_workers: str,
+    prefetch_depth: str,
+    text_model: str,
+    vision_model: str,
+    text_provider: str = "",
+    vision_provider: str = "",
+) -> OrganizeOptions:
+    """Map Web form values into the complete canonical organization contract."""
+    normalized_methodology = _normalize_methodology(methodology, default="")
+    if not normalized_methodology:
+        raise ApiError(
+            status_code=400,
+            error="invalid_organization_options",
+            message="Methodology must be none, para, or jd.",
+        )
+    resolved_transfer_mode = transfer_mode.strip()
+    if not resolved_transfer_mode:
+        resolved_transfer_mode = "hardlink" if form_bool(use_hardlinks) else "copy"
+    parsed_prefetch_depth = _optional_int(prefetch_depth, "Prefetch depth")
+    try:
+        return OrganizeOptions(
+            recursive=form_bool(recursive),
+            include_hidden=form_bool(include_hidden),
+            skip_existing=form_bool(skip_existing),
+            transfer_mode=resolved_transfer_mode,
+            methodology=normalized_methodology,
+            enable_vision=form_bool(enable_vision),
+            transcribe_audio=form_bool(transcribe_audio),
+            max_transcribe_seconds=_optional_float(
+                max_transcribe_seconds, "Maximum transcription seconds"
+            ),
+            whisper_model=whisper_model.strip(),
+            parallel_workers=_optional_int(parallel_workers, "Parallel workers"),
+            prefetch_depth=2 if parsed_prefetch_depth is None else parsed_prefetch_depth,
+            text_model=text_model.strip() or None,
+            vision_model=vision_model.strip() or None,
+            text_provider=(
+                cast(ModelProvider, text_provider.strip()) if text_provider.strip() else None
+            ),
+            vision_provider=(
+                cast(ModelProvider, vision_provider.strip()) if vision_provider.strip() else None
+            ),
+        )
+    except ValueError as exc:
+        raise ApiError(
+            status_code=400,
+            error="invalid_organization_options",
+            message=str(exc),
+        ) from exc
+
+
+def build_organize_plan(
+    *,
+    input_dir: str,
+    output_dir: str,
     allowed_paths: list[str] | None,
-    organizer_factory: Callable[..., FileOrganizer] = FileOrganizer,
+    options: OrganizeOptions | None = None,
+    organization_service: OrganizationService | None = None,
+    methodology: str = "none",
+    recursive: str = "1",
+    include_hidden: str = "0",
+    skip_existing: str = "1",
+    use_hardlinks: str = "1",
+    organizer_factory: Callable[..., FileOrganizer] | None = None,
 ) -> dict[str, Any]:
-    """Validate scan input, run a dry-run preview, and persist the resulting plan."""
+    """Validate paths and persist a scan/preview produced by the canonical service."""
     if not input_dir.strip():
         raise ApiError(
             status_code=400,
@@ -211,44 +230,33 @@ def build_organize_plan(
     if not safe_input.exists():
         raise ApiError(status_code=404, error="not_found", message="Input directory not found.")
 
-    normalized_methodology = _normalize_methodology(methodology)
-    recursive_enabled = form_bool(recursive)
-    include_hidden_enabled = form_bool(include_hidden)
-    if include_hidden_enabled:
-        raise ApiError(
-            status_code=400,
-            error="include_hidden_not_supported",
-            message="Including hidden files is not supported in this dashboard flow yet.",
+    if options is None:
+        options = parse_organize_options(
+            methodology=methodology,
+            recursive=recursive,
+            include_hidden=include_hidden,
+            skip_existing=skip_existing,
+            transfer_mode="",
+            use_hardlinks=use_hardlinks,
+            enable_vision="1",
+            transcribe_audio="0",
+            max_transcribe_seconds="600",
+            whisper_model="tiny",
+            parallel_workers="",
+            prefetch_depth="2",
+            text_model="",
+            vision_model="",
+            text_provider="",
+            vision_provider="",
         )
-    skip_existing_enabled = form_bool(skip_existing)
-    use_hardlinks_enabled = form_bool(use_hardlinks)
+    if organization_service is None:
+        organization_service = OrganizationService(
+            organizer_factory=organizer_factory or FileOrganizer,
+        )
 
-    scan_files = _scan_directory(
-        safe_input,
-        recursive=recursive_enabled,
-        include_hidden=include_hidden_enabled,
-    )
-    counts = _counts_by_type(scan_files)
-
-    options = OrganizeOptions(
-        recursive=recursive_enabled,
-        include_hidden=include_hidden_enabled,
-        skip_existing=skip_existing_enabled,
-        use_hardlinks=use_hardlinks_enabled,
-        methodology=normalized_methodology,
-    )
-    organizer = organizer_factory(
-        dry_run=True,
-        use_hardlinks=use_hardlinks_enabled,
-        recursive=recursive_enabled,
-        include_hidden=include_hidden_enabled,
-        organize_options=options,
-    )
-    preview_result = organizer.organize(
-        input_path=safe_input,
-        output_path=safe_output,
-        skip_existing=skip_existing_enabled,
-    )
+    organization_request = OrganizeRequest(safe_input, safe_output, options)
+    scan = organization_service.scan(organization_request)
+    preview_result = organization_service.preview(organization_request)
     plan = preview_result.plan
     if not isinstance(plan, OrganizationPlan):
         raise ApiError(
@@ -264,14 +272,15 @@ def build_organize_plan(
         {
             "input_dir": str(safe_input),
             "output_dir": str(safe_output),
-            "methodology": normalized_methodology,
-            "recursive": recursive_enabled,
-            "include_hidden": include_hidden_enabled,
-            "skip_existing": skip_existing_enabled,
-            "use_hardlinks": use_hardlinks_enabled,
-            "transfer_mode": options.effective_transfer_mode.value,
-            "scan_counts": counts,
-            "scan_total_files": len(scan_files),
+            "methodology": plan.options.effective_methodology.value,
+            "recursive": plan.options.recursive,
+            "include_hidden": plan.options.include_hidden,
+            "skip_existing": plan.options.skip_existing,
+            "use_hardlinks": plan.options.use_hardlinks,
+            "transfer_mode": plan.options.effective_transfer_mode.value,
+            "options": plan.options.to_dict(),
+            "scan_counts": scan.counts,
+            "scan_total_files": scan.total_files,
             "preview": preview.model_dump(),
             "movements": plan.movements(),
             "executable_plan": plan.to_dict(),

--- a/src/file_organizer/web/static/js/desktop_api.js
+++ b/src/file_organizer/web/static/js/desktop_api.js
@@ -33,7 +33,10 @@
    * @param {string} inputId - id of the text input to populate.
    */
   window.desktopBrowseDirectory = function desktopBrowseDirectory(inputId) {
-    if (!isDesktopApp()) {
+    if (
+      !isDesktopApp() ||
+      typeof window.pywebview.api.browse_directory !== "function"
+    ) {
       return;
     }
     window.pywebview.api

--- a/src/file_organizer/web/static/js/desktop_api.js
+++ b/src/file_organizer/web/static/js/desktop_api.js
@@ -3,11 +3,12 @@
  * browser fallbacks so the same HTML works in both the native desktop app
  * (pywebview) and a regular browser session.
  *
- * All three entry-points check for window.pywebview before calling into the
+ * All entry-points check for window.pywebview before calling into the
  * native API, so they are silent no-ops in browser mode.
  *
  * Usage (available globally after this script loads):
  *
+ *   window.desktopBrowseDirectory(inputId)
  *   window.desktopBrowseFile(inputId, fileTypes)
  *   window.desktopSaveFile(suggestedName, fileTypes)  → Promise<string>
  *   window.desktopOpenPath(path)
@@ -24,6 +25,32 @@
     typeof window.pywebview !== "undefined" &&
     window.pywebview !== null &&
     typeof window.pywebview.api !== "undefined";
+
+  /**
+   * Open a native directory picker and populate a text input. Browser mode is
+   * a no-op because browsers cannot disclose an absolute directory path.
+   *
+   * @param {string} inputId - id of the text input to populate.
+   */
+  window.desktopBrowseDirectory = function desktopBrowseDirectory(inputId) {
+    if (!isDesktopApp()) {
+      return;
+    }
+    window.pywebview.api
+      .browse_directory()
+      .then(function (path) {
+        if (path) {
+          const el = document.getElementById(inputId);
+          if (el) {
+            el.value = path;
+            el.dispatchEvent(new Event("change", { bubbles: true }));
+          }
+        }
+      })
+      .catch(function () {
+        /* dialog cancelled or unavailable — no-op */
+      });
+  };
 
   /**
    * Open a native file-picker dialog and populate a text input with the

--- a/src/file_organizer/web/templates/files/_results.html
+++ b/src/file_organizer/web/templates/files/_results.html
@@ -39,12 +39,12 @@
                 data-default-limit="{{ page_size }}"
             >
             <label class="search-field">
-                <span class="sr-only">Search</span>
+                <span class="sr-only">Filter current folder by filename</span>
                 <input
                     id="file-search"
                     type="search"
                     name="q"
-                    placeholder="Search files or folders"
+                    placeholder="Filter this folder by filename"
                     value="{{ query }}"
                 >
             </label>
@@ -84,6 +84,8 @@
         </div>
     </div>
 </section>
+
+<p class="organize-hint">This filter matches names only in the current folder; use Search for indexed full-text or semantic results.</p>
 
 <form
     id="upload-form"

--- a/src/file_organizer/web/templates/organize/_plan.html
+++ b/src/file_organizer/web/templates/organize/_plan.html
@@ -2,7 +2,10 @@
 <div class="banner banner-info">{{ info_message }}</div>
 {% endif %}
 {% if error_message %}
-<div class="banner banner-error">{{ error_message }}</div>
+<div
+    class="banner banner-error"
+    data-error-payload="{{ error_payload | tojson | forceescape }}"
+>{{ error_message }}</div>
 {% endif %}
 
 {% if plan %}

--- a/src/file_organizer/web/templates/organize/dashboard.html
+++ b/src/file_organizer/web/templates/organize/dashboard.html
@@ -25,31 +25,91 @@
     >
         <label for="organize-input-dir">Input directory</label>
         <input id="organize-input-dir" name="input_dir" type="text" value="{{ default_input_dir }}" required>
+        <button data-desktop-only type="button" class="btn-ghost" onclick="window.desktopBrowseDirectory('organize-input-dir')">Browse input…</button>
 
         <label for="organize-output-dir">Output directory</label>
         <input id="organize-output-dir" name="output_dir" type="text" value="{{ default_output_dir }}" required>
+        <button data-desktop-only type="button" class="btn-ghost" onclick="window.desktopBrowseDirectory('organize-output-dir')">Browse output…</button>
 
         <label for="organize-methodology">Methodology</label>
         <select id="organize-methodology" name="methodology">
             {% for key, label in methodology_options.items() %}
-            <option value="{{ key }}">{{ label }}</option>
+            <option value="{{ key }}" {% if organization_defaults.methodology == key %}selected{% endif %}>{{ label }}</option>
             {% endfor %}
         </select>
 
         <div class="organize-toggle-grid">
             <label class="toggle-option">
-                <input name="recursive" type="checkbox" value="1" checked>
+                <input name="recursive" type="hidden" value="0">
+                <input name="recursive" type="checkbox" value="1" {% if organization_defaults.recursive %}checked{% endif %}>
                 <span>Recursive scan</span>
             </label>
             <label class="toggle-option">
-                <input name="skip_existing" type="checkbox" value="1" checked>
+                <input name="include_hidden" type="hidden" value="0">
+                <input name="include_hidden" type="checkbox" value="1" {% if organization_defaults.include_hidden %}checked{% endif %}>
+                <span>Include hidden files</span>
+            </label>
+            <label class="toggle-option">
+                <input name="skip_existing" type="hidden" value="0">
+                <input name="skip_existing" type="checkbox" value="1" {% if organization_defaults.skip_existing %}checked{% endif %}>
                 <span>Skip existing files</span>
             </label>
             <label class="toggle-option">
-                <input name="use_hardlinks" type="checkbox" value="1" checked>
-                <span>Use hardlinks when possible</span>
+                <input name="enable_vision" type="hidden" value="0">
+                <input name="enable_vision" type="checkbox" value="1" {% if organization_defaults.enable_vision %}checked{% endif %}>
+                <span>Analyze images</span>
+            </label>
+            <label class="toggle-option">
+                <input name="transcribe_audio" type="hidden" value="0">
+                <input name="transcribe_audio" type="checkbox" value="1" {% if organization_defaults.transcribe_audio %}checked{% endif %}>
+                <span>Transcribe audio</span>
             </label>
         </div>
+
+        <details class="organize-advanced-options">
+            <summary>Transfer, model, and performance options</summary>
+            <div class="organize-form">
+                <label for="organize-transfer-mode">Transfer mode</label>
+                <select id="organize-transfer-mode" name="transfer_mode">
+                    <option value="copy" {% if organization_defaults.transfer_mode == 'copy' %}selected{% endif %}>Copy</option>
+                    <option value="hardlink" {% if organization_defaults.transfer_mode == 'hardlink' %}selected{% endif %}>Hardlink</option>
+                </select>
+
+                <label for="organize-text-model">Text model</label>
+                <input id="organize-text-model" name="text_model" type="text" value="{{ organization_defaults.text_model or '' }}">
+
+                <label for="organize-text-provider">Text provider</label>
+                <select id="organize-text-provider" name="text_provider">
+                    <option value="">Configured default</option>
+                    {% for provider in ('ollama', 'openai', 'llama_cpp', 'mlx', 'claude') %}
+                    <option value="{{ provider }}" {% if organization_defaults.text_provider == provider %}selected{% endif %}>{{ provider }}</option>
+                    {% endfor %}
+                </select>
+
+                <label for="organize-vision-model">Vision model</label>
+                <input id="organize-vision-model" name="vision_model" type="text" value="{{ organization_defaults.vision_model or '' }}">
+
+                <label for="organize-vision-provider">Vision provider</label>
+                <select id="organize-vision-provider" name="vision_provider">
+                    <option value="">Configured default</option>
+                    {% for provider in ('ollama', 'openai', 'llama_cpp', 'mlx', 'claude') %}
+                    <option value="{{ provider }}" {% if organization_defaults.vision_provider == provider %}selected{% endif %}>{{ provider }}</option>
+                    {% endfor %}
+                </select>
+
+                <label for="organize-whisper-model">Whisper model</label>
+                <input id="organize-whisper-model" name="whisper_model" type="text" value="{{ organization_defaults.whisper_model }}">
+
+                <label for="organize-max-transcribe">Maximum transcription seconds</label>
+                <input id="organize-max-transcribe" name="max_transcribe_seconds" type="number" min="0" step="1" value="{{ organization_defaults.max_transcribe_seconds if organization_defaults.max_transcribe_seconds is not none else '' }}">
+
+                <label for="organize-workers">Parallel workers</label>
+                <input id="organize-workers" name="parallel_workers" type="number" min="1" value="{{ organization_defaults.parallel_workers or '' }}" placeholder="Automatic">
+
+                <label for="organize-prefetch">Prefetch depth</label>
+                <input id="organize-prefetch" name="prefetch_depth" type="number" min="0" value="{{ organization_defaults.prefetch_depth }}">
+            </div>
+        </details>
 
         <div class="organize-actions">
             <button class="btn-primary" type="submit">Generate plan</button>
@@ -60,6 +120,18 @@
     {% else %}
     <p class="organize-hint">No allowed roots configured. Set <code>FO_API_ALLOWED_PATHS</code>.</p>
     {% endif %}
+</section>
+
+<section class="panel" aria-labelledby="organize-capabilities-title">
+    <h2 id="organize-capabilities-title">Surface capability status</h2>
+    <p class="organize-hint">Support states come from the canonical capability registry. Unavailable workflows are shown explicitly.</p>
+    <div class="chip-stack">
+        {% for capability in organization_capabilities %}
+        <span class="chip" data-capability-id="{{ capability.id }}">
+            {{ capability.name }}: {{ capability.implementation_status }} / {{ capability.conformance_status }}
+        </span>
+        {% endfor %}
+    </div>
 </section>
 
 <section class="panel-grid two organize-panels">

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -16,7 +16,7 @@ from tests.conformance.driver import (
     OrganizationConformanceDriver,
     PythonSDKConformanceDriver,
     RESTConformanceDriver,
-    WebDesktopConformanceDriver,
+    WebFormConformanceDriver,
 )
 
 
@@ -50,9 +50,9 @@ class ConformanceContext:
         RESTConformanceDriver,
         PythonSDKConformanceDriver,
         AsyncPythonSDKConformanceDriver,
-        WebDesktopConformanceDriver,
+        WebFormConformanceDriver,
     ),
-    ids=("direct", "cli", "rest", "python-sdk", "python-async-sdk", "web-desktop"),
+    ids=("direct", "cli", "rest", "python-sdk", "python-async-sdk", "web-form-adapter"),
 )
 def conformance(tmp_path: Path, request: pytest.FixtureRequest) -> ConformanceContext:
     """Run the golden corpus against the oracle and each migrated adapter."""

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -16,6 +16,7 @@ from tests.conformance.driver import (
     OrganizationConformanceDriver,
     PythonSDKConformanceDriver,
     RESTConformanceDriver,
+    WebDesktopConformanceDriver,
 )
 
 
@@ -49,8 +50,9 @@ class ConformanceContext:
         RESTConformanceDriver,
         PythonSDKConformanceDriver,
         AsyncPythonSDKConformanceDriver,
+        WebDesktopConformanceDriver,
     ),
-    ids=("direct", "cli", "rest", "python-sdk", "python-async-sdk"),
+    ids=("direct", "cli", "rest", "python-sdk", "python-async-sdk", "web-desktop"),
 )
 def conformance(tmp_path: Path, request: pytest.FixtureRequest) -> ConformanceContext:
     """Run the golden corpus against the oracle and each migrated adapter."""

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from datetime import UTC, datetime
+from html import unescape
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 from unittest.mock import patch
@@ -38,10 +40,14 @@ from starlette.testclient import TestClient
 from typer.testing import CliRunner
 
 from file_organizer.api.config import ApiSettings
-from file_organizer.api.dependencies import get_current_active_user, get_settings
+from file_organizer.api.dependencies import (
+    get_config_manager,
+    get_current_active_user,
+    get_settings,
+)
 from file_organizer.api.exceptions import setup_exception_handlers
 from file_organizer.api.routers.organize import get_organization_service
-from file_organizer.api.routers.organize import router as organize_router
+from file_organizer.api.routers.organize import router as api_organize_router
 from file_organizer.cli.main import app
 from file_organizer.client.async_client import AsyncFileOrganizerClient
 from file_organizer.client.exceptions import ClientError
@@ -50,6 +56,7 @@ from file_organizer.client.models import (
 )
 from file_organizer.client.models import OrganizationPlanPayload as ClientOrganizationPlan
 from file_organizer.client.sync_client import FileOrganizerClient
+from file_organizer.config.schema import AppConfig
 from file_organizer.core import dispatcher
 from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.organization_service import OrganizationScan, OrganizationService
@@ -69,9 +76,15 @@ from file_organizer.services.video.metadata_extractor import (
 )
 from file_organizer.undo import UndoManager
 from file_organizer.utils.atomic_write import atomic_write_text
+from file_organizer.web.organize_routes import (
+    get_web_organization_service,
+)
+from file_organizer.web.organize_routes import (
+    organize_router as web_organize_router,
+)
 from file_organizer.web.organize_services import (
     _delete_organize_plan,
-    build_organize_plan,
+    _get_organize_plan,
     parse_organize_options,
 )
 from tests.conformance.normalize import (
@@ -301,19 +314,40 @@ class DirectServiceDriver:
         }
 
 
-class WebDesktopConformanceDriver:
-    """Drive the Web form adapter against the canonical service seam.
+class WebFormConformanceDriver:
+    """Drive the real Web form routes against the canonical service seam.
 
-    Desktop loads these same ``/ui`` workflows; its Python bridge only adds
-    native path selection and reveal affordances, covered by Desktop tests.
+    Desktop loads these same ``/ui`` workflows, so its route behavior is
+    equivalent by construction rather than independently corpus-driven. Its
+    Python bridge adds native path selection and reveal affordances covered by
+    focused Desktop tests.
     """
 
-    name = "web-desktop"
+    name = "web-form-adapter"
+    _PLAN_ID_PATTERN = re.compile(r'data-plan-id="([^"]+)"')
+    _ERROR_PATTERN = re.compile(r'data-error-payload="([^"]+)"')
 
     def __init__(self, workspace: Path) -> None:
         self._workspace = workspace
         self._workspace.mkdir(parents=True, exist_ok=True)
         self._oracle = DirectServiceDriver(workspace / "service")
+        settings = ApiSettings(
+            allowed_paths=[str(workspace.parent)],
+            auth_enabled=False,
+            auth_db_path=str(workspace / "auth.db"),
+        )
+        manager = type(
+            "ConformanceConfigManager",
+            (),
+            {"load": staticmethod(AppConfig)},
+        )()
+        self._app = FastAPI()
+        self._app.dependency_overrides[get_settings] = lambda: settings
+        self._app.dependency_overrides[get_config_manager] = lambda: manager
+        self._app.dependency_overrides[get_web_organization_service] = lambda: self._oracle._service
+        setup_exception_handlers(self._app)
+        self._app.include_router(web_organize_router, prefix="/ui")
+        self._client = TestClient(self._app, raise_server_exceptions=False)
 
     @staticmethod
     def _mapped_request(request: OrganizeRequest) -> OrganizeRequest:
@@ -344,35 +378,114 @@ class WebDesktopConformanceDriver:
         )
         return OrganizeRequest(request.input_path, request.output_path, mapped)
 
-    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
-        """Return a normalized scan after Web form mapping."""
-        mapped = self._mapped_request(request)
-        roots = (mapped.input_path, mapped.output_path)
-        try:
-            scan = self._oracle._service.scan(mapped)
-        except (DomainError, ValueError, RuntimeError, OSError) as exc:
-            return {"outcome": "error", "error": normalize_error(exc, *roots)}
-        return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
+    @staticmethod
+    def _form_data(request: OrganizeRequest) -> dict[str, str]:
+        """Serialize every canonical option through the Web form contract."""
+        options = request.options
+        return {
+            "input_dir": str(request.input_path),
+            "output_dir": str(request.output_path),
+            "methodology": options.effective_methodology.value,
+            "recursive": "1" if options.recursive else "0",
+            "include_hidden": "1" if options.include_hidden else "0",
+            "skip_existing": "1" if options.skip_existing else "0",
+            "transfer_mode": options.effective_transfer_mode.value,
+            "use_hardlinks": "1" if options.use_hardlinks else "0",
+            "enable_vision": "1" if options.enable_vision else "0",
+            "transcribe_audio": "1" if options.transcribe_audio else "0",
+            "max_transcribe_seconds": (
+                ""
+                if options.max_transcribe_seconds is None
+                else str(options.max_transcribe_seconds)
+            ),
+            "whisper_model": options.whisper_model,
+            "parallel_workers": (
+                "" if options.parallel_workers is None else str(options.parallel_workers)
+            ),
+            "prefetch_depth": str(options.prefetch_depth),
+            "text_model": options.text_model or "",
+            "vision_model": options.vision_model or "",
+            "text_provider": options.text_provider or "",
+            "vision_provider": options.vision_provider or "",
+        }
 
-    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
-        """Generate and round-trip the exact serialized plan rendered by Web."""
-        mapped = self._mapped_request(request)
-        roots = (mapped.input_path, mapped.output_path)
+    def _post_scan(
+        self, request: OrganizeRequest
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        response = self._client.post("/ui/organize/scan", data=self._form_data(request))
+        if response.status_code != 200:
+            raise AssertionError(f"Web scan returned HTTP {response.status_code}.")
+        error_match = self._ERROR_PATTERN.search(response.text)
+        if error_match is not None:
+            payload = json.loads(unescape(error_match.group(1)))
+            payload.setdefault("details", {})
+            return None, payload
+        plan_match = self._PLAN_ID_PATTERN.search(response.text)
+        if plan_match is None:
+            raise AssertionError("Web scan response did not expose a plan or typed error.")
+        stored = _get_organize_plan(plan_match.group(1))
+        if stored is None:
+            raise AssertionError("Web scan response referenced an unavailable plan.")
+        return stored, None
+
+    @staticmethod
+    def _normalize_web_error(payload: dict[str, Any], roots: tuple[Path, Path]) -> dict[str, Any]:
+        try:
+            error = DomainError.from_dict(payload)
+        except (KeyError, ValueError):
+            return {
+                "code": str(payload.get("code", "execution_failed")),
+                "message": redact_roots(str(payload.get("message", "Request failed.")), *roots),
+                "retryable": bool(payload.get("retryable", False)),
+                "details": dict(payload.get("details", {})),
+            }
+        return normalize_error(error, *roots)
+
+    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return the scan persisted by the real Web form route."""
+        roots = (request.input_path, request.output_path)
         stored: dict[str, Any] | None = None
         try:
-            stored = build_organize_plan(
-                input_dir=str(mapped.input_path),
-                output_dir=str(mapped.output_path),
-                allowed_paths=[str(self._workspace.parent)],
-                options=mapped.options,
-                organization_service=self._oracle._service,
+            stored, error = self._post_scan(request)
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        if error is not None:
+            return {"outcome": "error", "error": self._normalize_web_error(error, roots)}
+        if stored is None:
+            raise AssertionError("Successful Web scan must persist a reviewed plan.")
+        try:
+            scan = OrganizationScan(
+                Path(stored["input_dir"]),
+                tuple(Path(path) for path in stored["scan_files"]),
+                dict(stored["scan_counts"]),
             )
+            return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
+        finally:
+            _delete_organize_plan(stored["plan_id"])
+
+    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Round-trip the plan through dashboard, scan, and clear routes."""
+        roots = (request.input_path, request.output_path)
+        stored: dict[str, Any] | None = None
+        try:
+            dashboard = self._client.get("/ui/organize")
+            if dashboard.status_code != 200:
+                raise AssertionError(f"Web dashboard returned HTTP {dashboard.status_code}.")
+            stored, error = self._post_scan(request)
+            if error is not None:
+                return {"outcome": "error", "error": self._normalize_web_error(error, roots)}
+            if stored is None:
+                raise AssertionError("Successful Web preview must persist a reviewed plan.")
             plan = OrganizationPlan.from_dict(stored["executable_plan"])
         except (DomainError, ValueError, RuntimeError, OSError) as exc:
             return {"outcome": "error", "error": normalize_error(exc, *roots)}
         finally:
             if stored is not None:
-                _delete_organize_plan(stored["plan_id"])
+                clear = self._client.post(
+                    "/ui/organize/plan/clear", data={"plan_id": stored["plan_id"]}
+                )
+                if clear.status_code != 200 or _get_organize_plan(stored["plan_id"]) is not None:
+                    raise AssertionError("Web clear-plan route did not remove the reviewed plan.")
         result = OrganizationResult(
             total_files=plan.total_files,
             processed_files=plan.processed_files,
@@ -620,7 +733,7 @@ class _HTTPConformanceDriver:
         self._app.dependency_overrides[get_settings] = lambda: settings
         self._app.dependency_overrides[get_current_active_user] = lambda: object()
         self._app.dependency_overrides[get_organization_service] = lambda: self._oracle._service
-        self._app.include_router(organize_router, prefix="/api/v1")
+        self._app.include_router(api_organize_router, prefix="/api/v1")
         self._test_client = TestClient(self._app, raise_server_exceptions=False)
 
     @staticmethod

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -69,6 +69,11 @@ from file_organizer.services.video.metadata_extractor import (
 )
 from file_organizer.undo import UndoManager
 from file_organizer.utils.atomic_write import atomic_write_text
+from file_organizer.web.organize_services import (
+    _delete_organize_plan,
+    build_organize_plan,
+    parse_organize_options,
+)
 from tests.conformance.normalize import (
     normalize_audit_events,
     normalize_error,
@@ -293,6 +298,120 @@ class DirectServiceDriver:
             "plan": normalize_plan(result.plan, *roots),
             "result": normalize_result(result, *roots),
             "audit_events": events,
+        }
+
+
+class WebDesktopConformanceDriver:
+    """Drive the Web form adapter against the canonical service seam.
+
+    Desktop loads these same ``/ui`` workflows; its Python bridge only adds
+    native path selection and reveal affordances, covered by Desktop tests.
+    """
+
+    name = "web-desktop"
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+        self._workspace.mkdir(parents=True, exist_ok=True)
+        self._oracle = DirectServiceDriver(workspace / "service")
+
+    @staticmethod
+    def _mapped_request(request: OrganizeRequest) -> OrganizeRequest:
+        options = request.options
+        mapped = parse_organize_options(
+            methodology=options.effective_methodology.value,
+            recursive="1" if options.recursive else "0",
+            include_hidden="1" if options.include_hidden else "0",
+            skip_existing="1" if options.skip_existing else "0",
+            transfer_mode=options.effective_transfer_mode.value,
+            use_hardlinks="1" if options.use_hardlinks else "0",
+            enable_vision="1" if options.enable_vision else "0",
+            transcribe_audio="1" if options.transcribe_audio else "0",
+            max_transcribe_seconds=(
+                ""
+                if options.max_transcribe_seconds is None
+                else str(options.max_transcribe_seconds)
+            ),
+            whisper_model=options.whisper_model,
+            parallel_workers=(
+                "" if options.parallel_workers is None else str(options.parallel_workers)
+            ),
+            prefetch_depth=str(options.prefetch_depth),
+            text_model=options.text_model or "",
+            vision_model=options.vision_model or "",
+            text_provider=options.text_provider or "",
+            vision_provider=options.vision_provider or "",
+        )
+        return OrganizeRequest(request.input_path, request.output_path, mapped)
+
+    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return a normalized scan after Web form mapping."""
+        mapped = self._mapped_request(request)
+        roots = (mapped.input_path, mapped.output_path)
+        try:
+            scan = self._oracle._service.scan(mapped)
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
+
+    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Generate and round-trip the exact serialized plan rendered by Web."""
+        mapped = self._mapped_request(request)
+        roots = (mapped.input_path, mapped.output_path)
+        stored: dict[str, Any] | None = None
+        try:
+            stored = build_organize_plan(
+                input_dir=str(mapped.input_path),
+                output_dir=str(mapped.output_path),
+                allowed_paths=[str(self._workspace.parent)],
+                options=mapped.options,
+                organization_service=self._oracle._service,
+            )
+            plan = OrganizationPlan.from_dict(stored["executable_plan"])
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        finally:
+            if stored is not None:
+                _delete_organize_plan(stored["plan_id"])
+        result = OrganizationResult(
+            total_files=plan.total_files,
+            processed_files=plan.processed_files,
+            skipped_files=plan.skipped_files,
+            failed_files=plan.failed_files,
+            deduplicated_files=plan.deduplicated_files,
+            organized_structure=plan.organized_structure(),
+            errors=plan.errors,
+            plan=plan,
+        )
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(plan, *roots),
+            "result": normalize_result(result, *roots),
+            "plan_payload": plan.to_dict(),
+        }
+
+    def execute(
+        self, request: OrganizeRequest, plan_payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Execute the reviewed serialized plan through the shared service."""
+        mapped = self._mapped_request(request)
+        roots = (mapped.input_path, mapped.output_path)
+        try:
+            plan = OrganizationPlan.from_dict(plan_payload) if plan_payload is not None else None
+            result = self._oracle._service.execute(mapped, plan)
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        if not isinstance(result.plan, OrganizationPlan):
+            raise AssertionError("Web execution must retain its executable plan.")
+        history = self._oracle._last_history
+        assert history is not None
+        operations = history.get_operations()
+        operations.sort(key=lambda operation: operation.id if operation.id is not None else -1)
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(result.plan, *roots),
+            "result": normalize_result(result, *roots),
+            "audit_events": normalize_audit_events(operations, *roots),
         }
 
 

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -60,7 +60,7 @@ from file_organizer.config.schema import AppConfig
 from file_organizer.core import dispatcher
 from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.organization_service import OrganizationScan, OrganizationService
-from file_organizer.core.organize_options import OrganizeRequest
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.plan import OrganizationPlan
 from file_organizer.core.types import OrganizationResult
@@ -351,40 +351,16 @@ class WebFormConformanceDriver:
 
     @staticmethod
     def _mapped_request(request: OrganizeRequest) -> OrganizeRequest:
-        options = request.options
+        """Map Web-form strings back onto the canonical request contract."""
         mapped = parse_organize_options(
-            methodology=options.effective_methodology.value,
-            recursive="1" if options.recursive else "0",
-            include_hidden="1" if options.include_hidden else "0",
-            skip_existing="1" if options.skip_existing else "0",
-            transfer_mode=options.effective_transfer_mode.value,
-            use_hardlinks="1" if options.use_hardlinks else "0",
-            enable_vision="1" if options.enable_vision else "0",
-            transcribe_audio="1" if options.transcribe_audio else "0",
-            max_transcribe_seconds=(
-                ""
-                if options.max_transcribe_seconds is None
-                else str(options.max_transcribe_seconds)
-            ),
-            whisper_model=options.whisper_model,
-            parallel_workers=(
-                "" if options.parallel_workers is None else str(options.parallel_workers)
-            ),
-            prefetch_depth=str(options.prefetch_depth),
-            text_model=options.text_model or "",
-            vision_model=options.vision_model or "",
-            text_provider=options.text_provider or "",
-            vision_provider=options.vision_provider or "",
+            **WebFormConformanceDriver._option_form_fields(request.options)
         )
         return OrganizeRequest(request.input_path, request.output_path, mapped)
 
     @staticmethod
-    def _form_data(request: OrganizeRequest) -> dict[str, str]:
+    def _option_form_fields(options: OrganizeOptions) -> dict[str, str]:
         """Serialize every canonical option through the Web form contract."""
-        options = request.options
         return {
-            "input_dir": str(request.input_path),
-            "output_dir": str(request.output_path),
             "methodology": options.effective_methodology.value,
             "recursive": "1" if options.recursive else "0",
             "include_hidden": "1" if options.include_hidden else "0",
@@ -407,6 +383,15 @@ class WebFormConformanceDriver:
             "vision_model": options.vision_model or "",
             "text_provider": options.text_provider or "",
             "vision_provider": options.vision_provider or "",
+        }
+
+    @staticmethod
+    def _form_data(request: OrganizeRequest) -> dict[str, str]:
+        """Add request paths to the shared canonical option serialization."""
+        return {
+            "input_dir": str(request.input_path),
+            "output_dir": str(request.output_path),
+            **WebFormConformanceDriver._option_form_fields(request.options),
         }
 
     def _post_scan(

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -63,7 +63,7 @@ def test_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
         "rest",
         "python-sdk",
         "python-async-sdk",
-        "web-desktop",
+        "web-form-adapter",
     }
 
 

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -63,6 +63,7 @@ def test_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
         "rest",
         "python-sdk",
         "python-async-sdk",
+        "web-desktop",
     }
 
 
@@ -172,6 +173,26 @@ def test_preview_sources_match_scan(conformance: ConformanceContext) -> None:
 
     assert [op["source"] for op in preview["plan"]["operations"]] == scan["files"]
     assert preview["plan"]["counts"]["total_files"] == scan["total_files"]
+
+
+def test_non_recursive_execution_applies_only_reviewed_top_level_files(
+    conformance: ConformanceContext,
+) -> None:
+    """Unchecked recursion must remain unchanged through reviewed execution (#1597)."""
+    conformance.stage("nested-mixed")
+    request = conformance.request(recursive=False, transfer_mode="copy")
+    preview = _ok(conformance.driver.preview(request))
+
+    executed = _ok(conformance.driver.execute(request, preview["plan_payload"]))
+
+    assert executed["plan"]["counts"]["total_files"] == 1
+    assert [operation["source"] for operation in executed["plan"]["operations"]] == [
+        "<input>/top.txt"
+    ]
+    assert executed["result"]["counts"]["processed_files"] == 1
+    assert [path.name for path in conformance.output_root.rglob("*") if path.is_file()] == [
+        "top.txt"
+    ]
 
 
 def test_media_routing_golden(conformance: ConformanceContext) -> None:

--- a/tests/desktop/test_pywebview_app.py
+++ b/tests/desktop/test_pywebview_app.py
@@ -150,6 +150,25 @@ class TestLaunch:
 
         mock_webview.start.assert_called_once()
 
+    def test_native_window_loads_the_shared_web_routes(self) -> None:
+        """Desktop points at the same FastAPI Web UI and only injects its native API."""
+        mock_webview = MagicMock()
+
+        from file_organizer.desktop import app as desktop_app
+
+        with (
+            patch.dict(sys.modules, {"webview": mock_webview}),
+            patch("file_organizer.desktop.app._find_free_port", return_value=43123),
+            patch("file_organizer.desktop.app._wait_for_server", return_value=True),
+            patch("file_organizer.desktop.app._run_server"),
+            patch("file_organizer.desktop.app.threading"),
+        ):
+            desktop_app.launch()
+
+        args, kwargs = mock_webview.create_window.call_args
+        assert args == ("File Organizer", "http://127.0.0.1:43123")
+        assert isinstance(kwargs["js_api"], desktop_app.DesktopAPI)
+
 
 # ---------------------------------------------------------------------------
 # _run_server — exercises lines 76-81 (uvicorn import + create_app + run)

--- a/tests/integration/test_executable_plan_review_regressions.py
+++ b/tests/integration/test_executable_plan_review_regressions.py
@@ -14,6 +14,8 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_current_active_user, get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
 from file_organizer.api.routers.organize import router
+from file_organizer.core.file_ops import collect_files
+from file_organizer.core.organization_service import count_files_by_type
 from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.organizer import FileOrganizer
 from file_organizer.core.plan import (
@@ -30,13 +32,10 @@ from file_organizer.services.text_processor import ProcessedFile
 from file_organizer.undo import UndoManager
 from file_organizer.web.organize_services import (
     _ORGANIZE_PLAN_STORE,
-    _build_plan_movements,
-    _counts_by_type,
     _delete_organize_plan,
     _get_organize_plan,
     _parse_delay_minutes,
     _prune_plan_store,
-    _scan_directory,
     _store_organize_plan,
 )
 
@@ -311,10 +310,18 @@ def test_web_organize_helpers_cover_scan_and_store_paths(tmp_path: Path) -> None
     nested.mkdir()
     (nested / "clip.mp4").write_text("video")
 
-    files = _scan_directory(tmp_path, recursive=True, include_hidden=False)
-    counts = _counts_by_type(files)
-    preview = MagicMock(organized_structure={"Documents": ["visible.txt"]})
-    movements = _build_plan_movements(files, tmp_path / "out", preview)
+    files = collect_files(tmp_path, recursive=True, include_hidden=False)
+    counts = count_files_by_type(files)
+    plan = build_plan_from_processed(
+        input_path=tmp_path,
+        output_path=tmp_path / "out",
+        processed=[_processed(visible, "Documents")],
+        skip_existing=True,
+        use_hardlinks=False,
+        total_files=1,
+        skipped_files=0,
+        deduplicated_files=0,
+    )
     record = _store_organize_plan({"payload": True})
     fetched = _get_organize_plan(record["plan_id"])
     _delete_organize_plan(record["plan_id"])
@@ -323,7 +330,7 @@ def test_web_organize_helpers_cover_scan_and_store_paths(tmp_path: Path) -> None
     assert counts["text"] == 1
     assert counts["cad"] == 1
     assert counts["video"] == 1
-    assert any(movement["destination"].endswith("visible.txt") for movement in movements)
+    assert plan.movements()[0]["destination"].endswith("visible.txt")
     assert fetched is not None and fetched["payload"] is True
     assert _get_organize_plan(record["plan_id"]) is None
 

--- a/tests/integration/test_web_organize_routes_extended.py
+++ b/tests/integration/test_web_organize_routes_extended.py
@@ -3,8 +3,8 @@
 Covers uncovered lines including:
 - _parse_delay_minutes: None/empty → 0, non-int raises, negative raises, over-max raises
 - _normalize_methodology: known key, unknown key → none (canonical default)
-- _scan_directory: single file input (hidden/not hidden), non-recursive glob
-- _counts_by_type: image, video, audio, cad, other categories
+- canonical collection: single file input (hidden/not hidden), non-recursive traversal
+- canonical organization counts: image, video, audio, cad, other categories
 - _store_organize_plan / _get_organize_plan / _delete_organize_plan
 - _set_job_metadata / _get_job_metadata / _prune_job_metadata (force=True)
 - _status_progress: queued, running, failed, unknown
@@ -34,14 +34,15 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_settings
 from file_organizer.api.exceptions import ApiError, setup_exception_handlers
 from file_organizer.api.test_utils import csrf_headers, seed_csrf_token
+from file_organizer.core.file_ops import collect_files as _scan_directory
 from file_organizer.core.lifecycle import JobStatus, RecoveryAction
+from file_organizer.core.organization_service import count_files_by_type as _counts_by_type
 from file_organizer.core.plan import OrganizationPlan, build_plan_from_processed
 from file_organizer.core.types import OrganizationResult
 from file_organizer.services.text_processor import ProcessedFile
 from file_organizer.web.organize_routes import (
     ORGANIZE_MAX_DELAY_MIN,
     _build_job_view,
-    _counts_by_type,
     _delete_organize_plan,
     _get_job_metadata,
     _get_organize_plan,
@@ -49,7 +50,6 @@ from file_organizer.web.organize_routes import (
     _parse_delay_minutes,
     _prune_job_metadata,
     _run_organize_plan_job,
-    _scan_directory,
     _set_job_metadata,
     _status_progress,
     _store_organize_plan,
@@ -311,7 +311,14 @@ class TestPlanStore:
             def __init__(self, **_: object) -> None:
                 pass
 
-            def organize(self, **_: object) -> OrganizationResult:
+            def organize(
+                self,
+                _input_path: Path,
+                _output_path: Path,
+                *,
+                skip_existing: bool,
+            ) -> OrganizationResult:
+                assert skip_existing is True
                 return OrganizationResult(
                     total_files=1,
                     processed_files=1,
@@ -366,15 +373,17 @@ class TestPlanStore:
             plan=plan,
         )
 
+        service = MagicMock()
+        service.execute.return_value = result
+        current = MagicMock(status=JobStatus.QUEUED, revision=0)
         with (
+            patch("file_organizer.web.organize_routes.get_job", return_value=current),
             patch("file_organizer.web.organize_routes.update_job") as mock_update,
-            patch("file_organizer.web.organize_routes.FileOrganizer") as mock_organizer_cls,
         ):
-            mock_organizer_cls.return_value.execute_plan.return_value = result
-            _run_organize_plan_job("job-1", plan.to_dict(), dry_run=False)
+            _run_organize_plan_job("job-1", plan.to_dict(), service, dry_run=False)
 
-        mock_organizer_cls.return_value.execute_plan.assert_called_once()
-        executed_plan = mock_organizer_cls.return_value.execute_plan.call_args.args[0]
+        service.execute.assert_called_once()
+        executed_plan = service.execute.call_args.args[1]
         assert executed_plan.plan_id == plan.plan_id
         assert mock_update.call_args_list[-1].kwargs["status"] == "completed"
 

--- a/tests/playwright/test_desktop_api_contract.py
+++ b/tests/playwright/test_desktop_api_contract.py
@@ -52,6 +52,19 @@ class TestBridgeMockInjection:
         result: str = page.evaluate("() => window.pywebview.api.browse_directory().then(v => v)")
         assert result == "/mock/dir"
 
+    def test_browse_directory_is_noop_when_bridge_method_is_missing(
+        self, page: Page, pywebview_mock: PywebviewMockHandle
+    ) -> None:
+        """The shared UI must tolerate a pywebview bridge without the new method."""
+        page.goto("/ui/organize")
+        input_path = page.locator("#organize-input-dir")
+        original_value = input_path.input_value()
+        page.evaluate(
+            "() => { delete window.pywebview.api.browse_directory; "
+            "window.desktopBrowseDirectory('organize-input-dir'); }"
+        )
+        expect(input_path).to_have_value(original_value)
+
     def test_browse_file_returns_mock_path(
         self, page: Page, pywebview_mock: PywebviewMockHandle
     ) -> None:

--- a/tests/playwright/test_organize_workflow.py
+++ b/tests/playwright/test_organize_workflow.py
@@ -86,7 +86,7 @@ def test_organize_scan_with_nonexistent_path_surfaces_error(
     # The bogus path MUST be under playwright_allowed_root so resolve_path()
     # succeeds (it raises ValueError for paths outside allowed_paths, which the
     # scan handler catches as the generic "Failed to generate plan." rather than
-    # the specific "Input directory not found." we need).
+    # the specific canonical missing-input error we need).
     bogus = playwright_allowed_root / "does-not-exist-xyz123"
     page.locator("#organize-input-dir").fill(str(bogus))
     page.locator("#organize-output-dir").fill(str(organize_output_dir))
@@ -94,7 +94,7 @@ def test_organize_scan_with_nonexistent_path_surfaces_error(
 
     error_banner = page.locator("#organize-plan .banner-error")
     expect(error_banner).to_be_visible()
-    expect(error_banner).to_contain_text("Input directory not found.")
+    expect(error_banner).to_contain_text("Input path does not exist:")
 
     # Sanity: the page itself did not 500 — the header still renders
     expect(page.locator("h1.page-title")).to_contain_text("Organization dashboard")

--- a/tests/web/test_organize_routes.py
+++ b/tests/web/test_organize_routes.py
@@ -1,30 +1,25 @@
 """Unit tests for web organize_routes helpers.
 
-Tests internal helpers (_parse_delay_minutes, _normalize_methodology,
-_scan_directory, _counts_by_type, _status_progress, _job_report_payload),
-plan-store operations, job-metadata operations, job-view builders,
-and cancel/schedule helpers.
+Tests presentation helpers, plan-store operations, job metadata, job views,
+and lifecycle adaptation.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from pathlib import Path
 from threading import Timer
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from file_organizer.api.exceptions import ApiError
-from file_organizer.core.lifecycle import RecoveryAction
+from file_organizer.core.lifecycle import JobStatus, RecoveryAction
 from file_organizer.web.organize_routes import (
     ORGANIZE_MAX_DELAY_MIN,
     ORGANIZE_METHODOLOGIES,
     _cancel_scheduled_job,
-    _counts_by_type,
     _normalize_methodology,
     _parse_delay_minutes,
-    _scan_directory,
     _status_progress,
 )
 
@@ -134,140 +129,6 @@ class TestNormalizeMethodology:
     def test_whitespace_trimmed(self):
         """Verifies leading/trailing whitespace is stripped before matching."""
         assert _normalize_methodology("  para  ") == "para"
-
-
-# ---------------------------------------------------------------------------
-# _scan_directory
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestScanDirectory:
-    """Test the _scan_directory helper."""
-
-    def test_scan_flat(self, tmp_path):
-        """Verifies non-recursive scan returns only top-level files, not subdirectory files."""
-        (tmp_path / "a.txt").write_text("x")
-        (tmp_path / "b.txt").write_text("y")
-        (tmp_path / "sub").mkdir()
-        (tmp_path / "sub" / "c.txt").write_text("z")
-
-        files = _scan_directory(tmp_path, recursive=False, include_hidden=False)
-        names = {f.name for f in files}
-        assert "a.txt" in names
-        assert "b.txt" in names
-        # sub/c.txt should NOT be included (non-recursive)
-        assert "c.txt" not in names
-
-    def test_scan_recursive(self, tmp_path):
-        """Verifies recursive scan includes files in subdirectories."""
-        (tmp_path / "a.txt").write_text("x")
-        (tmp_path / "sub").mkdir()
-        (tmp_path / "sub" / "c.txt").write_text("z")
-
-        files = _scan_directory(tmp_path, recursive=True, include_hidden=False)
-        names = {f.name for f in files}
-        assert "a.txt" in names
-        assert "c.txt" in names
-
-    def test_exclude_hidden(self, tmp_path):
-        """Verifies visible files are returned when hidden files are excluded."""
-        (tmp_path / "visible.txt").write_text("x")
-        (tmp_path / ".hidden.txt").write_text("y")
-
-        files = _scan_directory(tmp_path, recursive=False, include_hidden=False)
-        names = {f.name for f in files}
-        assert "visible.txt" in names
-        # Hidden file might or might not be excluded depending on is_hidden impl
-        # The function calls is_hidden() so we check at least visible is there
-
-    def test_include_hidden(self, tmp_path):
-        """Verifies hidden files are returned when include_hidden is True."""
-        (tmp_path / ".hidden.txt").write_text("y")
-
-        files = _scan_directory(tmp_path, recursive=False, include_hidden=True)
-        names = {f.name for f in files}
-        assert ".hidden.txt" in names
-
-    def test_single_file(self, tmp_path):
-        """Verifies a single visible file path is returned as a one-element list."""
-        f = tmp_path / "solo.txt"
-        f.write_text("data")
-
-        files = _scan_directory(f, recursive=False, include_hidden=True)
-        assert len(files) == 1
-        assert files[0].name == "solo.txt"
-
-    def test_single_hidden_file_excluded(self, tmp_path):
-        """Verifies a single hidden file path is excluded when include_hidden is False."""
-        f = tmp_path / ".hidden_solo"
-        f.write_text("data")
-
-        files = _scan_directory(f, recursive=False, include_hidden=False)
-        # is_hidden should filter this out
-        assert len(files) == 0
-
-    def test_nonexistent_path(self, tmp_path):
-        """Verifies a nonexistent path returns an empty list without raising."""
-        missing = tmp_path / "nope"
-        files = _scan_directory(missing, recursive=False, include_hidden=False)
-        assert files == []
-
-
-# ---------------------------------------------------------------------------
-# _counts_by_type
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestCountsByType:
-    """Test the _counts_by_type helper."""
-
-    def test_empty_list(self):
-        """Verifies an empty file list returns zeroed counts for all type buckets."""
-        result = _counts_by_type([])
-        assert result == {"text": 0, "image": 0, "video": 0, "audio": 0, "cad": 0, "other": 0}
-
-    def test_text_file(self):
-        """Verifies .txt and .md files are counted in the 'text' bucket."""
-        result = _counts_by_type([Path("doc.txt"), Path("notes.md")])
-        assert result["text"] == 2
-
-    def test_image_file(self):
-        """Verifies .jpg and .png files are counted in the 'image' bucket."""
-        result = _counts_by_type([Path("photo.jpg"), Path("diagram.png")])
-        assert result["image"] == 2
-
-    def test_video_file(self):
-        """Verifies .mp4 files are counted in the 'video' bucket."""
-        result = _counts_by_type([Path("clip.mp4")])
-        assert result["video"] == 1
-
-    def test_audio_file(self):
-        """Verifies .mp3 files are counted in the 'audio' bucket."""
-        result = _counts_by_type([Path("song.mp3")])
-        assert result["audio"] == 1
-
-    def test_unknown_extension(self):
-        """Verifies files with unrecognised extensions are counted in the 'other' bucket."""
-        result = _counts_by_type([Path("mystery.xyz")])
-        assert result["other"] == 1
-
-    def test_mixed(self):
-        """Verifies a mixed set of file types is counted correctly across all buckets."""
-        files = [
-            Path("a.txt"),
-            Path("b.jpg"),
-            Path("c.mp4"),
-            Path("d.mp3"),
-            Path("e.unknown"),
-        ]
-        result = _counts_by_type(files)
-        assert result["text"] == 1
-        assert result["image"] == 1
-        assert result["video"] == 1
-        assert result["audio"] == 1
-        assert result["other"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -618,6 +479,31 @@ class TestBuildJobView:
         assert view is not None
         assert view["can_cancel"] is True
 
+    def test_builds_view_queued_as_cancellable(self):
+        """Queued work can be cancelled before the background task starts."""
+        from file_organizer.web.organize_routes import _build_job_view
+
+        mock_job = MagicMock()
+        mock_job.job_id = "job-queued"
+        mock_job.status = JobStatus.QUEUED
+        mock_job.result = None
+        mock_job.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+        mock_job.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
+        mock_job.error = None
+        mock_job.scheduled_for = None
+        mock_job.transaction_id = None
+        mock_job.recovery_action = RecoveryAction.NONE
+        mock_job.revision = 0
+
+        with (
+            patch("file_organizer.web.organize_routes.get_job", return_value=mock_job),
+            patch("file_organizer.web.organize_routes._get_job_metadata", return_value={}),
+        ):
+            view = _build_job_view("job-queued")
+
+        assert view is not None
+        assert view["can_cancel"] is True
+
 
 # ---------------------------------------------------------------------------
 # _list_organize_jobs
@@ -734,12 +620,10 @@ class TestCancelScheduledJob:
         mock_timer = MagicMock(spec=Timer)
         _SCHEDULED_TIMERS["cancel-test"] = mock_timer
 
-        with patch("file_organizer.web.organize_routes.update_job") as update:
-            result = _cancel_scheduled_job("cancel-test")
+        result = _cancel_scheduled_job("cancel-test")
 
         assert result is True
         mock_timer.cancel.assert_called_once()
-        assert update.call_args.kwargs["status"] == "cancelled"
         assert "cancel-test" not in _SCHEDULED_TIMERS
 
     def test_cancel_nonexistent_timer(self):

--- a/tests/web/test_organize_routes_coverage.py
+++ b/tests/web/test_organize_routes_coverage.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from file_organizer.api.exceptions import ApiError
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.lifecycle import JobStatus
 from file_organizer.core.plan import OrganizationPlan, build_plan_from_processed
 from file_organizer.core.types import OrganizationResult
 from file_organizer.services.text_processor import ProcessedFile
@@ -55,6 +57,13 @@ class TestOrganizeDashboardRoute:
 
         settings = MagicMock()
         request = MagicMock()
+        manager = MagicMock()
+        manager.load.return_value = MagicMock(
+            default_input_dir=None,
+            default_output_dir=None,
+            default_methodology="none",
+            models=MagicMock(text_model="text", vision_model="vision"),
+        )
         with (
             patch("file_organizer.web._helpers.base_context", return_value={"request": request}),
             patch("file_organizer.web.organize_routes.allowed_roots", return_value=[tmp_path]),
@@ -63,7 +72,7 @@ class TestOrganizeDashboardRoute:
                 return_value={"total_jobs": 0},
             ),
         ):
-            organize_dashboard(request, settings)
+            organize_dashboard(request, settings, manager)
         mock_templates.TemplateResponse.assert_called_once()
 
 
@@ -341,19 +350,34 @@ class TestOrganizeJobCancelRoute:
     def test_cancel_success(self, mock_templates) -> None:
         from file_organizer.web.organize_routes import organize_job_cancel
 
-        job_view = {"job_id": "j1", "status": "queued", "can_cancel": True}
+        job_view = {
+            "job_id": "j1",
+            "status": "scheduled",
+            "can_cancel": True,
+            "revision": 0,
+        }
         request = MagicMock()
         with (
             patch("file_organizer.web.organize_routes._build_job_view", return_value=job_view),
             patch("file_organizer.web.organize_routes._cancel_scheduled_job", return_value=True),
+            patch(
+                "file_organizer.web.organize_routes.update_job",
+                return_value=MagicMock(),
+            ) as update,
         ):
             organize_job_cancel(request, "j1")
+        update.assert_called_once_with("j1", status="cancelled", expected_revision=0)
         mock_templates.TemplateResponse.assert_called_once()
 
     def test_cancel_not_scheduled(self, mock_templates) -> None:
         from file_organizer.web.organize_routes import organize_job_cancel
 
-        job_view = {"job_id": "j1", "status": "running", "can_cancel": False}
+        job_view = {
+            "job_id": "j1",
+            "status": "running",
+            "can_cancel": False,
+            "revision": 1,
+        }
         request = MagicMock()
         with (
             patch("file_organizer.web.organize_routes._build_job_view", return_value=job_view),
@@ -361,6 +385,33 @@ class TestOrganizeJobCancelRoute:
         ):
             organize_job_cancel(request, "j1")
         mock_templates.TemplateResponse.assert_called_once()
+
+    def test_cancel_queued_uses_revision_guard(self, mock_templates) -> None:
+        from file_organizer.web.organize_routes import organize_job_cancel
+
+        job_view = {
+            "job_id": "j1",
+            "status": "queued",
+            "can_cancel": True,
+            "revision": 7,
+        }
+        with (
+            patch(
+                "file_organizer.web.organize_routes._build_job_view",
+                side_effect=(job_view, {**job_view, "status": "cancelled"}),
+            ),
+            patch(
+                "file_organizer.web.organize_routes.update_job",
+                return_value=MagicMock(),
+            ) as update,
+        ):
+            organize_job_cancel(MagicMock(), "j1")
+
+        update.assert_called_once_with(
+            "j1",
+            status="cancelled",
+            expected_revision=7,
+        )
 
     def test_cancel_not_found(self) -> None:
         from file_organizer.web.organize_routes import organize_job_cancel
@@ -383,6 +434,7 @@ class TestOrganizeJobRollbackRoute:
             "job_id": "j1",
             "status": "running",
             "can_rollback": False,
+            "revision": 1,
         }
         request = MagicMock()
         with patch("file_organizer.web.organize_routes._build_job_view", return_value=job_view):
@@ -397,6 +449,7 @@ class TestOrganizeJobRollbackRoute:
             "status": "completed",
             "can_rollback": True,
             "transaction_id": "txn-1",
+            "revision": 1,
         }
         request = MagicMock()
         mock_manager = MagicMock()
@@ -404,9 +457,19 @@ class TestOrganizeJobRollbackRoute:
         with (
             patch("file_organizer.web.organize_routes._build_job_view", return_value=job_view),
             patch("file_organizer.undo.undo_manager.UndoManager", return_value=mock_manager),
+            patch("file_organizer.web.organize_routes.update_job") as update,
         ):
+            update.side_effect = (
+                MagicMock(revision=2),
+                MagicMock(revision=3),
+            )
             organize_job_rollback(request, "j1")
         mock_manager.undo_transaction.assert_called_once_with("txn-1")
+        assert update.call_args_list[0].kwargs == {
+            "status": "rolling_back",
+            "expected_revision": 1,
+        }
+        assert update.call_args_list[1].kwargs["expected_revision"] == 2
         mock_templates.TemplateResponse.assert_called_once()
 
     def test_rollback_exception(self, mock_templates) -> None:
@@ -417,10 +480,18 @@ class TestOrganizeJobRollbackRoute:
             "status": "completed",
             "can_rollback": True,
             "transaction_id": "txn-1",
+            "revision": 1,
         }
         request = MagicMock()
+        rolling_back = MagicMock(revision=2)
+        current = MagicMock(status="rolling_back", revision=2)
         with (
             patch("file_organizer.web.organize_routes._build_job_view", return_value=job_view),
+            patch(
+                "file_organizer.web.organize_routes.update_job",
+                side_effect=(rolling_back, MagicMock(revision=3)),
+            ),
+            patch("file_organizer.web.organize_routes.get_job", return_value=current),
             patch(
                 "file_organizer.undo.undo_manager.UndoManager",
                 side_effect=RuntimeError("undo failed"),
@@ -539,46 +610,6 @@ class TestOrganizeReportRoute:
             organize_report("missing", format="json")
 
 
-class TestRunOrganizeJob:
-    """Covers _run_organize_job."""
-
-    def test_run_success(self) -> None:
-        from file_organizer.web.organize_routes import _run_organize_job
-
-        mock_organizer = MagicMock()
-        mock_result = MagicMock()
-        mock_result.errors = []
-        mock_organizer.organize.return_value = mock_result
-
-        request = MagicMock()
-        request.dry_run = False
-        request.use_hardlinks = False
-        request.input_dir = "/in"
-        request.output_dir = "/out"
-        request.skip_existing = True
-
-        with (
-            patch("file_organizer.web.organize_routes.update_job"),
-            patch("file_organizer.web.organize_routes.FileOrganizer", return_value=mock_organizer),
-        ):
-            _run_organize_job("j1", request)
-
-    def test_run_failure(self) -> None:
-        from file_organizer.web.organize_routes import _run_organize_job
-
-        request = MagicMock()
-        request.dry_run = False
-        request.use_hardlinks = False
-
-        with (
-            patch("file_organizer.web.organize_routes.update_job"),
-            patch(
-                "file_organizer.web.organize_routes.FileOrganizer", side_effect=RuntimeError("boom")
-            ),
-        ):
-            _run_organize_job("j1", request)
-
-
 class TestRunOrganizePlanJob:
     """Covers executable-plan job execution."""
 
@@ -598,12 +629,18 @@ class TestRunOrganizePlanJob:
         from file_organizer.web.organize_routes import _run_organize_plan_job
 
         plan = _plan_for_routes(tmp_path)
+        service = MagicMock()
+        current = MagicMock(status="queued")
 
-        with patch("file_organizer.web.organize_routes.update_job") as mock_update:
-            _run_organize_plan_job("j1", plan.to_dict(), dry_run=True)
+        with (
+            patch("file_organizer.web.organize_routes.get_job", return_value=current),
+            patch("file_organizer.web.organize_routes.update_job") as mock_update,
+        ):
+            _run_organize_plan_job("j1", plan.to_dict(), service, dry_run=True)
 
         assert mock_update.call_args_list[-1].kwargs["status"] == "completed"
         assert mock_update.call_args_list[-1].kwargs["result"]["processed_files"] == 1
+        service.execute.assert_not_called()
 
     def test_run_executes_stored_plan(self, tmp_path) -> None:
         from file_organizer.web.organize_routes import _run_organize_plan_job
@@ -615,56 +652,57 @@ class TestRunOrganizePlanJob:
             organized_structure={"docs": ["notes.txt"]},
             plan=plan,
         )
-        organizer = MagicMock()
-        organizer.execute_plan.return_value = result
+        service = MagicMock()
+        service.execute.return_value = result
+        current = MagicMock(status="queued")
 
         with (
+            patch("file_organizer.web.organize_routes.get_job", return_value=current),
             patch("file_organizer.web.organize_routes.update_job") as mock_update,
-            patch("file_organizer.web.organize_routes.FileOrganizer", return_value=organizer),
         ):
-            _run_organize_plan_job("j1", plan.to_dict(), dry_run=False)
+            _run_organize_plan_job("j1", plan.to_dict(), service, dry_run=False)
 
-        organizer.execute_plan.assert_called_once()
+        request, executed_plan = service.execute.call_args.args
+        assert request.options == plan.options
+        assert executed_plan == plan
         assert mock_update.call_args_list[-1].kwargs["status"] == "completed"
 
     def test_run_reports_invalid_plan_failure(self) -> None:
         from file_organizer.web.organize_routes import _run_organize_plan_job
 
-        with patch("file_organizer.web.organize_routes.update_job") as mock_update:
-            _run_organize_plan_job("j1", {"operations": []}, dry_run=True)
+        current = MagicMock(status="queued")
+        with (
+            patch("file_organizer.web.organize_routes.get_job", return_value=current),
+            patch("file_organizer.web.organize_routes.update_job") as mock_update,
+        ):
+            _run_organize_plan_job("j1", {"operations": []}, MagicMock(), dry_run=True)
 
         assert mock_update.call_args_list[-1].kwargs["status"] == "failed"
         assert mock_update.call_args_list[-1].kwargs["error"]
 
+    def test_cancel_winning_start_race_does_not_reclassify_job_as_failed(self, tmp_path) -> None:
+        from file_organizer.web.organize_routes import _run_organize_plan_job
 
-class TestScheduleJob:
-    """Covers _schedule_job."""
-
-    def test_schedule_immediate(self) -> None:
-        from file_organizer.web.organize_routes import _schedule_job
-
-        request = MagicMock()
-        request.dry_run = False
-        request.use_hardlinks = False
-
-        with (
-            patch("file_organizer.web.organize_routes.update_job"),
-            patch("file_organizer.web.organize_routes.FileOrganizer", return_value=MagicMock()),
-        ):
-            _schedule_job("j1", request, delay_minutes=0)
-
-    def test_schedule_delayed(self) -> None:
-        from file_organizer.web.organize_routes import (
-            _SCHEDULED_TIMERS,
-            _schedule_job,
+        plan = _plan_for_routes(tmp_path)
+        queued = MagicMock(status=JobStatus.QUEUED, revision=0)
+        cancelled = MagicMock(status=JobStatus.CANCELLED, revision=1)
+        transition_error = DomainError(
+            DomainErrorCode.STALE_JOB_REVISION,
+            "Job state changed before execution started.",
         )
+        with (
+            patch(
+                "file_organizer.web.organize_routes.get_job",
+                side_effect=(queued, cancelled),
+            ),
+            patch(
+                "file_organizer.web.organize_routes.update_job",
+                side_effect=transition_error,
+            ) as update,
+        ):
+            _run_organize_plan_job("j1", plan.to_dict(), MagicMock(), dry_run=False)
 
-        request = MagicMock()
-        _schedule_job("j-delayed", request, delay_minutes=1)
-        assert "j-delayed" in _SCHEDULED_TIMERS
-        # Clean up
-        timer = _SCHEDULED_TIMERS.pop("j-delayed")
-        timer.cancel()
+        assert update.call_count == 1
 
 
 class TestSchedulePlanJob:
@@ -674,11 +712,12 @@ class TestSchedulePlanJob:
         from file_organizer.web.organize_routes import _schedule_plan_job
 
         plan = _plan_for_routes(tmp_path)
+        service = MagicMock()
 
         with patch("file_organizer.web.organize_routes._run_organize_plan_job") as mock_run:
-            _schedule_plan_job("j1", plan.to_dict(), delay_minutes=0, dry_run=True)
+            _schedule_plan_job("j1", plan.to_dict(), service, delay_minutes=0, dry_run=True)
 
-        mock_run.assert_called_once_with("j1", plan.to_dict(), dry_run=True)
+        mock_run.assert_called_once_with("j1", plan.to_dict(), service, dry_run=True)
 
     def test_schedule_delayed(self, tmp_path) -> None:
         from file_organizer.web.organize_routes import (
@@ -687,24 +726,9 @@ class TestSchedulePlanJob:
         )
 
         plan = _plan_for_routes(tmp_path)
+        service = MagicMock()
 
-        _schedule_plan_job("j-plan-delayed", plan.to_dict(), delay_minutes=1, dry_run=True)
+        _schedule_plan_job("j-plan-delayed", plan.to_dict(), service, delay_minutes=1, dry_run=True)
         assert "j-plan-delayed" in _SCHEDULED_TIMERS
         timer = _SCHEDULED_TIMERS.pop("j-plan-delayed")
         timer.cancel()
-
-
-class TestBuildPlanMovements:
-    """Covers _build_plan_movements."""
-
-    def test_movements(self, tmp_path) -> None:
-        from file_organizer.web.organize_routes import _build_plan_movements
-
-        files = [tmp_path / "a.txt", tmp_path / "b.pdf"]
-        preview = MagicMock()
-        preview.organized_structure = {"docs": ["a.txt"], "media": ["b.pdf"]}
-        output_dir = tmp_path / "output"
-
-        movements = _build_plan_movements(files, output_dir, preview)
-        assert len(movements) == 2
-        assert movements[0]["file_name"] in ("a.txt", "b.pdf")

--- a/tests/web/test_organize_routes_http.py
+++ b/tests/web/test_organize_routes_http.py
@@ -222,7 +222,7 @@ class TestOrganizeExecute:
                 return_value=mock_job,
             ),
             patch("file_organizer.web.organize_routes._set_job_metadata"),
-            patch("file_organizer.web.organize_routes._run_organize_job"),
+            patch("file_organizer.web.organize_routes._run_organize_plan_job"),
             patch("file_organizer.web.organize_routes.get_job", return_value=mock_job),
             patch(
                 "file_organizer.web.organize_routes._get_job_metadata",
@@ -323,6 +323,7 @@ class TestOrganizeJobCancel:
                 "file_organizer.web.organize_routes._cancel_scheduled_job",
                 return_value=True,
             ),
+            patch("file_organizer.web.organize_routes.update_job", return_value=mock_job),
         ):
             mock_tpl.TemplateResponse.return_value = HTMLResponse("<div>cancelled</div>")
             response = client.post("/ui/organize/jobs/test-job-1/cancel")
@@ -358,6 +359,7 @@ class TestOrganizeJobRollback:
                 return_value={"dry_run": False, "methodology": "para"},
             ),
             patch("file_organizer.undo.undo_manager.UndoManager") as mock_undo_cls,
+            patch("file_organizer.web.organize_routes.update_job", return_value=mock_job),
         ):
             mock_undo_cls.return_value.undo_transaction.return_value = True
             mock_tpl.TemplateResponse.return_value = HTMLResponse("<div>rolled back</div>")

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -7,21 +7,21 @@ from unittest.mock import MagicMock
 import pytest
 
 from file_organizer.api.exceptions import ApiError
+from file_organizer.core import file_ops
+from file_organizer.core.organization_service import count_files_by_type
 from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.plan import build_plan_from_processed
 from file_organizer.methodologies import apply_organization_methodology
 from file_organizer.services.text_processor import ProcessedFile
 from file_organizer.web.organize_services import (
     ORGANIZE_MAX_DELAY_MIN,
-    _build_plan_movements,
-    _counts_by_type,
     _delete_organize_plan,
     _get_organize_plan,
     _job_report_payload,
     _parse_delay_minutes,
-    _scan_directory,
     _store_organize_plan,
     build_organize_plan,
+    parse_organize_options,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
@@ -41,10 +41,21 @@ def _preview_result(structure: dict[str, list[str]]) -> MagicMock:
 
 
 def _preview_result_with_plan(
-    input_dir, output_dir, folder: str = "docs", methodology: str = "none"
+    input_dir,
+    output_dir,
+    folder: str = "docs",
+    methodology: str = "none",
+    *,
+    recursive: bool = False,
+    include_hidden: bool = False,
 ) -> MagicMock:
     source = input_dir / "notes.txt"
-    options = OrganizeOptions(transfer_mode="copy", methodology=methodology)
+    options = OrganizeOptions(
+        recursive=recursive,
+        include_hidden=include_hidden,
+        transfer_mode="copy",
+        methodology=methodology,
+    )
     processed = apply_organization_methodology(
         [
             ProcessedFile(
@@ -96,11 +107,11 @@ def test_scan_directory_handles_files_hidden_entries_and_recursive(tmp_path) -> 
     for path in (visible, hidden, nested):
         path.write_text("data")
 
-    assert _scan_directory(visible, recursive=False, include_hidden=False) == [visible]
-    assert _scan_directory(hidden, recursive=False, include_hidden=False) == []
-    assert _scan_directory(hidden, recursive=False, include_hidden=True) == [hidden]
-    assert _scan_directory(tmp_path, recursive=False, include_hidden=False) == [visible]
-    assert set(_scan_directory(tmp_path, recursive=True, include_hidden=True)) == {
+    assert file_ops.collect_files(visible, recursive=False, include_hidden=False) == [visible]
+    assert file_ops.collect_files(hidden, recursive=False, include_hidden=False) == []
+    assert file_ops.collect_files(hidden, recursive=False, include_hidden=True) == [hidden]
+    assert file_ops.collect_files(tmp_path, recursive=False, include_hidden=False) == [visible]
+    assert set(file_ops.collect_files(tmp_path, recursive=True, include_hidden=True)) == {
         visible,
         hidden,
         nested,
@@ -117,7 +128,7 @@ def test_counts_by_type_covers_all_buckets(tmp_path) -> None:
         tmp_path / "archive.bin",
     ]
 
-    assert _counts_by_type(files) == {
+    assert count_files_by_type(files) == {
         "text": 1,
         "image": 1,
         "video": 1,
@@ -127,17 +138,43 @@ def test_counts_by_type_covers_all_buckets(tmp_path) -> None:
     }
 
 
-def test_build_plan_movements_uses_name_when_source_is_unknown(tmp_path) -> None:
-    preview = _preview_result({"docs": ["missing.txt"]})
+def test_parse_organize_options_maps_complete_canonical_contract() -> None:
+    options = parse_organize_options(
+        methodology="johnny_decimal",
+        recursive="0",
+        include_hidden="1",
+        skip_existing="0",
+        transfer_mode="copy",
+        use_hardlinks="1",
+        enable_vision="0",
+        transcribe_audio="1",
+        max_transcribe_seconds="42.5",
+        whisper_model="base",
+        parallel_workers="3",
+        prefetch_depth="4",
+        text_model="text-test",
+        vision_model="vision-test",
+        text_provider="openai",
+        vision_provider="mlx",
+    )
 
-    assert _build_plan_movements([], tmp_path, preview) == [
-        {
-            "file_name": "missing.txt",
-            "source": "missing.txt",
-            "destination": str(tmp_path / "docs" / "missing.txt"),
-            "reason": "Categorized into docs",
-        }
-    ]
+    assert options.to_dict() == {
+        "recursive": False,
+        "include_hidden": True,
+        "skip_existing": False,
+        "transfer_mode": "copy",
+        "methodology": "jd",
+        "enable_vision": False,
+        "transcribe_audio": True,
+        "max_transcribe_seconds": 42.5,
+        "whisper_model": "base",
+        "parallel_workers": 3,
+        "prefetch_depth": 4,
+        "text_model": "text-test",
+        "vision_model": "vision-test",
+        "text_provider": "openai",
+        "vision_provider": "mlx",
+    }
 
 
 def test_plan_store_prunes_and_missing_lookup_returns_none(monkeypatch) -> None:
@@ -226,8 +263,8 @@ class TestBuildOrganizePlan:
             assert call["include_hidden"] is False
             assert call["organize_options"].effective_methodology.value == "none"
             organizer.organize.assert_called_once_with(
-                input_path=input_dir,
-                output_path=output_dir,
+                input_dir,
+                output_dir,
                 skip_existing=True,
             )
         finally:
@@ -396,25 +433,36 @@ class TestBuildOrganizePlan:
         assert exc_info.value.error == "not_found"
         organizer_factory.assert_not_called()
 
-    def test_rejects_hidden_inclusion_before_preview(self, tmp_path) -> None:
+    def test_supports_hidden_inclusion_through_canonical_options(self, tmp_path) -> None:
         input_dir = tmp_path / "input"
         output_dir = tmp_path / "output"
         input_dir.mkdir()
         output_dir.mkdir()
-        organizer_factory = MagicMock()
+        (input_dir / ".hidden.txt").write_text("hidden")
+        organizer = MagicMock()
+        organizer.organize.return_value = _preview_result_with_plan(
+            input_dir,
+            output_dir,
+            recursive=True,
+            include_hidden=True,
+        )
+        organizer_factory = MagicMock(return_value=organizer)
 
-        with pytest.raises(ApiError) as exc_info:
-            build_organize_plan(
-                input_dir=str(input_dir),
-                output_dir=str(output_dir),
-                methodology="none",
-                recursive="1",
-                include_hidden="1",
-                skip_existing="1",
-                use_hardlinks="1",
-                allowed_paths=[str(tmp_path)],
-                organizer_factory=organizer_factory,
-            )
+        plan = build_organize_plan(
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            methodology="none",
+            recursive="1",
+            include_hidden="1",
+            skip_existing="1",
+            use_hardlinks="0",
+            allowed_paths=[str(tmp_path)],
+            organizer_factory=organizer_factory,
+        )
 
-        assert exc_info.value.error == "include_hidden_not_supported"
-        organizer_factory.assert_not_called()
+        try:
+            assert plan["include_hidden"] is True
+            assert plan["scan_total_files"] == 1
+            assert organizer_factory.call_args.kwargs["include_hidden"] is True
+        finally:
+            _delete_organize_plan(plan["plan_id"])

--- a/tests/web/test_web_organize_routes.py
+++ b/tests/web/test_web_organize_routes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from file_organizer.core import file_ops
 from file_organizer.core.plan import build_plan_from_processed
 from file_organizer.core.types import OrganizationResult
 from file_organizer.services.text_processor import ProcessedFile
@@ -32,10 +33,18 @@ def mock_file_organizer(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     mock_organizer = MagicMock()
     organizer_options: dict[str, Any] = {}
 
-    def organize_side_effect(**kwargs: Any) -> OrganizationResult:
-        input_path = Path(kwargs["input_path"])
-        output_path = Path(kwargs["output_path"])
-        files = [path for path in sorted(input_path.rglob("*")) if path.is_file()]
+    def organize_side_effect(
+        input_path: Path,
+        output_path: Path,
+        *,
+        skip_existing: bool,
+    ) -> OrganizationResult:
+        options = organizer_options["organize_options"]
+        files = file_ops.collect_files(
+            input_path,
+            recursive=options.recursive,
+            include_hidden=options.include_hidden,
+        )
         processed = [
             ProcessedFile(
                 file_path=path,
@@ -49,7 +58,7 @@ def mock_file_organizer(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
             input_path=input_path,
             output_path=output_path,
             processed=processed,
-            skip_existing=bool(kwargs.get("skip_existing", True)),
+            skip_existing=skip_existing,
             use_hardlinks=bool(organizer_options["use_hardlinks"]),
             options=organizer_options["organize_options"],
             total_files=len(files),
@@ -106,6 +115,18 @@ class TestOrganizePage:
         client = web_client_builder(allowed_paths=[str(tmp_path)])
         response = client.get("/ui/organize")
         assert response.status_code == 200
+
+    def test_organize_page_exposes_desktop_only_directory_pickers(
+        self, tmp_path: Path, web_client_builder
+    ) -> None:
+        """Desktop affordances select paths without changing submitted fields."""
+        client = web_client_builder(allowed_paths=[str(tmp_path)])
+
+        response = client.get("/ui/organize")
+
+        assert 'data-desktop-only type="button"' in response.text
+        assert "desktopBrowseDirectory('organize-input-dir')" in response.text
+        assert "desktopBrowseDirectory('organize-output-dir')" in response.text
 
 
 @pytest.mark.unit
@@ -208,8 +229,10 @@ class TestScanOptions:
         assert response.status_code == 200
         assert "plan" in response.text.lower()
 
-    def test_scan_with_hidden_files(self, tmp_path: Path, web_client_builder) -> None:
-        """Scan should reject hidden file inclusion."""
+    def test_scan_with_hidden_files(
+        self, tmp_path: Path, web_client_builder, mock_file_organizer: MagicMock
+    ) -> None:
+        """Scan should pass hidden-file inclusion through canonical options."""
         (tmp_path / ".hidden").write_text("test")
         output_dir = tmp_path / "organized"
         output_dir.mkdir()
@@ -226,7 +249,8 @@ class TestScanOptions:
             headers=csrf_headers,
         )
         assert response.status_code == 200
-        assert "not supported" in response.text.lower()
+        assert "Plan generated" in response.text
+        assert mock_file_organizer.call_args.kwargs["include_hidden"] is True
 
 
 @pytest.mark.unit

--- a/tests/web/test_web_ui.py
+++ b/tests/web/test_web_ui.py
@@ -15,6 +15,7 @@ from starlette.testclient import TestClient
 
 from file_organizer.api.main import create_app
 from file_organizer.api.test_utils import build_test_settings
+from file_organizer.core import file_ops
 from file_organizer.core.organizer import OrganizationResult
 from file_organizer.core.plan import OrganizationPlan, build_plan_from_processed
 from file_organizer.plugins.marketplace import compute_sha256
@@ -95,6 +96,7 @@ class DummyOrganizer:
     def __init__(self, *args, **kwargs) -> None:
         self.dry_run = bool(kwargs.get("dry_run", False))
         self.use_hardlinks = bool(kwargs.get("use_hardlinks", False))
+        self.organize_options = kwargs["organize_options"]
 
     def organize(
         self,
@@ -103,8 +105,10 @@ class DummyOrganizer:
         skip_existing: bool = True,
     ) -> OrganizationResult:
         source = Path(input_path)
-        files = sorted(
-            path for path in source.rglob("*") if path.is_file() and not path.name.startswith(".")
+        files = file_ops.collect_files(
+            source,
+            recursive=self.organize_options.recursive,
+            include_hidden=self.organize_options.include_hidden,
         )
         text_files = [path.name for path in files if path.suffix.lower() == ".txt"]
         image_files = [
@@ -135,6 +139,7 @@ class DummyOrganizer:
             processed=processed,
             skip_existing=skip_existing,
             use_hardlinks=self.use_hardlinks,
+            options=self.organize_options,
             total_files=len(files),
             skipped_files=0,
             deduplicated_files=0,
@@ -383,7 +388,7 @@ def test_organize_scan_blocks_outside_allowed_root(monkeypatch, tmp_path: Path) 
     assert "outside allowed roots" in scan.text.lower()
 
 
-def test_organize_scan_rejects_include_hidden(monkeypatch, tmp_path: Path) -> None:
+def test_organize_scan_supports_include_hidden(monkeypatch, tmp_path: Path) -> None:
     organize_mod = importlib.import_module("file_organizer.web.organize_routes")
 
     monkeypatch.setattr(organize_mod, "FileOrganizer", DummyOrganizer)
@@ -403,7 +408,8 @@ def test_organize_scan_rejects_include_hidden(monkeypatch, tmp_path: Path) -> No
         headers=get_csrf_headers(client, seed_url="/ui/"),
     )
     assert scan.status_code == 200
-    assert "not supported" in scan.text.lower()
+    assert "Plan generated" in scan.text
+    assert ".secret.txt" in scan.text
 
 
 def test_organize_schedule_and_cancel(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- route Web scan, preview, and exact reviewed-plan execution through the canonical `OrganizationService`
- map the complete `OrganizeOptions` contract, including recursion, hidden files, collision/transfer policy, methodology, media, model/provider, and performance controls
- standardize Web jobs on the canonical `organize` job type with revision-guarded queued/scheduled cancellation and rollback transitions
- render registry-backed support states and clearly distinguish filename filtering from full-text/semantic search
- keep Desktop on the same `/ui` workflow while adding only native directory selection and existing reveal/file/save affordances

## Conformance and claims

A `WebFormConformanceDriver` now sends the shared golden corpus through the real `GET /ui/organize`, `POST /ui/organize/scan`, and `POST /ui/organize/plan/clear` entry points. It validates full form-to-options mapping, reads the serialized reviewed plan persisted by the route, and proves clear-plan eviction. A cross-surface regression also proves that `recursive=false` excludes nested files through execution, not only scan and preview.

The registry promotes Web/Desktop scan and preview to `verified` because every declared Web entry point is now exercised. Desktop organization behavior is equivalent by construction because the native shell loads these same `/ui` routes; focused Desktop tests cover the additional path-selection and reveal bridge, but Desktop is not claimed as independently corpus-driven. Execution and jobs/recovery remain `unverified` because queued background execution, cancellation, and rollback are not yet fully represented in the shared corpus.

## User-visible behavior

- unchecked recursive traversal is honored consistently by counts, plans, and execution
- hidden-file inclusion is supported instead of rejected
- methodology destinations come only from the canonical core implementation
- the Web adapter executes the exact serialized plan shown for review
- unavailable organization capabilities remain visible through registry-derived states
- Desktop directory pickers populate the same Web form fields and do not alter domain semantics

## Validation

- `pytest -q tests/web tests/desktop tests/core/test_capabilities.py tests/conformance/test_direct_service_conformance.py --no-cov` — 1,038 passed, 3 skipped
- `pytest tests/conformance -m conformance --override-ini='addopts=' -q` — 173 passed
- focused Web/Desktop route suite — 67 passed, 1 skipped
- `pytest tests/playwright/test_organize_workflow.py --override-ini='addopts=' -q` — 2 passed
- `ruff check` and `ruff format --check` on changed Python files
- `mypy src/file_organizer/web/organize_routes.py src/file_organizer/web/organize_services.py`
- pre-commit smoke, CI guardrail, WebSocket, Web UI, JSON, docs, type, and policy hooks passed

The local sequential diff-cover hook was interrupted after it stopped making progress; GitHub CI remains the authoritative changed-line coverage gate for this PR.

## Risk

The main behavioral change is intentional: Web-specific destination rewriting is removed, so users receive the same canonical PARA/Johnny Decimal layouts as every other migrated surface. The Web missing-input message now preserves the canonical domain wording. Background execution remains conservatively unverified until lifecycle corpus coverage is promoted.

Fixes #1597
Part of #1593


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded organization options, including hidden files, transfer modes, AI models, audio transcription, and performance settings.
  * Added desktop directory browsing controls.
  * Added capability status indicators to the organization dashboard.
  * Added support for cancelling queued jobs and rolling back completed runs.

* **Bug Fixes**
  * Improved organization plan execution reliability and error reporting.
  * Clarified filename filtering behavior in the file browser.

* **Documentation**
  * Updated desktop, web organization, and conformance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->