### PR TITLE
docs: gate parity enforcement on Textual test isolation

### DIFF
--- a/docs/architecture/cross-surface-parity-execution.md
+++ b/docs/architecture/cross-surface-parity-execution.md
@@ -85,6 +85,7 @@ items because they were not sub-sliced. This is not duplicate scope.
   [#1597](https://github.com/curdriceaurora/Local-File-Organizer/issues/1597),
   [#1598](https://github.com/curdriceaurora/Local-File-Organizer/issues/1598), and
   [#1608](https://github.com/curdriceaurora/Local-File-Organizer/issues/1608)
+- Gate readiness: [#1633](https://github.com/curdriceaurora/Local-File-Organizer/issues/1633)
 - Enforcement and claims: [#1606](https://github.com/curdriceaurora/Local-File-Organizer/issues/1606),
   [#1609](https://github.com/curdriceaurora/Local-File-Organizer/issues/1609), and
   [#1610](https://github.com/curdriceaurora/Local-File-Organizer/issues/1610)
@@ -94,7 +95,8 @@ items because they were not sub-sliced. This is not duplicate scope.
 - #1595 starts after #1603 and #1605, and merges after #1602 and #1604 stabilize. Its #1608
   `fo api` slice additionally waits for #1596.
 - #1599 starts #1605 after #1603. #1606 lands incrementally with #1595 through #1598 and completes
-  after their supported adapters are integrated.
+  after their supported adapters are integrated. #1633 must close before TUI/conformance suites
+  become required gates.
 - #1600 starts #1609 after #1601. #1610 waits for both #1606 and #1609.
 
 ## Dependency graph
@@ -114,10 +116,11 @@ flowchart TD
     F --> H["#1597 Web and Desktop"]
     F --> I["#1598 TUI"]
     G --> J["#1608 fo api"]
-    G --> K["#1606 Required conformance gates"]
-    H --> K
-    I --> K
-    J --> K
+    G --> O["#1633 Textual test isolation"]
+    H --> O
+    I --> O
+    J --> O
+    O --> K["#1606 Required conformance gates"]
     A --> L["#1609 Capability matrix"]
     C --> K
     K --> M["#1610 Claims evidence gates"]
@@ -176,6 +179,13 @@ Web/Desktop is the primary stress test for recursion and methodology drift. REST
 OpenAPI-to-Python/TypeScript coverage. TUI work owns cross-view workspace state and removal of
 hard-coded working-directory defaults.
 
+### Gate-readiness prerequisite
+
+[#1633: Textual test isolation](https://github.com/curdriceaurora/Local-File-Organizer/issues/1633)
+removes the order-dependent class-level test pollution discovered after the TUI adapter landed. It
+must close before #1606 promotes TUI or cross-surface conformance suites to required gates; a
+known false timeout is not an acceptable blocking signal.
+
 ### Phase 3: enforcement
 
 [#1606: adapter drivers and required gates](https://github.com/curdriceaurora/Local-File-Organizer/issues/1606)
@@ -201,7 +211,7 @@ When one contributor performs the entire epic, use this order:
 
 ```text
 #1611 → #1601 → #1603 → #1605 → #1602 → #1604 → #1607 → #1596 → #1608
-→ #1597 → #1598 → #1606 → #1609 → #1610
+→ #1597 → #1598 → #1633 → #1606 → #1609 → #1610
 ```
 
 With multiple contributors, #1605 overlaps the tail of foundation work; #1596 and #1597 run in


### PR DESCRIPTION
## Summary

- add #1633 as the gate-readiness prerequisite after the TUI adapter and before #1606
- update the contributor queue, precise dependencies, dependency graph, and strict serial order
- document why order-dependent Textual timeouts must be removed before conformance gates become blocking

Part of #1593. Related to #1633.

## User and developer impact

Contributors now have one explicit place in the execution sequence for the pre-existing TUI test-isolation repair. Required-gate promotion cannot accidentally turn a known 30-second false failure into a blocking integration signal.

## Validation

- `uv run pytest tests/docs/test_doc_file_paths.py -q --override-ini='addopts='` — 73 passed
- `uv run mkdocs build --strict` — passed
- repository pre-commit suite — passed
- `git diff --check` — passed

## Risk

Low. Documentation-only coordination change. The main risk is plan drift, mitigated by updating #1593 and #1606 alongside this repository document.