### PR TITLE
feat(tui): connect workflows through canonical workspace

### DIFF
--- a/src/file_organizer/core/capabilities.py
+++ b/src/file_organizer/core/capabilities.py
@@ -12,6 +12,7 @@ import json
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from importlib.resources import files
 from typing import Any, TypeVar
 
@@ -272,6 +273,7 @@ class CapabilityRegistry:
         )
 
 
+@lru_cache(maxsize=1)
 def get_capability_registry() -> CapabilityRegistry:
     """Load the packaged canonical capability registry."""
     resource = files("file_organizer.core").joinpath("capability_registry.json")

--- a/src/file_organizer/core/capability_registry.json
+++ b/src/file_organizer/core/capability_registry.json
@@ -1736,9 +1736,10 @@
         "tui": {
           "conformance_status": "unverified",
           "entry_points": [
-            "OrganizationPreviewView"
+            "OrganizationPreviewView",
+            "TUIOrganizationAdapter.execute"
           ],
-          "implementation_status": "partial",
+          "implementation_status": "implemented",
           "target_support": "full"
         },
         "typescript-sdk": {
@@ -1896,9 +1897,10 @@
         "tui": {
           "conformance_status": "unverified",
           "entry_points": [
-            "OrganizationPreviewView"
+            "OrganizationPreviewView",
+            "TUIOrganizationAdapter.preview"
           ],
-          "implementation_status": "partial",
+          "implementation_status": "implemented",
           "target_support": "full"
         },
         "typescript-sdk": {
@@ -1969,7 +1971,8 @@
           "conformance_status": "unverified",
           "entry_points": [
             "FileBrowserView",
-            "OrganizationPreviewView"
+            "OrganizationPreviewView",
+            "TUIOrganizationAdapter.scan"
           ],
           "implementation_status": "partial",
           "target_support": "full"

--- a/src/file_organizer/tui/analytics_view.py
+++ b/src/file_organizer/tui/analytics_view.py
@@ -196,7 +196,7 @@ class AnalyticsView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        directory: str | Path | None = ".",
+        directory: str | Path | None = None,
         *,
         workspace: TUIWorkspace | None = None,
         name: str | None = None,

--- a/src/file_organizer/tui/analytics_view.py
+++ b/src/file_organizer/tui/analytics_view.py
@@ -8,6 +8,7 @@ and duplicate statistics in a scrollable panel layout.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from textual import work
 from textual.app import ComposeResult
@@ -16,6 +17,9 @@ from textual.containers import Vertical
 from textual.widgets import Static
 
 from file_organizer.tui.status import StatusMixin
+
+if TYPE_CHECKING:
+    from file_organizer.tui.workspace import TUIWorkspace
 
 
 class StorageOverviewPanel(Static):
@@ -192,19 +196,27 @@ class AnalyticsView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        directory: str | Path = ".",
+        directory: str | Path | None = ".",
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the analytics view for the given directory."""
         super().__init__(name=name, id=id, classes=classes)
-        self._directory = Path(directory)
+        self._workspace = workspace
+        resolved_directory = workspace.active_root if workspace is not None else directory
+        self._directory = Path(resolved_directory) if resolved_directory is not None else None
 
     def compose(self) -> ComposeResult:
         """Build the analytics dashboard layout."""
-        yield Static("[b]Analytics Dashboard[/b]\n", id="analytics-header")
+        selected = len(self._workspace.selected_files) if self._workspace is not None else 0
+        yield Static(
+            "[b]Analytics Dashboard[/b]\n"
+            f"[dim]Active-root analysis; workspace selection retained ({selected} files).[/dim]\n",
+            id="analytics-header",
+        )
         yield StorageOverviewPanel("[dim]Loading...[/dim]")
         yield FileDistributionPanel("[dim]Loading...[/dim]")
         yield QualityScorePanel("[dim]Loading...[/dim]")
@@ -234,6 +246,8 @@ class AnalyticsView(StatusMixin, Vertical):
             )
 
             service = AnalyticsService()
+            if self._directory is None:
+                raise ValueError("Set a source directory in Settings before loading analytics.")
             dashboard = service.generate_dashboard(self._directory)
 
             ss = dashboard.storage_stats

--- a/src/file_organizer/tui/app.py
+++ b/src/file_organizer/tui/app.py
@@ -370,11 +370,7 @@ class FileOrganizerApp(App[None]):
         if name == "files":
             from file_organizer.tui.file_preview import FilePreviewView
 
-            return FilePreviewView(
-                path=None if workspace is not None else ".",
-                workspace=workspace,
-                id="view",
-            )
+            return FilePreviewView(workspace=workspace, id="view")
 
         if name == "organized":
             from file_organizer.tui.organization_preview import (
@@ -386,29 +382,17 @@ class FileOrganizerApp(App[None]):
         if name == "analytics":
             from file_organizer.tui.analytics_view import AnalyticsView
 
-            return AnalyticsView(
-                directory=None if workspace is not None else ".",
-                workspace=workspace,
-                id="view",
-            )
+            return AnalyticsView(workspace=workspace, id="view")
 
         if name == "methodology":
             from file_organizer.tui.methodology_view import MethodologyView
 
-            return MethodologyView(
-                scan_dir=None if workspace is not None else ".",
-                workspace=workspace,
-                id="view",
-            )
+            return MethodologyView(workspace=workspace, id="view")
 
         if name == "audio":
             from file_organizer.tui.audio_view import AudioView
 
-            return AudioView(
-                scan_dir=None if workspace is not None else ".",
-                workspace=workspace,
-                id="view",
-            )
+            return AudioView(workspace=workspace, id="view")
 
         if name == "history":
             from file_organizer.tui.undo_history_view import UndoHistoryView

--- a/src/file_organizer/tui/app.py
+++ b/src/file_organizer/tui/app.py
@@ -18,6 +18,7 @@ from textual.widgets import Footer, Header, Static
 
 from file_organizer.config.manager import ConfigManager
 from file_organizer.config.schema import AppConfig
+from file_organizer.tui.workspace import TUIWorkspace
 
 
 class WizardCompleteMessage(Message):
@@ -205,6 +206,7 @@ class FileOrganizerApp(App[None]):
         super().__init__()
         self._current_view = "files"
         self._config_manager = ConfigManager()
+        self.workspace = TUIWorkspace.from_config(self._config_manager)
         self._setup_needed = self._check_setup_needed()
         self._in_wizard = self._setup_needed
 
@@ -238,7 +240,7 @@ class FileOrganizerApp(App[None]):
                 with Horizontal():
                     yield Sidebar()
                     with Vertical(id="main-content"):
-                        yield self._create_view("files")
+                        yield self._create_view("files", self.workspace)
         yield StatusBar()
         yield Footer()
 
@@ -265,6 +267,7 @@ class FileOrganizerApp(App[None]):
             # unsupported-version profile rather than crash on the save guard (#1276).
             ConfigManager.mark_setup_completed(config)  # pragma: no cover
             self._config_manager.save(config, force=True)
+            self.workspace = TUIWorkspace.from_config(self._config_manager)
 
             # Update internal state
             self._in_wizard = False
@@ -280,7 +283,7 @@ class FileOrganizerApp(App[None]):
                     Horizontal(
                         Sidebar(),
                         Vertical(
-                            self._create_view("files"),
+                            self._create_view("files", self.workspace),
                             id="main-content",
                         ),
                     )
@@ -324,7 +327,7 @@ class FileOrganizerApp(App[None]):
         self._current_view = name
         old = self.query_one("#view")
         await old.remove()
-        new_view = self._create_view(name)
+        new_view = self._create_view(name, self.workspace)
         container = self.query_one("#main-content")
         await container.mount(new_view)
         status = self.query_one(StatusBar)
@@ -349,16 +352,17 @@ class FileOrganizerApp(App[None]):
     def action_toggle_help(self) -> None:
         """Toggle the help overlay."""
         self.query_one(StatusBar).set_status(
-            "Press q to quit, 1-7 to switch views, Tab to navigate"
+            "Press q to quit, 1-8 to switch views, Tab to navigate"
         )
 
     @staticmethod
-    def _create_view(name: str) -> Widget:
+    def _create_view(name: str, workspace: TUIWorkspace | None = None) -> Widget:
         """Create and return the widget for a named view.
 
         Args:
             name: View identifier (files, organized, analytics,
                 methodology, settings).
+            workspace: Optional shared state supplied by the mounted app.
 
         Returns:
             Widget to mount as ``#view`` in the main content area.
@@ -366,44 +370,60 @@ class FileOrganizerApp(App[None]):
         if name == "files":
             from file_organizer.tui.file_preview import FilePreviewView
 
-            return FilePreviewView(id="view")
+            return FilePreviewView(
+                path=None if workspace is not None else ".",
+                workspace=workspace,
+                id="view",
+            )
 
         if name == "organized":
             from file_organizer.tui.organization_preview import (
                 OrganizationPreviewView,
             )
 
-            return OrganizationPreviewView(id="view")
+            return OrganizationPreviewView(workspace=workspace, id="view")
 
         if name == "analytics":
             from file_organizer.tui.analytics_view import AnalyticsView
 
-            return AnalyticsView(id="view")
+            return AnalyticsView(
+                directory=None if workspace is not None else ".",
+                workspace=workspace,
+                id="view",
+            )
 
         if name == "methodology":
             from file_organizer.tui.methodology_view import MethodologyView
 
-            return MethodologyView(id="view")
+            return MethodologyView(
+                scan_dir=None if workspace is not None else ".",
+                workspace=workspace,
+                id="view",
+            )
 
         if name == "audio":
             from file_organizer.tui.audio_view import AudioView
 
-            return AudioView(id="view")
+            return AudioView(
+                scan_dir=None if workspace is not None else ".",
+                workspace=workspace,
+                id="view",
+            )
 
         if name == "history":
             from file_organizer.tui.undo_history_view import UndoHistoryView
 
-            return UndoHistoryView(id="view")
+            return UndoHistoryView(workspace=workspace, id="view")
 
         if name == "copilot":
             from file_organizer.tui.copilot_view import CopilotView
 
-            return CopilotView(id="view")
+            return CopilotView(workspace=workspace, id="view")
 
         if name == "settings":
             from file_organizer.tui.settings_view import SettingsView
 
-            return SettingsView(id="view")
+            return SettingsView(workspace=workspace, id="view")
 
         return PlaceholderView(f"[b]{name.capitalize()}[/b]", id="view")
 

--- a/src/file_organizer/tui/audio_view.py
+++ b/src/file_organizer/tui/audio_view.py
@@ -21,6 +21,7 @@ from file_organizer.tui.status import StatusMixin
 if TYPE_CHECKING:
     from file_organizer.services.audio.classifier import ClassificationResult
     from file_organizer.services.audio.metadata_extractor import AudioMetadata
+    from file_organizer.tui.workspace import TUIWorkspace
 
 # Audio file extensions to scan for
 _AUDIO_EXTENSIONS = frozenset({".mp3", ".wav", ".flac", ".m4a", ".ogg"})
@@ -200,15 +201,18 @@ class AudioView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        scan_dir: str | Path = ".",
+        scan_dir: str | Path | None = ".",
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the audio view to scan the given directory."""
         super().__init__(name=name, id=id, classes=classes)
-        self._scan_dir = Path(scan_dir)
+        self._workspace = workspace
+        resolved_dir = workspace.active_root if workspace is not None else scan_dir
+        self._scan_dir = Path(resolved_dir) if resolved_dir is not None else None
         self._files: list[
             tuple[Path, AudioMetadata | None, ClassificationResult | None]
         ] = []  # (path, metadata, classification)
@@ -216,7 +220,17 @@ class AudioView(StatusMixin, Vertical):
 
     def compose(self) -> ComposeResult:
         """Build the audio view layout."""
-        yield Static("[b]Audio Files[/b]\n", id="audio-header")
+        transcription = (
+            "enabled for organization"
+            if self._workspace is not None and self._workspace.options.transcribe_audio
+            else "disabled by default"
+        )
+        yield Static(
+            "[b]Audio Files[/b]\n"
+            "[dim]This view classifies metadata. Transcription-backed organization is "
+            f"{transcription} and requires the optional Whisper dependency.[/dim]\n",
+            id="audio-header",
+        )
         yield AudioFileListPanel("[dim]Scanning...[/dim]")
         yield AudioMetadataPanel("[dim]Loading...[/dim]")
         yield AudioClassificationPanel("[dim]Loading...[/dim]")
@@ -263,7 +277,21 @@ class AudioView(StatusMixin, Vertical):
             # Collect audio files
             audio_paths: list[Path] = []
             scan_dir = self._scan_dir
-            if scan_dir.is_dir():
+            if scan_dir is None:
+                raise ValueError("Set a source directory in Settings before scanning audio.")
+            has_selection = self._workspace is not None and bool(self._workspace.selected_files)
+            selected_audio = (
+                sorted(
+                    path
+                    for path in self._workspace.selected_files
+                    if path.suffix.lower() in _AUDIO_EXTENSIONS and path.is_file()
+                )
+                if has_selection and self._workspace is not None
+                else []
+            )
+            if has_selection:
+                audio_paths.extend(selected_audio[:_MAX_SCAN_FILES])
+            elif scan_dir.is_dir():
                 for p in sorted(scan_dir.rglob("*")):
                     if p.suffix.lower() in _AUDIO_EXTENSIONS and p.is_file():
                         audio_paths.append(p)

--- a/src/file_organizer/tui/audio_view.py
+++ b/src/file_organizer/tui/audio_view.py
@@ -201,7 +201,7 @@ class AudioView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        scan_dir: str | Path | None = ".",
+        scan_dir: str | Path | None = None,
         *,
         workspace: TUIWorkspace | None = None,
         name: str | None = None,

--- a/src/file_organizer/tui/copilot_view.py
+++ b/src/file_organizer/tui/copilot_view.py
@@ -21,6 +21,7 @@ from file_organizer.tui.status import StatusMixin
 
 if TYPE_CHECKING:
     from file_organizer.services.copilot.engine import CopilotEngine
+    from file_organizer.tui.workspace import TUIWorkspace
 
 
 class CopilotMessageLog(VerticalScroll):
@@ -93,12 +94,14 @@ class CopilotView(StatusMixin, Vertical):
     def __init__(
         self,
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the copilot view with the given Textual widget parameters."""
         super().__init__(name=name, id=id, classes=classes)
+        self._workspace = workspace
         self._engine: CopilotEngine | None = None
 
     def compose(self) -> ComposeResult:
@@ -116,6 +119,11 @@ class CopilotView(StatusMixin, Vertical):
         log.add_system_note(
             "Welcome! Type a request like 'organise ~/Downloads' or 'find report.pdf'."
         )
+        if self._workspace is not None:
+            root = self._workspace.active_root or "unset"
+            log.add_system_note(
+                f"Workspace source: {root}; selected files: {len(self._workspace.selected_files)}."
+            )
         self.query_one(CopilotInput).focus()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
@@ -148,7 +156,8 @@ class CopilotView(StatusMixin, Vertical):
         """
         try:
             engine = self._get_engine()
-            response = engine.chat(text)
+            request = self._contextual_request(text)
+            response = engine.chat(request)
             self.app.call_from_thread(
                 self.query_one(CopilotMessageLog).add_message,
                 MessageRole.ASSISTANT,
@@ -162,6 +171,17 @@ class CopilotView(StatusMixin, Vertical):
 
         # Update status bar
         self.app.call_from_thread(self._set_status, "Copilot: ready")
+
+    def _contextual_request(self, text: str) -> str:
+        """Attach the active root and selection without changing displayed user text."""
+        if self._workspace is None:
+            return text
+        root = (
+            str(self._workspace.active_root) if self._workspace.active_root is not None else "unset"
+        )
+        selected = sorted(str(path) for path in self._workspace.selected_files)
+        selection = ", ".join(selected) if selected else "none"
+        return f"[TUI workspace source={root}; selected={selection}]\n{text}"
 
     def _get_engine(self) -> CopilotEngine:
         """Lazily initialise the copilot engine.

--- a/src/file_organizer/tui/file_browser.py
+++ b/src/file_organizer/tui/file_browser.py
@@ -56,7 +56,7 @@ class FileBrowserTree(DirectoryTree):
 
     def __init__(
         self,
-        path: str | Path = ".",
+        path: str | Path,
         *,
         name: str | None = None,
         id: str | None = None,
@@ -233,7 +233,7 @@ class FileBrowserView(Vertical):
 
     def __init__(
         self,
-        path: str | Path = ".",
+        path: str | Path,
         *,
         name: str | None = None,
         id: str | None = None,

--- a/src/file_organizer/tui/file_preview.py
+++ b/src/file_organizer/tui/file_preview.py
@@ -282,7 +282,7 @@ class FilePreviewView(Horizontal):
 
     def __init__(
         self,
-        path: str | Path | None = ".",
+        path: str | Path | None = None,
         *,
         workspace: TUIWorkspace | None = None,
         name: str | None = None,

--- a/src/file_organizer/tui/file_preview.py
+++ b/src/file_organizer/tui/file_preview.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from textual import on, work
 from textual.app import ComposeResult
@@ -18,6 +19,9 @@ from textual.message import Message
 from textual.widgets import Static
 
 from file_organizer.tui.file_browser import FileBrowserView
+
+if TYPE_CHECKING:
+    from file_organizer.tui.workspace import TUIWorkspace
 
 logger = logging.getLogger(__name__)
 
@@ -278,20 +282,32 @@ class FilePreviewView(Horizontal):
 
     def __init__(
         self,
-        path: str | Path = ".",
+        path: str | Path | None = ".",
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the file preview view rooted at the given path."""
         super().__init__(name=name, id=id, classes=classes)
-        self._root_path = Path(path)
+        self._workspace = workspace
+        resolved_path = workspace.active_root if workspace is not None else path
+        self._root_path = Path(resolved_path) if resolved_path is not None else None
         self.selection = FileSelectionManager()
+        if workspace is not None:
+            self.selection.select_all(workspace.selected_files)
         self._current_path: Path | None = None
 
     def compose(self) -> ComposeResult:
         """Build the split-pane layout."""
+        if self._root_path is None:
+            yield Static(
+                "[yellow]Source directory is unset.[/yellow]\n\n"
+                "Open Settings (7), enter explicit source and output directories, then save.",
+                id="files-source-required",
+            )
+            return
         yield FileBrowserView(self._root_path)
         yield FilePreviewPanel("[dim]Select a file to preview[/dim]")
 
@@ -313,6 +329,8 @@ class FilePreviewView(Horizontal):
 
     def action_select_all(self) -> None:
         """Select all files in the current directory."""
+        if self._root_path is None:
+            return
         try:
             all_files = {p for p in self._root_path.rglob("*") if p.is_file()}
             self.selection.select_all(all_files)
@@ -327,6 +345,8 @@ class FilePreviewView(Horizontal):
 
     def _notify_selection(self) -> None:
         """Post a ``SelectionChanged`` message and update the status bar."""
+        if self._workspace is not None:
+            self._workspace.set_selected_files(self.selection.selected_files)
         self.post_message(self.SelectionChanged(self.selection.count))
         # Try to update the app's status bar if available
         try:

--- a/src/file_organizer/tui/methodology_view.py
+++ b/src/file_organizer/tui/methodology_view.py
@@ -8,6 +8,7 @@ or none) and preview how files would be categorized under the selected scheme.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from textual import work
 from textual.app import ComposeResult
@@ -16,6 +17,9 @@ from textual.containers import Vertical
 from textual.widgets import Static
 
 from file_organizer.tui.status import StatusMixin
+
+if TYPE_CHECKING:
+    from file_organizer.tui.workspace import TUIWorkspace
 
 
 class MethodologySelectorPanel(Static):
@@ -172,16 +176,21 @@ class MethodologyView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        scan_dir: str | Path = ".",
+        scan_dir: str | Path | None = ".",
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the methodology view to scan the given directory."""
         super().__init__(name=name, id=id, classes=classes)
-        self._scan_dir = Path(scan_dir)
-        self._methodology = "none"
+        self._workspace = workspace
+        resolved_dir = workspace.active_root if workspace is not None else scan_dir
+        self._scan_dir = Path(resolved_dir) if resolved_dir is not None else None
+        self._methodology = (
+            workspace.options.effective_methodology.value if workspace is not None else "none"
+        )
 
     def compose(self) -> ComposeResult:
         """Build the methodology view layout."""
@@ -190,24 +199,27 @@ class MethodologyView(StatusMixin, Vertical):
 
     def on_mount(self) -> None:
         """Show initial preview."""
+        self.query_one(MethodologySelectorPanel).set_methodology(self._methodology)
         self._update_preview()
 
     def action_set_para(self) -> None:
         """Switch to PARA methodology."""
-        self._methodology = "para"
-        self.query_one(MethodologySelectorPanel).set_methodology("para")
-        self._update_preview()
+        self._set_methodology("para")
 
     def action_set_jd(self) -> None:
         """Switch to Johnny Decimal methodology."""
-        self._methodology = "jd"
-        self.query_one(MethodologySelectorPanel).set_methodology("jd")
-        self._update_preview()
+        self._set_methodology("jd")
 
     def action_set_none(self) -> None:
         """Switch to no methodology."""
-        self._methodology = "none"
-        self.query_one(MethodologySelectorPanel).set_methodology("none")
+        self._set_methodology("none")
+
+    def _set_methodology(self, methodology: str) -> None:
+        """Update the shared canonical methodology and its preview."""
+        self._methodology = methodology
+        if self._workspace is not None:
+            self._workspace.set_options(methodology=methodology)
+        self.query_one(MethodologySelectorPanel).set_methodology(methodology)
         self._update_preview()
 
     def action_migrate(self) -> None:
@@ -236,7 +248,14 @@ class MethodologyView(StatusMixin, Vertical):
 
             mapper = CategoryFolderMapper()
             scan = self._scan_dir
-            files = [p for p in scan.rglob("*") if p.is_file()][: self._MAX_SAMPLE_FILES]
+            if scan is None:
+                raise ValueError("Set a source directory in Settings before methodology preview.")
+            if self._workspace is not None and self._workspace.selected_files:
+                files = sorted(path for path in self._workspace.selected_files if path.is_file())[
+                    : self._MAX_SAMPLE_FILES
+                ]
+            else:
+                files = [p for p in scan.rglob("*") if p.is_file()][: self._MAX_SAMPLE_FILES]
 
             if not files:
                 self.app.call_from_thread(

--- a/src/file_organizer/tui/methodology_view.py
+++ b/src/file_organizer/tui/methodology_view.py
@@ -176,7 +176,7 @@ class MethodologyView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        scan_dir: str | Path | None = ".",
+        scan_dir: str | Path | None = None,
         *,
         workspace: TUIWorkspace | None = None,
         name: str | None = None,

--- a/src/file_organizer/tui/organization_adapter.py
+++ b/src/file_organizer/tui/organization_adapter.py
@@ -1,0 +1,77 @@
+"""Canonical organization adapter for the Textual workspace."""
+
+from __future__ import annotations
+
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.organization_service import OrganizationScan, OrganizationService
+from file_organizer.core.organize_options import OrganizeRequest
+from file_organizer.core.plan import OrganizationPlan
+from file_organizer.core.types import OrganizationResult
+from file_organizer.tui.workspace import TUIWorkspace
+
+
+class TUIOrganizationAdapter:
+    """Map shared TUI state onto the transport-neutral organization service."""
+
+    def __init__(
+        self,
+        workspace: TUIWorkspace,
+        service: OrganizationService | None = None,
+    ) -> None:
+        """Bind a session workspace to one canonical service instance."""
+        self.workspace = workspace
+        self.service = service or OrganizationService()
+
+    def scan(self) -> OrganizationScan:
+        """Scan the active root using the exact options visible in the TUI."""
+        return self.service.scan(self.request())
+
+    def preview(self) -> OrganizationResult:
+        """Build and retain the canonical executable plan for confirmation."""
+        try:
+            result = self.service.preview(self.request())
+            if not isinstance(result.plan, OrganizationPlan):
+                raise DomainError(
+                    DomainErrorCode.EXECUTION_FAILED,
+                    "Organization preview did not produce an executable plan.",
+                )
+        except Exception as exc:
+            self.workspace.record_error(exc)
+            raise
+        self.workspace.reviewed_plan = result.plan
+        self.workspace.last_error = None
+        return result
+
+    def execute(self, plan: OrganizationPlan | None = None) -> OrganizationResult:
+        """Execute the reviewed plan unchanged through the canonical service."""
+        reviewed_plan = plan or self.workspace.reviewed_plan
+        if reviewed_plan is None:
+            error = DomainError(
+                DomainErrorCode.INVALID_REQUEST,
+                "Refresh and review an organization plan before applying it.",
+            )
+            self.workspace.record_error(error)
+            raise error
+        try:
+            result = self.service.execute(self.request(), reviewed_plan)
+        except Exception as exc:
+            self.workspace.record_error(exc)
+            raise
+        self.workspace.reviewed_plan = reviewed_plan
+        self.workspace.last_result = result
+        self.workspace.last_error = None
+        return result
+
+    def request(self) -> OrganizeRequest:
+        """Resolve the supported TUI scope without silently widening selection."""
+        if self.workspace.selected_files:
+            raise DomainError(
+                DomainErrorCode.OPTIONAL_FEATURE_UNAVAILABLE,
+                "Selected-file-only organization is not supported by the canonical service; "
+                "clear the selection to organize the active root.",
+                details={
+                    "feature": "selected-file-scope",
+                    "selected_files": len(self.workspace.selected_files),
+                },
+            )
+        return self.workspace.request()

--- a/src/file_organizer/tui/organization_preview.py
+++ b/src/file_organizer/tui/organization_preview.py
@@ -147,8 +147,8 @@ class OrganizationPreviewView(StatusMixin, Vertical):
 
     def __init__(
         self,
-        input_dir: str | Path = ".",
-        output_dir: str | Path = "organized_output",
+        input_dir: str | Path | None = None,
+        output_dir: str | Path | None = None,
         *,
         workspace: TUIWorkspace | None = None,
         name: str | None = None,
@@ -158,8 +158,10 @@ class OrganizationPreviewView(StatusMixin, Vertical):
         """Set up the preview view for the given input and output directories."""
         super().__init__(name=name, id=id, classes=classes)
         self._workspace = workspace
-        self._input_dir = workspace.active_root if workspace is not None else Path(input_dir)
-        self._output_dir = workspace.output_root if workspace is not None else Path(output_dir)
+        resolved_input = workspace.active_root if workspace is not None else input_dir
+        resolved_output = workspace.output_root if workspace is not None else output_dir
+        self._input_dir = Path(resolved_input) if resolved_input is not None else None
+        self._output_dir = Path(resolved_output) if resolved_output is not None else None
         self._is_applying = False
         self._current_plan = workspace.reviewed_plan if workspace is not None else None
         self._current_request: OrganizeRequest | None = None

--- a/src/file_organizer/tui/organization_preview.py
+++ b/src/file_organizer/tui/organization_preview.py
@@ -8,6 +8,7 @@ along with an organization summary with file counts and status.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from textual import work
 from textual.app import ComposeResult
@@ -15,9 +16,17 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import Static
 
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.organization_service import OrganizationService
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from file_organizer.core.plan import OrganizationPlan
+from file_organizer.core.types import OrganizationResult
+from file_organizer.tui.organization_adapter import TUIOrganizationAdapter
 from file_organizer.tui.settings_view import load_parallel_runtime_settings
 from file_organizer.tui.status import StatusMixin
+
+if TYPE_CHECKING:
+    from file_organizer.tui.workspace import TUIWorkspace
 
 
 class BeforeAfterPanel(Static):
@@ -141,20 +150,25 @@ class OrganizationPreviewView(StatusMixin, Vertical):
         input_dir: str | Path = ".",
         output_dir: str | Path = "organized_output",
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the preview view for the given input and output directories."""
         super().__init__(name=name, id=id, classes=classes)
-        self._input_dir = Path(input_dir)
-        self._output_dir = Path(output_dir)
+        self._workspace = workspace
+        self._input_dir = workspace.active_root if workspace is not None else Path(input_dir)
+        self._output_dir = workspace.output_root if workspace is not None else Path(output_dir)
         self._is_applying = False
-        self._current_plan: OrganizationPlan | None = None
+        self._current_plan = workspace.reviewed_plan if workspace is not None else None
+        self._current_request: OrganizeRequest | None = None
+        self._adapter = TUIOrganizationAdapter(workspace) if workspace is not None else None
 
     def compose(self) -> ComposeResult:
         """Build the preview layout."""
         yield Static("[b]Organization Preview[/b] (dry-run)\n", id="org-header")
+        yield Static(self._options_summary(), id="org-options")
         yield BeforeAfterPanel("[dim]Loading preview...[/dim]")
         yield OrganizationSummary("[dim]Calculating...[/dim]")
 
@@ -197,24 +211,18 @@ class OrganizationPreviewView(StatusMixin, Vertical):
     def _load_preview(self) -> None:
         """Run a dry-run organization in a worker thread."""
         try:
-            from file_organizer.core.organizer import FileOrganizer
-
-            runtime_settings = load_parallel_runtime_settings()
-            organizer = FileOrganizer(
-                dry_run=True,
-                parallel_workers=runtime_settings.max_workers,
-                prefetch_depth=runtime_settings.prefetch_depth,
-            )
-            result = organizer.organize(
-                input_path=self._input_dir,
-                output_path=self._output_dir,
+            request = self._build_request()
+            result = (
+                self._adapter.preview()
+                if self._adapter is not None
+                else self._create_service().preview(request)
             )
             plan = getattr(result, "plan", None)
             if result.total_files == 0:
                 panel = self.query_one(BeforeAfterPanel)
                 summary = self.query_one(OrganizationSummary)
                 self.app.call_from_thread(self._set_current_plan, None)
-                self.app.call_from_thread(panel.set_structure, {}, str(self._input_dir))
+                self.app.call_from_thread(panel.set_structure, {}, str(request.input_path))
                 self.app.call_from_thread(
                     summary.set_result,
                     total=result.total_files,
@@ -236,10 +244,11 @@ class OrganizationPreviewView(StatusMixin, Vertical):
                 self._set_current_plan,
                 plan,
             )
+            self.app.call_from_thread(self._set_current_request, request)
             self.app.call_from_thread(
                 panel.set_structure,
                 plan.organized_structure(),
-                str(self._input_dir),
+                str(request.input_path),
             )
             self.app.call_from_thread(
                 summary.set_result,
@@ -253,11 +262,12 @@ class OrganizationPreviewView(StatusMixin, Vertical):
             self.app.call_from_thread(self._set_status, "Preview loaded")
 
         except Exception as exc:
+            self._record_error(exc)
             self.app.call_from_thread(self._set_current_plan, None)
             self.app.call_from_thread(
                 self.query_one(BeforeAfterPanel).update,
-                f"[red]Models unavailable:[/red] {exc}\n\n"
-                "[dim]Ensure Ollama is running with required models.[/dim]",
+                f"[red]Preview unavailable:[/red] {exc}\n\n"
+                "[dim]Review the workspace paths, selection scope, options, and model setup.[/dim]",
             )
             self.app.call_from_thread(
                 self.query_one(OrganizationSummary).update,
@@ -268,29 +278,36 @@ class OrganizationPreviewView(StatusMixin, Vertical):
     def _apply_organization(self, plan: OrganizationPlan | None) -> None:
         """Run the reviewed organization for real and navigate to history."""
         try:
-            from file_organizer.core.organizer import FileOrganizer
-
             if plan is None:
                 raise RuntimeError("Refresh preview before applying.")
-            runtime_settings = load_parallel_runtime_settings()
-            organizer = FileOrganizer(
-                dry_run=False,
-                parallel_workers=runtime_settings.max_workers,
-                prefetch_depth=runtime_settings.prefetch_depth,
+            request = self._current_request or self._build_request()
+            result = (
+                self._adapter.execute(plan)
+                if self._adapter is not None
+                else self._create_service().execute(request, plan)
             )
-            result = organizer.execute_plan(plan)
 
             self.app.call_from_thread(self._handle_apply_success, result)
         except Exception as exc:
+            self._record_error(exc)
             self.app.call_from_thread(self._handle_apply_error, exc)
 
     def _set_current_plan(self, plan: OrganizationPlan | None) -> None:
         """Store the last reviewed executable plan."""
         self._current_plan = plan
+        if self._workspace is not None:
+            self._workspace.reviewed_plan = plan
 
-    def _handle_apply_success(self, result: object) -> None:
+    def _set_current_request(self, request: OrganizeRequest) -> None:
+        """Store the exact request represented by the reviewed plan."""
+        self._current_request = request
+
+    def _handle_apply_success(self, result: OrganizationResult) -> None:
         """Update the preview with the applied result and switch to History."""
         self._is_applying = False
+        if self._workspace is not None:
+            self._workspace.last_result = result
+            self._workspace.last_error = None
         panel = self.query_one(BeforeAfterPanel)
         summary = self.query_one(OrganizationSummary)
         organized_structure = getattr(result, "organized_structure", {})
@@ -319,3 +336,65 @@ class OrganizationPreviewView(StatusMixin, Vertical):
         )
         self.query_one(OrganizationSummary).update("[dim]No data available.[/dim]")
         self._set_status("Apply failed")
+
+    def _build_request(self) -> OrganizeRequest:
+        """Build the exact canonical request represented by the visible workspace."""
+        if self._workspace is not None:
+            if self._adapter is None:
+                raise RuntimeError("TUI organization adapter is unavailable.")
+            return self._adapter.request()
+        runtime_settings = load_parallel_runtime_settings()
+        options = OrganizeOptions(
+            parallel_workers=runtime_settings.max_workers,
+            prefetch_depth=runtime_settings.prefetch_depth,
+        )
+        if self._input_dir is None or self._output_dir is None:
+            raise DomainError(
+                DomainErrorCode.INVALID_REQUEST,
+                "Explicit source and output directories are required before preview.",
+            )
+        return OrganizeRequest(self._input_dir, self._output_dir, options)
+
+    @staticmethod
+    def _create_service() -> OrganizationService:
+        """Create the canonical service while preserving the organizer test seam."""
+        from file_organizer.core.organizer import FileOrganizer
+
+        return OrganizationService(organizer_factory=FileOrganizer)
+
+    def _options_summary(self) -> str:
+        """Render effective roots, scope, and every behavior-affecting option."""
+        if self._workspace is not None:
+            source = (
+                str(self._workspace.active_root)
+                if self._workspace.active_root is not None
+                else "[unset]"
+            )
+            output = (
+                str(self._workspace.output_root)
+                if self._workspace.output_root is not None
+                else "[unset]"
+            )
+            selected = len(self._workspace.selected_files)
+            options = self._workspace.options
+        else:
+            source = str(self._input_dir) if self._input_dir is not None else "[unset]"
+            output = str(self._output_dir) if self._output_dir is not None else "[unset]"
+            selected = 0
+            runtime = load_parallel_runtime_settings()
+            options = OrganizeOptions(
+                parallel_workers=runtime.max_workers,
+                prefetch_depth=runtime.prefetch_depth,
+            )
+        fields = options.to_dict()
+        option_text = " · ".join(f"{name}={value}" for name, value in fields.items())
+        return (
+            f"Source: {source}\nOutput: {output}\nSelection: {selected} files\n"
+            f"[dim]{option_text}[/dim]"
+        )
+
+    def _record_error(self, exc: Exception) -> None:
+        """Retain domain failures unchanged in meaning for the History view."""
+        if self._workspace is None:
+            return
+        self._workspace.record_error(exc)

--- a/src/file_organizer/tui/settings_view.py
+++ b/src/file_organizer/tui/settings_view.py
@@ -313,6 +313,7 @@ class SettingsView(StatusMixin, Vertical):
             return
         self._max_workers = current + 1
         self._record_non_sequential_snapshot()
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_workers_down(self) -> None:
@@ -325,6 +326,7 @@ class SettingsView(StatusMixin, Vertical):
             return
         self._max_workers = self._max_workers - 1 if self._max_workers > 1 else None
         self._record_non_sequential_snapshot()
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_prefetch_up(self) -> None:
@@ -334,6 +336,7 @@ class SettingsView(StatusMixin, Vertical):
             return
         self._prefetch_depth += 1
         self._record_non_sequential_snapshot()
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_prefetch_down(self) -> None:
@@ -343,6 +346,7 @@ class SettingsView(StatusMixin, Vertical):
             return
         self._prefetch_depth = max(0, self._prefetch_depth - 1)
         self._record_non_sequential_snapshot()
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_auto_workers(self) -> None:
@@ -352,6 +356,7 @@ class SettingsView(StatusMixin, Vertical):
             return
         self._max_workers = 1 if self._max_workers is None else None
         self._record_non_sequential_snapshot()
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_sequential(self) -> None:
@@ -365,6 +370,7 @@ class SettingsView(StatusMixin, Vertical):
             self._max_workers = 1
             self._prefetch_depth = 0
             self._set_status("Sequential mode enabled.")
+        self._sync_workspace_options()
         self._refresh_panel()
 
     # ------------------------------------------------------------------
@@ -377,6 +383,7 @@ class SettingsView(StatusMixin, Vertical):
         index = _METHODOLOGY_ORDER.index(current)
         self._methodology = _METHODOLOGY_ORDER[(index + 1) % len(_METHODOLOGY_ORDER)]
         self._set_status(f"Methodology: {_METHODOLOGY_LABELS[self._methodology]}")
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_cycle_text_model(self) -> None:
@@ -388,6 +395,7 @@ class SettingsView(StatusMixin, Vertical):
             index = -1
         self._text_model = options[(index + 1) % len(options)]
         self._set_status(f"Text model: {self._text_model}")
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_update_check(self) -> None:
@@ -407,31 +415,37 @@ class SettingsView(StatusMixin, Vertical):
     def action_toggle_recursive(self) -> None:
         """Toggle recursive traversal for this TUI session."""
         self._recursive = not self._recursive
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_hidden(self) -> None:
         """Toggle hidden-file inclusion for this TUI session."""
         self._include_hidden = not self._include_hidden
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_transfer(self) -> None:
         """Toggle between canonical hardlink and copy transfer modes."""
         self._transfer_mode = "copy" if self._transfer_mode == "hardlink" else "hardlink"
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_skip_existing(self) -> None:
         """Toggle collision behavior between skip and counter rename."""
         self._skip_existing = not self._skip_existing
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_vision(self) -> None:
         """Toggle vision-backed analysis for this TUI session."""
         self._enable_vision = not self._enable_vision
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def action_toggle_transcription(self) -> None:
         """Toggle optional transcription-backed audio analysis."""
         self._transcribe_audio = not self._transcribe_audio
+        self._sync_workspace_options()
         self._refresh_panel()
 
     def on_input_changed(self, event: Input.Changed) -> None:
@@ -449,10 +463,12 @@ class SettingsView(StatusMixin, Vertical):
         """Reload persisted settings from configuration."""
         self._reload_parallel_settings()
         self._reload_workflow_settings()
+        self._sync_workspace()
         self._refresh_panel()
 
     def action_save_settings(self) -> None:
         """Persist current settings to configuration."""
+        self._sync_workspace()
         try:
             save_parallel_runtime_settings(
                 ParallelRuntimeSettings(
@@ -466,9 +482,13 @@ class SettingsView(StatusMixin, Vertical):
                 profile=self._profile,
             )
         except Exception as exc:
-            self._set_status(f"Failed to save settings: {exc}")
+            message = (
+                f"Session updated; failed to save settings: {exc}"
+                if self._workspace is not None
+                else f"Failed to save settings: {exc}"
+            )
+            self._set_status(message)
         else:
-            self._sync_workspace()
             self._set_status("Settings saved.")
         self._refresh_panel()
 
@@ -520,6 +540,12 @@ class SettingsView(StatusMixin, Vertical):
         if self._workspace is None:
             return
         self._workspace.set_roots(self._input_dir, self._output_dir)
+        self._sync_workspace_options()
+
+    def _sync_workspace_options(self) -> None:
+        """Apply behavior controls immediately without persisting path edits."""
+        if self._workspace is None:
+            return
         self._workspace.set_options(
             recursive=self._recursive,
             include_hidden=self._include_hidden,

--- a/src/file_organizer/tui/settings_view.py
+++ b/src/file_organizer/tui/settings_view.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -34,6 +34,9 @@ from file_organizer.config.methodology import LABELS as _METHODOLOGY_LABELS
 from file_organizer.config.methodology import ORDER as _METHODOLOGY_ORDER
 from file_organizer.config.methodology import normalize as _normalize_methodology
 from file_organizer.tui.status import StatusMixin
+
+if TYPE_CHECKING:
+    from file_organizer.tui.workspace import TUIWorkspace
 
 _DEFAULT_PREFETCH_DEPTH = 2
 _MAX_WORKERS_CAP = max(1, os.cpu_count() or 1)
@@ -228,6 +231,12 @@ class SettingsView(StatusMixin, Vertical):
         Binding("t", "cycle_text_model", "Model", show=True),
         Binding("u", "toggle_update_check", "Updates", show=True),
         Binding("p", "toggle_prereleases", "Pre-releases", show=True),
+        Binding("c", "toggle_recursive", "Recursive", show=False),
+        Binding("h", "toggle_hidden", "Hidden", show=False),
+        Binding("x", "toggle_transfer", "Transfer", show=False),
+        Binding("k", "toggle_skip_existing", "Collisions", show=False),
+        Binding("v", "toggle_vision", "Vision", show=False),
+        Binding("d", "toggle_transcription", "Transcription", show=False),
         Binding("enter", "save_settings", "Save", show=True),
         Binding("r", "reload_settings", "Reload", show=True),
     ]
@@ -236,6 +245,7 @@ class SettingsView(StatusMixin, Vertical):
         self,
         *,
         profile: str = "default",
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
@@ -243,6 +253,7 @@ class SettingsView(StatusMixin, Vertical):
         """Create the settings view with profile-backed persisted state."""
         super().__init__(name=name, id=id, classes=classes)
         self._profile = profile
+        self._workspace = workspace
         # Parallelism controls
         self._max_workers: int | None = None
         self._prefetch_depth: int = _DEFAULT_PREFETCH_DEPTH
@@ -255,6 +266,22 @@ class SettingsView(StatusMixin, Vertical):
         self._text_model: str = DEFAULT_TEXT_MODEL
         self._check_updates: bool = True
         self._include_prereleases: bool = False
+        options = workspace.options if workspace is not None else None
+        self._recursive = options.recursive if options is not None else True
+        self._include_hidden = options.include_hidden if options is not None else False
+        self._skip_existing = options.skip_existing if options is not None else True
+        self._transfer_mode = (
+            options.effective_transfer_mode.value if options is not None else "hardlink"
+        )
+        self._enable_vision = options.enable_vision if options is not None else True
+        self._transcribe_audio = options.transcribe_audio if options is not None else False
+        if workspace is not None:
+            self._input_dir = str(workspace.active_root or "")
+            self._output_dir = str(workspace.output_root or "")
+            self._methodology = workspace.options.effective_methodology.value
+            self._text_model = workspace.options.text_model or DEFAULT_TEXT_MODEL
+            self._max_workers = workspace.options.parallel_workers
+            self._prefetch_depth = workspace.options.prefetch_depth
 
     def compose(self) -> ComposeResult:
         """Render settings panel content."""
@@ -264,7 +291,11 @@ class SettingsView(StatusMixin, Vertical):
 
     def on_mount(self) -> None:
         """Load persisted settings when mounted."""
-        self.action_reload_settings()
+        if self._workspace is None:
+            self.action_reload_settings()
+        else:
+            self._sync_dir_inputs()
+            self._refresh_panel()
 
     # ------------------------------------------------------------------
     # Parallelism actions
@@ -373,6 +404,36 @@ class SettingsView(StatusMixin, Vertical):
         self._set_status(f"Include pre-releases: {state}")
         self._refresh_panel()
 
+    def action_toggle_recursive(self) -> None:
+        """Toggle recursive traversal for this TUI session."""
+        self._recursive = not self._recursive
+        self._refresh_panel()
+
+    def action_toggle_hidden(self) -> None:
+        """Toggle hidden-file inclusion for this TUI session."""
+        self._include_hidden = not self._include_hidden
+        self._refresh_panel()
+
+    def action_toggle_transfer(self) -> None:
+        """Toggle between canonical hardlink and copy transfer modes."""
+        self._transfer_mode = "copy" if self._transfer_mode == "hardlink" else "hardlink"
+        self._refresh_panel()
+
+    def action_toggle_skip_existing(self) -> None:
+        """Toggle collision behavior between skip and counter rename."""
+        self._skip_existing = not self._skip_existing
+        self._refresh_panel()
+
+    def action_toggle_vision(self) -> None:
+        """Toggle vision-backed analysis for this TUI session."""
+        self._enable_vision = not self._enable_vision
+        self._refresh_panel()
+
+    def action_toggle_transcription(self) -> None:
+        """Toggle optional transcription-backed audio analysis."""
+        self._transcribe_audio = not self._transcribe_audio
+        self._refresh_panel()
+
     def on_input_changed(self, event: Input.Changed) -> None:
         """Track directory inputs as the user edits them."""
         if event.input.id == "settings-input-dir":
@@ -407,6 +468,7 @@ class SettingsView(StatusMixin, Vertical):
         except Exception as exc:
             self._set_status(f"Failed to save settings: {exc}")
         else:
+            self._sync_workspace()
             self._set_status("Settings saved.")
         self._refresh_panel()
 
@@ -453,6 +515,24 @@ class SettingsView(StatusMixin, Vertical):
             include_prereleases=self._include_prereleases,
         )
 
+    def _sync_workspace(self) -> None:
+        """Apply the displayed settings to the shared canonical session state."""
+        if self._workspace is None:
+            return
+        self._workspace.set_roots(self._input_dir, self._output_dir)
+        self._workspace.set_options(
+            recursive=self._recursive,
+            include_hidden=self._include_hidden,
+            skip_existing=self._skip_existing,
+            transfer_mode=self._transfer_mode,
+            methodology=self._methodology,
+            enable_vision=self._enable_vision,
+            transcribe_audio=self._transcribe_audio,
+            parallel_workers=self._max_workers,
+            prefetch_depth=self._prefetch_depth,
+            text_model=self._text_model,
+        )
+
     def _text_model_options(self) -> list[str]:
         """Return cycle options, prepending any persisted custom model."""
         if self._text_model in _TEXT_MODEL_PRESETS:
@@ -491,6 +571,11 @@ class SettingsView(StatusMixin, Vertical):
         output_text = self._output_dir or "[dim](unset)[/dim]"
         update_text = "on" if self._check_updates else "off"
         prerelease_text = "on" if self._include_prereleases else "off"
+        recursive_text = "on" if self._recursive else "off"
+        hidden_text = "include" if self._include_hidden else "exclude"
+        collision_text = "skip existing" if self._skip_existing else "rename with counter"
+        vision_text = "on" if self._enable_vision else "off"
+        transcription_text = "on" if self._transcribe_audio else "off"
         return (
             "[b]Settings[/b]\n\n"
             "[b]Workflow[/b]\n"
@@ -498,6 +583,12 @@ class SettingsView(StatusMixin, Vertical):
             f"  output dir    : {output_text}\n"
             f"  methodology   : {_METHODOLOGY_LABELS[self._methodology]}\n"
             f"  text model    : {self._text_model}\n"
+            f"  recursive     : {recursive_text}\n"
+            f"  hidden files  : {hidden_text}\n"
+            f"  transfer mode : {self._transfer_mode}\n"
+            f"  collisions    : {collision_text}\n"
+            f"  vision        : {vision_text}\n"
+            f"  transcription : {transcription_text}\n"
             f"  update check  : {update_text}\n"
             f"  pre-releases  : {prerelease_text}\n\n"
             "[b]Persistent Runtime Controls[/b]\n"
@@ -506,5 +597,7 @@ class SettingsView(StatusMixin, Vertical):
             f"  sequential    : {sequential_text}\n\n"
             "[dim]Arrows: workers/prefetch · s: sequential · a: auto workers[/dim]\n"
             "[dim]m: methodology · t: model · u: update check · p: pre-releases[/dim]\n"
+            "[dim]c: recursive · h: hidden · x: transfer · k: collisions · "
+            "v: vision · d: transcription[/dim]\n"
             "[dim]Type in the fields below to set directories · Enter: save · r: reload[/dim]"
         )

--- a/src/file_organizer/tui/undo_history_view.py
+++ b/src/file_organizer/tui/undo_history_view.py
@@ -20,6 +20,37 @@ from file_organizer.tui.status import StatusMixin
 
 if TYPE_CHECKING:
     from file_organizer.history.models import Operation
+    from file_organizer.tui.workspace import TUIWorkspace
+
+
+class CanonicalLifecyclePanel(Static):
+    """Show the shared job/result/error state and intentional support limits."""
+
+    def set_workspace(self, workspace: TUIWorkspace | None) -> None:
+        """Render canonical lifecycle state for the current TUI session."""
+        if workspace is None:
+            self.update("[b]Canonical Lifecycle[/b]\n\n  [dim]No shared session attached.[/dim]")
+            return
+        job = workspace.active_job
+        job_text = f"{job.job_id} ({job.status.value})" if job is not None else "none"
+        result = workspace.last_result
+        result_text = (
+            f"{result.processed_files} processed / {result.failed_files} failed"
+            if result is not None
+            else "none"
+        )
+        error_text = workspace.last_error.message if workspace.last_error is not None else "none"
+        support = workspace.capability_status("organization.jobs-recovery")
+        self.update(
+            "[b]Canonical Lifecycle[/b]\n\n"
+            f"  active job: {job_text}\n"
+            f"  last result: {result_text}\n"
+            f"  last error: {error_text}\n"
+            f"  registry: {support}\n\n"
+            "[dim]Local TUI execution is synchronous: in-flight cancellation is unsupported. "
+            "Undo/redo provide operation-history recovery; press b to roll back the latest "
+            "undoable operation.[/dim]"
+        )
 
 
 class OperationHistoryPanel(Static):
@@ -195,21 +226,28 @@ class UndoHistoryView(StatusMixin, Vertical):
         Binding("r", "refresh_history", "Refresh", show=True),
         Binding("u", "undo_last", "Undo", show=True),
         Binding("y", "redo_last", "Redo", show=True),
+        Binding("b", "rollback_last", "Rollback", show=True),
+        Binding("c", "cancel_active", "Cancel Job", show=True),
     ]
 
     def __init__(
         self,
         *,
+        workspace: TUIWorkspace | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         """Set up the undo history view with the given Textual widget parameters."""
         super().__init__(name=name, id=id, classes=classes)
+        self._workspace = workspace
 
     def compose(self) -> ComposeResult:
         """Build the undo/history layout."""
         yield Static("[b]Undo / Redo & Operation History[/b]\n", id="history-header")
+        lifecycle = CanonicalLifecyclePanel()
+        lifecycle.set_workspace(self._workspace)
+        yield lifecycle
         yield OperationHistoryPanel("[dim]Loading...[/dim]")
         yield UndoRedoStackPanel("[dim]Loading...[/dim]")
         yield HistoryStatsPanel("[dim]Loading...[/dim]")
@@ -231,6 +269,15 @@ class UndoHistoryView(StatusMixin, Vertical):
     def action_redo_last(self) -> None:
         """Redo the most recently undone operation."""
         self._run_redo()
+
+    def action_rollback_last(self) -> None:
+        """Roll back the latest undoable operation through the history manager."""
+        self._set_status("Rolling back latest undoable operation...")
+        self._run_undo()
+
+    def action_cancel_active(self) -> None:
+        """Explain the intentional cancellation limit for synchronous TUI runs."""
+        self._set_status("No asynchronous TUI job to cancel; local execution is synchronous.")
 
     @work(thread=True)
     def _load_history(self) -> None:

--- a/src/file_organizer/tui/workspace.py
+++ b/src/file_organizer/tui/workspace.py
@@ -38,8 +38,10 @@ class TUIWorkspace:
         resolved_manager = manager or ConfigManager()
         try:
             config = resolved_manager.load()
-        except Exception:
-            return cls()
+        except Exception as exc:
+            workspace = cls()
+            workspace.record_error(exc)
+            return workspace
 
         parallel = config.parallel or {}
         workers = parallel.get("max_workers")
@@ -77,9 +79,15 @@ class TUIWorkspace:
         """Set explicit workflow roots and invalidate any reviewed plan."""
         source = str(input_path).strip()
         destination = str(output_path).strip()
-        self.active_root = Path(source).expanduser() if source else None
-        self.output_root = Path(destination).expanduser() if destination else None
+        active_root = Path(source).expanduser() if source else None
+        output_root = Path(destination).expanduser() if destination else None
+        roots_changed = (active_root, output_root) != (self.active_root, self.output_root)
+        self.active_root = active_root
+        self.output_root = output_root
         self.reviewed_plan = None
+        if roots_changed:
+            self.active_job = None
+            self.last_result = None
         self.last_error = None
         if self.active_root is not None:
             self.selected_files = {

--- a/src/file_organizer/tui/workspace.py
+++ b/src/file_organizer/tui/workspace.py
@@ -1,0 +1,138 @@
+"""Shared state for the connected Textual workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from file_organizer.config.manager import ConfigManager
+from file_organizer.core.capabilities import Surface, get_capability_registry
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.lifecycle import JobSnapshot
+from file_organizer.core.organize_options import ModelProvider, OrganizeOptions, OrganizeRequest
+from file_organizer.core.plan import OrganizationPlan
+from file_organizer.core.types import OrganizationResult
+
+
+@dataclass(slots=True)
+class TUIWorkspace:
+    """Session state shared by all eight TUI views.
+
+    Empty roots are represented by ``None`` so no workflow silently falls back
+    to the process working directory.
+    """
+
+    active_root: Path | None = None
+    output_root: Path | None = None
+    selected_files: set[Path] = field(default_factory=set)
+    options: OrganizeOptions = field(default_factory=OrganizeOptions)
+    reviewed_plan: OrganizationPlan | None = None
+    active_job: JobSnapshot | None = None
+    last_result: OrganizationResult | None = None
+    last_error: DomainError | None = None
+
+    @classmethod
+    def from_config(cls, manager: ConfigManager | None = None) -> TUIWorkspace:
+        """Build initial session state from explicit persisted defaults."""
+        resolved_manager = manager or ConfigManager()
+        try:
+            config = resolved_manager.load()
+        except Exception:
+            return cls()
+
+        parallel = config.parallel or {}
+        workers = parallel.get("max_workers")
+        prefetch_depth = parallel.get("prefetch_depth", 2)
+        provider = config.models.framework
+        supported_providers = {"ollama", "openai", "llama_cpp", "mlx", "claude"}
+        model_provider = cast(ModelProvider, provider) if provider in supported_providers else None
+        try:
+            options = OrganizeOptions(
+                methodology=config.default_methodology,
+                parallel_workers=workers,
+                prefetch_depth=prefetch_depth,
+                text_model=config.models.text_model,
+                vision_model=config.models.vision_model,
+                text_provider=model_provider,
+                vision_provider=model_provider,
+            )
+        except (TypeError, ValueError):
+            options = OrganizeOptions()
+        input_dir = config.default_input_dir
+        output_dir = config.default_output_dir
+        return cls(
+            active_root=(
+                Path(input_dir) if isinstance(input_dir, (str, Path)) and str(input_dir) else None
+            ),
+            output_root=(
+                Path(output_dir)
+                if isinstance(output_dir, (str, Path)) and str(output_dir)
+                else None
+            ),
+            options=options,
+        )
+
+    def set_roots(self, input_path: str | Path, output_path: str | Path) -> None:
+        """Set explicit workflow roots and invalidate any reviewed plan."""
+        source = str(input_path).strip()
+        destination = str(output_path).strip()
+        self.active_root = Path(source).expanduser() if source else None
+        self.output_root = Path(destination).expanduser() if destination else None
+        self.reviewed_plan = None
+        self.last_error = None
+        if self.active_root is not None:
+            self.selected_files = {
+                path for path in self.selected_files if path.is_relative_to(self.active_root)
+            }
+        else:
+            self.selected_files.clear()
+
+    def set_options(self, **changes: Any) -> None:
+        """Update canonical session options and invalidate the reviewed plan."""
+        payload = self.options.to_dict()
+        payload.update(changes)
+        self.options = OrganizeOptions.from_dict(payload)
+        self.reviewed_plan = None
+        self.last_error = None
+
+    def set_selected_files(self, paths: set[Path]) -> None:
+        """Persist the selected-file context across view switches."""
+        self.selected_files = {Path(path) for path in paths}
+        self.reviewed_plan = None
+
+    def request(self) -> OrganizeRequest:
+        """Return the canonical request or an actionable missing-root error."""
+        missing = []
+        if self.active_root is None:
+            missing.append("source")
+        if self.output_root is None:
+            missing.append("output")
+        if missing:
+            raise DomainError(
+                DomainErrorCode.INVALID_REQUEST,
+                f"Set explicit {' and '.join(missing)} directories in Settings before preview.",
+                details={"missing": missing, "action": "Open Settings (7)"},
+            )
+        return OrganizeRequest(
+            cast(Path, self.active_root),
+            cast(Path, self.output_root),
+            self.options,
+        )
+
+    def capability_status(self, capability_id: str) -> str:
+        """Return the registry-backed TUI support label for a capability."""
+        capability = get_capability_registry().get(capability_id)
+        support = capability.support_for(Surface.TUI)
+        return f"{support.implementation_status.value}/{support.conformance_status.value}"
+
+    def record_error(self, exc: Exception) -> None:
+        """Retain a domain failure without changing its meaning."""
+        if isinstance(exc, DomainError):
+            self.last_error = exc
+        else:
+            self.last_error = DomainError(
+                DomainErrorCode.EXECUTION_FAILED,
+                str(exc) or type(exc).__name__,
+                details={"error_type": type(exc).__name__},
+            )

--- a/src/file_organizer/tui/workspace.py
+++ b/src/file_organizer/tui/workspace.py
@@ -106,7 +106,7 @@ class TUIWorkspace:
 
     def set_selected_files(self, paths: set[Path]) -> None:
         """Persist the selected-file context across view switches."""
-        self.selected_files = {Path(path) for path in paths}
+        self.selected_files = {Path(path).expanduser() for path in paths}
         self.reviewed_plan = None
 
     def request(self) -> OrganizeRequest:

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -17,6 +17,7 @@ from tests.conformance.driver import (
     PythonSDKConformanceDriver,
     RemoteCLIConformanceDriver,
     RESTConformanceDriver,
+    TUIConformanceDriver,
     WebFormConformanceDriver,
 )
 
@@ -53,6 +54,7 @@ class ConformanceContext:
         RemoteCLIConformanceDriver,
         AsyncPythonSDKConformanceDriver,
         WebFormConformanceDriver,
+        TUIConformanceDriver,
     ),
     ids=(
         "direct",
@@ -62,6 +64,7 @@ class ConformanceContext:
         "fo-api",
         "python-async-sdk",
         "web-form-adapter",
+        "tui-workspace-adapter",
     ),
 )
 def conformance(tmp_path: Path, request: pytest.FixtureRequest) -> ConformanceContext:

--- a/tests/conformance/driver.py
+++ b/tests/conformance/driver.py
@@ -77,6 +77,8 @@ from file_organizer.services.video.metadata_extractor import (
     VideoMetadata,
     VideoMetadataExtractor,
 )
+from file_organizer.tui.organization_adapter import TUIOrganizationAdapter
+from file_organizer.tui.workspace import TUIWorkspace
 from file_organizer.undo import UndoManager
 from file_organizer.utils.atomic_write import atomic_write_text
 from file_organizer.web.organize_routes import (
@@ -314,6 +316,80 @@ class DirectServiceDriver:
             "plan": normalize_plan(result.plan, *roots),
             "result": normalize_result(result, *roots),
             "audit_events": events,
+        }
+
+
+class TUIConformanceDriver:
+    """Drive the production TUI state adapter against the golden corpus."""
+
+    name = "tui-workspace-adapter"
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace_root = workspace
+        self._workspace_root.mkdir(parents=True, exist_ok=True)
+        self._oracle = DirectServiceDriver(workspace / "service")
+        self._state = TUIWorkspace()
+        self._adapter = TUIOrganizationAdapter(self._state, self._oracle._service)
+
+    def _map(self, request: OrganizeRequest) -> None:
+        """Round-trip every canonical option through shared TUI session state."""
+        self._state.set_roots(request.input_path, request.output_path)
+        self._state.set_options(**request.options.to_dict())
+        self._state.set_selected_files(set())
+
+    def scan(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Return the canonical scan reached from TUI workspace state."""
+        self._map(request)
+        roots = (request.input_path, request.output_path)
+        try:
+            scan = self._adapter.scan()
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        return {"outcome": "ok", "scan": normalize_scan(scan, *roots)}
+
+    def preview(self, request: OrganizeRequest) -> dict[str, Any]:
+        """Preview and retain the exact plan represented by TUI state."""
+        self._map(request)
+        roots = (request.input_path, request.output_path)
+        try:
+            result = self._adapter.preview()
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        plan = self._state.reviewed_plan
+        if plan is None:
+            raise AssertionError("TUI preview must retain an executable plan.")
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(plan, *roots),
+            "result": normalize_result(result, *roots),
+            "plan_payload": plan.to_dict(),
+        }
+
+    def execute(
+        self, request: OrganizeRequest, plan_payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Apply the reviewed serialized plan through the TUI adapter."""
+        self._map(request)
+        roots = (request.input_path, request.output_path)
+        try:
+            plan = OrganizationPlan.from_dict(plan_payload) if plan_payload is not None else None
+            if plan is None:
+                self._adapter.preview()
+                plan = self._state.reviewed_plan
+            result = self._adapter.execute(plan)
+        except (DomainError, ValueError, RuntimeError, OSError) as exc:
+            return {"outcome": "error", "error": normalize_error(exc, *roots)}
+        if not isinstance(result.plan, OrganizationPlan):
+            raise AssertionError("TUI execution must retain its executable plan.")
+        history = self._oracle._last_history
+        assert history is not None
+        operations = history.get_operations()
+        operations.sort(key=lambda operation: operation.id if operation.id is not None else -1)
+        return {
+            "outcome": "ok",
+            "plan": normalize_plan(result.plan, *roots),
+            "result": normalize_result(result, *roots),
+            "audit_events": normalize_audit_events(operations, *roots),
         }
 
 

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -65,6 +65,7 @@ def test_driver_satisfies_protocol(conformance: ConformanceContext) -> None:
         "fo-api",
         "python-async-sdk",
         "web-form-adapter",
+        "tui-workspace-adapter",
     }
 
 

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -39,6 +39,11 @@ def test_packaged_registry_is_complete_and_queryable() -> None:
         assert {status.surface for status in capability.surfaces} == set(Surface)
 
 
+def test_packaged_registry_loader_is_cached() -> None:
+    """Runtime consumers reuse the immutable parsed registry."""
+    assert get_capability_registry() is get_capability_registry()
+
+
 def test_organization_conformance_matches_exercised_corpus_scope() -> None:
     registry = get_capability_registry()
 

--- a/tests/integration/test_tui_app_pilot_integration.py
+++ b/tests/integration/test_tui_app_pilot_integration.py
@@ -12,6 +12,8 @@ main layout composes instead of the wizard) and the background update thread
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from file_organizer.tui.analytics_view import AnalyticsView
@@ -25,11 +27,13 @@ pytestmark = [pytest.mark.integration, pytest.mark.ci]
 
 
 @pytest.fixture
-def app(monkeypatch: pytest.MonkeyPatch) -> FileOrganizerApp:
+def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> FileOrganizerApp:
     """A FileOrganizerApp with the wizard skipped and update thread stubbed."""
     monkeypatch.setattr(FileOrganizerApp, "_check_setup_needed", lambda self: False)
     monkeypatch.setattr(FileOrganizerApp, "_check_for_updates", lambda self: None)
-    return FileOrganizerApp()
+    instance = FileOrganizerApp()
+    instance.workspace.set_roots(tmp_path, tmp_path / "organized")
+    return instance
 
 
 async def test_app_boots_into_files_view(app: FileOrganizerApp) -> None:
@@ -43,24 +47,31 @@ async def test_app_boots_into_files_view(app: FileOrganizerApp) -> None:
         assert app._in_wizard is False
 
 
-async def test_view_switching_transitions_between_views(app: FileOrganizerApp) -> None:
-    """Number keys switch the main-content view to the corresponding widget.
+async def test_view_switching_transitions_between_views(
+    app: FileOrganizerApp,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Switch actions mount the corresponding real view widgets.
 
     The ``organized`` view is intentionally excluded: mounting it kicks off a
     real organization preview (network-dependent) and overwrites the status
-    bar, which would make this transition-focused test slow and flaky.
+    bar. Key-to-action mappings are covered by the app binding tests; calling
+    the actions here isolates view mounting from Textual's global key-pump wait.
     """
     transitions = [
-        ("3", "analytics", AnalyticsView),
-        ("4", "methodology", MethodologyView),
-        ("6", "history", UndoHistoryView),
-        ("7", "settings", SettingsView),
-        ("1", "files", FilePreviewView),
+        ("analytics", AnalyticsView),
+        ("methodology", MethodologyView),
+        ("history", UndoHistoryView),
+        ("settings", SettingsView),
+        ("files", FilePreviewView),
     ]
+    monkeypatch.setattr(AnalyticsView, "_load_analytics", lambda self: None)
+    monkeypatch.setattr(MethodologyView, "_update_preview", lambda self: None)
+    monkeypatch.setattr(UndoHistoryView, "_load_history", lambda self: None)
     async with app.run_test() as pilot:
         await pilot.pause()
-        for key, expected_name, expected_type in transitions:
-            await pilot.press(key)
+        for expected_name, expected_type in transitions:
+            await app.action_switch_view(expected_name)
             await pilot.pause()
             # The transition itself: the named view widget is now mounted.
             assert app._current_view == expected_name

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -20,6 +20,13 @@ def tui_completed_setup(
 
     mock_config = MagicMock()
     mock_config.setup_completed = True
+    mock_config.default_input_dir = str(tmp_path)
+    mock_config.default_output_dir = str(tmp_path / "organized")
+    mock_config.default_methodology = "none"
+    mock_config.parallel = {}
+    mock_config.models.framework = "ollama"
+    mock_config.models.text_model = None
+    mock_config.models.vision_model = None
     mock_config_manager = MagicMock()
     mock_config_manager.load.return_value = mock_config
 

--- a/tests/tui/test_analytics_view.py
+++ b/tests/tui/test_analytics_view.py
@@ -354,10 +354,10 @@ class TestAnalyticsView:
         assert "r" in keys
 
     @pytest.mark.keep_default_paths
-    def test_initialization_with_default_directory(self) -> None:
-        """Test AnalyticsView initialization with default directory."""
+    def test_initialization_without_directory_is_unset(self) -> None:
+        """An unattached analytics view has no implicit directory."""
         view = AnalyticsView()
-        assert view._directory == Path(".")
+        assert view._directory is None
 
     def test_initialization_with_custom_directory(self) -> None:
         """Test AnalyticsView initialization with custom directory."""

--- a/tests/tui/test_analytics_view_coverage.py
+++ b/tests/tui/test_analytics_view_coverage.py
@@ -6,6 +6,7 @@ action_refresh_analytics, and _set_status.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
@@ -50,7 +51,7 @@ class TestAnalyticsViewLoadAnalytics:
     """Test _load_analytics worker thread paths."""
 
     def test_load_analytics_success(self) -> None:
-        view = AnalyticsView()
+        view = AnalyticsView(directory=Path("."))
         storage_panel = MagicMock()
         distribution_panel = MagicMock()
         quality_panel = MagicMock()
@@ -131,7 +132,7 @@ class TestAnalyticsViewLoadAnalytics:
         )
 
     def test_load_analytics_exception(self) -> None:
-        view = AnalyticsView()
+        view = AnalyticsView(directory=Path("."))
         storage_panel = MagicMock()
         distribution_panel = MagicMock()
         quality_panel = MagicMock()

--- a/tests/tui/test_audio_view.py
+++ b/tests/tui/test_audio_view.py
@@ -261,9 +261,9 @@ class TestAudioViewInit:
     """Test AudioView initialization."""
 
     @pytest.mark.keep_default_paths
-    def test_default_scan_dir(self):
+    def test_default_scan_dir_is_unset(self):
         view = AudioView()
-        assert view._scan_dir == Path(".")
+        assert view._scan_dir is None
         assert view._files == []
         assert view._current_index == 0
 

--- a/tests/tui/test_file_browser_coverage.py
+++ b/tests/tui/test_file_browser_coverage.py
@@ -76,31 +76,31 @@ class TestFileBrowserTree:
     """Test FileBrowserTree filtering and actions."""
 
     def test_init_default_path(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         assert tree._extension_filter == set()
 
     def test_set_extension_filter_normalizes(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         tree.set_extension_filter({"py", ".txt", "json"})
         assert ".py" in tree._extension_filter
         assert ".txt" in tree._extension_filter
         assert ".json" in tree._extension_filter
 
     def test_set_extension_filter_empty_clears(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         tree.set_extension_filter({".py"})
         assert len(tree._extension_filter) == 1
         tree.set_extension_filter(set())
         assert tree._extension_filter == set()
 
     def test_filter_paths_no_filter_returns_all(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         paths = [Path("a.py"), Path("b.txt"), Path("c.jpg")]
         result = list(tree.filter_paths(paths))
         assert len(result) == 3
 
     def test_filter_paths_with_filter(self, tmp_path: Path) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         tree._extension_filter = {".py"}
         # Create actual files/dirs so is_dir() works
         py_file = tmp_path / "a.py"
@@ -117,12 +117,12 @@ class TestFileBrowserTree:
         assert txt_file not in result
 
     def test_action_cursor_parent_with_no_node(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         with patch.object(type(tree), "cursor_node", new_callable=PropertyMock, return_value=None):
             tree.action_cursor_parent()  # Should not crash
 
     def test_action_cursor_parent_with_no_parent(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         mock_node = MagicMock()
         mock_node.parent = None
         with patch.object(
@@ -131,7 +131,7 @@ class TestFileBrowserTree:
             tree.action_cursor_parent()  # Should not crash
 
     def test_action_cursor_toggle_expandable_node(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         mock_node = MagicMock()
         mock_node.allow_expand = True
         with patch.object(
@@ -141,7 +141,7 @@ class TestFileBrowserTree:
         mock_node.toggle.assert_called_once()
 
     def test_action_cursor_toggle_file_node(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         mock_node = MagicMock()
         mock_node.allow_expand = False
         # Patch FileSelected to avoid constructor issues
@@ -158,7 +158,7 @@ class TestFileBrowserTree:
         mock_fs.assert_called_once_with(mock_node, mock_node.data.path)
 
     def test_action_cursor_toggle_none_node(self) -> None:
-        tree = FileBrowserTree()
+        tree = FileBrowserTree(Path("."))
         with patch.object(type(tree), "cursor_node", new_callable=PropertyMock, return_value=None):
             tree.action_cursor_toggle()  # Should not crash
 
@@ -280,7 +280,7 @@ class TestFileBrowserView:
     """Test FileBrowserView init and bindings."""
 
     def test_default_init(self) -> None:
-        view = FileBrowserView()
+        view = FileBrowserView(Path("."))
         assert view._root_path == Path(".")
 
     def test_custom_path_init(self) -> None:
@@ -296,7 +296,7 @@ class TestFileBrowserView:
         assert "slash" in keys
 
     def test_action_toggle_filter_shown_keeps_input_focus(self) -> None:
-        view = FileBrowserView()
+        view = FileBrowserView(Path("."))
         mock_fi = MagicMock()
         mock_fi.has_class.return_value = True
         view.query_one = MagicMock(return_value=mock_fi)
@@ -305,7 +305,7 @@ class TestFileBrowserView:
         view.query_one.assert_called_once()  # tree not queried while visible
 
     def test_action_toggle_filter_hidden_refocuses_tree(self) -> None:
-        view = FileBrowserView()
+        view = FileBrowserView(Path("."))
         mock_fi = MagicMock()
         mock_fi.has_class.return_value = False
         mock_tree = MagicMock()
@@ -315,7 +315,7 @@ class TestFileBrowserView:
         mock_tree.focus.assert_called_once()
 
     def test_on_filter_applied_sets_filter_and_refocuses_tree(self) -> None:
-        view = FileBrowserView()
+        view = FileBrowserView(Path("."))
         mock_tree = MagicMock()
         view.query_one = MagicMock(return_value=mock_tree)
         view._on_filter_applied(FilterInput.FilterApplied(" .py, txt "))
@@ -323,7 +323,7 @@ class TestFileBrowserView:
         mock_tree.focus.assert_called_once()
 
     def test_on_filter_applied_empty_clears_filter(self) -> None:
-        view = FileBrowserView()
+        view = FileBrowserView(Path("."))
         mock_tree = MagicMock()
         view.query_one = MagicMock(return_value=mock_tree)
         view._on_filter_applied(FilterInput.FilterApplied("   "))

--- a/tests/tui/test_methodology_view.py
+++ b/tests/tui/test_methodology_view.py
@@ -250,10 +250,10 @@ class TestMethodologyView:
         assert "m" in keys  # Migrate
 
     @pytest.mark.keep_default_paths
-    def test_initialization_with_default_directory(self) -> None:
-        """Test MethodologyView initialization with default directory."""
+    def test_initialization_without_directory_is_unset(self) -> None:
+        """An unattached methodology view has no implicit directory."""
         view = MethodologyView()
-        assert view._scan_dir == Path(".")
+        assert view._scan_dir is None
         assert view._methodology == "none"
 
     def test_initialization_with_custom_directory(self) -> None:

--- a/tests/tui/test_organization_preview.py
+++ b/tests/tui/test_organization_preview.py
@@ -259,11 +259,11 @@ class TestOrganizationPreviewView:
         assert "escape" in keys  # Cancel
 
     @pytest.mark.keep_default_paths
-    def test_initialization_with_defaults(self) -> None:
-        """Test OrganizationPreviewView with default directories."""
+    def test_initialization_requires_explicit_directories(self) -> None:
+        """An unattached preview never falls back to process-relative paths."""
         view = OrganizationPreviewView()
-        assert view._input_dir == Path(".")
-        assert view._output_dir == Path("organized_output")
+        assert view._input_dir is None
+        assert view._output_dir is None
 
     def test_initialization_with_custom_directories(self) -> None:
         """Test OrganizationPreviewView with custom directories."""

--- a/tests/tui/test_organization_preview.py
+++ b/tests/tui/test_organization_preview.py
@@ -336,7 +336,7 @@ class TestOrganizationPreviewView:
     def test_compose_yields_widgets(self) -> None:
         view = OrganizationPreviewView()
         widgets = list(view.compose())
-        assert len(widgets) == 3
+        assert len(widgets) == 4
 
     def test_on_mount_calls_load_preview(self) -> None:
         view = OrganizationPreviewView()
@@ -442,7 +442,6 @@ class TestOrganizationPreviewView:
             pass
 
         with (
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org,
             patch(
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings"
             ) as mock_settings,
@@ -450,9 +449,9 @@ class TestOrganizationPreviewView:
             mock_settings.return_value.max_workers = 2
             mock_settings.return_value.prefetch_depth = 4
 
-            mock_instance = mock_org.return_value
+            mock_service = MagicMock()
             plan = _make_plan(tmp_path)
-            mock_instance.organize.return_value = SimpleNamespace(
+            mock_service.preview.return_value = SimpleNamespace(
                 organized_structure={"A": ["b.txt"]},
                 total_files=1,
                 processed_files=1,
@@ -465,15 +464,15 @@ class TestOrganizationPreviewView:
             app = MockApp()
             async with app.run_test():
                 view = OrganizationPreviewView()
+                view._create_service = MagicMock(return_value=mock_service)
                 await app.mount(view)
 
                 for worker in view.workers:
                     await worker.wait()
 
-                mock_instance.organize.assert_called_once_with(
-                    input_path=view._input_dir,
-                    output_path=view._output_dir,
-                )
+                request = mock_service.preview.call_args.args[0]
+                assert request.input_path == view._input_dir
+                assert request.output_path == view._output_dir
 
                 panel = view.query_one(BeforeAfterPanel)
                 assert "A/" in str(panel.render())
@@ -486,7 +485,6 @@ class TestOrganizationPreviewView:
             pass
 
         with (
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org,
             patch(
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings"
             ) as mock_settings,
@@ -494,12 +492,13 @@ class TestOrganizationPreviewView:
             mock_settings.return_value.max_workers = 2
             mock_settings.return_value.prefetch_depth = 4
 
-            mock_instance = mock_org.return_value
-            mock_instance.organize.side_effect = Exception("test error")
+            mock_service = MagicMock()
+            mock_service.preview.side_effect = Exception("test error")
 
             app = MockApp()
             async with app.run_test():
                 view = OrganizationPreviewView()
+                view._create_service = MagicMock(return_value=mock_service)
                 await app.mount(view)
 
                 for worker in view.workers:
@@ -507,7 +506,7 @@ class TestOrganizationPreviewView:
 
                 panel = view.query_one(BeforeAfterPanel)
                 rendered = str(panel.render())
-                assert "Models unavailable" in rendered
+                assert "Preview unavailable" in rendered
                 assert "test error" in rendered
 
     @pytest.mark.asyncio
@@ -518,7 +517,6 @@ class TestOrganizationPreviewView:
             pass
 
         with (
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org,
             patch(
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings"
             ) as mock_settings,
@@ -529,11 +527,13 @@ class TestOrganizationPreviewView:
             mock_result = MagicMock()
             mock_result.total_files = 1
             mock_result.plan = None
-            mock_org.return_value.organize.return_value = mock_result
+            mock_service = MagicMock()
+            mock_service.preview.return_value = mock_result
 
             app = MockApp()
             async with app.run_test():
                 view = OrganizationPreviewView()
+                view._create_service = MagicMock(return_value=mock_service)
                 await app.mount(view)
 
                 for worker in view.workers:
@@ -588,16 +588,13 @@ class TestOrganizationPreviewView:
         class MockApp(App):
             action_switch_view = MagicMock()
 
-        with (
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org,
-            patch(
-                "file_organizer.tui.organization_preview.load_parallel_runtime_settings"
-            ) as mock_settings,
-        ):
+        with patch(
+            "file_organizer.tui.organization_preview.load_parallel_runtime_settings"
+        ) as mock_settings:
             mock_settings.return_value.max_workers = 2
             mock_settings.return_value.prefetch_depth = 4
 
-            mock_instance = mock_org.return_value
+            mock_service = MagicMock()
             plan = _make_plan(tmp_path)
             result = SimpleNamespace(
                 organized_structure={"A": ["b.txt"]},
@@ -608,27 +605,29 @@ class TestOrganizationPreviewView:
                 errors=[],
                 plan=plan,
             )
-            mock_instance.organize.return_value = result
-            mock_instance.execute_plan.return_value = result
+            mock_service.preview.return_value = result
+            mock_service.execute.return_value = result
 
             app = MockApp()
             async with app.run_test():
                 view = OrganizationPreviewView()
+                view._create_service = MagicMock(return_value=mock_service)
                 await app.mount(view)
 
                 for worker in view.workers:
                     await worker.wait()
 
-                mock_instance.organize.reset_mock()
-                mock_instance.execute_plan.reset_mock()
+                mock_service.preview.reset_mock()
+                mock_service.execute.reset_mock()
 
                 view.action_confirm()
 
                 for worker in view.workers:
                     await worker.wait()
 
-                mock_instance.organize.assert_not_called()
-                mock_instance.execute_plan.assert_called_once_with(plan)
+                mock_service.preview.assert_not_called()
+                mock_service.execute.assert_called_once()
+                assert mock_service.execute.call_args.args[1] is plan
 
                 app.action_switch_view.assert_called_once_with("history")
 
@@ -640,7 +639,6 @@ class TestOrganizationPreviewView:
             action_switch_view = MagicMock()
 
         with (
-            patch("file_organizer.core.organizer.FileOrganizer") as mock_org,
             patch(
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings"
             ) as mock_settings,
@@ -648,7 +646,7 @@ class TestOrganizationPreviewView:
             mock_settings.return_value.max_workers = 2
             mock_settings.return_value.prefetch_depth = 4
 
-            mock_instance = mock_org.return_value
+            mock_service = MagicMock()
             plan = _make_plan(tmp_path)
             result = SimpleNamespace(
                 organized_structure={"A": ["b.txt"]},
@@ -659,18 +657,17 @@ class TestOrganizationPreviewView:
                 errors=[],
                 plan=plan,
             )
-            mock_instance.organize.return_value = result
-            mock_instance.execute_plan.return_value = result
+            mock_service.preview.return_value = result
+            mock_service.execute.side_effect = Exception("apply error")
 
             app = MockApp()
             async with app.run_test():
                 view = OrganizationPreviewView()
+                view._create_service = MagicMock(return_value=mock_service)
                 await app.mount(view)
 
                 for worker in view.workers:
                     await worker.wait()
-
-                mock_instance.execute_plan.side_effect = Exception("apply error")
 
                 view.action_confirm()
 

--- a/tests/tui/test_organization_preview_coverage.py
+++ b/tests/tui/test_organization_preview_coverage.py
@@ -149,8 +149,8 @@ class TestOrganizationPreviewViewLoadPreview:
         )
         mock_plan = _make_plan(tmp_path)
         mock_result.plan = mock_plan
-        mock_organizer = MagicMock()
-        mock_organizer.organize.return_value = mock_result
+        mock_service = MagicMock()
+        mock_service.preview.return_value = mock_result
 
         mock_app = MagicMock()
         mock_app.call_from_thread.side_effect = lambda fn, *a, **kw: fn(*a, **kw)
@@ -159,20 +159,15 @@ class TestOrganizationPreviewViewLoadPreview:
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings",
                 return_value=ParallelRuntimeSettings(max_workers=2, prefetch_depth=1),
             ),
-            patch(
-                "file_organizer.core.organizer.FileOrganizer",
-                return_value=mock_organizer,
-            ) as mock_org_cls,
+            patch.object(view, "_create_service", return_value=mock_service),
             patch.object(type(view), "app", new_callable=PropertyMock, return_value=mock_app),
         ):
             OrganizationPreviewView._load_preview.__wrapped__(view)
 
-        mock_org_cls.assert_called_once_with(
-            dry_run=True,
-            parallel_workers=2,
-            prefetch_depth=1,
-        )
-        assert mock_app.call_from_thread.call_count == 4
+        request = mock_service.preview.call_args.args[0]
+        assert request.options.parallel_workers == 2
+        assert request.options.prefetch_depth == 1
+        assert mock_app.call_from_thread.call_count == 5
         assert view._current_plan is mock_plan
         before_after_panel.set_structure.assert_called_once_with(
             {"Docs": ["a.pdf"]},
@@ -212,8 +207,9 @@ class TestOrganizationPreviewViewLoadPreview:
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings",
                 return_value=ParallelRuntimeSettings(max_workers=None, prefetch_depth=2),
             ),
-            patch(
-                "file_organizer.core.organizer.FileOrganizer",
+            patch.object(
+                view,
+                "_create_service",
                 side_effect=RuntimeError("model not found"),
             ),
             patch.object(type(view), "app", new_callable=PropertyMock, return_value=mock_app),
@@ -223,8 +219,8 @@ class TestOrganizationPreviewViewLoadPreview:
         assert mock_app.call_from_thread.call_count == 3
         assert view._current_plan is None
         before_after_panel.update.assert_called_once_with(
-            "[red]Models unavailable:[/red] model not found\n\n"
-            "[dim]Ensure Ollama is running with required models.[/dim]"
+            "[red]Preview unavailable:[/red] model not found\n\n"
+            "[dim]Review the workspace paths, selection scope, options, and model setup.[/dim]"
         )
         summary_panel.update.assert_called_once_with("[dim]No data available.[/dim]")
 
@@ -281,8 +277,8 @@ class TestOrganizationPreviewViewLoadPreview:
             failed_files=0,
             errors=[],
         )
-        mock_organizer = MagicMock()
-        mock_organizer.execute_plan.return_value = mock_result
+        mock_service = MagicMock()
+        mock_service.execute.return_value = mock_result
         mock_app = MagicMock()
         mock_app.call_from_thread.side_effect = lambda fn, *a, **kw: fn(*a, **kw)
         view._handle_apply_success = MagicMock()
@@ -292,20 +288,15 @@ class TestOrganizationPreviewViewLoadPreview:
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings",
                 return_value=ParallelRuntimeSettings(max_workers=3, prefetch_depth=4),
             ),
-            patch(
-                "file_organizer.core.organizer.FileOrganizer",
-                return_value=mock_organizer,
-            ) as mock_org_cls,
+            patch.object(view, "_create_service", return_value=mock_service),
             patch.object(type(view), "app", new_callable=PropertyMock, return_value=mock_app),
         ):
             OrganizationPreviewView._apply_organization.__wrapped__(view, plan)
 
-        mock_org_cls.assert_called_once_with(
-            dry_run=False,
-            parallel_workers=3,
-            prefetch_depth=4,
-        )
-        mock_organizer.execute_plan.assert_called_once_with(plan)
+        request, executed_plan = mock_service.execute.call_args.args
+        assert request.options.parallel_workers == 3
+        assert request.options.prefetch_depth == 4
+        assert executed_plan is plan
         view._handle_apply_success.assert_called_once_with(mock_result)
 
     def test_apply_organization_without_plan_reports_error(self) -> None:
@@ -431,8 +422,9 @@ class TestOrganizationPreviewViewLoadPreview:
                 "file_organizer.tui.organization_preview.load_parallel_runtime_settings",
                 return_value=ParallelRuntimeSettings(max_workers=1, prefetch_depth=1),
             ),
-            patch(
-                "file_organizer.core.organizer.FileOrganizer",
+            patch.object(
+                view,
+                "_create_service",
                 side_effect=RuntimeError("model offline"),
             ),
             patch.object(type(view), "app", new_callable=PropertyMock, return_value=mock_app),

--- a/tests/tui/test_settings_view.py
+++ b/tests/tui/test_settings_view.py
@@ -562,12 +562,19 @@ async def test_settings_view_mounted_end_to_end(monkeypatch) -> None:
     )
 
     app = FileOrganizerApp()
+    app.workspace.set_roots("/seed/in", "/seed/out")
+    app.workspace.set_options(
+        methodology="para",
+        text_model="qwen2.5:7b-instruct-q4_K_M",
+        parallel_workers=2,
+        prefetch_depth=2,
+    )
     async with app.run_test() as pilot:
         await app.action_switch_view("settings")
         await pilot.pause()
         view = app.query_one(SettingsView)
 
-        # on_mount ran reload; loaded workflow values pushed into the inputs.
+        # Mount reflects the shared session rather than replacing it with stale config.
         input_field = view.query_one("#settings-input-dir", Input)
         output_field = view.query_one("#settings-output-dir", Input)
         assert input_field.value == "/seed/in"

--- a/tests/tui/test_tui_analytics_view.py
+++ b/tests/tui/test_tui_analytics_view.py
@@ -125,7 +125,7 @@ class TestAnalyticsView:
 
     def test_default_init(self) -> None:
         view = AnalyticsView(id="view")
-        assert str(view._directory) == "."
+        assert view._directory is None
 
     def test_custom_directory(self) -> None:
         view = AnalyticsView(directory="/tmp/data", id="view")  # noqa: test-hardcoded-paths

--- a/tests/tui/test_tui_organization_preview.py
+++ b/tests/tui/test_tui_organization_preview.py
@@ -90,10 +90,10 @@ class TestOrganizationPreviewView:
     """Tests for OrganizationPreviewView composition."""
 
     @pytest.mark.keep_default_paths
-    def test_default_init(self) -> None:
+    def test_default_init_has_no_implicit_roots(self) -> None:
         view = OrganizationPreviewView(id="view")
-        assert str(view._input_dir) == "."
-        assert str(view._output_dir) == "organized_output"
+        assert view._input_dir is None
+        assert view._output_dir is None
 
     def test_custom_dirs(self) -> None:
         view = OrganizationPreviewView(

--- a/tests/tui/test_undo_history_view.py
+++ b/tests/tui/test_undo_history_view.py
@@ -261,11 +261,13 @@ class TestUndoHistoryViewInit:
         assert isinstance(view, UndoHistoryView)
 
     def test_bindings(self):
-        assert len(UndoHistoryView.BINDINGS) == 3
+        assert len(UndoHistoryView.BINDINGS) == 5
         keys = [b.key for b in UndoHistoryView.BINDINGS]
         assert "r" in keys
         assert "u" in keys
         assert "y" in keys
+        assert "b" in keys
+        assert "c" in keys
 
     def test_action_undo_last_calls_run_undo(self):
         view = UndoHistoryView()

--- a/tests/tui/test_undo_history_view_coverage.py
+++ b/tests/tui/test_undo_history_view_coverage.py
@@ -12,6 +12,7 @@ import pytest
 from textual.widgets import Static
 
 from file_organizer.tui.undo_history_view import (
+    CanonicalLifecyclePanel,
     HistoryStatsPanel,
     OperationHistoryPanel,
     UndoHistoryView,
@@ -205,11 +206,12 @@ def test_undo_history_view_compose() -> None:
     """Verify widgets yielded by compose."""
     view = UndoHistoryView()
     widgets = list(view.compose())
-    assert len(widgets) == 4
+    assert len(widgets) == 5
     assert widgets[0].id == "history-header"
-    assert isinstance(widgets[1], OperationHistoryPanel)
-    assert isinstance(widgets[2], UndoRedoStackPanel)
-    assert isinstance(widgets[3], HistoryStatsPanel)
+    assert isinstance(widgets[1], CanonicalLifecyclePanel)
+    assert isinstance(widgets[2], OperationHistoryPanel)
+    assert isinstance(widgets[3], UndoRedoStackPanel)
+    assert isinstance(widgets[4], HistoryStatsPanel)
 
 
 def test_undo_history_view_on_mount() -> None:

--- a/tests/tui/test_workspace_parity.py
+++ b/tests/tui/test_workspace_parity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -126,6 +126,14 @@ def test_selection_persists_across_file_views(tmp_path: Path) -> None:
     assert second.selection.selected_files == {selected}
 
 
+def test_selection_paths_expand_user_before_root_filtering() -> None:
+    workspace = TUIWorkspace()
+
+    workspace.set_selected_files({Path("~") / "selected.txt"})
+
+    assert workspace.selected_files == {Path.home() / "selected.txt"}
+
+
 def test_settings_map_losslessly_to_canonical_options(tmp_path: Path) -> None:
     workspace = TUIWorkspace()
     view = SettingsView(workspace=workspace)
@@ -157,6 +165,65 @@ def test_settings_map_losslessly_to_canonical_options(tmp_path: Path) -> None:
         "prefetch_depth": 3,
         "text_model": "custom-text",
     }
+
+
+def test_settings_actions_update_session_options_immediately(tmp_path: Path) -> None:
+    workspace = TUIWorkspace(tmp_path, tmp_path / "out")
+    view = SettingsView(workspace=workspace)
+    view._refresh_panel = MagicMock()
+    view._set_status = MagicMock()
+
+    view.action_toggle_recursive()
+    view.action_toggle_hidden()
+    view.action_toggle_transfer()
+    view.action_toggle_skip_existing()
+    view.action_toggle_vision()
+    view.action_toggle_transcription()
+    view.action_cycle_methodology()
+    view.action_cycle_text_model()
+    view.action_workers_up()
+    view.action_prefetch_up()
+
+    options = workspace.options
+    assert options.recursive is view._recursive is False
+    assert options.include_hidden is view._include_hidden is True
+    assert options.skip_existing is view._skip_existing is False
+    assert options.effective_transfer_mode.value == view._transfer_mode == "copy"
+    assert options.enable_vision is view._enable_vision is False
+    assert options.transcribe_audio is view._transcribe_audio is True
+    assert options.effective_methodology.value == view._methodology == "para"
+    assert options.text_model == view._text_model
+    assert options.parallel_workers == view._max_workers == 2
+    assert options.prefetch_depth == view._prefetch_depth == 3
+
+    recreated = SettingsView(workspace=workspace)
+    assert recreated._recursive is False
+    assert recreated._include_hidden is True
+    assert recreated._transfer_mode == "copy"
+    assert recreated._methodology == "para"
+
+
+def test_failed_persistence_does_not_block_session_apply(tmp_path: Path) -> None:
+    workspace = TUIWorkspace()
+    view = SettingsView(workspace=workspace)
+    view._input_dir = str(tmp_path / "input")
+    view._output_dir = str(tmp_path / "output")
+    view._recursive = False
+    view._refresh_panel = MagicMock()
+    view._set_status = MagicMock()
+
+    with patch(
+        "file_organizer.tui.settings_view.save_parallel_runtime_settings",
+        side_effect=OSError("read-only config"),
+    ):
+        view.action_save_settings()
+
+    assert workspace.active_root == tmp_path / "input"
+    assert workspace.output_root == tmp_path / "output"
+    assert workspace.options.recursive is False
+    view._set_status.assert_called_once_with(
+        "Session updated; failed to save settings: read-only config"
+    )
 
 
 def test_methodology_action_updates_shared_canonical_state(tmp_path: Path) -> None:

--- a/tests/tui/test_workspace_parity.py
+++ b/tests/tui/test_workspace_parity.py
@@ -1,0 +1,189 @@
+"""Behavioral parity coverage for the connected Textual workspace (#1598)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from file_organizer.core.errors import DomainError, DomainErrorCode
+from file_organizer.core.organize_options import OrganizeOptions
+from file_organizer.core.plan import build_plan_from_processed
+from file_organizer.core.types import OrganizationResult
+from file_organizer.services.text_processor import ProcessedFile
+from file_organizer.tui.app import FileOrganizerApp
+from file_organizer.tui.file_preview import FilePreviewView
+from file_organizer.tui.methodology_view import MethodologyView
+from file_organizer.tui.organization_adapter import TUIOrganizationAdapter
+from file_organizer.tui.organization_preview import OrganizationPreviewView
+from file_organizer.tui.settings_view import SettingsView
+from file_organizer.tui.workspace import TUIWorkspace
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def _plan(input_root: Path, output_root: Path, options: OrganizeOptions):
+    input_root.mkdir(parents=True, exist_ok=True)
+    output_root.mkdir(parents=True, exist_ok=True)
+    source = input_root / "report.txt"
+    source.write_text("report")
+    return build_plan_from_processed(
+        input_path=input_root,
+        output_path=output_root,
+        processed=[
+            ProcessedFile(
+                file_path=source,
+                description="Document",
+                folder_name="Documents",
+                filename="report",
+            )
+        ],
+        options=options,
+        skip_existing=options.skip_existing,
+        use_hardlinks=options.use_hardlinks,
+        total_files=1,
+        skipped_files=0,
+        deduplicated_files=0,
+    )
+
+
+def test_all_eight_views_share_one_workspace(tmp_path: Path) -> None:
+    workspace = TUIWorkspace(tmp_path, tmp_path / "out")
+
+    views = {
+        name: FileOrganizerApp._create_view(name, workspace)
+        for name in (
+            "files",
+            "organized",
+            "analytics",
+            "methodology",
+            "audio",
+            "history",
+            "copilot",
+            "settings",
+        )
+    }
+
+    assert len(views) == 8
+    assert all(getattr(view, "_workspace", None) is workspace for view in views.values())
+
+
+def test_unset_workspace_never_falls_back_to_cwd() -> None:
+    workspace = TUIWorkspace()
+
+    files = FilePreviewView(path=None, workspace=workspace)
+    organized = OrganizationPreviewView(workspace=workspace)
+
+    assert files._root_path is None
+    assert organized._input_dir is None
+    assert organized._output_dir is None
+    with pytest.raises(DomainError, match="Set explicit source and output") as exc_info:
+        workspace.request()
+    assert exc_info.value.code == DomainErrorCode.INVALID_REQUEST
+
+
+def test_selection_persists_across_file_views(tmp_path: Path) -> None:
+    selected = tmp_path / "selected.txt"
+    selected.write_text("selected")
+    workspace = TUIWorkspace(tmp_path, tmp_path / "out")
+    first = FilePreviewView(workspace=workspace)
+    first.selection.toggle(selected)
+    first._notify_selection()
+
+    second = FilePreviewView(workspace=workspace)
+
+    assert workspace.selected_files == {selected}
+    assert second.selection.selected_files == {selected}
+
+
+def test_settings_map_losslessly_to_canonical_options(tmp_path: Path) -> None:
+    workspace = TUIWorkspace()
+    view = SettingsView(workspace=workspace)
+    view._input_dir = str(tmp_path / "input")
+    view._output_dir = str(tmp_path / "output")
+    view._recursive = False
+    view._include_hidden = True
+    view._skip_existing = False
+    view._transfer_mode = "copy"
+    view._methodology = "jd"
+    view._enable_vision = False
+    view._transcribe_audio = True
+    view._max_workers = 5
+    view._prefetch_depth = 3
+    view._text_model = "custom-text"
+
+    view._sync_workspace()
+
+    assert workspace.request().options.to_dict() == {
+        **OrganizeOptions().to_dict(),
+        "recursive": False,
+        "include_hidden": True,
+        "skip_existing": False,
+        "transfer_mode": "copy",
+        "methodology": "jd",
+        "enable_vision": False,
+        "transcribe_audio": True,
+        "parallel_workers": 5,
+        "prefetch_depth": 3,
+        "text_model": "custom-text",
+    }
+
+
+def test_methodology_action_updates_shared_canonical_state(tmp_path: Path) -> None:
+    workspace = TUIWorkspace(tmp_path, tmp_path / "out")
+    view = MethodologyView(workspace=workspace)
+    view.query_one = MagicMock()
+    view._update_preview = MagicMock()
+
+    view.action_set_jd()
+
+    assert workspace.options.effective_methodology.value == "jd"
+    view._update_preview.assert_called_once()
+
+
+def test_selected_file_scope_fails_closed_without_widening(tmp_path: Path) -> None:
+    selected = tmp_path / "selected.txt"
+    selected.write_text("selected")
+    workspace = TUIWorkspace(tmp_path, tmp_path / "out", selected_files={selected})
+    service = MagicMock()
+
+    with pytest.raises(DomainError) as exc_info:
+        TUIOrganizationAdapter(workspace, service).preview()
+
+    assert exc_info.value.code == DomainErrorCode.OPTIONAL_FEATURE_UNAVAILABLE
+    assert exc_info.value.details["selected_files"] == 1
+    service.preview.assert_not_called()
+
+
+def test_previewed_plan_is_the_plan_executed_unchanged(tmp_path: Path) -> None:
+    options = OrganizeOptions(
+        recursive=False,
+        include_hidden=True,
+        skip_existing=False,
+        transfer_mode="copy",
+        methodology="para",
+        enable_vision=False,
+        transcribe_audio=True,
+        parallel_workers=2,
+        prefetch_depth=1,
+    )
+    input_root, output_root = tmp_path / "input", tmp_path / "output"
+    plan = _plan(input_root, output_root, options)
+    preview_result = OrganizationResult(total_files=1, processed_files=1, plan=plan)
+    execute_result = OrganizationResult(total_files=1, processed_files=1, plan=plan)
+    service = MagicMock()
+    service.preview.return_value = preview_result
+    service.execute.return_value = execute_result
+    workspace = TUIWorkspace(input_root, output_root, options=options)
+    adapter = TUIOrganizationAdapter(workspace, service)
+
+    adapter.preview()
+    result = adapter.execute()
+
+    preview_request = service.preview.call_args.args[0]
+    execute_request, executed_plan = service.execute.call_args.args
+    assert preview_request == execute_request == workspace.request()
+    assert executed_plan is plan
+    assert workspace.reviewed_plan is plan
+    assert workspace.last_result is result

--- a/tests/tui/test_workspace_parity.py
+++ b/tests/tui/test_workspace_parity.py
@@ -83,6 +83,35 @@ def test_unset_workspace_never_falls_back_to_cwd() -> None:
     assert exc_info.value.code == DomainErrorCode.INVALID_REQUEST
 
 
+def test_root_change_clears_root_bound_lifecycle_state(tmp_path: Path) -> None:
+    workspace = TUIWorkspace(
+        tmp_path / "first",
+        tmp_path / "first-output",
+        reviewed_plan=MagicMock(),
+        active_job=MagicMock(),
+        last_result=OrganizationResult(total_files=12, processed_files=12),
+    )
+
+    workspace.set_roots(tmp_path / "second", tmp_path / "second-output")
+
+    assert workspace.reviewed_plan is None
+    assert workspace.active_job is None
+    assert workspace.last_result is None
+
+
+def test_config_load_failure_is_retained_as_workspace_error() -> None:
+    manager = MagicMock()
+    manager.load.side_effect = OSError("config unreadable")
+
+    workspace = TUIWorkspace.from_config(manager)
+
+    assert workspace.active_root is None
+    assert workspace.output_root is None
+    assert workspace.last_error is not None
+    assert workspace.last_error.code == DomainErrorCode.EXECUTION_FAILED
+    assert workspace.last_error.message == "config unreadable"
+
+
 def test_selection_persists_across_file_views(tmp_path: Path) -> None:
     selected = tmp_path / "selected.txt"
     selected.write_text("selected")


### PR DESCRIPTION
## Summary

- introduce one shared TUI workspace for explicit roots, selections, canonical options, reviewed plans, lifecycle state, and results
- route organization preview/execution through a production TUI adapter backed by `OrganizationService`, retaining and executing the reviewed plan unchanged
- propagate workspace context through all eight views, remove app-level cwd/output fallbacks, and render intentional unsupported states for selected-file execution and synchronous cancellation
- add the TUI adapter to the golden conformance corpus and update registry implementation claims conservatively

## User-visible behavior

- Files selections and configured roots persist across view switches.
- Organized displays effective canonical options and never silently organizes `.` or `organized_output`.
- Methodology, Audio, Analytics, and Copilot consume the shared root/selection context.
- History shows canonical lifecycle results/errors and clearly identifies unsupported in-flight cancellation.

## Validation

- `uv run pytest tests/tui tests/unit/tui tests/integration/test_tui_app_pilot_integration.py --override-ini=addopts= -q` — 726 passed before adding 7 dedicated parity tests; the dedicated file then passed 7/7
- `uv run pytest tests/conformance --override-ini=addopts= -q` — 229 passed
- `uv run pytest tests/core/test_capabilities.py --override-ini=addopts= -q` — 29 passed
- `uv run interrogate -v src/ --fail-under 95` — 99.3%
- `uv run ruff check src/file_organizer/tui tests/tui tests/conformance`
- `uv run mypy src/file_organizer/tui`
- diff coverage against the repository merge base — 82% (80% required)
- commit hooks: smoke, CI guardrails, Web UI, websocket, mypy, interrogate, deptry, and CI rails passed

The repository-wide non-integration run reached 14,348 passed / 17 skipped with one independently reproducible pre-existing failure in `tests/web/test_organize_services.py::TestBuildOrganizePlan::test_rejects_missing_input_path_before_preview` (`DomainError` is not translated to the test's expected `ApiError`). This PR does not modify that Web path.

## Risk

- TUI preview and execute now use the canonical service contract, so previously implicit per-view defaults are replaced by explicit workspace configuration.
- Selected-file-only organization remains unsupported by the canonical service; the TUI now fails closed with an actionable domain error instead of widening the scope to the active root.
- Registry conformance remains `unverified` because the corpus covers the production TUI adapter while #1606 still owns promotion of every declared Textual entry point to a required gate.

Fixes #1598
Part of #1593