### PR TITLE
fix(parity): validate the conformance-verified claim against registry evidence

### DIFF
--- a/docs/developer/capability-registry.md
+++ b/docs/developer/capability-registry.md
@@ -95,10 +95,20 @@ Changes to `capability_registry.json` require re-running the generator script. P
 
 Public claims in `README.md` link directly to capability evidence in `capability-matrix.md`.
 
-Verify claim links, matrix anchors, and canonical capability/surface counts using:
+Verify claim links, matrix anchors, canonical capability/surface counts, and the
+conformance-verified claim using:
 
 ```bash
-python scripts/verify_claims_freshness.py --check
+python scripts/verify_claims_freshness.py
 ```
 
-CI enforces claim freshness, anchor accuracy, and count stability via `test_public_claims_freshness` in `tests/core/test_capabilities.py`.
+The script has no write mode, so verification always runs; `--check` is accepted only for symmetry
+with `generate_capability_matrix.py --check`.
+
+The conformance check closes the loop in both directions. A capability may not be advertised as
+conformance-verified unless it holds a `verified` surface in the registry, and a capability holding
+verified evidence may not be omitted from that claim. Promoting or revoking conformance evidence
+therefore fails the check until `README.md` is updated to match.
+
+CI enforces claim freshness, anchor accuracy, count stability, and conformance-claim accuracy via
+`test_public_claims_freshness` in `tests/core/test_capabilities.py`.

--- a/scripts/verify_claims_freshness.py
+++ b/scripts/verify_claims_freshness.py
@@ -8,6 +8,8 @@ This script parses README.md and docs/developer/capability-matrix.md to ensure:
 4. Product metrics (capability count, surface count, TUI views) match canonical registry state.
 5. No unverified marketing metrics or un-inventoried feature claims exist in README.md.
 6. Optional feature pack requirements ([audio], [video], [dedup]) are properly qualified.
+7. Capabilities advertised as conformance-verified actually hold conformance evidence, and no
+   conformance-verified capability is omitted from that claim.
 """
 
 from __future__ import annotations
@@ -41,9 +43,11 @@ _CAPABILITY_ID_PATTERN = re.compile(r"`?([a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)`?")
 _HTML_ANCHOR_PATTERN = re.compile(r'<a\s+(?:id|name)="([^"]+)"')
 _HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 
-# Pattern for unverified quantitative marketing claims (e.g. "840 tests", "408 modules", "1200 devices", "99.99% uptime")
+# Retired hand-maintained inventory claims. These counted source artefacts rather than product
+# capabilities and were never reproducible; the canonical counts below replace them. Uptime is
+# listed because a locally executed tool cannot substantiate an availability figure at all.
 _UNVERIFIED_MARKETING_PATTERN = re.compile(
-    r"\b(?:\d+\s+(?:tests|modules|file types|devices)|99\.\d+%\s+uptime)\b", re.IGNORECASE
+    r"\b(?:\d+\s+(?:tests|modules|file types)|\d+(?:\.\d+)?%\s+uptime)\b", re.IGNORECASE
 )
 
 # Canonical counts verification patterns
@@ -51,13 +55,27 @@ _CAPABILITY_COUNT_CLAIM_PATTERN = re.compile(r"\b(\d+)\s+product capabilities\b"
 _SURFACE_COUNT_CLAIM_PATTERN = re.compile(r"\b(\d+)\s+official surfaces\b", re.IGNORECASE)
 _TUI_VIEW_COUNT_CLAIM_PATTERN = re.compile(r"\b(\d+)-view Textual TUI\b", re.IGNORECASE)
 
+# Clause advertising which capabilities hold conformance evidence, e.g.
+# "conformance-verified for [`organization.execute`](...), and [`methodology.configure`](...))".
+_CONFORMANCE_CLAIM_PATTERN = re.compile(r"conformance-verified for\b(?P<claim>[^\n]*)")
+
 CANONICAL_TUI_VIEW_COUNT = 8
 
 
-def _slugify_heading(heading_text: str) -> str:
-    """Convert Markdown heading text to GitHub Markdown anchor slug format."""
-    clean = re.sub(r"[^\w\s-]", "", heading_text.lower())
-    return re.sub(r"[\s_]+", "-", clean.strip())
+def _slugify_heading(heading_text: str) -> set[str]:
+    """Return candidate GitHub anchor slugs for one Markdown heading.
+
+    GitHub emits one hyphen per whitespace character, while many Markdown tools collapse runs of
+    whitespace into a single hyphen. Headings here contain em dashes surrounded by spaces, so the
+    two conventions disagree. Accept both rather than guess which renderer the reader uses.
+    """
+    clean = re.sub(r"[^\w\s-]", "", heading_text.lower()).strip()
+    if not clean:
+        return set()
+    return {
+        re.sub(r"[\s_]+", "-", clean),  # collapsed runs
+        re.sub(r"[\s_]", "-", clean),  # one hyphen per whitespace character
+    }
 
 
 def extract_matrix_anchors(matrix_path: Path) -> set[str]:
@@ -71,11 +89,61 @@ def extract_matrix_anchors(matrix_path: Path) -> set[str]:
     for match in _HTML_ANCHOR_PATTERN.finditer(content):
         anchors.add(match.group(1))
 
+    # GitHub disambiguates repeated heading slugs with -1, -2, ... in document order.
+    seen: dict[str, int] = {}
     for match in _HEADING_PATTERN.finditer(content):
-        heading_text = match.group(2).strip()
-        anchors.add(_slugify_heading(heading_text))
+        for slug in _slugify_heading(match.group(2).strip()):
+            occurrence = seen.get(slug, 0)
+            anchors.add(slug if occurrence == 0 else f"{slug}-{occurrence}")
+            seen[slug] = occurrence + 1
 
     return anchors
+
+
+def _verified_capability_ids() -> set[str]:
+    """Return capability IDs holding conformance evidence on at least one surface."""
+    from file_organizer.core.capabilities import ConformanceStatus
+
+    return {
+        capability.capability_id
+        for capability in get_capability_registry().capabilities
+        for surface in Surface
+        if capability.support_for(surface).conformance_status is ConformanceStatus.VERIFIED
+    }
+
+
+def _verify_conformance_claims(content: str) -> list[str]:
+    """Audit the conformance-verified claim against actual registry evidence.
+
+    A link resolving to a real capability proves nothing about that capability holding evidence.
+    This closes the loop in both directions: nothing may be advertised as conformance-verified
+    without evidence, and nothing holding evidence may be quietly omitted.
+    """
+    claim_match = _CONFORMANCE_CLAIM_PATTERN.search(content)
+    if not claim_match:
+        return []
+
+    claimed: set[str] = set()
+    for link in _MATRIX_LINK_PATTERN.finditer(claim_match.group("claim")):
+        cap_match = _CAPABILITY_ID_PATTERN.search(link.group(1))
+        if cap_match:
+            claimed.add(cap_match.group(1))
+    if not claimed:
+        return ["README.md advertises conformance-verified capabilities but links none of them."]
+
+    verified = _verified_capability_ids()
+    errors: list[str] = []
+    for capability_id in sorted(claimed - verified):
+        errors.append(
+            f"README.md advertises '{capability_id}' as conformance-verified, but it holds no "
+            "verified surface in the capability registry."
+        )
+    for capability_id in sorted(verified - claimed):
+        errors.append(
+            f"README.md omits '{capability_id}' from its conformance-verified claim even though "
+            "it holds verified conformance evidence."
+        )
+    return errors
 
 
 def _verify_marketing_stats(content: str) -> list[str]:
@@ -218,6 +286,7 @@ def verify_public_claims(
         _verify_matrix_links(readme_content, valid_anchors, valid_capability_ids, matrix_path.name)
     )
     errors.extend(_verify_feature_bullets(readme_content))
+    errors.extend(_verify_conformance_claims(readme_content))
 
     return errors
 
@@ -241,8 +310,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--check",
         action="store_true",
-        default=True,
-        help="Verify claims freshness and link resolution (default: True)",
+        help=(
+            "Accepted for symmetry with generate_capability_matrix.py --check. This script has no "
+            "write mode, so verification always runs whether or not the flag is passed."
+        ),
     )
     args = parser.parse_args(argv)
 

--- a/scripts/verify_claims_freshness.py
+++ b/scripts/verify_claims_freshness.py
@@ -101,14 +101,19 @@ def extract_matrix_anchors(matrix_path: Path) -> set[str]:
 
 
 def _verified_capability_ids() -> set[str]:
-    """Return capability IDs holding conformance evidence on at least one surface."""
+    """Return capability IDs holding conformance evidence on at least one surface.
+
+    Iterate declared surfaces rather than the Surface enum: ``support_for`` raises for a surface a
+    capability does not declare, so enum iteration would depend on the registry loader's
+    completeness invariant holding forever.
+    """
     from file_organizer.core.capabilities import ConformanceStatus
 
     return {
         capability.capability_id
         for capability in get_capability_registry().capabilities
-        for surface in Surface
-        if capability.support_for(surface).conformance_status is ConformanceStatus.VERIFIED
+        for status in capability.surfaces
+        if status.conformance_status is ConformanceStatus.VERIFIED
     }
 
 
@@ -118,9 +123,19 @@ def _verify_conformance_claims(content: str) -> list[str]:
     A link resolving to a real capability proves nothing about that capability holding evidence.
     This closes the loop in both directions: nothing may be advertised as conformance-verified
     without evidence, and nothing holding evidence may be quietly omitted.
+
+    The clause is required only when the README advertises a capability count. Quoting a headline
+    capability total without scoping which of those capabilities are actually proven is the claim
+    this whole script exists to prevent, so deleting the clause must not be a way to pass. A README
+    that makes no capability-count claim has nothing to scope and is left alone.
     """
     claim_match = _CONFORMANCE_CLAIM_PATTERN.search(content)
     if not claim_match:
+        if _CAPABILITY_COUNT_CLAIM_PATTERN.search(content):
+            return [
+                "README.md advertises a product capability count but no conformance-verified "
+                "claim scoping which of those capabilities hold evidence."
+            ]
         return []
 
     claimed: set[str] = set()

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import inspect
 import json
+from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
 
@@ -462,3 +463,78 @@ def test_public_claims_freshness_anchor_mismatch(tmp_path: Path) -> None:
         "has mismatched anchor '#audiotranscribe' (expected '#analysisinspect')" in err
         for err in errors
     )
+
+
+def _conformance_claim_readme(capability_ids: Iterable[str]) -> str:
+    """Render a minimal README advertising the given capabilities as conformance-verified."""
+    links = ", ".join(
+        f"[`{capability_id}`](docs/developer/capability-matrix.md#{capability_id.replace('.', '')})"
+        for capability_id in capability_ids
+    )
+    return f"## Features\n\n- **Matrix**: conformance-verified for {links}.\n"
+
+
+def test_public_claims_rejects_capability_advertised_without_evidence(tmp_path: Path) -> None:
+    from scripts.verify_claims_freshness import _verified_capability_ids, verify_public_claims
+
+    verified = _verified_capability_ids()
+    unverified = sorted(
+        capability.capability_id
+        for capability in get_capability_registry().capabilities
+        if capability.capability_id not in verified
+    )
+    assert unverified, "registry must retain at least one capability without conformance evidence"
+
+    readme = tmp_path / "README_overclaim.md"
+    readme.write_text(_conformance_claim_readme([unverified[0]]), encoding="utf-8")
+
+    errors = verify_public_claims(readme)
+    assert any(
+        f"advertises '{unverified[0]}' as conformance-verified, but it holds no verified surface"
+        in err
+        for err in errors
+    )
+
+
+def test_public_claims_rejects_omitting_a_verified_capability(tmp_path: Path) -> None:
+    from scripts.verify_claims_freshness import _verified_capability_ids, verify_public_claims
+
+    verified = sorted(_verified_capability_ids())
+    assert len(verified) > 1, "registry must hold more than one verified capability"
+
+    # Advertise every verified capability except one; the omission must be reported.
+    readme = tmp_path / "README_omission.md"
+    readme.write_text(_conformance_claim_readme(verified[1:]), encoding="utf-8")
+
+    errors = verify_public_claims(readme)
+    assert any(
+        f"omits '{verified[0]}' from its conformance-verified claim" in err for err in errors
+    )
+
+
+def test_public_claims_rejects_retired_inventory_metrics(tmp_path: Path) -> None:
+    from scripts.verify_claims_freshness import verify_public_claims
+
+    readme = tmp_path / "README_metrics.md"
+    readme.write_text(
+        "## Features\n\n- **Support**: Operates on 840 tests, 408 modules, and 39 file types "
+        "with 99.99% uptime (see [`analysis.inspect`]"
+        "(docs/developer/capability-matrix.md#analysisinspect)).\n",
+        encoding="utf-8",
+    )
+
+    errors = verify_public_claims(readme)
+    for retired in ("840 tests", "408 modules", "39 file types", "99.99% uptime"):
+        assert any(retired in err for err in errors), f"{retired} must be rejected"
+
+
+def test_matrix_heading_slugs_accept_both_whitespace_conventions() -> None:
+    from scripts.verify_claims_freshness import _slugify_heading
+
+    # GitHub emits one hyphen per whitespace character; other renderers collapse runs.
+    assert _slugify_heading("`organization.execute` — Organization execution") == {
+        "organizationexecute-organization-execution",
+        "organizationexecute--organization-execution",
+    }
+    assert _slugify_heading("Summary Statistics") == {"summary-statistics"}
+    assert _slugify_heading("!!!") == set()

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -528,6 +528,48 @@ def test_public_claims_rejects_retired_inventory_metrics(tmp_path: Path) -> None
         assert any(retired in err for err in errors), f"{retired} must be rejected"
 
 
+def test_public_claims_rejects_capability_count_without_conformance_scope(tmp_path: Path) -> None:
+    from scripts.verify_claims_freshness import verify_public_claims
+
+    # Deleting the conformance clause must not be a way to pass while still quoting a headline total.
+    readme = tmp_path / "README_unscoped.md"
+    readme.write_text(
+        "## Features\n\n- **Matrix**: Built on [34 product capabilities]"
+        "(docs/developer/capability-matrix.md#summary-statistics).\n",
+        encoding="utf-8",
+    )
+
+    errors = verify_public_claims(readme)
+    assert any("no conformance-verified claim scoping" in err for err in errors)
+
+
+def test_public_claims_allows_readme_making_no_capability_count_claim(tmp_path: Path) -> None:
+    from scripts.verify_claims_freshness import verify_public_claims
+
+    # Nothing to scope, so the conformance clause is not required.
+    readme = tmp_path / "README_noclaim.md"
+    readme.write_text(
+        "## Features\n\n- **Analysis**: See [`analysis.inspect`]"
+        "(docs/developer/capability-matrix.md#analysisinspect).\n",
+        encoding="utf-8",
+    )
+
+    errors = verify_public_claims(readme)
+    assert not any("conformance-verified" in err for err in errors), errors
+
+
+def test_matrix_anchors_disambiguate_repeated_headings() -> None:
+    from scripts.verify_claims_freshness import DEFAULT_MATRIX_PATH, extract_matrix_anchors
+
+    # "#### Surface Status & Entry Points" repeats once per capability, so GitHub's -1/-2
+    # disambiguation is load-bearing here rather than theoretical.
+    anchors = extract_matrix_anchors(DEFAULT_MATRIX_PATH)
+    base = "surface-status--entry-points"
+    assert base in anchors
+    assert f"{base}-1" in anchors
+    assert f"{base}-33" in anchors
+
+
 def test_matrix_heading_slugs_accept_both_whitespace_conventions() -> None:
     from scripts.verify_claims_freshness import _slugify_heading
 


### PR DESCRIPTION
## Summary

Closes the last review finding on #1610, which merged in #1647 without it.

The claims checker confirmed README links resolved to real capabilities but never asked whether those capabilities held evidence. Revoking conformance in the registry therefore left the public claim silently false — the exact drift #1610 exists to catch.

- verify the conformance-verified claim in **both** directions: nothing may be advertised without a `verified` surface, and nothing holding evidence may be omitted
- drop `--check`'s `default=True`, which made it permanently true and unusable
- narrow the retired-metrics pattern to the inventory claims it exists to retire
- accept both GitHub and collapsed-whitespace heading slugs, plus GitHub's `-1`/`-2` duplicate suffixes

## Evidence

Against the merged tree (`102ea7d5`), revoking `methodology.configure`'s evidence while README still advertises it: **exit 0, undetected**.

With this change:

| Mutation | Result |
| --- | --- |
| Revoke evidence for an advertised capability | exit 1 — caught |
| Grant evidence to a capability README omits | exit 1 — caught |
| Dead matrix anchors | exit 1 — caught |
| Unlinked new feature bullet | exit 1 — caught |
| Capability-count drift | exit 1 — caught |

Four new negative-path tests (37 → 41 passed). The conformance fixtures derive from the registry at runtime rather than hardcoding capability names, so they cannot silently stop testing anything as conformance status changes.

`pre-commit run --files` passed on all three files. `ruff check` / `ruff format` clean.

## Note

The exhaustiveness half means promoting any capability to `verified` now fails CI until `README.md` names it. That is deliberate — it stops the claim rotting in the understating direction — but it does add a required README edit to each future conformance promotion. Say the word and I will drop that half.

Part of #1610
Part of #1593