### PR TITLE
Restore dependency-sync test compatibility

### DIFF
--- a/tests/_route_inventory.py
+++ b/tests/_route_inventory.py
@@ -14,6 +14,9 @@ def iter_effective_routes(app: FastAPI) -> Iterator[Any]:
         effective_route_contexts = getattr(route, "effective_route_contexts", None)
         if callable(effective_route_contexts):
             for route_context in effective_route_contexts():
+                # Most HTTP contexts expose their effective path and methods directly.
+                # WebSocket and raw Starlette contexts instead carry the prefixed leaf
+                # route in ``starlette_route``.
                 yield getattr(route_context, "starlette_route", None) or route_context
         else:
             yield route

--- a/tests/api/route_inventory.py
+++ b/tests/api/route_inventory.py
@@ -1,0 +1,19 @@
+"""Compatibility helpers for enumerating public FastAPI routes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from fastapi import FastAPI
+
+
+def iter_effective_routes(app: FastAPI) -> Iterator[Any]:
+    """Yield leaf routes across flattened and nested FastAPI router models."""
+    for route in app.routes:
+        effective_route_contexts = getattr(route, "effective_route_contexts", None)
+        if callable(effective_route_contexts):
+            for route_context in effective_route_contexts():
+                yield getattr(route_context, "starlette_route", None) or route_context
+        else:
+            yield route

--- a/tests/api/test_capability_registry_inventory.py
+++ b/tests/api/test_capability_registry_inventory.py
@@ -7,7 +7,7 @@ import pytest
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.main import create_app
 from file_organizer.core.capabilities import Surface, get_capability_registry
-from tests.api.route_inventory import iter_effective_routes
+from tests._route_inventory import iter_effective_routes
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 

--- a/tests/api/test_capability_registry_inventory.py
+++ b/tests/api/test_capability_registry_inventory.py
@@ -7,6 +7,7 @@ import pytest
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.main import create_app
 from file_organizer.core.capabilities import Surface, get_capability_registry
+from tests.api.route_inventory import iter_effective_routes
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
@@ -26,7 +27,7 @@ def test_public_routes_match_registered_entry_points(path_prefix: str, surface: 
         for entry_point in capability.support_for(surface).entry_points
     }
     public_routes: set[str] = set()
-    for route in app.routes:
+    for route in iter_effective_routes(app):
         path = getattr(route, "path", "")
         if not path.startswith(path_prefix):
             continue

--- a/tests/client/test_endpoint_inventory.py
+++ b/tests/client/test_endpoint_inventory.py
@@ -13,7 +13,7 @@ from file_organizer.client.async_client import AsyncFileOrganizerClient
 from file_organizer.client.endpoint_spec import INTENTIONAL_EXCLUSIONS, PUBLIC_ENDPOINTS
 from file_organizer.client.sync_client import FileOrganizerClient
 from file_organizer.core.capabilities import Surface, get_capability_registry
-from tests.api.route_inventory import iter_effective_routes
+from tests._route_inventory import iter_effective_routes
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 

--- a/tests/client/test_endpoint_inventory.py
+++ b/tests/client/test_endpoint_inventory.py
@@ -13,6 +13,7 @@ from file_organizer.client.async_client import AsyncFileOrganizerClient
 from file_organizer.client.endpoint_spec import INTENTIONAL_EXCLUSIONS, PUBLIC_ENDPOINTS
 from file_organizer.client.sync_client import FileOrganizerClient
 from file_organizer.core.capabilities import Surface, get_capability_registry
+from tests.api.route_inventory import iter_effective_routes
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
@@ -26,7 +27,7 @@ def _app():
 def test_endpoint_spec_exactly_matches_public_openapi_routes() -> None:
     actual = {
         f"{method} {route.path}"
-        for route in _app().routes
+        for route in iter_effective_routes(_app())
         if route.path.startswith("/api/v1")
         for method in (getattr(route, "methods", None) or set())
         if method in _HTTP_METHODS

--- a/tests/integration/test_services_coverage.py
+++ b/tests/integration/test_services_coverage.py
@@ -800,17 +800,16 @@ class TestServiceAudioTranscriber:
 
 @pytest.fixture
 def require_sklearn() -> None:
-    """Skip positive DocumentEmbedder behavior when the dedup extra is absent."""
+    """Skip positive behavior unless scikit-learn is provided by dedup or search."""
     pytest.importorskip("sklearn")
 
 
-@pytest.mark.extras
 class TestDocumentEmbedder:
     def test_document_embedder_constructor_import_error(self) -> None:
         real_import = builtins.__import__
 
         def reject_sklearn(name: str, *args, **kwargs):
-            if name.startswith("sklearn"):
+            if name == "sklearn" or name.startswith("sklearn."):
                 raise ImportError("simulated missing optional dependency")
             return real_import(name, *args, **kwargs)
 
@@ -819,6 +818,7 @@ class TestDocumentEmbedder:
                 DocumentEmbedder()
             assert "scikit-learn is required" in str(exc.value)
 
+    @pytest.mark.extras
     def test_embedder_fit_transform_and_caching(
         self, tmp_path: Path, require_sklearn: None
     ) -> None:
@@ -875,6 +875,7 @@ class TestDocumentEmbedder:
         emb_batch = embedder.transform_batch([doc, "cherry date"])
         assert emb_batch.shape == (2, 5)
 
+    @pytest.mark.extras
     def test_vocabulary_features_and_top_terms(self, require_sklearn: None) -> None:
         embedder = DocumentEmbedder(max_features=10, max_df=1.0, ngram_range=(1, 1))
 
@@ -906,6 +907,7 @@ class TestDocumentEmbedder:
         assert len(top) == 2
         assert top[0][0] in ["apple", "banana"]
 
+    @pytest.mark.extras
     def test_save_load_model_and_cache_persistency(
         self, tmp_path: Path, require_sklearn: None
     ) -> None:
@@ -944,6 +946,7 @@ class TestDocumentEmbedder:
         embedder3.clear_cache()
         assert len(embedder3.embedding_cache) == 0
 
+    @pytest.mark.extras
     def test_embedder_error_and_edge_cases(self, tmp_path: Path, require_sklearn: None) -> None:
         # 1. fit_transform with 1 document (triggers length * max_df < 1)
         embedder = DocumentEmbedder(max_features=5, max_df=0.95, ngram_range=(1, 1))

--- a/tests/integration/test_services_coverage.py
+++ b/tests/integration/test_services_coverage.py
@@ -11,6 +11,7 @@ Files covered:
 
 from __future__ import annotations
 
+import builtins
 import sys
 import types
 from pathlib import Path
@@ -797,14 +798,30 @@ class TestServiceAudioTranscriber:
 # ===========================================================================
 
 
+@pytest.fixture
+def require_sklearn() -> None:
+    """Skip positive DocumentEmbedder behavior when the dedup extra is absent."""
+    pytest.importorskip("sklearn")
+
+
+@pytest.mark.extras
 class TestDocumentEmbedder:
     def test_document_embedder_constructor_import_error(self) -> None:
-        with patch("sklearn.feature_extraction.text.TfidfVectorizer", side_effect=ImportError()):
+        real_import = builtins.__import__
+
+        def reject_sklearn(name: str, *args, **kwargs):
+            if name.startswith("sklearn"):
+                raise ImportError("simulated missing optional dependency")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=reject_sklearn):
             with pytest.raises(ImportError, match="scikit-learn is required") as exc:
                 DocumentEmbedder()
             assert "scikit-learn is required" in str(exc.value)
 
-    def test_embedder_fit_transform_and_caching(self, tmp_path: Path) -> None:
+    def test_embedder_fit_transform_and_caching(
+        self, tmp_path: Path, require_sklearn: None
+    ) -> None:
         embedder = DocumentEmbedder(
             max_features=10,
             ngram_range=(1, 1),
@@ -858,7 +875,7 @@ class TestDocumentEmbedder:
         emb_batch = embedder.transform_batch([doc, "cherry date"])
         assert emb_batch.shape == (2, 5)
 
-    def test_vocabulary_features_and_top_terms(self) -> None:
+    def test_vocabulary_features_and_top_terms(self, require_sklearn: None) -> None:
         embedder = DocumentEmbedder(max_features=10, max_df=1.0, ngram_range=(1, 1))
 
         # Fit fitted checks
@@ -889,7 +906,9 @@ class TestDocumentEmbedder:
         assert len(top) == 2
         assert top[0][0] in ["apple", "banana"]
 
-    def test_save_load_model_and_cache_persistency(self, tmp_path: Path) -> None:
+    def test_save_load_model_and_cache_persistency(
+        self, tmp_path: Path, require_sklearn: None
+    ) -> None:
         model_file = tmp_path / "tfidf.pkl"
         cache_file = tmp_path / "cache.pkl"
 
@@ -925,7 +944,7 @@ class TestDocumentEmbedder:
         embedder3.clear_cache()
         assert len(embedder3.embedding_cache) == 0
 
-    def test_embedder_error_and_edge_cases(self, tmp_path: Path) -> None:
+    def test_embedder_error_and_edge_cases(self, tmp_path: Path, require_sklearn: None) -> None:
         # 1. fit_transform with 1 document (triggers length * max_df < 1)
         embedder = DocumentEmbedder(max_features=5, max_df=0.95, ngram_range=(1, 1))
         res = embedder.fit_transform(["apple"])


### PR DESCRIPTION
## Summary

- enumerate effective FastAPI leaf routes across both flattened and nested included-router models
- preserve bidirectional REST/Web capability ownership checks, including WebSocket routes
- classify positive DocumentEmbedder behavior as optional-extra coverage
- run those positive tests when scikit-learn is supplied by either the `dedup` or `search` extra
- keep the missing-dependency error path hermetic and executable in minimal jobs

## Why

The synchronized dependency set upgraded FastAPI to a router model that retains `_IncludedRouter` containers. Inventory tests reading only top-level `app.routes` therefore reported registered routes as stale. Separately, four positive DocumentEmbedder tests assumed scikit-learn was installed even though it is optional through both the `dedup` and `search` extras; the missing-dependency test also tried to patch through the absent package.

## Validation

Validation used the workspace `.venv` for both commands:

- `uv run which python` and `uv run which pytest` resolve inside the workspace `.venv`
- FastAPI 0.139.2 (the `uv.lock` pin), pytest 9.1.1, scikit-learn absent
- isolated compatibility matrix: 4 passed, 4 intentionally skipped
- `-m "not extras"` selector check: 1 passed, 4 deselected, proving the hermetic missing-dependency test remains in minimal runs
- affected modules: 40 passed, 4 intentionally skipped
- `uv run --with "scikit-learn~=1.4" pytest tests/integration/test_services_coverage.py::TestDocumentEmbedder --override-ini="addopts=" -q`: 5 passed
- full `uv run pytest`: 21,862 passed, 188 skipped, 2 randomized-order failures:
  - `tests/pipeline/test_orchestrator_branches.py::TestStagedBatchProcessing::test_prefetch_stages_greater_than_one_logs_warning`
  - `tests/parallel/test_checkpoint.py::TestCheckpointManagerInit::test_default_dir`
- both randomized-order failures passed together in isolation
- targeted pre-commit formatting, lint, spelling, and repository guard checks passed

## Risk

Low and test-only. The route helper follows FastAPI effective route contexts and falls back to the prior flattened model. The uncommon `starlette_route` branch handles raw Starlette/WebSocket contexts explicitly. Positive optional-extra coverage still runs when scikit-learn is installed; only minimal environments skip it.

Fixes #1640