### PR TITLE
Complete fo api remote organization parity

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1387,6 +1387,9 @@ file-organizer api organize INPUT_DIR OUTPUT_DIR [OPTIONS]
 Organization queues a background job by default. Use `--foreground` to wait
 for a result, `--plan PATH` to execute a reviewed plan, and
 `--idempotency-key TEXT` to deduplicate background submissions.
+In JSON mode, `result` is `null` for a queued submission and `job` contains
+its `job_id` and `status`; foreground execution places the operation result in
+`result` and emits `job: null`.
 
 #### `api job`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1243,6 +1243,22 @@ file-organizer marketplace update PLUGIN_NAME
 
 Interact with a running File Organizer API server.
 
+Organization commands accept `--token` or `--api-key`, `--base-url`,
+`--timeout`, and `--json`. Run `file-organizer api COMMAND --help` for the
+complete canonical option surface.
+
+#### `api capabilities`
+
+Show which remote capabilities are available through `fo api`, exposed only
+through an official SDK, or unavailable.
+
+```bash
+file-organizer api capabilities [OPTIONS]
+```
+
+**Options:**
+- `--json` — Print deterministic machine-readable output
+
 #### `api health`
 
 Check API server health.
@@ -1312,13 +1328,113 @@ file-organizer api files PATH [OPTIONS]
 - `PATH` — Directory to list
 
 **Options:**
-- `--token TEXT` — Bearer token (required)
+- `--token TEXT` — Bearer token
+- `--api-key TEXT` — API key
 - `--base-url TEXT` — API base URL (default: `http://localhost:8000`)
 - `--recursive/--no-recursive` — Include nested files (default: `--no-recursive`)
 - `--include-hidden/--no-include-hidden` — Include hidden files (default: `--no-include-hidden`)
 - `--limit INTEGER` — Maximum rows (default: `100`)
 - `--timeout FLOAT` — Request timeout in seconds (default: `30.0`)
 - `--json` — Print JSON output
+
+#### `api scan`
+
+Scan a server-side directory with canonical recursion and hidden-file policy.
+
+```bash
+file-organizer api scan INPUT_DIR [OPTIONS]
+```
+
+**Arguments:**
+- `INPUT_DIR` — Server-side directory to scan
+
+#### `api preview`
+
+Build a canonical remote organization plan without applying it.
+
+```bash
+file-organizer api preview INPUT_DIR OUTPUT_DIR [OPTIONS]
+```
+
+**Arguments:**
+- `INPUT_DIR` — Server-side source directory
+- `OUTPUT_DIR` — Server-side destination directory
+
+Use `--save-plan PATH` to persist the reviewed plan. The command accepts the
+same recursion, hidden-file, collision, transfer, methodology, media, model,
+provider, and performance options as local organization.
+
+#### `api organize`
+
+Execute a canonical remote request or an exact reviewed plan.
+
+```bash
+file-organizer api organize INPUT_DIR OUTPUT_DIR [OPTIONS]
+```
+
+**Arguments:**
+- `INPUT_DIR` — Server-side source directory
+- `OUTPUT_DIR` — Server-side destination directory
+
+Organization queues a background job by default. Use `--foreground` to wait
+for a result, `--plan PATH` to execute a reviewed plan, and
+`--idempotency-key TEXT` to deduplicate background submissions.
+
+#### `api job`
+
+Inspect one remote organization job.
+
+```bash
+file-organizer api job JOB_ID [OPTIONS]
+```
+
+**Arguments:**
+- `JOB_ID` — Organization job identifier
+
+#### `api jobs`
+
+List recent remote organization jobs, optionally filtered by status.
+
+```bash
+file-organizer api jobs [OPTIONS]
+```
+
+#### `api cancel`
+
+Cancel a queued or scheduled organization job.
+
+```bash
+file-organizer api cancel JOB_ID [OPTIONS]
+```
+
+**Arguments:**
+- `JOB_ID` — Organization job identifier
+
+Use `--expected-revision INTEGER` for optimistic concurrency control.
+
+#### `api rollback`
+
+Roll back a completed remote organization job.
+
+```bash
+file-organizer api rollback JOB_ID [OPTIONS]
+```
+
+**Arguments:**
+- `JOB_ID` — Organization job identifier
+
+Use `--expected-revision INTEGER` for optimistic concurrency control.
+
+#### `api suggest`
+
+Request a non-mutating single-file organization suggestion.
+
+```bash
+file-organizer api suggest FILENAME [OPTIONS]
+```
+
+**Arguments:**
+- `FILENAME` — File name to classify remotely
 
 #### `api system-status`
 
@@ -1332,7 +1448,8 @@ file-organizer api system-status [PATH] [OPTIONS]
 - `PATH` — Path to inspect (default: `.`)
 
 **Options:**
-- `--token TEXT` — Bearer token (required)
+- `--token TEXT` — Bearer token
+- `--api-key TEXT` — API key
 - `--base-url TEXT` — API base URL (default: `http://localhost:8000`)
 - `--timeout FLOAT` — Request timeout in seconds (default: `30.0`)
 - `--json` — Print JSON output
@@ -1349,7 +1466,8 @@ file-organizer api system-stats [PATH] [OPTIONS]
 - `PATH` — Directory to analyze (default: `.`)
 
 **Options:**
-- `--token TEXT` — Bearer token (required)
+- `--token TEXT` — Bearer token
+- `--api-key TEXT` — API key
 - `--base-url TEXT` — API base URL (default: `http://localhost:8000`)
 - `--max-depth INTEGER` — Optional max depth
 - `--use-cache/--no-use-cache` — Use server-side cache (default: `--use-cache`)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1247,6 +1247,14 @@ Organization commands accept `--token` or `--api-key`, `--base-url`,
 `--timeout`, and `--json`. Run `file-organizer api COMMAND --help` for the
 complete canonical option surface.
 
+Every `fo api ... --json` success and failure emits the same versioned
+top-level envelope as local organization commands: `schema_version`,
+`outcome`, `command`, and either normalized result fields or `error`.
+Connection, DNS, TLS, and timeout failures use `transport_error` with
+`retryable: true`. Exit code `2` covers invalid or missing requests, exit code
+`3` covers conflicts, plan mismatches, and recovery-required outcomes, and
+other failures exit `1`.
+
 #### `api capabilities`
 
 Show which remote capabilities are available through `fo api`, exposed only

--- a/docs/developer/conformance-scaffold.md
+++ b/docs/developer/conformance-scaffold.md
@@ -13,7 +13,7 @@ never from any adapter.
 | --- | --- |
 | `tests/conformance/corpus.py` | Deterministic fixture corpus: pinned bytes and mtimes, tagged cases |
 | `tests/conformance/normalize.py` | Strips presentation-only differences while preserving executable ordering and complete source fingerprints |
-| `tests/conformance/driver.py` | Driver protocol, direct-service oracle, and CLI/REST/Python SDK/Web-form adapters |
+| `tests/conformance/driver.py` | Driver protocol, direct-service oracle, and local CLI/`fo api`/REST/Python SDK/Web-form adapters |
 | `tests/conformance/test_direct_service_conformance.py` | Golden expectations for canonical semantics |
 
 ## Fixture corpus
@@ -37,6 +37,13 @@ through in-process HTTP transports. This verifies traversal, complete option
 mapping, executable-plan round trips, stable errors, execution results, and
 audit effects against the direct-service oracle without relying on route
 construction alone.
+
+The `fo api` driver runs the same corpus through Typer, the synchronous
+official SDK, and the REST routes. It proves remote option mapping, exact
+reviewed-plan execution, stable machine output, and local-versus-remote
+behavioral equivalence. Background submission and lifecycle commands have
+focused adapter tests and remain unverified until #1606 extends the shared job
+corpus.
 
 The Web form driver sends the corpus through the real `/ui/organize`,
 `/ui/organize/scan`, and `/ui/organize/plan/clear` routes. It round-trips every

--- a/src/file_organizer/cli/api.py
+++ b/src/file_organizer/cli/api.py
@@ -12,11 +12,18 @@ if TYPE_CHECKING:
     from file_organizer.client.models import OrganizationOptionsPayload, OrganizationPlanPayload
     from file_organizer.client.sync_client import FileOrganizerClient
 
+import httpx
 import typer
 from click.core import ParameterSource
 from rich.console import Console
 from rich.table import Table
 
+from file_organizer.cli.organize import (
+    _emit_json,
+    _error_code_exit_code,
+    _json_success_payload,
+    _raise_cli_contract_error,
+)
 from file_organizer.utils.atomic_write import atomic_write_text
 
 api_app = typer.Typer(
@@ -74,51 +81,84 @@ def _build_client(
     ), ClientError
 
 
-def _print_json(payload: object) -> None:
-    """Print one deterministic JSON document without terminal wrapping.
+def _success_payload(
+    command: str,
+    result: Any,
+    *,
+    request: dict[str, Any] | None = None,
+    scan: dict[str, Any] | None = None,
+    plan: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the shared CLI success envelope for a remote result."""
+    return _json_success_payload(
+        command,
+        mode="remote",
+        request=request,
+        scan=scan,
+        result=result,
+        plan=plan,
+    )
 
-    Args:
-        payload: Any Python object to serialize and print as JSON.
-    """
-    typer.echo(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str))
 
-
-def _client_error_payload(exc: ClientError) -> dict[str, Any]:
-    """Return the official SDK error without changing its domain meaning."""
+def _client_error_payload(exc: Exception) -> dict[str, Any]:
+    """Return the official SDK error in the shared CLI error shape."""
+    status_code = int(getattr(exc, "status_code", 0))
+    fallback_codes = {404: "not_found", 409: "conflict", 422: "invalid_request"}
     return {
-        "error": getattr(exc, "error_code", "") or "client_error",
+        "code": getattr(exc, "error_code", "") or fallback_codes.get(status_code, "client_error"),
         "message": getattr(exc, "detail", "") or str(exc),
         "retryable": bool(getattr(exc, "retryable", False)),
         "details": getattr(exc, "details", None) or {},
-        "status_code": int(getattr(exc, "status_code", 0)),
     }
 
 
-def _raise_client_error(label: str, exc: ClientError, *, as_json: bool) -> None:
-    """Render one remote failure consistently and terminate the command."""
-    if as_json:
-        _print_json(_client_error_payload(exc))
+def _raise_remote_error(command: str, exc: Exception, *, as_json: bool) -> None:
+    """Normalize SDK and transport failures through the shared CLI contract."""
+    if isinstance(exc, httpx.RequestError):
+        error = {
+            "code": "transport_error",
+            "message": str(exc) or "Unable to reach the File Organizer API.",
+            "retryable": True,
+            "details": {"error_type": type(exc).__name__},
+        }
     else:
-        console.print(f"[red]{label}:[/red] {getattr(exc, 'detail', '') or exc}")
-    raise typer.Exit(code=1) from exc
+        error = _client_error_payload(exc)
+    exit_code = _error_code_exit_code(str(error["code"]))
+    if not isinstance(exc, httpx.RequestError) and exit_code == 1:
+        status_code = int(getattr(exc, "status_code", 0))
+        if status_code in {400, 404, 422}:
+            exit_code = 2
+        elif status_code == 409:
+            exit_code = 3
+    _raise_cli_contract_error(
+        command,
+        error,
+        json_output=as_json,
+        exit_code=exit_code,
+        cause=exc,
+    )
 
 
-def _raise_request_error(exc: Exception, *, as_json: bool) -> None:
+def _raise_request_error(command: str, exc: Exception, *, as_json: bool) -> None:
     """Render local option/plan validation failures before any remote request."""
-    if as_json:
-        _print_json(
-            {
-                "error": "invalid_request",
-                "message": str(exc),
-                "retryable": False,
-                "details": {},
-                "status_code": 0,
-            }
-        )
-        raise typer.Exit(code=2) from exc
     if isinstance(exc, typer.BadParameter):
-        raise exc
-    raise typer.BadParameter(str(exc)) from exc
+        request_error = exc
+    else:
+        request_error = typer.BadParameter(str(exc))
+    if not as_json:
+        raise request_error from exc
+    _raise_cli_contract_error(
+        command,
+        {
+            "code": "invalid_request",
+            "message": str(exc),
+            "retryable": False,
+            "details": {},
+        },
+        json_output=True,
+        exit_code=2,
+        cause=exc,
+    )
 
 
 def _organization_options(
@@ -202,13 +242,13 @@ def health(
     try:
         result = client.health()
         if as_json:
-            _print_json(result.model_dump())
+            _emit_json(_success_payload("api health", result.model_dump(mode="json")))
             return
         console.print(f"[green]Status:[/green] {result.status}")
         console.print(f"[green]Version:[/green] {result.version}")
         console.print(f"[green]Readiness:[/green] {result.readiness}")
-    except ClientError as exc:
-        _raise_client_error("API error", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api health", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -247,7 +287,7 @@ def remote_capabilities(
             }
         )
     if as_json:
-        _print_json(rows)
+        _emit_json(_success_payload("api capabilities", rows))
         return
     table = Table(title="Remote capability availability")
     table.add_column("Capability")
@@ -280,7 +320,7 @@ def login(
     )
     try:
         tokens = client.login(username, password)
-        payload = tokens.model_dump()
+        payload = tokens.model_dump(mode="json")
         if save_to is not None:
             from file_organizer.cli.path_validation import resolve_cli_path
 
@@ -292,12 +332,12 @@ def login(
             if not as_json:
                 console.print(f"[green]Saved tokens to[/green] {save_to}")
         if as_json:
-            _print_json(payload)
+            _emit_json(_success_payload("api login", payload))
         else:
             console.print("[green]Login successful[/green]")
             console.print("Use --json to print token payload.")
-    except ClientError as exc:
-        _raise_client_error("Login failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api login", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -316,13 +356,13 @@ def me(
     try:
         user = client.me()
         if as_json:
-            _print_json(user.model_dump())
+            _emit_json(_success_payload("api me", user.model_dump(mode="json")))
             return
         console.print(f"[green]User:[/green] {user.username}")
         console.print(f"[green]Email:[/green] {user.email}")
         console.print(f"[green]Admin:[/green] {user.is_admin}")
-    except ClientError as exc:
-        _raise_client_error("Request failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api me", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -341,9 +381,8 @@ def logout(
     try:
         client.logout(refresh_token)
         console.print("[green]Logout successful[/green]")
-    except ClientError as exc:
-        console.print(f"[red]Logout failed:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api logout", exc, as_json=False)
     finally:
         client.close()
 
@@ -372,7 +411,7 @@ def files_list(
             limit=limit,
         )
         if as_json:
-            _print_json(result.model_dump())
+            _emit_json(_success_payload("api files", result.model_dump(mode="json")))
             return
         table = Table(title=f"Files ({result.total})")
         table.add_column("Name")
@@ -381,8 +420,8 @@ def files_list(
         for item in result.items:
             table.add_row(item.name, item.file_type, str(item.size))
         console.print(table)
-    except ClientError as exc:
-        _raise_client_error("Request failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api files", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -414,13 +453,33 @@ def organization_scan(
         )
         payload = result.model_dump(mode="json")
         if as_json:
-            _print_json(payload)
+            scan = {
+                "input_path": payload.get("input_dir", input_dir),
+                "files": payload.get("files", []),
+                "counts": payload.get("counts", {}),
+                "total_files": payload.get("total_files", 0),
+            }
+            _emit_json(
+                _success_payload(
+                    "api scan",
+                    None,
+                    request={
+                        "input_path": input_dir,
+                        "output_path": None,
+                        "options": {
+                            "recursive": recursive,
+                            "include_hidden": include_hidden,
+                        },
+                    },
+                    scan=scan,
+                )
+            )
             return
         console.print(f"[green]Scanned:[/green] {result.total_files} files")
         for category, count in sorted(result.counts.items()):
             console.print(f"  {category}: {count}")
-    except ClientError as exc:
-        _raise_client_error("Remote scan failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api scan", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -494,15 +553,27 @@ def organization_preview(
         else:
             destination = None
         if as_json:
-            _print_json(payload)
+            plan_payload = payload.pop("plan", None)
+            _emit_json(
+                _success_payload(
+                    "api preview",
+                    payload,
+                    request={
+                        "input_path": input_dir,
+                        "output_path": output_dir,
+                        "options": options.model_dump(mode="json"),
+                    },
+                    plan=plan_payload,
+                )
+            )
             return
         console.print(f"[green]Preview:[/green] {result.total_files} files")
         if destination is not None:
             console.print(f"[green]Plan saved:[/green] {destination}")
-    except ClientError as exc:
-        _raise_client_error("Remote preview failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api preview", exc, as_json=as_json)
     except (OSError, ValueError, typer.BadParameter) as exc:
-        _raise_request_error(exc, as_json=as_json)
+        _raise_request_error("api preview", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -595,7 +666,31 @@ def organization_execute(
         )
         payload = result.model_dump(mode="json")
         if as_json:
-            _print_json(payload)
+            operation_result = payload.get("result")
+            if isinstance(operation_result, dict):
+                operation_result = dict(operation_result)
+                plan_payload = operation_result.pop("plan", None)
+            else:
+                operation_result = payload
+                plan_payload = None
+            if options is not None:
+                request_options = options.model_dump(mode="json")
+            elif (plan_options := getattr(plan, "options", None)) is not None:
+                request_options = plan_options.model_dump(mode="json")
+            else:
+                request_options = None
+            _emit_json(
+                _success_payload(
+                    "api organize",
+                    operation_result,
+                    request={
+                        "input_path": input_dir,
+                        "output_path": output_dir,
+                        "options": request_options,
+                    },
+                    plan=plan_payload,
+                )
+            )
             return
         if result.job_id is not None:
             console.print(f"[green]Queued job:[/green] {result.job_id}")
@@ -606,10 +701,10 @@ def organization_execute(
             )
         else:
             console.print(f"[yellow]Remote status:[/yellow] {result.status}")
-    except ClientError as exc:
-        _raise_client_error("Remote organization failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api organize", exc, as_json=as_json)
     except (OSError, ValueError, typer.BadParameter) as exc:
-        _raise_request_error(exc, as_json=as_json)
+        _raise_request_error("api organize", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -630,13 +725,13 @@ def organization_job(
     try:
         job = client.get_job(job_id)
         if as_json:
-            _print_json(job.model_dump(mode="json"))
+            _emit_json(_success_payload("api job", job.model_dump(mode="json")))
             return
         console.print(f"[green]Job:[/green] {job.job_id}")
         console.print(f"[green]Status:[/green] {job.status}")
         console.print(f"[green]Revision:[/green] {job.revision}")
-    except ClientError as exc:
-        _raise_client_error("Remote job lookup failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api job", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -658,7 +753,7 @@ def organization_jobs(
     try:
         jobs = client.list_jobs(status=status, limit=limit)
         if as_json:
-            _print_json([job.model_dump(mode="json") for job in jobs])
+            _emit_json(_success_payload("api jobs", [job.model_dump(mode="json") for job in jobs]))
             return
         table = Table(title=f"Organization jobs ({len(jobs)})")
         table.add_column("Job")
@@ -667,8 +762,8 @@ def organization_jobs(
         for job in jobs:
             table.add_row(job.job_id, job.status, str(job.revision))
         console.print(table)
-    except ClientError as exc:
-        _raise_client_error("Remote job listing failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api jobs", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -692,11 +787,11 @@ def _mutate_organization_job(
         operation = client.cancel_job if action == "cancel" else client.rollback_job
         job = operation(job_id, expected_revision=expected_revision)
         if as_json:
-            _print_json(job.model_dump(mode="json"))
+            _emit_json(_success_payload(f"api {action}", job.model_dump(mode="json")))
             return
         console.print(f"[green]Job {action} accepted:[/green] {job.job_id} ({job.status})")
-    except ClientError as exc:
-        _raise_client_error(f"Remote job {action} failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error(f"api {action}", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -773,12 +868,12 @@ def organization_suggest(
             folder_suggestion=folder_suggestion,
         )
         if as_json:
-            _print_json(payload)
+            _emit_json(_success_payload("api suggest", payload))
             return
         console.print(f"[green]File:[/green] {payload.get('filename', filename)}")
         console.print(f"[green]Folder:[/green] {payload.get('folder_suggestion', '')}")
-    except ClientError as exc:
-        _raise_client_error("Remote suggestion failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api suggest", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -799,13 +894,13 @@ def system_status(
     try:
         result = client.system_status(path)
         if as_json:
-            _print_json(result.model_dump())
+            _emit_json(_success_payload("api system-status", result.model_dump(mode="json")))
             return
         console.print(f"[green]Disk free:[/green] {result.disk_free}")
         console.print(f"[green]Disk used:[/green] {result.disk_used}")
         console.print(f"[green]Active jobs:[/green] {result.active_jobs}")
-    except ClientError as exc:
-        _raise_client_error("Request failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api system-status", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -828,12 +923,12 @@ def system_stats(
     try:
         stats = client.system_stats(path=path, max_depth=max_depth, use_cache=use_cache)
         if as_json:
-            _print_json(stats.model_dump())
+            _emit_json(_success_payload("api system-stats", stats.model_dump(mode="json")))
             return
         console.print(f"[green]File count:[/green] {stats.file_count}")
         console.print(f"[green]Directory count:[/green] {stats.directory_count}")
         console.print(f"[green]Total size:[/green] {stats.total_size}")
-    except ClientError as exc:
-        _raise_client_error("Request failed", exc, as_json=as_json)
+    except (ClientError, httpx.RequestError) as exc:
+        _raise_remote_error("api system-stats", exc, as_json=as_json)
     finally:
         client.close()

--- a/src/file_organizer/cli/api.py
+++ b/src/file_organizer/cli/api.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 if TYPE_CHECKING:
     from file_organizer.client.exceptions import ClientError
+    from file_organizer.client.models import OrganizationOptionsPayload, OrganizationPlanPayload
     from file_organizer.client.sync_client import FileOrganizerClient
 
 import typer
+from click.core import ParameterSource
 from rich.console import Console
 from rich.table import Table
 
@@ -22,6 +24,25 @@ api_app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
+_REMOTE_PLAN_OPTION_NAMES = (
+    "recursive",
+    "include_hidden",
+    "skip_existing",
+    "transfer_mode",
+    "methodology",
+    "max_workers",
+    "sequential",
+    "no_vision",
+    "prefetch_depth",
+    "no_prefetch",
+    "transcribe_audio",
+    "max_transcribe_seconds",
+    "whisper_model",
+    "text_model",
+    "vision_model",
+    "text_provider",
+    "vision_provider",
+)
 
 
 def _build_client(
@@ -54,12 +75,118 @@ def _build_client(
 
 
 def _print_json(payload: object) -> None:
-    """Print a payload as formatted JSON to the console.
+    """Print one deterministic JSON document without terminal wrapping.
 
     Args:
         payload: Any Python object to serialize and print as JSON.
     """
-    console.print(json.dumps(payload, indent=2, default=str))
+    typer.echo(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str))
+
+
+def _client_error_payload(exc: ClientError) -> dict[str, Any]:
+    """Return the official SDK error without changing its domain meaning."""
+    return {
+        "error": getattr(exc, "error_code", "") or "client_error",
+        "message": getattr(exc, "detail", "") or str(exc),
+        "retryable": bool(getattr(exc, "retryable", False)),
+        "details": getattr(exc, "details", None) or {},
+        "status_code": int(getattr(exc, "status_code", 0)),
+    }
+
+
+def _raise_client_error(label: str, exc: ClientError, *, as_json: bool) -> None:
+    """Render one remote failure consistently and terminate the command."""
+    if as_json:
+        _print_json(_client_error_payload(exc))
+    else:
+        console.print(f"[red]{label}:[/red] {getattr(exc, 'detail', '') or exc}")
+    raise typer.Exit(code=1) from exc
+
+
+def _raise_request_error(exc: Exception, *, as_json: bool) -> None:
+    """Render local option/plan validation failures before any remote request."""
+    if as_json:
+        _print_json(
+            {
+                "error": "invalid_request",
+                "message": str(exc),
+                "retryable": False,
+                "details": {},
+                "status_code": 0,
+            }
+        )
+        raise typer.Exit(code=2) from exc
+    if isinstance(exc, typer.BadParameter):
+        raise exc
+    raise typer.BadParameter(str(exc)) from exc
+
+
+def _organization_options(
+    *,
+    recursive: bool,
+    include_hidden: bool,
+    skip_existing: bool,
+    transfer_mode: str,
+    methodology: str,
+    no_vision: bool,
+    transcribe_audio: bool,
+    max_transcribe_seconds: float,
+    whisper_model: str,
+    sequential: bool,
+    max_workers: int | None,
+    prefetch_depth: int,
+    no_prefetch: bool,
+    text_model: str | None,
+    vision_model: str | None,
+    text_provider: str | None,
+    vision_provider: str | None,
+) -> OrganizationOptionsPayload:
+    """Build the SDK payload from the same canonical CLI mapper as local runs."""
+    from file_organizer.cli.organize import _build_options
+    from file_organizer.client.models import OrganizationOptionsPayload
+
+    options = _build_options(
+        recursive=recursive,
+        include_hidden=include_hidden,
+        skip_existing=skip_existing,
+        transfer_mode=transfer_mode,
+        methodology=methodology,
+        no_vision=no_vision,
+        transcribe_audio=transcribe_audio,
+        max_transcribe_seconds=max_transcribe_seconds,
+        whisper_model=whisper_model,
+        sequential=sequential,
+        max_workers=max_workers,
+        prefetch_depth=prefetch_depth,
+        no_prefetch=no_prefetch,
+        text_model=text_model,
+        vision_model=vision_model,
+        text_provider=text_provider,
+        vision_provider=vision_provider,
+    )
+    return OrganizationOptionsPayload.model_validate(options.to_dict())
+
+
+def _load_remote_plan(path: Path) -> OrganizationPlanPayload:
+    """Load and validate a canonical plan for remote execution."""
+    from file_organizer.cli.path_validation import resolve_cli_path, validate_regular_file
+    from file_organizer.client.models import OrganizationPlanPayload
+
+    validated = resolve_cli_path(path, must_exist=True, must_be_dir=False)
+    validate_regular_file(validated, "plan file")
+    return OrganizationPlanPayload.model_validate_json(validated.read_text(encoding="utf-8"))
+
+
+def _save_remote_plan(path: Path, payload: object) -> Path:
+    """Persist a reviewed remote plan atomically."""
+    from file_organizer.cli.path_validation import resolve_cli_path
+
+    destination = resolve_cli_path(path, must_exist=False, must_be_dir=False)
+    if destination.exists() and not destination.is_file():
+        raise typer.BadParameter(f"Plan output path is not a regular file: {destination!s}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(destination, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return destination
 
 
 @api_app.command("health")
@@ -81,10 +208,58 @@ def health(
         console.print(f"[green]Version:[/green] {result.version}")
         console.print(f"[green]Readiness:[/green] {result.readiness}")
     except ClientError as exc:
-        console.print(f"[red]API error:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+        _raise_client_error("API error", exc, as_json=as_json)
     finally:
         client.close()
+
+
+@api_app.command("capabilities")
+def remote_capabilities(
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Show which remote capabilities have a fo api command or SDK-only access."""
+    from file_organizer.core.capabilities import (
+        ExecutionScope,
+        ImplementationStatus,
+        Surface,
+        get_capability_registry,
+    )
+
+    rows: list[dict[str, Any]] = []
+    for capability in get_capability_registry().capabilities:
+        if ExecutionScope.REMOTE not in capability.execution_scopes:
+            continue
+        cli = capability.support_for(Surface.CLI)
+        sdk = capability.support_for(Surface.PYTHON_SDK)
+        commands = [entry for entry in cli.entry_points if entry.startswith("fo api ")]
+        if commands:
+            availability = "available"
+        elif sdk.implementation_status is ImplementationStatus.IMPLEMENTED:
+            availability = "sdk-only"
+        else:
+            availability = "unavailable"
+        rows.append(
+            {
+                "capability_id": capability.capability_id,
+                "availability": availability,
+                "auth_gated": ExecutionScope.AUTH_GATED in capability.execution_scopes,
+                "commands": commands,
+            }
+        )
+    if as_json:
+        _print_json(rows)
+        return
+    table = Table(title="Remote capability availability")
+    table.add_column("Capability")
+    table.add_column("Availability")
+    table.add_column("fo api commands")
+    for row in rows:
+        table.add_row(
+            str(row["capability_id"]),
+            str(row["availability"]),
+            ", ".join(row["commands"]),
+        )
+    console.print(table)
 
 
 @api_app.command("login")
@@ -114,15 +289,15 @@ def login(
                 raise typer.BadParameter(f"Token output path is not a regular file: {save_to!s}")
             save_to.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(save_to, json.dumps(payload, indent=2) + "\n")
-            console.print(f"[green]Saved tokens to[/green] {save_to}")
+            if not as_json:
+                console.print(f"[green]Saved tokens to[/green] {save_to}")
         if as_json:
             _print_json(payload)
         else:
             console.print("[green]Login successful[/green]")
             console.print("Use --json to print token payload.")
     except ClientError as exc:
-        console.print(f"[red]Login failed:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+        _raise_client_error("Login failed", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -147,8 +322,7 @@ def me(
         console.print(f"[green]Email:[/green] {user.email}")
         console.print(f"[green]Admin:[/green] {user.is_admin}")
     except ClientError as exc:
-        console.print(f"[red]Request failed:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+        _raise_client_error("Request failed", exc, as_json=as_json)
     finally:
         client.close()
 
@@ -177,7 +351,8 @@ def logout(
 @api_app.command("files")
 def files_list(
     path: Annotated[str, typer.Argument(help="Directory to list.")],
-    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
     base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
     recursive: Annotated[bool, typer.Option(help="Include nested files.")] = False,
     include_hidden: Annotated[bool, typer.Option(help="Include hidden files.")] = False,
@@ -187,7 +362,7 @@ def files_list(
 ) -> None:
     """List files via the API client."""
     client, ClientError = _build_client(
-        base_url=base_url, token=token, api_key=None, timeout=timeout
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
     )
     try:
         result = client.list_files(
@@ -207,23 +382,419 @@ def files_list(
             table.add_row(item.name, item.file_type, str(item.size))
         console.print(table)
     except ClientError as exc:
-        console.print(f"[red]Request failed:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+        _raise_client_error("Request failed", exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+@api_app.command("scan")
+def organization_scan(
+    input_dir: Annotated[str, typer.Argument(help="Server-side directory to scan.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    recursive: Annotated[
+        bool, typer.Option("--recursive/--no-recursive", help="Include nested files.")
+    ] = True,
+    include_hidden: Annotated[
+        bool, typer.Option("--include-hidden/--exclude-hidden", help="Include hidden files.")
+    ] = False,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Scan a remote directory with canonical traversal semantics."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        result = client.scan(
+            input_dir,
+            recursive=recursive,
+            include_hidden=include_hidden,
+        )
+        payload = result.model_dump(mode="json")
+        if as_json:
+            _print_json(payload)
+            return
+        console.print(f"[green]Scanned:[/green] {result.total_files} files")
+        for category, count in sorted(result.counts.items()):
+            console.print(f"  {category}: {count}")
+    except ClientError as exc:
+        _raise_client_error("Remote scan failed", exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+@api_app.command("preview")
+def organization_preview(
+    input_dir: Annotated[str, typer.Argument(help="Server-side source directory.")],
+    output_dir: Annotated[str, typer.Argument(help="Server-side destination directory.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    save_plan: Annotated[
+        Path | None, typer.Option("--save-plan", help="Write the reviewed plan as JSON.")
+    ] = None,
+    recursive: Annotated[bool, typer.Option("--recursive/--no-recursive")] = True,
+    include_hidden: Annotated[bool, typer.Option("--include-hidden/--exclude-hidden")] = False,
+    skip_existing: Annotated[bool, typer.Option("--skip-existing/--overwrite-existing")] = True,
+    transfer_mode: Annotated[str, typer.Option("--transfer-mode")] = "hardlink",
+    methodology: Annotated[str, typer.Option("--methodology")] = "none",
+    max_workers: Annotated[int | None, typer.Option("--max-workers", min=1)] = None,
+    sequential: Annotated[bool, typer.Option("--sequential")] = False,
+    no_vision: Annotated[bool, typer.Option("--no-vision", "--text-only")] = False,
+    prefetch_depth: Annotated[int, typer.Option("--prefetch-depth", min=0)] = 2,
+    no_prefetch: Annotated[bool, typer.Option("--no-prefetch")] = False,
+    transcribe_audio: Annotated[bool, typer.Option("--transcribe-audio")] = False,
+    max_transcribe_seconds: Annotated[
+        float, typer.Option("--max-transcribe-seconds", min=0.0)
+    ] = 600.0,
+    whisper_model: Annotated[str, typer.Option("--whisper-model")] = "tiny",
+    text_model: Annotated[str | None, typer.Option("--text-model")] = None,
+    vision_model: Annotated[str | None, typer.Option("--vision-model")] = None,
+    text_provider: Annotated[str | None, typer.Option("--text-provider")] = None,
+    vision_provider: Annotated[str | None, typer.Option("--vision-provider")] = None,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Build a canonical remote plan without applying it."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        if save_plan is not None:
+            from file_organizer.cli.path_validation import resolve_cli_path
+
+            save_plan = resolve_cli_path(save_plan, must_exist=False, must_be_dir=False)
+        options = _organization_options(
+            recursive=recursive,
+            include_hidden=include_hidden,
+            skip_existing=skip_existing,
+            transfer_mode=transfer_mode,
+            methodology=methodology,
+            no_vision=no_vision,
+            transcribe_audio=transcribe_audio,
+            max_transcribe_seconds=max_transcribe_seconds,
+            whisper_model=whisper_model,
+            sequential=sequential,
+            max_workers=max_workers,
+            prefetch_depth=prefetch_depth,
+            no_prefetch=no_prefetch,
+            text_model=text_model,
+            vision_model=vision_model,
+            text_provider=text_provider,
+            vision_provider=vision_provider,
+        )
+        result = client.preview_organize(input_dir, output_dir, options=options)
+        payload = result.model_dump(mode="json")
+        if save_plan is not None:
+            if result.plan is None:
+                raise typer.BadParameter("Remote preview did not return an executable plan.")
+            destination = _save_remote_plan(save_plan, result.plan.model_dump(mode="json"))
+        else:
+            destination = None
+        if as_json:
+            _print_json(payload)
+            return
+        console.print(f"[green]Preview:[/green] {result.total_files} files")
+        if destination is not None:
+            console.print(f"[green]Plan saved:[/green] {destination}")
+    except ClientError as exc:
+        _raise_client_error("Remote preview failed", exc, as_json=as_json)
+    except (OSError, ValueError, typer.BadParameter) as exc:
+        _raise_request_error(exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+@api_app.command("organize")
+def organization_execute(
+    ctx: typer.Context,
+    input_dir: Annotated[str, typer.Argument(help="Server-side source directory.")],
+    output_dir: Annotated[str, typer.Argument(help="Server-side destination directory.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    plan_path: Annotated[
+        Path | None, typer.Option("--plan", help="Execute a reviewed canonical plan JSON file.")
+    ] = None,
+    background: Annotated[
+        bool,
+        typer.Option(
+            "--background/--foreground",
+            help="Queue the job or wait for its result.",
+        ),
+    ] = True,
+    idempotency_key: Annotated[
+        str | None, typer.Option("--idempotency-key", help="Deduplicate background submission.")
+    ] = None,
+    recursive: Annotated[bool, typer.Option("--recursive/--no-recursive")] = True,
+    include_hidden: Annotated[bool, typer.Option("--include-hidden/--exclude-hidden")] = False,
+    skip_existing: Annotated[bool, typer.Option("--skip-existing/--overwrite-existing")] = True,
+    transfer_mode: Annotated[str, typer.Option("--transfer-mode")] = "hardlink",
+    methodology: Annotated[str, typer.Option("--methodology")] = "none",
+    max_workers: Annotated[int | None, typer.Option("--max-workers", min=1)] = None,
+    sequential: Annotated[bool, typer.Option("--sequential")] = False,
+    no_vision: Annotated[bool, typer.Option("--no-vision", "--text-only")] = False,
+    prefetch_depth: Annotated[int, typer.Option("--prefetch-depth", min=0)] = 2,
+    no_prefetch: Annotated[bool, typer.Option("--no-prefetch")] = False,
+    transcribe_audio: Annotated[bool, typer.Option("--transcribe-audio")] = False,
+    max_transcribe_seconds: Annotated[
+        float, typer.Option("--max-transcribe-seconds", min=0.0)
+    ] = 600.0,
+    whisper_model: Annotated[str, typer.Option("--whisper-model")] = "tiny",
+    text_model: Annotated[str | None, typer.Option("--text-model")] = None,
+    vision_model: Annotated[str | None, typer.Option("--vision-model")] = None,
+    text_provider: Annotated[str | None, typer.Option("--text-provider")] = None,
+    vision_provider: Annotated[str | None, typer.Option("--vision-provider")] = None,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Execute a canonical organization request through the official SDK."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        if plan_path is not None:
+            from file_organizer.cli.path_validation import resolve_cli_path
+
+            plan_path = resolve_cli_path(plan_path, must_exist=False, must_be_dir=False)
+        plan = _load_remote_plan(plan_path) if plan_path is not None else None
+        options = None
+        has_explicit_options = any(
+            ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+            for name in _REMOTE_PLAN_OPTION_NAMES
+        )
+        if plan is None or has_explicit_options:
+            options = _organization_options(
+                recursive=recursive,
+                include_hidden=include_hidden,
+                skip_existing=skip_existing,
+                transfer_mode=transfer_mode,
+                methodology=methodology,
+                no_vision=no_vision,
+                transcribe_audio=transcribe_audio,
+                max_transcribe_seconds=max_transcribe_seconds,
+                whisper_model=whisper_model,
+                sequential=sequential,
+                max_workers=max_workers,
+                prefetch_depth=prefetch_depth,
+                no_prefetch=no_prefetch,
+                text_model=text_model,
+                vision_model=vision_model,
+                text_provider=text_provider,
+                vision_provider=vision_provider,
+            )
+        result = client.organize(
+            input_dir,
+            output_dir,
+            options=options,
+            plan=plan,
+            run_in_background=background,
+            idempotency_key=idempotency_key,
+        )
+        payload = result.model_dump(mode="json")
+        if as_json:
+            _print_json(payload)
+            return
+        if result.job_id is not None:
+            console.print(f"[green]Queued job:[/green] {result.job_id}")
+        elif result.result is not None:
+            console.print(
+                f"[green]Done:[/green] {result.result.processed_files} processed, "
+                f"{result.result.skipped_files} skipped, {result.result.failed_files} failed"
+            )
+        else:
+            console.print(f"[yellow]Remote status:[/yellow] {result.status}")
+    except ClientError as exc:
+        _raise_client_error("Remote organization failed", exc, as_json=as_json)
+    except (OSError, ValueError, typer.BadParameter) as exc:
+        _raise_request_error(exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+@api_app.command("job")
+def organization_job(
+    job_id: Annotated[str, typer.Argument(help="Organization job identifier.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Inspect one remote organization job."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        job = client.get_job(job_id)
+        if as_json:
+            _print_json(job.model_dump(mode="json"))
+            return
+        console.print(f"[green]Job:[/green] {job.job_id}")
+        console.print(f"[green]Status:[/green] {job.status}")
+        console.print(f"[green]Revision:[/green] {job.revision}")
+    except ClientError as exc:
+        _raise_client_error("Remote job lookup failed", exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+@api_app.command("jobs")
+def organization_jobs(
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    status: Annotated[str | None, typer.Option("--status", help="Filter by job status.")] = None,
+    limit: Annotated[int, typer.Option(min=1, max=500, help="Maximum rows.")] = 100,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """List remote organization jobs."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        jobs = client.list_jobs(status=status, limit=limit)
+        if as_json:
+            _print_json([job.model_dump(mode="json") for job in jobs])
+            return
+        table = Table(title=f"Organization jobs ({len(jobs)})")
+        table.add_column("Job")
+        table.add_column("Status")
+        table.add_column("Revision", justify="right")
+        for job in jobs:
+            table.add_row(job.job_id, job.status, str(job.revision))
+        console.print(table)
+    except ClientError as exc:
+        _raise_client_error("Remote job listing failed", exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+def _mutate_organization_job(
+    action: str,
+    job_id: str,
+    *,
+    expected_revision: int | None,
+    token: str | None,
+    api_key: str | None,
+    base_url: str,
+    timeout: float,
+    as_json: bool,
+) -> None:
+    """Apply one revision-guarded remote lifecycle action."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        operation = client.cancel_job if action == "cancel" else client.rollback_job
+        job = operation(job_id, expected_revision=expected_revision)
+        if as_json:
+            _print_json(job.model_dump(mode="json"))
+            return
+        console.print(f"[green]Job {action} accepted:[/green] {job.job_id} ({job.status})")
+    except ClientError as exc:
+        _raise_client_error(f"Remote job {action} failed", exc, as_json=as_json)
+    finally:
+        client.close()
+
+
+@api_app.command("cancel")
+def organization_cancel(
+    job_id: Annotated[str, typer.Argument(help="Organization job identifier.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    expected_revision: Annotated[
+        int | None, typer.Option("--expected-revision", min=0, help="Optimistic revision guard.")
+    ] = None,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Cancel a queued or scheduled remote organization job."""
+    _mutate_organization_job(
+        "cancel",
+        job_id,
+        expected_revision=expected_revision,
+        token=token,
+        api_key=api_key,
+        base_url=base_url,
+        timeout=timeout,
+        as_json=as_json,
+    )
+
+
+@api_app.command("rollback")
+def organization_rollback(
+    job_id: Annotated[str, typer.Argument(help="Organization job identifier.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    expected_revision: Annotated[
+        int | None, typer.Option("--expected-revision", min=0, help="Optimistic revision guard.")
+    ] = None,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Roll back a completed remote organization job."""
+    _mutate_organization_job(
+        "rollback",
+        job_id,
+        expected_revision=expected_revision,
+        token=token,
+        api_key=api_key,
+        base_url=base_url,
+        timeout=timeout,
+        as_json=as_json,
+    )
+
+
+@api_app.command("suggest")
+def organization_suggest(
+    filename: Annotated[str, typer.Argument(help="File name to classify remotely.")],
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
+    base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
+    folder_suggestion: Annotated[
+        str | None, typer.Option("--folder-suggestion", help="Optional suggested folder hint.")
+    ] = None,
+    timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
+    as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
+) -> None:
+    """Request a non-mutating remote organization suggestion."""
+    client, ClientError = _build_client(
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
+    )
+    try:
+        payload = client.suggest_organization(
+            filename,
+            folder_suggestion=folder_suggestion,
+        )
+        if as_json:
+            _print_json(payload)
+            return
+        console.print(f"[green]File:[/green] {payload.get('filename', filename)}")
+        console.print(f"[green]Folder:[/green] {payload.get('folder_suggestion', '')}")
+    except ClientError as exc:
+        _raise_client_error("Remote suggestion failed", exc, as_json=as_json)
     finally:
         client.close()
 
 
 @api_app.command("system-status")
 def system_status(
-    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
     path: Annotated[str, typer.Argument(help="Path to inspect.")] = ".",
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
     base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
     timeout: Annotated[float, typer.Option(help="Request timeout in seconds.")] = 30.0,
     as_json: Annotated[bool, typer.Option("--json", help="Print JSON output.")] = False,
 ) -> None:
     """Show system status from the API."""
     client, ClientError = _build_client(
-        base_url=base_url, token=token, api_key=None, timeout=timeout
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
     )
     try:
         result = client.system_status(path)
@@ -234,16 +805,16 @@ def system_status(
         console.print(f"[green]Disk used:[/green] {result.disk_used}")
         console.print(f"[green]Active jobs:[/green] {result.active_jobs}")
     except ClientError as exc:
-        console.print(f"[red]Request failed:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+        _raise_client_error("Request failed", exc, as_json=as_json)
     finally:
         client.close()
 
 
 @api_app.command("system-stats")
 def system_stats(
-    token: Annotated[str, typer.Option("--token", help="Bearer token.")],
     path: Annotated[str, typer.Argument(help="Directory to analyze.")] = ".",
+    token: Annotated[str | None, typer.Option("--token", help="Bearer token.")] = None,
+    api_key: Annotated[str | None, typer.Option("--api-key", help="API key.")] = None,
     base_url: Annotated[str, typer.Option(help="API base URL.")] = "http://localhost:8000",
     max_depth: Annotated[int | None, typer.Option(min=1, help="Optional max depth.")] = None,
     use_cache: Annotated[bool, typer.Option(help="Use server-side cache.")] = True,
@@ -252,7 +823,7 @@ def system_stats(
 ) -> None:
     """Show storage analytics stats from the API."""
     client, ClientError = _build_client(
-        base_url=base_url, token=token, api_key=None, timeout=timeout
+        base_url=base_url, token=token, api_key=api_key, timeout=timeout
     )
     try:
         stats = client.system_stats(path=path, max_depth=max_depth, use_cache=use_cache)
@@ -263,7 +834,6 @@ def system_stats(
         console.print(f"[green]Directory count:[/green] {stats.directory_count}")
         console.print(f"[green]Total size:[/green] {stats.total_size}")
     except ClientError as exc:
-        console.print(f"[red]Request failed:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
+        _raise_client_error("Request failed", exc, as_json=as_json)
     finally:
         client.close()

--- a/src/file_organizer/cli/api.py
+++ b/src/file_organizer/cli/api.py
@@ -19,9 +19,11 @@ from rich.console import Console
 from rich.table import Table
 
 from file_organizer.cli.organize import (
+    _PLAN_PARAMETER_FIELDS,
     _emit_json,
     _error_code_exit_code,
     _json_success_payload,
+    _merge_explicit_plan_options,
     _raise_cli_contract_error,
 )
 from file_organizer.utils.atomic_write import atomic_write_text
@@ -31,25 +33,7 @@ api_app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
-_REMOTE_PLAN_OPTION_NAMES = (
-    "recursive",
-    "include_hidden",
-    "skip_existing",
-    "transfer_mode",
-    "methodology",
-    "max_workers",
-    "sequential",
-    "no_vision",
-    "prefetch_depth",
-    "no_prefetch",
-    "transcribe_audio",
-    "max_transcribe_seconds",
-    "whisper_model",
-    "text_model",
-    "vision_model",
-    "text_provider",
-    "vision_provider",
-)
+_REMOTE_PLAN_OPTION_NAMES = tuple(_PLAN_PARAMETER_FIELDS)
 
 
 def _build_client(
@@ -88,9 +72,11 @@ def _success_payload(
     request: dict[str, Any] | None = None,
     scan: dict[str, Any] | None = None,
     plan: dict[str, Any] | None = None,
+    job: dict[str, Any] | None = None,
+    include_job: bool = False,
 ) -> dict[str, Any]:
     """Build the shared CLI success envelope for a remote result."""
-    return _json_success_payload(
+    payload = _json_success_payload(
         command,
         mode="remote",
         request=request,
@@ -98,6 +84,9 @@ def _success_payload(
         result=result,
         plan=plan,
     )
+    if include_job:
+        payload["job"] = job
+    return payload
 
 
 def _client_error_payload(exc: Exception) -> dict[str, Any]:
@@ -209,12 +198,28 @@ def _organization_options(
 
 def _load_remote_plan(path: Path) -> OrganizationPlanPayload:
     """Load and validate a canonical plan for remote execution."""
-    from file_organizer.cli.path_validation import resolve_cli_path, validate_regular_file
+    from file_organizer.cli.path_validation import validate_regular_file
     from file_organizer.client.models import OrganizationPlanPayload
 
-    validated = resolve_cli_path(path, must_exist=True, must_be_dir=False)
-    validate_regular_file(validated, "plan file")
-    return OrganizationPlanPayload.model_validate_json(validated.read_text(encoding="utf-8"))
+    validate_regular_file(path, "plan file")
+    return OrganizationPlanPayload.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _merge_remote_plan_options(
+    ctx: typer.Context,
+    plan_options: OrganizationOptionsPayload,
+    cli_options: OrganizationOptionsPayload,
+) -> OrganizationOptionsPayload:
+    """Overlay only explicitly supplied remote flags onto reviewed plan options."""
+    from file_organizer.client.models import OrganizationOptionsPayload
+    from file_organizer.core.organize_options import OrganizeOptions
+
+    merged = _merge_explicit_plan_options(
+        ctx,
+        OrganizeOptions.from_dict(plan_options.model_dump(mode="json")),
+        OrganizeOptions.from_dict(cli_options.model_dump(mode="json")),
+    )
+    return OrganizationOptionsPayload.model_validate(merged.to_dict())
 
 
 def _save_remote_plan(path: Path, payload: object) -> Path:
@@ -629,7 +634,7 @@ def organization_execute(
         if plan_path is not None:
             from file_organizer.cli.path_validation import resolve_cli_path
 
-            plan_path = resolve_cli_path(plan_path, must_exist=False, must_be_dir=False)
+            plan_path = resolve_cli_path(plan_path, must_exist=True, must_be_dir=False)
         plan = _load_remote_plan(plan_path) if plan_path is not None else None
         options = None
         has_explicit_options = any(
@@ -637,7 +642,7 @@ def organization_execute(
             for name in _REMOTE_PLAN_OPTION_NAMES
         )
         if plan is None or has_explicit_options:
-            options = _organization_options(
+            cli_options = _organization_options(
                 recursive=recursive,
                 include_hidden=include_hidden,
                 skip_existing=skip_existing,
@@ -656,6 +661,12 @@ def organization_execute(
                 text_provider=text_provider,
                 vision_provider=vision_provider,
             )
+            plan_options = getattr(plan, "options", None)
+            options = (
+                _merge_remote_plan_options(ctx, plan_options, cli_options)
+                if plan_options is not None
+                else cli_options
+            )
         result = client.organize(
             input_dir,
             output_dir,
@@ -670,9 +681,14 @@ def organization_execute(
             if isinstance(operation_result, dict):
                 operation_result = dict(operation_result)
                 plan_payload = operation_result.pop("plan", None)
+                job_payload = None
             else:
-                operation_result = payload
+                operation_result = None
                 plan_payload = None
+                job_payload = {
+                    "job_id": payload.get("job_id"),
+                    "status": payload.get("status"),
+                }
             if options is not None:
                 request_options = options.model_dump(mode="json")
             elif (plan_options := getattr(plan, "options", None)) is not None:
@@ -689,6 +705,8 @@ def organization_execute(
                         "options": request_options,
                     },
                     plan=plan_payload,
+                    job=job_payload,
+                    include_job=True,
                 )
             )
             return
@@ -784,7 +802,14 @@ def _mutate_organization_job(
         base_url=base_url, token=token, api_key=api_key, timeout=timeout
     )
     try:
-        operation = client.cancel_job if action == "cancel" else client.rollback_job
+        operations = {
+            "cancel": client.cancel_job,
+            "rollback": client.rollback_job,
+        }
+        try:
+            operation = operations[action]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported organization job action: {action}") from exc
         job = operation(job_id, expected_revision=expected_revision)
         if as_json:
             _emit_json(_success_payload(f"api {action}", job.model_dump(mode="json")))

--- a/src/file_organizer/cli/organize.py
+++ b/src/file_organizer/cli/organize.py
@@ -234,19 +234,39 @@ def _success_payload(
     scan: OrganizationScan | None = None,
 ) -> dict[str, Any]:
     """Build the versioned success envelope shared by both CLI commands."""
+    return _json_success_payload(
+        command,
+        mode=mode,
+        request={
+            "input_path": str(request.input_path),
+            "output_path": str(request.output_path),
+            "options": request.options.to_dict(),
+        },
+        scan=_scan_payload(scan) if scan is not None else None,
+        result=_result_payload(result),
+        plan=result.plan.to_dict() if isinstance(result.plan, OrganizationPlan) else None,
+    )
+
+
+def _json_success_payload(
+    command: str,
+    *,
+    mode: str,
+    result: Any,
+    request: dict[str, Any] | None = None,
+    scan: dict[str, Any] | None = None,
+    plan: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the shared versioned success envelope for CLI adapters."""
     return {
         "schema_version": _JSON_SCHEMA_VERSION,
         "outcome": "ok",
         "command": command,
         "mode": mode,
-        "request": {
-            "input_path": str(request.input_path),
-            "output_path": str(request.output_path),
-            "options": request.options.to_dict(),
-        },
-        "scan": _scan_payload(scan) if scan is not None else None,
-        "result": _result_payload(result),
-        "plan": result.plan.to_dict() if isinstance(result.plan, OrganizationPlan) else None,
+        "request": request,
+        "scan": scan,
+        "result": result,
+        "plan": plan,
     }
 
 
@@ -280,18 +300,47 @@ def _load_plan(path: Path) -> OrganizationPlan:
 
 def _error_exit_code(exc: Exception) -> int:
     """Map stable domain failure categories onto documented CLI exit codes."""
-    if isinstance(exc, DomainError) and exc.code in {
-        DomainErrorCode.INVALID_REQUEST,
-        DomainErrorCode.NOT_FOUND,
-    }:
+    if isinstance(exc, DomainError):
+        return _error_code_exit_code(exc.code.value)
+    return 1
+
+
+def _error_code_exit_code(code: str) -> int:
+    """Map one stable error identifier onto the shared CLI exit categories."""
+    if code in {DomainErrorCode.INVALID_REQUEST.value, DomainErrorCode.NOT_FOUND.value}:
         return 2
-    if isinstance(exc, DomainError) and exc.code in {
-        DomainErrorCode.CONFLICT,
-        DomainErrorCode.PLAN_MISMATCH,
-        DomainErrorCode.RECOVERY_REQUIRED,
+    if code in {
+        DomainErrorCode.CONFLICT.value,
+        DomainErrorCode.PLAN_MISMATCH.value,
+        DomainErrorCode.RECOVERY_REQUIRED.value,
     }:
         return 3
     return 1
+
+
+def _raise_cli_contract_error(
+    command: str,
+    error: dict[str, Any],
+    *,
+    json_output: bool,
+    exit_code: int,
+    cause: Exception,
+) -> None:
+    """Render a normalized CLI error envelope shared by local and remote adapters."""
+    if json_output:
+        _emit_json(
+            {
+                "schema_version": _JSON_SCHEMA_VERSION,
+                "outcome": "error",
+                "command": command,
+                "error": error,
+            }
+        )
+    else:
+        console.print(f"[red]Error: {error['message']}[/red]")
+        if _get_state().debug:
+            console.print_exception(show_locals=False)
+    raise typer.Exit(code=exit_code) from cause
 
 
 def _raise_cli_error(command: str, exc: Exception, *, json_output: bool) -> None:
@@ -313,20 +362,13 @@ def _raise_cli_error(command: str, exc: Exception, *, json_output: bool) -> None
             "error_type": type(exc).__name__,
             "message": str(exc),
         }
-    if json_output:
-        _emit_json(
-            {
-                "schema_version": _JSON_SCHEMA_VERSION,
-                "outcome": "error",
-                "command": command,
-                "error": error,
-            }
-        )
-    else:
-        console.print(f"[red]Error: {error['message']}[/red]")
-        if _get_state().debug:
-            console.print_exception(show_locals=False)
-    raise typer.Exit(code=code) from exc
+    _raise_cli_contract_error(
+        command,
+        error,
+        json_output=json_output,
+        exit_code=code,
+        cause=exc,
+    )
 
 
 def _raise_usage_error(command: str, exc: typer.BadParameter, *, json_output: bool) -> None:

--- a/src/file_organizer/core/capability_registry.json
+++ b/src/file_organizer/core/capability_registry.json
@@ -1566,7 +1566,9 @@
           "entry_points": [
             "fo config edit",
             "fo organize --methodology",
-            "fo preview --methodology"
+            "fo preview --methodology",
+            "fo api organize --methodology",
+            "fo api preview --methodology"
           ],
           "implementation_status": "implemented",
           "target_support": "full"
@@ -1708,7 +1710,8 @@
         "cli": {
           "conformance_status": "verified",
           "entry_points": [
-            "fo organize"
+            "fo organize",
+            "fo api organize"
           ],
           "implementation_status": "implemented",
           "target_support": "full"
@@ -1778,7 +1781,11 @@
           "entry_points": [
             "fo recover",
             "fo undo",
-            "fo history"
+            "fo history",
+            "fo api job",
+            "fo api jobs",
+            "fo api cancel",
+            "fo api rollback"
           ],
           "implementation_status": "partial",
           "target_support": "full"
@@ -1863,7 +1870,8 @@
           "conformance_status": "verified",
           "entry_points": [
             "fo preview",
-            "fo organize --dry-run"
+            "fo organize --dry-run",
+            "fo api preview"
           ],
           "implementation_status": "implemented",
           "target_support": "full"
@@ -1934,7 +1942,8 @@
           "conformance_status": "unverified",
           "entry_points": [
             "fo preview",
-            "fo organize"
+            "fo organize",
+            "fo api scan"
           ],
           "implementation_status": "partial",
           "target_support": "full"
@@ -2002,8 +2011,10 @@
       "surfaces": {
         "cli": {
           "conformance_status": "unverified",
-          "entry_points": [],
-          "implementation_status": "not-implemented",
+          "entry_points": [
+            "fo api suggest"
+          ],
+          "implementation_status": "partial",
           "target_support": "full"
         },
         "python-sdk": {
@@ -2307,6 +2318,7 @@
             "fo version",
             "fo doctor",
             "fo hardware-info",
+            "fo api capabilities",
             "fo api health",
             "fo api system-status",
             "fo api system-stats"

--- a/tests/cli/test_api.py
+++ b/tests/cli/test_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
@@ -51,7 +52,10 @@ def test_health_command_json(mock_client_cls):
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
-    assert data["status"] == "ok"
+    assert data["schema_version"] == 1
+    assert data["outcome"] == "ok"
+    assert data["command"] == "api health"
+    assert data["result"]["status"] == "ok"
 
 
 def test_health_command_error(mock_client_cls):
@@ -63,7 +67,7 @@ def test_health_command_error(mock_client_cls):
     result = runner.invoke(api_app, ["health"])
 
     assert result.exit_code == 1
-    assert "API error:" in result.stdout
+    assert "Error:" in result.stdout
     assert "Connection failed" in result.stdout
 
 
@@ -72,7 +76,9 @@ def test_remote_capabilities_distinguish_commands_from_sdk_only_access():
     result = runner.invoke(api_app, ["capabilities", "--json"])
 
     assert result.exit_code == 0
-    rows = {row["capability_id"]: row for row in json.loads(result.stdout)}
+    payload = json.loads(result.stdout)
+    assert payload["outcome"] == "ok"
+    rows = {row["capability_id"]: row for row in payload["result"]}
     assert rows["organization.preview"]["availability"] == "available"
     assert "fo api preview" in rows["organization.preview"]["commands"]
     assert rows["deduplication.manage"]["availability"] == "sdk-only"
@@ -111,7 +117,7 @@ def test_login_command_error(mock_client_cls):
     result = runner.invoke(api_app, ["login"], input="user\npass\n")
 
     assert result.exit_code == 1
-    assert "Login failed" in result.stdout
+    assert "Error:" in result.stdout
 
 
 def test_me_command(mock_client_cls):
@@ -213,7 +219,13 @@ def test_remote_scan_maps_traversal_and_emits_machine_json(mock_client_cls):
     )
 
     assert result.exit_code == 0
-    assert json.loads(result.stdout)["total_files"] == 2
+    payload = json.loads(result.stdout)
+    assert payload["outcome"] == "ok"
+    assert payload["scan"]["total_files"] == 2
+    assert payload["request"]["options"] == {
+        "include_hidden": True,
+        "recursive": False,
+    }
     mock_instance.scan.assert_called_once_with(
         "/remote/input", recursive=False, include_hidden=True
     )
@@ -335,6 +347,23 @@ def test_remote_job_mutations_preserve_revision_guard(mock_client_cls, command, 
     getattr(mock_instance, method).assert_called_once_with("job-1", expected_revision=3)
 
 
+def test_remote_jobs_wraps_list_in_shared_success_envelope(mock_client_cls):
+    """List-valued results must not replace the versioned top-level JSON object."""
+    mock_instance = MagicMock()
+    job = MagicMock()
+    job.model_dump.return_value = {"job_id": "job-1", "status": "queued"}
+    mock_instance.list_jobs.return_value = [job]
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(api_app, ["jobs", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["outcome"] == "ok"
+    assert payload["command"] == "api jobs"
+    assert payload["result"] == [{"job_id": "job-1", "status": "queued"}]
+
+
 def test_remote_json_error_preserves_sdk_auth_evidence(mock_client_cls):
     """Machine output must distinguish authentication failures from local-only gaps."""
     mock_instance = MagicMock()
@@ -350,11 +379,15 @@ def test_remote_json_error_preserves_sdk_auth_evidence(mock_client_cls):
 
     assert result.exit_code == 1
     assert json.loads(result.stdout) == {
-        "details": {},
-        "error": "unauthorized",
-        "message": "Authentication required.",
-        "retryable": False,
-        "status_code": 401,
+        "command": "api scan",
+        "error": {
+            "code": "unauthorized",
+            "details": {},
+            "message": "Authentication required.",
+            "retryable": False,
+        },
+        "outcome": "error",
+        "schema_version": 1,
     }
 
 
@@ -376,5 +409,53 @@ def test_remote_preview_invalid_options_preserve_json_contract(mock_client_cls):
 
     assert result.exit_code == 2
     payload = json.loads(result.stdout)
-    assert payload["error"] == "invalid_request"
-    assert payload["retryable"] is False
+    assert payload["outcome"] == "error"
+    assert payload["command"] == "api preview"
+    assert payload["error"]["code"] == "invalid_request"
+    assert payload["error"]["retryable"] is False
+
+
+def test_health_transport_failure_preserves_json_contract(mock_client_cls):
+    """Connection failures must emit one retryable machine-readable error."""
+    mock_instance = MagicMock()
+    request = httpx.Request("GET", "http://127.0.0.1:9/api/v1/health")
+    mock_instance.health.side_effect = httpx.ConnectError("Connection refused", request=request)
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(api_app, ["health", "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout) == {
+        "command": "api health",
+        "error": {
+            "code": "transport_error",
+            "details": {"error_type": "ConnectError"},
+            "message": "Connection refused",
+            "retryable": True,
+        },
+        "outcome": "error",
+        "schema_version": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_code", "expected_exit"),
+    [(404, "not_found", 2), (422, "validation_error", 2), (409, "plan_mismatch", 3)],
+)
+def test_remote_errors_share_local_exit_categories(
+    mock_client_cls, status_code, error_code, expected_exit
+):
+    """Remote domain failures must use the local CLI's documented exit categories."""
+    mock_instance = MagicMock()
+    mock_instance.scan.side_effect = ClientError(
+        "Request failed",
+        status_code=status_code,
+        detail="Request failed",
+        error_code=error_code,
+    )
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(api_app, ["scan", "/remote/input", "--json"])
+
+    assert result.exit_code == expected_exit
+    assert json.loads(result.stdout)["error"]["code"] == error_code

--- a/tests/cli/test_api.py
+++ b/tests/cli/test_api.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from file_organizer.cli.api import api_app
 from file_organizer.client.exceptions import ClientError
+from file_organizer.client.models import OrganizationOptionsPayload
 
 runner = CliRunner()
 
@@ -301,6 +302,8 @@ def test_remote_organize_applies_reviewed_plan_without_default_overrides(mock_cl
     mock_instance.organize.return_value = response
     mock_client_cls.return_value = mock_instance
     plan = object()
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text("{}", encoding="utf-8")
 
     with patch("file_organizer.cli.api._load_remote_plan", return_value=plan):
         result = runner.invoke(
@@ -310,7 +313,7 @@ def test_remote_organize_applies_reviewed_plan_without_default_overrides(mock_cl
                 "/remote/input",
                 "/remote/output",
                 "--plan",
-                str(tmp_path / "plan.json"),
+                str(plan_path),
                 "--json",
             ],
         )
@@ -324,6 +327,77 @@ def test_remote_organize_applies_reviewed_plan_without_default_overrides(mock_cl
         run_in_background=True,
         idempotency_key=None,
     )
+    payload = json.loads(result.stdout)
+    assert payload["result"] is None
+    assert payload["job"] == {"job_id": "job-1", "status": "queued"}
+
+
+def test_remote_plan_overlays_only_explicit_behavior_flags(mock_client_cls, tmp_path):
+    """Explicit remote flags must preserve every unspecified reviewed-plan option."""
+    mock_instance = MagicMock()
+    response = MagicMock(job_id="job-1", result=None, status="queued")
+    response.model_dump.return_value = {"status": "queued", "job_id": "job-1"}
+    mock_instance.organize.return_value = response
+    mock_client_cls.return_value = mock_instance
+    reviewed_options = OrganizationOptionsPayload(
+        recursive=False,
+        include_hidden=True,
+        skip_existing=False,
+        transfer_mode="copy",
+        methodology="para",
+        enable_vision=False,
+        parallel_workers=3,
+        prefetch_depth=7,
+    )
+    plan = MagicMock(options=reviewed_options)
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text("{}", encoding="utf-8")
+
+    with patch("file_organizer.cli.api._load_remote_plan", return_value=plan):
+        result = runner.invoke(
+            api_app,
+            [
+                "organize",
+                "/remote/input",
+                "/remote/output",
+                "--plan",
+                str(plan_path),
+                "--methodology",
+                "jd",
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    options = mock_instance.organize.call_args.kwargs["options"]
+    assert options.model_dump() == {
+        **reviewed_options.model_dump(),
+        "methodology": "jd",
+    }
+
+
+def test_remote_foreground_reserves_result_for_operation_result(mock_client_cls):
+    """Foreground and queued responses must keep stable result and job slots."""
+    mock_instance = MagicMock()
+    operation_result = MagicMock(processed_files=3, skipped_files=0, failed_files=0)
+    response = MagicMock(job_id=None, result=operation_result, status="completed")
+    response.model_dump.return_value = {
+        "status": "completed",
+        "job_id": None,
+        "result": {"processed_files": 3, "plan": None},
+    }
+    mock_instance.organize.return_value = response
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(
+        api_app,
+        ["organize", "/remote/input", "/remote/output", "--foreground", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["result"] == {"processed_files": 3}
+    assert payload["job"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_api.py
+++ b/tests/cli/test_api.py
@@ -67,6 +67,18 @@ def test_health_command_error(mock_client_cls):
     assert "Connection failed" in result.stdout
 
 
+def test_remote_capabilities_distinguish_commands_from_sdk_only_access():
+    """Remote inventory must make unsupported fo api operations explicit."""
+    result = runner.invoke(api_app, ["capabilities", "--json"])
+
+    assert result.exit_code == 0
+    rows = {row["capability_id"]: row for row in json.loads(result.stdout)}
+    assert rows["organization.preview"]["availability"] == "available"
+    assert "fo api preview" in rows["organization.preview"]["commands"]
+    assert rows["deduplication.manage"]["availability"] == "sdk-only"
+    assert rows["organization.preview"]["auth_gated"] is True
+
+
 def test_login_command(mock_client_cls, tmp_path):
     """Test the login command success."""
     mock_instance = MagicMock()
@@ -180,3 +192,189 @@ def test_system_stats_command(mock_client_cls):
     assert result.exit_code == 0
     assert "100" in result.stdout
     assert "1MB" in result.stdout
+
+
+def test_remote_scan_maps_traversal_and_emits_machine_json(mock_client_cls):
+    """Remote scan must preserve traversal flags through the official SDK."""
+    mock_instance = MagicMock()
+    response = MagicMock(total_files=2, counts={"text": 2})
+    response.model_dump.return_value = {
+        "input_dir": "/remote/input",
+        "total_files": 2,
+        "files": ["/remote/input/a.txt", "/remote/input/b.txt"],
+        "counts": {"text": 2},
+    }
+    mock_instance.scan.return_value = response
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(
+        api_app,
+        ["scan", "/remote/input", "--no-recursive", "--include-hidden", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["total_files"] == 2
+    mock_instance.scan.assert_called_once_with(
+        "/remote/input", recursive=False, include_hidden=True
+    )
+
+
+def test_remote_preview_maps_complete_canonical_options(mock_client_cls):
+    """Remote preview must pass every behavior option as one SDK payload."""
+    mock_instance = MagicMock()
+    response = MagicMock(total_files=1, plan=None)
+    response.model_dump.return_value = {"total_files": 1, "plan": None}
+    mock_instance.preview_organize.return_value = response
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(
+        api_app,
+        [
+            "preview",
+            "/remote/input",
+            "/remote/output",
+            "--no-recursive",
+            "--include-hidden",
+            "--overwrite-existing",
+            "--transfer-mode",
+            "copy",
+            "--methodology",
+            "para",
+            "--no-vision",
+            "--transcribe-audio",
+            "--max-transcribe-seconds",
+            "0",
+            "--whisper-model",
+            "small",
+            "--sequential",
+            "--no-prefetch",
+            "--text-model",
+            "text-model",
+            "--vision-model",
+            "vision-model",
+            "--text-provider",
+            "ollama",
+            "--vision-provider",
+            "openai",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    options = mock_instance.preview_organize.call_args.kwargs["options"]
+    assert options.model_dump() == {
+        "recursive": False,
+        "include_hidden": True,
+        "skip_existing": False,
+        "transfer_mode": "copy",
+        "methodology": "para",
+        "enable_vision": False,
+        "transcribe_audio": True,
+        "max_transcribe_seconds": None,
+        "whisper_model": "small",
+        "parallel_workers": 1,
+        "prefetch_depth": 0,
+        "text_model": "text-model",
+        "vision_model": "vision-model",
+        "text_provider": "ollama",
+        "vision_provider": "openai",
+    }
+
+
+def test_remote_organize_applies_reviewed_plan_without_default_overrides(mock_client_cls, tmp_path):
+    """A plan-only invocation must let the server resolve the reviewed options."""
+    mock_instance = MagicMock()
+    response = MagicMock(job_id="job-1", result=None, status="queued")
+    response.model_dump.return_value = {"status": "queued", "job_id": "job-1"}
+    mock_instance.organize.return_value = response
+    mock_client_cls.return_value = mock_instance
+    plan = object()
+
+    with patch("file_organizer.cli.api._load_remote_plan", return_value=plan):
+        result = runner.invoke(
+            api_app,
+            [
+                "organize",
+                "/remote/input",
+                "/remote/output",
+                "--plan",
+                str(tmp_path / "plan.json"),
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_instance.organize.assert_called_once_with(
+        "/remote/input",
+        "/remote/output",
+        options=None,
+        plan=plan,
+        run_in_background=True,
+        idempotency_key=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "method"),
+    [("cancel", "cancel_job"), ("rollback", "rollback_job")],
+)
+def test_remote_job_mutations_preserve_revision_guard(mock_client_cls, command, method):
+    """Remote lifecycle mutations must forward optimistic revision guards."""
+    mock_instance = MagicMock()
+    job = MagicMock(job_id="job-1", status="cancelled", revision=4)
+    job.model_dump.return_value = {"job_id": "job-1", "status": job.status, "revision": 4}
+    getattr(mock_instance, method).return_value = job
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(
+        api_app,
+        [command, "job-1", "--expected-revision", "3", "--json"],
+    )
+
+    assert result.exit_code == 0
+    getattr(mock_instance, method).assert_called_once_with("job-1", expected_revision=3)
+
+
+def test_remote_json_error_preserves_sdk_auth_evidence(mock_client_cls):
+    """Machine output must distinguish authentication failures from local-only gaps."""
+    mock_instance = MagicMock()
+    mock_instance.scan.side_effect = ClientError(
+        "Unauthorized",
+        status_code=401,
+        detail="Authentication required.",
+        error_code="unauthorized",
+    )
+    mock_client_cls.return_value = mock_instance
+
+    result = runner.invoke(api_app, ["scan", "/remote/input", "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout) == {
+        "details": {},
+        "error": "unauthorized",
+        "message": "Authentication required.",
+        "retryable": False,
+        "status_code": 401,
+    }
+
+
+def test_remote_preview_invalid_options_preserve_json_contract(mock_client_cls):
+    """Local option validation must not replace JSON output with a usage banner."""
+    mock_client_cls.return_value = MagicMock()
+
+    result = runner.invoke(
+        api_app,
+        [
+            "preview",
+            "/remote/input",
+            "/remote/output",
+            "--methodology",
+            "invented",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "invalid_request"
+    assert payload["retryable"] is False

--- a/tests/cli/test_cli_api.py
+++ b/tests/cli/test_cli_api.py
@@ -19,7 +19,7 @@ runner = CliRunner()
 class _Model:
     payload: dict[str, Any]
 
-    def model_dump(self) -> dict[str, Any]:
+    def model_dump(self, **_: Any) -> dict[str, Any]:
         return dict(self.payload)
 
     def __getattr__(self, item: str) -> Any:
@@ -131,4 +131,4 @@ def test_api_error_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     result = runner.invoke(app, ["api", "health"])
     assert result.exit_code == 1
-    assert "API error" in result.stdout
+    assert "Error:" in result.stdout

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -15,6 +15,7 @@ from tests.conformance.driver import (
     DirectServiceDriver,
     OrganizationConformanceDriver,
     PythonSDKConformanceDriver,
+    RemoteCLIConformanceDriver,
     RESTConformanceDriver,
     WebFormConformanceDriver,
 )
@@ -49,10 +50,19 @@ class ConformanceContext:
         CLIConformanceDriver,
         RESTConformanceDriver,
         PythonSDKConformanceDriver,
+        RemoteCLIConformanceDriver,
         AsyncPythonSDKConformanceDriver,
         WebFormConformanceDriver,
     ),
-    ids=("direct", "cli", "rest", "python-sdk", "python-async-sdk", "web-form-adapter"),
+    ids=(
+        "direct",
+        "cli",
+        "rest",
+        "python-sdk",
+        "fo-api",
+        "python-async-sdk",
+        "web-form-adapter",
+    ),
 )
 def conformance(tmp_path: Path, request: pytest.FixtureRequest) -> ConformanceContext:
     """Run the golden corpus against the oracle and each migrated adapter."""

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from contextlib import redirect_stdout
 from datetime import UTC, datetime
 from html import unescape
+from io import StringIO
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 from unittest.mock import patch
@@ -48,6 +50,7 @@ from file_organizer.api.dependencies import (
 from file_organizer.api.exceptions import setup_exception_handlers
 from file_organizer.api.routers.organize import get_organization_service
 from file_organizer.api.routers.organize import router as api_organize_router
+from file_organizer.cli.api import api_app
 from file_organizer.cli.main import app
 from file_organizer.client.async_client import AsyncFileOrganizerClient
 from file_organizer.client.exceptions import ClientError
@@ -975,6 +978,95 @@ class PythonSDKConformanceDriver(_HTTPConformanceDriver):
         if response.result is None:
             raise AssertionError(f"Python SDK execution omitted its result: {response}")
         return response.result.model_dump(mode="json")
+
+
+class _NonClosingSDKProxy:
+    """Delegate SDK calls while leaving the shared test transport open."""
+
+    def __init__(self, sdk: FileOrganizerClient) -> None:
+        self._sdk = sdk
+
+    def __getattr__(self, name: str) -> Any:
+        attribute = getattr(self._sdk, name)
+        if not callable(attribute):
+            return attribute
+
+        def invoke(*args: Any, **kwargs: Any) -> Any:
+            with redirect_stdout(StringIO()):
+                return attribute(*args, **kwargs)
+
+        return invoke
+
+    def close(self) -> None:
+        """Keep the conformance TestClient available for the next command."""
+
+
+class RemoteCLIConformanceDriver(PythonSDKConformanceDriver):
+    """Drive ``fo api`` through the official synchronous SDK and REST routes."""
+
+    name = "fo-api"
+
+    def _invoke(self, args: list[str]) -> dict[str, Any]:
+        proxy = _NonClosingSDKProxy(self._sdk)
+        with patch(
+            "file_organizer.cli.api._build_client",
+            return_value=(proxy, ClientError),
+        ):
+            result = CliRunner().invoke(api_app, args)
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"fo api did not emit valid JSON (exit {result.exit_code}): {result.stdout}"
+            ) from exc
+        if result.exit_code != 0:
+            raise _TransportFailure(payload)
+        return payload
+
+    def _scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        return self._invoke(
+            [
+                "scan",
+                str(request.input_path),
+                "--json",
+                "--recursive" if request.options.recursive else "--no-recursive",
+                ("--include-hidden" if request.options.include_hidden else "--exclude-hidden"),
+            ]
+        )
+
+    def _preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        return self._invoke(
+            [
+                "preview",
+                str(request.input_path),
+                str(request.output_path),
+                "--json",
+                *CLIConformanceDriver._option_args(request),
+            ]
+        )
+
+    def _execute(
+        self, request: OrganizeRequest, plan_payload: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        args = [
+            "organize",
+            str(request.input_path),
+            str(request.output_path),
+            "--foreground",
+            "--json",
+        ]
+        if plan_payload is None:
+            args.extend(CLIConformanceDriver._option_args(request))
+        else:
+            plan_path = self._workspace / "fo-api-plan.json"
+            atomic_write_text(plan_path, json.dumps(plan_payload))
+            args.extend(("--plan", str(plan_path)))
+            args.extend(CLIConformanceDriver._option_args(request))
+        outer = self._invoke(args)
+        result = outer.get("result")
+        if not isinstance(result, dict):
+            raise AssertionError(f"fo api execution omitted its result: {outer}")
+        return result
 
 
 class AsyncPythonSDKConformanceDriver(_HTTPConformanceDriver):

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -1020,11 +1020,14 @@ class RemoteCLIConformanceDriver(PythonSDKConformanceDriver):
                 f"fo api did not emit valid JSON (exit {result.exit_code}): {result.stdout}"
             ) from exc
         if result.exit_code != 0:
-            raise _TransportFailure(payload)
+            error = payload.get("error")
+            raise _TransportFailure(error if isinstance(error, dict) else payload)
+        if payload.get("outcome") != "ok":
+            raise AssertionError(f"fo api succeeded with a non-success envelope: {payload}")
         return payload
 
     def _scan(self, request: OrganizeRequest) -> dict[str, Any]:
-        return self._invoke(
+        outer = self._invoke(
             [
                 "scan",
                 str(request.input_path),
@@ -1033,9 +1036,12 @@ class RemoteCLIConformanceDriver(PythonSDKConformanceDriver):
                 ("--include-hidden" if request.options.include_hidden else "--exclude-hidden"),
             ]
         )
+        scan = dict(outer["scan"])
+        scan["input_dir"] = scan.pop("input_path")
+        return scan
 
     def _preview(self, request: OrganizeRequest) -> dict[str, Any]:
-        return self._invoke(
+        outer = self._invoke(
             [
                 "preview",
                 str(request.input_path),
@@ -1044,6 +1050,9 @@ class RemoteCLIConformanceDriver(PythonSDKConformanceDriver):
                 *CLIConformanceDriver._option_args(request),
             ]
         )
+        result = dict(outer["result"])
+        result["plan"] = outer["plan"]
+        return result
 
     def _execute(
         self, request: OrganizeRequest, plan_payload: dict[str, Any] | None
@@ -1066,6 +1075,8 @@ class RemoteCLIConformanceDriver(PythonSDKConformanceDriver):
         result = outer.get("result")
         if not isinstance(result, dict):
             raise AssertionError(f"fo api execution omitted its result: {outer}")
+        result = dict(result)
+        result["plan"] = outer["plan"]
         return result
 
 

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -62,6 +62,7 @@ def test_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
         "cli",
         "rest",
         "python-sdk",
+        "fo-api",
         "python-async-sdk",
         "web-form-adapter",
     }


### PR DESCRIPTION
## Summary

Completes `fo api` as a thin remote organization adapter over the official Python SDK.

- adds remote scan, preview, reviewed-plan execution, job inspection/listing, cancellation, rollback, and organization suggestions
- maps the complete canonical `OrganizeOptions` surface through the same option builder used by local CLI organization
- overlays explicit `--plan` flags onto reviewed options without resetting unspecified behavior
- supports bearer-token and API-key authentication and reports remote capabilities as available, SDK-only, or unavailable
- shares the local CLI versioned success/error envelope and exit-code mapping across every `fo api --json` command
- keeps organization response slots stable: queued submissions emit `result: null` plus `job`, while foreground execution emits the operation under `result` plus `job: null`
- normalizes connection, DNS, TLS, and timeout failures as retryable `transport_error` results instead of leaking `httpx` exceptions
- records the new CLI entry points in the capability registry and documents the command surface
- adds a `fo-api` golden-corpus conformance driver that invokes the real Typer adapter through the official SDK and REST stack

Background job lifecycle paths remain conservatively unverified until the required-gate work in #1606.

## Validation

- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run mypy src/file_organizer/cli/api.py src/file_organizer/cli/organize.py`
- `uv run pytest tests/cli tests/conformance tests/core/test_capabilities.py tests/docs/test_cli_docs_accuracy.py --override-ini=addopts= -q` — 1,334 passed
- `uv run pytest tests/cli/test_api.py tests/conformance --override-ini=addopts= -q` — 226 passed
- direct refused-connection invocation through the Typer app — exit 1 with one retryable `transport_error` JSON envelope
- `uv run interrogate src/file_organizer/cli/api.py src/file_organizer/cli/organize.py --fail-under 95` — 100%
- `uv run mkdocs build --strict`
- pre-commit hooks, including smoke, CI guardrails, WebSocket, Web UI, mypy, docs-link, and CI-rails checks
- `git diff --check`

The local `diff-cover` pre-commit hook was skipped because it is known to stall; the broader changed-area suites above were run directly.

## Risk

Moderate. This substantially expands the remote CLI surface, but it delegates behavior to the existing official SDK/service contracts. Capability claims remain conservative, and the conformance driver verifies local-vs-remote option, plan, result, and error behavior. Targeted unit tests cover transport faults, default background submissions, foreground result shape, and reviewed-plan flag overlays that the foreground in-process corpus cannot exercise.

Fixes #1608
Part of #1593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote organization commands for scanning, previewing, organizing, suggestions, and job management.
  * Added capability discovery through the API.
  * Added API key authentication support alongside bearer tokens.
  * Added reviewed-plan workflows, concurrency controls, and recovery actions.

* **Bug Fixes**
  * Standardized JSON responses and error handling across API commands.
  * Clarified stable exit codes and retryable transport failures.
  * Improved handling of authentication, validation, and remote operation errors.

* **Documentation**
  * Expanded CLI reference documentation for API commands, options, responses, and workflows.
  * Added API coverage details to the conformance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->