### PR TITLE
Align stale tests with parity contracts

### DIFF
--- a/docs/architecture/cross-surface-parity-execution.md
+++ b/docs/architecture/cross-surface-parity-execution.md
@@ -85,8 +85,9 @@ items because they were not sub-sliced. This is not duplicate scope.
   [#1597](https://github.com/curdriceaurora/Local-File-Organizer/issues/1597),
   [#1598](https://github.com/curdriceaurora/Local-File-Organizer/issues/1598), and
   [#1608](https://github.com/curdriceaurora/Local-File-Organizer/issues/1608)
-- Gate readiness: [#1633](https://github.com/curdriceaurora/Local-File-Organizer/issues/1633) and
-  [#1636](https://github.com/curdriceaurora/Local-File-Organizer/issues/1636)
+- Gate readiness: [#1633](https://github.com/curdriceaurora/Local-File-Organizer/issues/1633),
+  [#1636](https://github.com/curdriceaurora/Local-File-Organizer/issues/1636), and
+  [#1640](https://github.com/curdriceaurora/Local-File-Organizer/issues/1640)
 - Enforcement and claims: [#1606](https://github.com/curdriceaurora/Local-File-Organizer/issues/1606),
   [#1609](https://github.com/curdriceaurora/Local-File-Organizer/issues/1609), and
   [#1610](https://github.com/curdriceaurora/Local-File-Organizer/issues/1610)
@@ -96,8 +97,8 @@ items because they were not sub-sliced. This is not duplicate scope.
 - #1595 starts after #1603 and #1605, and merges after #1602 and #1604 stabilize. Its #1608
   `fo api` slice additionally waits for #1596.
 - #1599 starts #1605 after #1603. #1606 lands incrementally with #1595 through #1598 and completes
-  after their supported adapters are integrated. #1633 and #1636 must close before the affected
-  suites become required gates.
+  after their supported adapters are integrated. #1633, #1636, and #1640 must close before the
+  affected suites become required gates.
 - #1600 starts #1609 after #1601. #1610 waits for both #1606 and #1609.
 
 ## Dependency graph
@@ -121,8 +122,9 @@ flowchart TD
     H --> O
     I --> O
     J --> O
-    O --> P["#1636 Stale contract tests"]
-    P --> K["#1606 Required conformance gates"]
+    O --> Q["#1636 Stale contract tests"]
+    Q --> R["#1640 Dependency-sync test compatibility"]
+    R --> K["#1606 Required conformance gates"]
     A --> L["#1609 Capability matrix"]
     C --> K
     K --> M["#1610 Claims evidence gates"]
@@ -192,6 +194,10 @@ known false timeout is not an acceptable blocking signal.
 updates assertions that still encode pre-parity CLI envelopes, HTTP exit mappings, domain errors,
 and rollback fixtures. It follows #1633 and must close before #1606 promotes the affected suites.
 
+[#1640: dependency-sync test compatibility](https://github.com/curdriceaurora/Local-File-Organizer/issues/1640)
+adapts inventory checks to the locked FastAPI router model and makes optional scikit-learn test
+requirements explicit. It follows #1636 and must close before #1606 promotes the full suite.
+
 ### Phase 3: enforcement
 
 [#1606: adapter drivers and required gates](https://github.com/curdriceaurora/Local-File-Organizer/issues/1606)
@@ -217,7 +223,7 @@ When one contributor performs the entire epic, use this order:
 
 ```text
 #1611 → #1601 → #1603 → #1605 → #1602 → #1604 → #1607 → #1596 → #1608
-→ #1597 → #1598 → #1633 → #1636 → #1606 → #1609 → #1610
+→ #1597 → #1598 → #1633 → #1636 → #1640 → #1606 → #1609 → #1610
 ```
 
 With multiple contributors, #1605 overlaps the tail of foundation work; #1596 and #1597 run in

--- a/docs/architecture/cross-surface-parity-execution.md
+++ b/docs/architecture/cross-surface-parity-execution.md
@@ -85,7 +85,8 @@ items because they were not sub-sliced. This is not duplicate scope.
   [#1597](https://github.com/curdriceaurora/Local-File-Organizer/issues/1597),
   [#1598](https://github.com/curdriceaurora/Local-File-Organizer/issues/1598), and
   [#1608](https://github.com/curdriceaurora/Local-File-Organizer/issues/1608)
-- Gate readiness: [#1633](https://github.com/curdriceaurora/Local-File-Organizer/issues/1633)
+- Gate readiness: [#1633](https://github.com/curdriceaurora/Local-File-Organizer/issues/1633) and
+  [#1636](https://github.com/curdriceaurora/Local-File-Organizer/issues/1636)
 - Enforcement and claims: [#1606](https://github.com/curdriceaurora/Local-File-Organizer/issues/1606),
   [#1609](https://github.com/curdriceaurora/Local-File-Organizer/issues/1609), and
   [#1610](https://github.com/curdriceaurora/Local-File-Organizer/issues/1610)
@@ -95,8 +96,8 @@ items because they were not sub-sliced. This is not duplicate scope.
 - #1595 starts after #1603 and #1605, and merges after #1602 and #1604 stabilize. Its #1608
   `fo api` slice additionally waits for #1596.
 - #1599 starts #1605 after #1603. #1606 lands incrementally with #1595 through #1598 and completes
-  after their supported adapters are integrated. #1633 must close before TUI/conformance suites
-  become required gates.
+  after their supported adapters are integrated. #1633 and #1636 must close before the affected
+  suites become required gates.
 - #1600 starts #1609 after #1601. #1610 waits for both #1606 and #1609.
 
 ## Dependency graph
@@ -120,7 +121,8 @@ flowchart TD
     H --> O
     I --> O
     J --> O
-    O --> K["#1606 Required conformance gates"]
+    O --> P["#1636 Stale contract tests"]
+    P --> K["#1606 Required conformance gates"]
     A --> L["#1609 Capability matrix"]
     C --> K
     K --> M["#1610 Claims evidence gates"]
@@ -186,6 +188,10 @@ removes the order-dependent class-level test pollution discovered after the TUI 
 must close before #1606 promotes TUI or cross-surface conformance suites to required gates; a
 known false timeout is not an acceptable blocking signal.
 
+[#1636: stale contract tests](https://github.com/curdriceaurora/Local-File-Organizer/issues/1636)
+updates assertions that still encode pre-parity CLI envelopes, HTTP exit mappings, domain errors,
+and rollback fixtures. It follows #1633 and must close before #1606 promotes the affected suites.
+
 ### Phase 3: enforcement
 
 [#1606: adapter drivers and required gates](https://github.com/curdriceaurora/Local-File-Organizer/issues/1606)
@@ -211,7 +217,7 @@ When one contributor performs the entire epic, use this order:
 
 ```text
 #1611 → #1601 → #1603 → #1605 → #1602 → #1604 → #1607 → #1596 → #1608
-→ #1597 → #1598 → #1633 → #1606 → #1609 → #1610
+→ #1597 → #1598 → #1633 → #1636 → #1606 → #1609 → #1610
 ```
 
 With multiple contributors, #1605 overlaps the tail of foundation work; #1596 and #1597 run in

--- a/src/file_organizer/cli/api.py
+++ b/src/file_organizer/cli/api.py
@@ -114,6 +114,8 @@ def _raise_remote_error(command: str, exc: Exception, *, as_json: bool) -> None:
         error = _client_error_payload(exc)
     exit_code = _error_code_exit_code(str(error["code"]))
     if not isinstance(exc, httpx.RequestError) and exit_code == 1:
+        # Preserve HTTP-category semantics for older servers that return a
+        # generic or otherwise non-canonical error code.
         status_code = int(getattr(exc, "status_code", 0))
         if status_code in {400, 404, 422}:
             exit_code = 2

--- a/tests/integration/test_cli_api.py
+++ b/tests/integration/test_cli_api.py
@@ -456,7 +456,9 @@ class TestFilesListCommand:
         from file_organizer.client.exceptions import ClientError
 
         client = MagicMock()
-        client.list_files.side_effect = ClientError("not found", status_code=404, detail="x")
+        client.list_files.side_effect = ClientError(
+            "not found", status_code=404, detail="not found"
+        )
         with _patch_build_client(client):
             result = runner.invoke(
                 api_app,
@@ -464,7 +466,27 @@ class TestFilesListCommand:
             )
 
         assert result.exit_code == 2
-        assert "Request failed" in result.output or "error" in result.output.lower()
+        assert "Error: not found" in result.output
+
+    def test_files_conflict_exits_3(self) -> None:
+        """A remote conflict uses the shared conflict/recovery exit category."""
+        from file_organizer.client.exceptions import ClientError
+
+        client = MagicMock()
+        client.list_files.side_effect = ClientError(
+            "conflict",
+            status_code=409,
+            detail="conflict",
+            error_code="client_error",
+        )
+        with _patch_build_client(client):
+            result = runner.invoke(
+                api_app,
+                ["files", "/conflict", "--token", "tok"],
+            )
+
+        assert result.exit_code == 3
+        assert "Error: conflict" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cli_api.py
+++ b/tests/integration/test_cli_api.py
@@ -199,8 +199,8 @@ class TestHealthCommand:
         output = result.output
         start = output.find("{")
         parsed = json.loads(output[start:])
-        assert parsed["status"] == "ok"
-        assert parsed["version"] == "1.2.3"
+        assert parsed["result"]["status"] == "ok"
+        assert parsed["result"]["version"] == "1.2.3"
 
     def test_health_client_error_exits_1(self) -> None:
         """ClientError exits with code 1 and shows error message."""
@@ -258,7 +258,7 @@ class TestLoginCommand:
         output = result.output
         start = output.find("{")
         parsed = json.loads(output[start:])
-        assert parsed["access_token"] == "at-xyz"
+        assert parsed["result"]["access_token"] == "at-xyz"
 
     def test_login_saves_token_to_file(self, tmp_path: Path) -> None:
         """--save-token writes a JSON token file to the specified path."""
@@ -362,8 +362,8 @@ class TestMeCommand:
         output = result.output
         start = output.find("{")
         parsed = json.loads(output[start:])
-        assert parsed["username"] == "bob"
-        assert parsed["email"] == "bob@y.com"
+        assert parsed["result"]["username"] == "bob"
+        assert parsed["result"]["email"] == "bob@y.com"
 
     def test_me_client_error_exits_1(self) -> None:
         """ClientError exits with code 1."""
@@ -448,11 +448,11 @@ class TestFilesListCommand:
         output = result.output
         start = output.find("{")
         parsed = json.loads(output[start:])
-        assert parsed["total"] == 3
-        assert len(parsed["items"]) == 3
+        assert parsed["result"]["total"] == 3
+        assert len(parsed["result"]["items"]) == 3
 
-    def test_files_client_error_exits_1(self) -> None:
-        """ClientError exits with code 1."""
+    def test_files_not_found_exits_2(self) -> None:
+        """A remote not-found response exits with the shared usage/not-found code."""
         from file_organizer.client.exceptions import ClientError
 
         client = MagicMock()
@@ -463,7 +463,7 @@ class TestFilesListCommand:
                 ["files", "/missing", "--token", "tok"],
             )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Request failed" in result.output or "error" in result.output.lower()
 
 
@@ -501,8 +501,8 @@ class TestSystemStatusCommand:
         output = result.output
         start = output.find("{")
         parsed = json.loads(output[start:])
-        assert parsed["disk_free"] == 600_000
-        assert parsed["active_jobs"] == 3
+        assert parsed["result"]["disk_free"] == 600_000
+        assert parsed["result"]["active_jobs"] == 3
 
     def test_system_status_client_error_exits_1(self) -> None:
         """ClientError exits with code 1."""
@@ -553,8 +553,8 @@ class TestSystemStatsCommand:
         output = result.output
         start = output.find("{")
         parsed = json.loads(output[start:])
-        assert parsed["file_count"] == 42
-        assert parsed["directory_count"] == 7
+        assert parsed["result"]["file_count"] == 42
+        assert parsed["result"]["directory_count"] == 7
 
     def test_system_stats_client_error_exits_1(self) -> None:
         """ClientError exits with code 1."""

--- a/tests/integration/test_web_files_organize_extended.py
+++ b/tests/integration/test_web_files_organize_extended.py
@@ -565,7 +565,7 @@ class TestOrganizeRollback:
             patch(
                 "file_organizer.web.organize_routes.update_job",
                 side_effect=(MagicMock(revision=2), MagicMock(revision=3)),
-            ),
+            ) as update_job,
             patch("file_organizer.undo.undo_manager.UndoManager") as manager,
         ):
             tpl.TemplateResponse.return_value = _HTML
@@ -575,6 +575,14 @@ class TestOrganizeRollback:
             )
         assert r.status_code == 200
         manager.return_value.undo_transaction.assert_called_once_with("txn-1")
+        assert update_job.call_args_list[1].kwargs["status"] == "rolled_back"
+        template_call = tpl.TemplateResponse.call_args
+        context = (
+            template_call.kwargs["context"]
+            if "context" in template_call.kwargs
+            else template_call.args[2]
+        )
+        assert context["rollback_message"] == "Rollback completed for this job's transaction."
 
     def test_rollback_without_transaction_is_unavailable(self, org_client: TestClient) -> None:
         completed_job = _mock_job(status="completed", transaction_id=None)
@@ -589,7 +597,13 @@ class TestOrganizeRollback:
             )
 
         assert r.status_code == 200
-        assert tpl.TemplateResponse.call_args.args[2]["error_message"] == (
+        template_call = tpl.TemplateResponse.call_args
+        context = (
+            template_call.kwargs["context"]
+            if "context" in template_call.kwargs
+            else template_call.args[2]
+        )
+        assert context["error_message"] == (
             "Rollback is only available for completed non-dry-run jobs."
         )
         manager.assert_not_called()

--- a/tests/integration/test_web_files_organize_extended.py
+++ b/tests/integration/test_web_files_organize_extended.py
@@ -21,6 +21,7 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.dependencies import get_settings
 from file_organizer.api.exceptions import setup_exception_handlers
 from file_organizer.api.test_utils import csrf_headers, seed_csrf_token
+from file_organizer.core.lifecycle import RecoveryAction
 from file_organizer.web.files_routes import files_router
 from file_organizer.web.organize_routes import organize_router
 
@@ -40,6 +41,7 @@ def _mock_job(
     status: str = "completed",
     result: dict | None = None,
     error: str | None = None,
+    transaction_id: str | None = None,
 ) -> MagicMock:
     from datetime import UTC, datetime
 
@@ -47,6 +49,9 @@ def _mock_job(
     job.job_id = job_id
     job.status = status
     job.error = error
+    job.error_code = None
+    job.error_retryable = False
+    job.error_details = None
     job.result = result or {
         "processed_files": 2,
         "total_files": 2,
@@ -56,6 +61,10 @@ def _mock_job(
     }
     job.created_at = datetime(2026, 1, 1, tzinfo=UTC)
     job.updated_at = datetime(2026, 1, 1, 0, 1, tzinfo=UTC)
+    job.scheduled_for = None
+    job.transaction_id = transaction_id
+    job.recovery_action = RecoveryAction.NONE
+    job.revision = 1
     return job
 
 
@@ -546,15 +555,41 @@ class TestOrganizeRollback:
         assert r.status_code == 404
 
     def test_rollback_completed_job_returns_200(self, org_client: TestClient) -> None:
+        completed_job = _mock_job(status="completed", transaction_id="txn-1")
         with (
             patch("file_organizer.web.organize_routes.templates") as tpl,
             patch(
                 "file_organizer.web.organize_routes.get_job",
-                return_value=_mock_job(status="completed"),
+                return_value=completed_job,
             ),
+            patch(
+                "file_organizer.web.organize_routes.update_job",
+                side_effect=(MagicMock(revision=2), MagicMock(revision=3)),
+            ),
+            patch("file_organizer.undo.undo_manager.UndoManager") as manager,
+        ):
+            tpl.TemplateResponse.return_value = _HTML
+            manager.return_value.undo_transaction.return_value = True
+            r = org_client.post(
+                "/ui/organize/jobs/job-1/rollback", headers=csrf_headers(org_client)
+            )
+        assert r.status_code == 200
+        manager.return_value.undo_transaction.assert_called_once_with("txn-1")
+
+    def test_rollback_without_transaction_is_unavailable(self, org_client: TestClient) -> None:
+        completed_job = _mock_job(status="completed", transaction_id=None)
+        with (
+            patch("file_organizer.web.organize_routes.templates") as tpl,
+            patch("file_organizer.web.organize_routes.get_job", return_value=completed_job),
+            patch("file_organizer.undo.undo_manager.UndoManager") as manager,
         ):
             tpl.TemplateResponse.return_value = _HTML
             r = org_client.post(
                 "/ui/organize/jobs/job-1/rollback", headers=csrf_headers(org_client)
             )
+
         assert r.status_code == 200
+        assert tpl.TemplateResponse.call_args.args[2]["error_message"] == (
+            "Rollback is only available for completed non-dry-run jobs."
+        )
+        manager.assert_not_called()

--- a/tests/web/test_organize_services.py
+++ b/tests/web/test_organize_services.py
@@ -8,6 +8,7 @@ import pytest
 
 from file_organizer.api.exceptions import ApiError
 from file_organizer.core import file_ops
+from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.organization_service import count_files_by_type
 from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.plan import build_plan_from_processed
@@ -417,7 +418,7 @@ class TestBuildOrganizePlan:
     def test_rejects_missing_input_path_before_preview(self, tmp_path) -> None:
         organizer_factory = MagicMock()
 
-        with pytest.raises(ApiError) as exc_info:
+        with pytest.raises(DomainError) as exc_info:
             build_organize_plan(
                 input_dir=str(tmp_path / "missing"),
                 output_dir=str(tmp_path),
@@ -430,7 +431,7 @@ class TestBuildOrganizePlan:
                 organizer_factory=organizer_factory,
             )
 
-        assert exc_info.value.error == "not_found"
+        assert exc_info.value.code is DomainErrorCode.NOT_FOUND
         organizer_factory.assert_not_called()
 
     def test_supports_hidden_inclusion_through_canonical_options(self, tmp_path) -> None:


### PR DESCRIPTION
## Summary

- update integration assertions for the shared `fo api` JSON envelope and exit-code mapping
- prove remote HTTP 409 conflicts map to shared exit code 3, including the defensive generic-code fallback
- assert the canonical `DomainError` emitted for missing organization inputs
- make rollback fixtures transaction-aware and assert the successful terminal status and message
- correct the Mermaid dependency graph and record #1636/#1640 before required gate promotion

## Why

Merged parity slices intentionally changed these contracts, while nine older integration assertions still encoded pre-parity behavior. Review also found that the execution graph reused a Mermaid node ID and that the rollback success test could not distinguish success from manual recovery.

A missing rollback transaction intentionally returns HTTP 200 with a rollback-unavailable message for an existing job; 404 remains reserved for a missing job.

## Validation

- `uv run pytest tests/integration/test_cli_api.py tests/integration/test_web_files_organize_extended.py tests/web/test_organize_services.py --override-ini="addopts=" -q` — 83 passed
- full `uv run pytest` — 21,860 passed, 184 skipped, 8 unrelated failures
- all eight full-suite failures reproduce in isolation: three FastAPI 0.139 nested-router inventory assumptions and five tests requiring the uninstalled `dedup` extra; tracked by #1640
- targeted pre-commit formatting, lint, mypy, interrogate, deptry, spelling, Markdown, and documentation-link checks passed

## Risk

Low. Executable product behavior is unchanged. The only source change documents the existing defensive HTTP-status fallback; the functional changes strengthen tests and correct planning documentation.

Fixes #1636