### PR TITLE
refactor(parity): consolidate the methodology vocabulary onto one authority (#1618)

### DIFF
--- a/docs/developer/organization-service.md
+++ b/docs/developer/organization-service.md
@@ -71,12 +71,27 @@ form fields where a stale value must not crash the surface. `OrganizeOptions` is
 anything non-canonical, including aliases: an alias reaching the domain means an adapter skipped
 normalization, which should fail loudly rather than be quietly understood.
 
-Adapters that cannot derive their vocabulary — the Pydantic `Literal` annotations in the REST and
-Python SDK models, and the TypeScript union in `types.ts` — are pinned by
-`tests/core/test_methodology_vocabulary.py` instead. Deriving them would change the emitted OpenAPI
-schema and the generated client surface for no behavioral gain, so the guard proves they cannot
-drift rather than removing the duplication. Adding a methodology therefore means updating the enum
-and those three declarations; the guard fails until they agree.
+Five adapters cannot derive their vocabulary and are pinned by
+`tests/core/test_methodology_vocabulary.py` instead. The REST and Python SDK models and the
+TypeScript union stay literal because deriving them would change the emitted OpenAPI schema and the
+generated client surface for no behavioral gain. The TUI view's `BINDINGS` and `action_set_*`
+handlers stay literal because Textual resolves both at class-definition time and dispatches actions
+by name. In each case the guard proves the duplication cannot drift rather than removing it.
+
+Adding a methodology therefore means updating `OrganizationMethodology` and then, by hand:
+
+| Site | Change |
+| --- | --- |
+| `api/models.py` | add the value to the `methodology` `Literal` |
+| `client/models.py` | add the value to the `methodology` `Literal` |
+| `client/typescript/types.ts` | add the value to the `methodology` union |
+| `tui/methodology_view.py` | add a `Binding` and a matching `action_set_<value>` handler |
+| `tui/methodology_view.py` | add the value to `MethodologySelectorPanel._METHODS` and `_SHORTCUTS` |
+| `config/methodology.py` | add a display label to `LABELS` |
+
+Everything else — `ORDER`, `DEFAULT`, the CLI validator, the CLI setup prompt, the CLI help text,
+and the domain error message — derives automatically. The vocabulary guard fails until every manual
+site above agrees with the enum, so an incomplete addition cannot ship.
 
 ## Plan compatibility
 

--- a/docs/developer/organization-service.md
+++ b/docs/developer/organization-service.md
@@ -55,6 +55,29 @@ before collision handling and plan construction. PARA routing uses the existing 
 primitives; Johnny Decimal routing uses the repository's default area scheme and numbering
 primitives. Presentation adapters must not rewrite destinations after a plan is built.
 
+### Methodology vocabulary
+
+`OrganizationMethodology` in `file_organizer.core.organize_options` is the single authoritative
+value model. No adapter defines its own. `file_organizer.config.methodology` derives every constant
+from that enum and adds the two things the domain deliberately does not carry:
+
+- **display labels**, a presentation concern that may legitimately differ per surface;
+- **legacy aliases** (`content_based` → `none`, `johnny_decimal` → `jd`), accepted only at
+  configuration and transport boundaries.
+
+The two layers differ in strictness on purpose. `config.methodology.normalize()` is lenient and
+falls back to a caller-supplied default, because it reads persisted configuration and user-supplied
+form fields where a stale value must not crash the surface. `OrganizeOptions` is strict and rejects
+anything non-canonical, including aliases: an alias reaching the domain means an adapter skipped
+normalization, which should fail loudly rather than be quietly understood.
+
+Adapters that cannot derive their vocabulary — the Pydantic `Literal` annotations in the REST and
+Python SDK models, and the TypeScript union in `types.ts` — are pinned by
+`tests/core/test_methodology_vocabulary.py` instead. Deriving them would change the emitted OpenAPI
+schema and the generated client surface for no behavioral gain, so the guard proves they cannot
+drift rather than removing the duplication. Adding a methodology therefore means updating the enum
+and those three declarations; the guard fails until they agree.
+
 ## Plan compatibility
 
 Organization plan schema 3 records canonical `transfer_mode` and `methodology` options. Schema-1

--- a/src/file_organizer/cli/config_cli.py
+++ b/src/file_organizer/cli/config_cli.py
@@ -7,6 +7,8 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
+from file_organizer.config.methodology import ORDER as _METHODOLOGY_ORDER
+
 console = Console()
 
 config_app = typer.Typer(help="Configuration management.")
@@ -59,7 +61,8 @@ def config_edit(
         str | None, typer.Option(help="Set device (auto, cpu, cuda, mps, metal).")
     ] = None,
     methodology: Annotated[
-        str | None, typer.Option(help="Set default methodology (none, para, jd).")
+        str | None,
+        typer.Option(help=f"Set default methodology ({', '.join(_METHODOLOGY_ORDER)})."),
     ] = None,
 ) -> None:
     """Edit a configuration profile."""
@@ -67,7 +70,7 @@ def config_edit(
     from file_organizer.utils.cli_errors import format_validation_error
 
     _VALID_DEVICES = {"auto", "cpu", "cuda", "mps", "metal"}
-    _VALID_METHODOLOGIES = {"none", "para", "jd"}
+    _VALID_METHODOLOGIES = set(_METHODOLOGY_ORDER)
 
     # Validate constrained inputs before touching the config file. Use
     # `format_validation_error` so each site emits a "valid values: ..."

--- a/src/file_organizer/cli/setup.py
+++ b/src/file_organizer/cli/setup.py
@@ -9,6 +9,8 @@ from rich.panel import Panel
 from rich.table import Table
 
 from file_organizer.cli.interactive import confirm_action, console, prompt_choice
+from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
+from file_organizer.config.methodology import ORDER as _METHODOLOGY_ORDER
 from file_organizer.core.setup_wizard import SetupWizard, WizardMode, ollama_next_steps
 
 setup_app = typer.Typer(help="Interactive setup wizard for first-run configuration.")
@@ -193,8 +195,8 @@ def setup_run(  # noqa: C901
         # Methodology selection
         methodology = prompt_choice(
             "Select default organization methodology",
-            ["none", "para", "jd"],
-            default="none",
+            list(_METHODOLOGY_ORDER),
+            default=_DEFAULT_METHODOLOGY,
         )
         custom_settings["methodology"] = methodology
 

--- a/src/file_organizer/config/methodology.py
+++ b/src/file_organizer/config/methodology.py
@@ -19,6 +19,9 @@ map it to.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
+
 from file_organizer.core.organize_options import OrganizationMethodology
 
 NONE = OrganizationMethodology.NONE.value
@@ -35,10 +38,15 @@ LABELS: dict[str, str] = {
     JOHNNY_DECIMAL: "Johnny Decimal",
 }
 
-ALIASES: dict[str, str] = {
-    "content_based": NONE,
-    "johnny_decimal": JOHNNY_DECIMAL,
-}
+# Public so callers and guards can enumerate what the boundary accepts, and immutable because a
+# mutable module-level dict would let any importer widen the accepted vocabulary at runtime —
+# exactly the drift this module exists to prevent.
+ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "content_based": NONE,
+        "johnny_decimal": JOHNNY_DECIMAL,
+    }
+)
 
 
 def resolve(value: object) -> OrganizationMethodology | None:

--- a/src/file_organizer/config/methodology.py
+++ b/src/file_organizer/config/methodology.py
@@ -1,21 +1,33 @@
-"""Canonical organization-methodology vocabulary.
+"""Configuration and presentation vocabulary for organization methodologies.
 
-Single source of truth for the three organization methodologies (flat/none,
-PARA, Johnny Decimal) shared across ``AppConfig``, the TUI, the web UI, and
-the API. Previously the web layer defined its own, partially incompatible
-vocabulary (``content_based`` / ``date_based`` instead of ``none``), with no
-implementation ever backing ``date_based`` — see #1538.
+The canonical value model is :class:`~file_organizer.core.organize_options.OrganizationMethodology`.
+Every constant here derives from that enum, so this module cannot introduce a methodology the
+domain does not recognize. It adds two things the domain deliberately does not carry:
+
+* display labels, which are a presentation concern;
+* legacy aliases, which are accepted only at configuration and transport boundaries.
+
+Aliases are resolved on the way in and never written back out. The domain contract stays strict:
+``OrganizeOptions`` accepts canonical values only, so an alias reaching it means an adapter failed
+to normalize rather than a value the domain should quietly understand.
+
+Historically the web layer defined its own partially incompatible vocabulary (``content_based`` /
+``date_based`` instead of ``none``), with no implementation ever backing ``date_based`` — see #1538.
+``date_based`` is therefore deliberately absent from the alias table: there is no canonical value to
+map it to.
 """
 
 from __future__ import annotations
 
-NONE = "none"
-PARA = "para"
-JOHNNY_DECIMAL = "jd"
+from file_organizer.core.organize_options import OrganizationMethodology
 
-DEFAULT = NONE
+NONE = OrganizationMethodology.NONE.value
+PARA = OrganizationMethodology.PARA.value
+JOHNNY_DECIMAL = OrganizationMethodology.JOHNNY_DECIMAL.value
 
-ORDER: tuple[str, ...] = (NONE, PARA, JOHNNY_DECIMAL)
+DEFAULT = OrganizationMethodology.NONE.value
+
+ORDER: tuple[str, ...] = tuple(member.value for member in OrganizationMethodology)
 
 LABELS: dict[str, str] = {
     NONE: "None (flat / content-based)",
@@ -23,20 +35,41 @@ LABELS: dict[str, str] = {
     JOHNNY_DECIMAL: "Johnny Decimal",
 }
 
-# Legacy string values from before the vocabulary was unified (old
-# web-settings.json files, in-memory web job metadata, hand-typed API
-# requests). Mapped to their canonical equivalent by normalize(); never
-# written back out. ``date_based`` is deliberately absent: it was a web-only
-# dropdown option with no organizer implementation behind it anywhere in the
-# codebase, so there is no canonical value to alias it to.
-_ALIASES: dict[str, str] = {
+ALIASES: dict[str, str] = {
     "content_based": NONE,
     "johnny_decimal": JOHNNY_DECIMAL,
 }
 
 
+def resolve(value: object) -> OrganizationMethodology | None:
+    """Return the canonical methodology for ``value``, or ``None`` if unrecognized.
+
+    Args:
+        value: Candidate methodology from any surface (form field, API request,
+            persisted config or settings file).
+
+    Returns:
+        The matching :class:`OrganizationMethodology`, or ``None`` when ``value`` is
+        neither a canonical value nor a known legacy alias.
+    """
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    try:
+        return OrganizationMethodology(candidate)
+    except ValueError:
+        aliased = ALIASES.get(candidate)
+        return OrganizationMethodology(aliased) if aliased is not None else None
+
+
 def normalize(value: object, *, default: str = DEFAULT) -> str:
     """Return a canonical methodology value, mapping known legacy aliases.
+
+    Deliberately lenient: an unrecognized value yields *default* rather than raising, because
+    callers read persisted configuration and user-supplied form fields where a stale value must not
+    crash the surface. Paths that require strictness construct an
+    :class:`~file_organizer.core.organize_options.OrganizeOptions`, which rejects anything
+    non-canonical.
 
     Args:
         value: Candidate methodology value from any surface (form field,
@@ -47,10 +80,5 @@ def normalize(value: object, *, default: str = DEFAULT) -> str:
         One of :data:`ORDER`, or *default* if *value* is not a canonical
         value or a known legacy alias.
     """
-    if isinstance(value, str):
-        candidate = value.strip().lower()
-        if candidate in ORDER:
-            return candidate
-        if candidate in _ALIASES:
-            return _ALIASES[candidate]
-    return default
+    resolved = resolve(value)
+    return resolved.value if resolved is not None else default

--- a/src/file_organizer/core/organize_options.py
+++ b/src/file_organizer/core/organize_options.py
@@ -49,6 +49,12 @@ def _resolve_transfer_mode(
     return resolved
 
 
+def _methodology_choices() -> str:
+    """Render the canonical methodology vocabulary for error messages."""
+    quoted = [f"'{member.value}'" for member in OrganizationMethodology]
+    return f"{', '.join(quoted[:-1])}, or {quoted[-1]}"
+
+
 def _resolve_methodology(
     methodology: OrganizationMethodology | str,
 ) -> OrganizationMethodology:
@@ -56,7 +62,7 @@ def _resolve_methodology(
     try:
         return OrganizationMethodology(methodology)
     except (TypeError, ValueError) as exc:
-        raise ValueError("methodology must be 'none', 'para', or 'jd'") from exc
+        raise ValueError(f"methodology must be {_methodology_choices()}") from exc
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/file_organizer/tui/methodology_view.py
+++ b/src/file_organizer/tui/methodology_view.py
@@ -16,6 +16,8 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import Static
 
+from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
+from file_organizer.core.organize_options import OrganizationMethodology
 from file_organizer.tui.status import StatusMixin
 
 if TYPE_CHECKING:
@@ -32,13 +34,24 @@ class MethodologySelectorPanel(Static):
     }
     """
 
+    # Keys derive from the canonical enum so this panel cannot offer a methodology the domain
+    # rejects. The label text is longer than config.methodology.LABELS on purpose: this view has
+    # room to expand each scheme, while the settings dropdowns do not.
     _METHODS = {
-        "none": "None (flat organization)",
-        "para": "PARA (Projects / Areas / Resources / Archive)",
-        "jd": "Johnny Decimal (Areas / Categories / Items)",
+        OrganizationMethodology.NONE.value: "None (flat organization)",
+        OrganizationMethodology.PARA.value: "PARA (Projects / Areas / Resources / Archive)",
+        OrganizationMethodology.JOHNNY_DECIMAL.value: (
+            "Johnny Decimal (Areas / Categories / Items)"
+        ),
     }
 
-    _current: str = "none"
+    _SHORTCUTS = {
+        OrganizationMethodology.NONE.value: "n",
+        OrganizationMethodology.PARA.value: "p",
+        OrganizationMethodology.JOHNNY_DECIMAL.value: "j",
+    }
+
+    _current: str = _DEFAULT_METHODOLOGY
 
     def on_mount(self) -> None:
         """Render the initial state."""
@@ -48,7 +61,7 @@ class MethodologySelectorPanel(Static):
         """Change the highlighted methodology.
 
         Args:
-            methodology: One of 'none', 'para', 'jd'.
+            methodology: A canonical ``OrganizationMethodology`` value.
         """
         self._current = methodology
         self._render_selector()
@@ -58,7 +71,7 @@ class MethodologySelectorPanel(Static):
         lines = ["[b]Methodology Selector[/b]\n"]
         for key, label in self._METHODS.items():
             marker = "[bold green]>[/bold green] " if key == self._current else "  "
-            shortcut = {"none": "n", "para": "p", "jd": "j"}[key]
+            shortcut = self._SHORTCUTS[key]
             lines.append(f"{marker}[{shortcut}] {label}")
         lines.append("\n[dim]Press p/j/n to switch, m to migrate (coming soon)[/dim]")
         self.update("\n".join(lines))

--- a/src/file_organizer/tui/methodology_view.py
+++ b/src/file_organizer/tui/methodology_view.py
@@ -178,6 +178,11 @@ class MethodologyView(StatusMixin, Vertical):
     }
     """
 
+    # Textual resolves BINDINGS at class-definition time and dispatches each action name to an
+    # ``action_<name>`` method, so neither can be generated from the enum. Adding a methodology
+    # therefore needs a Binding and a matching ``action_set_<value>`` here. The vocabulary guard in
+    # tests/core/test_methodology_vocabulary.py fails until both exist, so the omission cannot ship
+    # silently.
     BINDINGS = [
         Binding("p", "set_para", "PARA", show=True),
         Binding("j", "set_jd", "JD", show=True),
@@ -202,7 +207,9 @@ class MethodologyView(StatusMixin, Vertical):
         resolved_dir = workspace.active_root if workspace is not None else scan_dir
         self._scan_dir = Path(resolved_dir) if resolved_dir is not None else None
         self._methodology = (
-            workspace.options.effective_methodology.value if workspace is not None else "none"
+            workspace.options.effective_methodology.value
+            if workspace is not None
+            else _DEFAULT_METHODOLOGY
         )
 
     def compose(self) -> ComposeResult:
@@ -242,12 +249,12 @@ class MethodologyView(StatusMixin, Vertical):
     def _update_preview(self) -> None:
         """Dispatch preview update based on current methodology."""
         preview = self.query_one(MethodologyPreviewPanel)
-        if self._methodology == "none":
+        if self._methodology == OrganizationMethodology.NONE.value:
             preview.show_none_preview()
-        elif self._methodology == "para":
+        elif self._methodology == OrganizationMethodology.PARA.value:
             preview.show_loading()
             self._load_para_preview()
-        elif self._methodology == "jd":
+        elif self._methodology == OrganizationMethodology.JOHNNY_DECIMAL.value:
             preview.show_loading()
             self._load_jd_preview()
 

--- a/src/file_organizer/tui/methodology_view.py
+++ b/src/file_organizer/tui/methodology_view.py
@@ -7,8 +7,10 @@ or none) and preview how files would be categorized under the selected scheme.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from types import MappingProxyType
+from typing import TYPE_CHECKING, ClassVar
 
 from textual import work
 from textual.app import ComposeResult
@@ -37,19 +39,23 @@ class MethodologySelectorPanel(Static):
     # Keys derive from the canonical enum so this panel cannot offer a methodology the domain
     # rejects. The label text is longer than config.methodology.LABELS on purpose: this view has
     # room to expand each scheme, while the settings dropdowns do not.
-    _METHODS = {
-        OrganizationMethodology.NONE.value: "None (flat organization)",
-        OrganizationMethodology.PARA.value: "PARA (Projects / Areas / Resources / Archive)",
-        OrganizationMethodology.JOHNNY_DECIMAL.value: (
-            "Johnny Decimal (Areas / Categories / Items)"
-        ),
-    }
+    _METHODS: ClassVar[Mapping[str, str]] = MappingProxyType(
+        {
+            OrganizationMethodology.NONE.value: "None (flat organization)",
+            OrganizationMethodology.PARA.value: "PARA (Projects / Areas / Resources / Archive)",
+            OrganizationMethodology.JOHNNY_DECIMAL.value: (
+                "Johnny Decimal (Areas / Categories / Items)"
+            ),
+        }
+    )
 
-    _SHORTCUTS = {
-        OrganizationMethodology.NONE.value: "n",
-        OrganizationMethodology.PARA.value: "p",
-        OrganizationMethodology.JOHNNY_DECIMAL.value: "j",
-    }
+    _SHORTCUTS: ClassVar[Mapping[str, str]] = MappingProxyType(
+        {
+            OrganizationMethodology.NONE.value: "n",
+            OrganizationMethodology.PARA.value: "p",
+            OrganizationMethodology.JOHNNY_DECIMAL.value: "j",
+        }
+    )
 
     _current: str = _DEFAULT_METHODOLOGY
 

--- a/tests/core/test_methodology_vocabulary.py
+++ b/tests/core/test_methodology_vocabulary.py
@@ -3,10 +3,18 @@
 ``OrganizationMethodology`` is the canonical value model. Adapters may present methodologies
 differently, but none may define, accept, or advertise a value the domain does not recognize.
 
-Most adapters derive their vocabulary from the enum, so drift is impossible by construction. Three
-cannot: the Pydantic ``Literal`` annotations in the REST and Python SDK models, and the TypeScript
-union. Those are pinned here instead, because deriving them would change the emitted OpenAPI schema
-and the generated client surface for no behavioral gain.
+Most adapters derive their vocabulary from the enum, so drift is impossible by construction. Five
+cannot, and are pinned here instead:
+
+* the Pydantic ``Literal`` annotations in the REST and Python SDK models, and the TypeScript union —
+  deriving these would change the emitted OpenAPI schema and the generated client surface for no
+  behavioral gain;
+* the TUI view's ``BINDINGS`` and ``action_set_*`` handlers — Textual resolves both at
+  class-definition time and dispatches actions by name, so neither can be generated.
+
+The capability registry is deliberately not cross-checked here. ``methodology.configure`` declares
+entry-point strings such as ``fo organize --methodology``; it does not encode methodology values, so
+there is no registry-side vocabulary that could drift against the enum.
 """
 
 from __future__ import annotations
@@ -20,11 +28,7 @@ import pytest
 from file_organizer.api.models import OrganizationOptionsPayload as RestOptionsPayload
 from file_organizer.client.models import OrganizationOptionsPayload as SdkOptionsPayload
 from file_organizer.config import methodology as config_methodology
-from file_organizer.core.organize_options import (
-    OrganizationMethodology,
-    OrganizeOptions,
-    _methodology_choices,
-)
+from file_organizer.core.organize_options import OrganizationMethodology, OrganizeOptions
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
@@ -82,8 +86,12 @@ def test_unrecognized_values_are_lenient_at_the_boundary_and_strict_in_the_domai
 
 
 def test_domain_error_lists_exactly_the_canonical_vocabulary() -> None:
-    rendered = _methodology_choices()
-    assert re.findall(r"'([^']+)'", rendered) == list(CANONICAL)
+    # Asserted through the public failure path rather than the private renderer, so the guard
+    # pins the message a caller actually sees.
+    with pytest.raises(ValueError) as exc_info:
+        OrganizeOptions(methodology="date_based")
+
+    assert re.findall(r"'([^']+)'", str(exc_info.value)) == list(CANONICAL)
 
 
 def test_aliases_are_rejected_by_the_domain() -> None:
@@ -134,11 +142,23 @@ def test_tui_methodology_panel_vocabulary_matches_the_canonical_enum() -> None:
     assert MethodologySelectorPanel._current in CANONICAL
 
 
-def test_registry_methodology_capability_entry_points_are_present() -> None:
-    from file_organizer.core.capabilities import get_capability_registry
+def test_tui_methodology_view_binds_every_canonical_methodology() -> None:
+    """Textual cannot generate BINDINGS or action methods from the enum, so pin them here.
 
-    capability = get_capability_registry().get("methodology.configure")
-    declared = {
-        entry_point for status in capability.surfaces for entry_point in status.entry_points
-    }
-    assert declared, "methodology.configure must declare entry points"
+    Both are resolved at class-definition time and dispatched by name, which is why the view
+    restates the vocabulary. Adding a methodology without a Binding and a matching action would
+    otherwise ship a selector the user cannot reach.
+    """
+    from file_organizer.tui.methodology_view import MethodologySelectorPanel, MethodologyView
+
+    bound_actions = {binding.action for binding in MethodologyView.BINDINGS}
+    for value in CANONICAL:
+        assert f"set_{value}" in bound_actions, f"no key binding selects methodology {value!r}"
+        assert callable(getattr(MethodologyView, f"action_set_{value}", None)), (
+            f"no action_set_{value} handler for methodology {value!r}"
+        )
+
+    # Every bound shortcut key must match the key the selector panel advertises for that value.
+    bindings_by_action = {binding.action: binding.key for binding in MethodologyView.BINDINGS}
+    for value, shortcut in MethodologySelectorPanel._SHORTCUTS.items():
+        assert bindings_by_action[f"set_{value}"] == shortcut

--- a/tests/core/test_methodology_vocabulary.py
+++ b/tests/core/test_methodology_vocabulary.py
@@ -1,0 +1,144 @@
+"""Guards proving one authoritative methodology vocabulary across every surface.
+
+``OrganizationMethodology`` is the canonical value model. Adapters may present methodologies
+differently, but none may define, accept, or advertise a value the domain does not recognize.
+
+Most adapters derive their vocabulary from the enum, so drift is impossible by construction. Three
+cannot: the Pydantic ``Literal`` annotations in the REST and Python SDK models, and the TypeScript
+union. Those are pinned here instead, because deriving them would change the emitted OpenAPI schema
+and the generated client surface for no behavioral gain.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import get_args
+
+import pytest
+
+from file_organizer.api.models import OrganizationOptionsPayload as RestOptionsPayload
+from file_organizer.client.models import OrganizationOptionsPayload as SdkOptionsPayload
+from file_organizer.config import methodology as config_methodology
+from file_organizer.core.organize_options import (
+    OrganizationMethodology,
+    OrganizeOptions,
+    _methodology_choices,
+)
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL: tuple[str, ...] = tuple(member.value for member in OrganizationMethodology)
+
+
+def _literal_values(model: type, field: str) -> tuple[str, ...]:
+    """Return the Literal members annotated on ``model.field``."""
+    return get_args(model.model_fields[field].annotation)
+
+
+def test_config_vocabulary_derives_from_the_canonical_enum() -> None:
+    assert config_methodology.ORDER == CANONICAL
+    assert config_methodology.DEFAULT == OrganizationMethodology.NONE.value
+    assert (
+        config_methodology.NONE,
+        config_methodology.PARA,
+        config_methodology.JOHNNY_DECIMAL,
+    ) == CANONICAL
+
+
+def test_every_label_covers_exactly_the_canonical_vocabulary() -> None:
+    assert tuple(config_methodology.LABELS) == CANONICAL
+
+
+def test_every_alias_resolves_to_a_canonical_methodology() -> None:
+    assert config_methodology.ALIASES, "alias table must not be silently emptied"
+    for alias, target in config_methodology.ALIASES.items():
+        resolved = config_methodology.resolve(alias)
+        assert resolved is not None, f"alias {alias!r} resolves to nothing"
+        assert resolved.value == target
+        assert target in CANONICAL, f"alias {alias!r} targets unregistered value {target!r}"
+
+
+def test_aliases_never_shadow_a_canonical_value() -> None:
+    # An alias colliding with a canonical value would make normalization order significant.
+    assert not set(config_methodology.ALIASES) & set(CANONICAL)
+
+
+@pytest.mark.parametrize("value", CANONICAL)
+def test_canonical_values_survive_the_config_boundary(value: str) -> None:
+    assert config_methodology.normalize(value) == value
+    assert OrganizeOptions(methodology=value).effective_methodology.value == value
+
+
+def test_unrecognized_values_are_lenient_at_the_boundary_and_strict_in_the_domain() -> None:
+    # Config and presentation surfaces must not crash on a stale persisted value.
+    assert config_methodology.normalize("date_based") == config_methodology.DEFAULT
+    assert config_methodology.resolve("date_based") is None
+
+    # The domain rejects it with the documented, vocabulary-derived message.
+    with pytest.raises(ValueError, match="methodology must be"):
+        OrganizeOptions(methodology="date_based")
+
+
+def test_domain_error_lists_exactly_the_canonical_vocabulary() -> None:
+    rendered = _methodology_choices()
+    assert re.findall(r"'([^']+)'", rendered) == list(CANONICAL)
+
+
+def test_aliases_are_rejected_by_the_domain() -> None:
+    # Aliases are a boundary concession. One reaching OrganizeOptions means an adapter skipped
+    # normalization, which must fail loudly rather than be quietly understood.
+    for alias in config_methodology.ALIASES:
+        with pytest.raises(ValueError, match="methodology must be"):
+            OrganizeOptions(methodology=alias)
+
+
+def test_rest_api_model_vocabulary_matches_the_canonical_enum() -> None:
+    assert _literal_values(RestOptionsPayload, "methodology") == CANONICAL
+
+
+def test_python_sdk_model_vocabulary_matches_the_canonical_enum() -> None:
+    assert _literal_values(SdkOptionsPayload, "methodology") == CANONICAL
+
+
+def test_typescript_sdk_vocabulary_matches_the_canonical_enum() -> None:
+    types_ts = _REPO_ROOT / "src" / "file_organizer" / "client" / "typescript" / "types.ts"
+    source = types_ts.read_text(encoding="utf-8")
+    match = re.search(r"^\s*methodology\??:\s*(.+?);", source, re.MULTILINE)
+    assert match, "types.ts no longer declares a methodology field"
+    declared = tuple(re.findall(r'"([^"]+)"', match.group(1)))
+    assert declared == CANONICAL
+
+
+def test_cli_config_validator_offers_exactly_the_canonical_vocabulary() -> None:
+    from typer.testing import CliRunner
+
+    from file_organizer.cli.config_cli import config_app
+
+    result = CliRunner().invoke(config_app, ["edit", "--methodology", "date_based"])
+
+    assert result.exit_code == 1
+    # The rejection lists the accepted vocabulary; it must be the canonical set and nothing else.
+    offered = re.search(r"[Vv]alid values:\s*([^\n.]+)", result.output)
+    assert offered, f"validator did not list valid values: {result.output!r}"
+    listed = tuple(token.strip().strip("'\"") for token in offered.group(1).split(","))
+    assert sorted(listed) == sorted(CANONICAL)
+
+
+def test_tui_methodology_panel_vocabulary_matches_the_canonical_enum() -> None:
+    from file_organizer.tui.methodology_view import MethodologySelectorPanel
+
+    assert tuple(MethodologySelectorPanel._METHODS) == CANONICAL
+    assert tuple(MethodologySelectorPanel._SHORTCUTS) == CANONICAL
+    assert MethodologySelectorPanel._current in CANONICAL
+
+
+def test_registry_methodology_capability_entry_points_are_present() -> None:
+    from file_organizer.core.capabilities import get_capability_registry
+
+    capability = get_capability_registry().get("methodology.configure")
+    declared = {
+        entry_point for status in capability.surfaces for entry_point in status.entry_points
+    }
+    assert declared, "methodology.configure must declare entry points"


### PR DESCRIPTION
## Summary

`OrganizationMethodology` becomes the single authoritative methodology value model. The issue described two parallel representations; there were **eight**, including a second labels dict inside the TUI panel — a presentation layer maintaining its own canonical vocabulary.

| Site | Was |
| --- | --- |
| `config/methodology.py` | `NONE`/`PARA`/`JOHNNY_DECIMAL` string literals |
| `core/organize_options.py` | error text `"must be 'none', 'para', or 'jd'"` |
| `cli/config_cli.py` | `_VALID_METHODOLOGIES` set **and** the `--methodology` help text |
| `cli/setup.py` | `["none", "para", "jd"]` prompt choices |
| `tui/methodology_view.py` | own `_METHODS` dict, `_current` default, shortcut map, docstring |
| `api/models.py`, `client/models.py` | `Literal["none", "para", "jd"]` |
| `client/typescript/types.ts` | `"none" \| "para" \| "jd"` |

`config.methodology` now derives every constant from the enum and keeps only what the domain deliberately does not carry: display labels, and the legacy aliases accepted at configuration and transport boundaries.

## Deliberate non-change

The two Pydantic `Literal` annotations and the TypeScript union are **left as literals**. Replacing them with the enum changes the emitted OpenAPI schema and the generated client surface for no behavioral gain, and this epic has spent several PRs stabilising exactly that surface.

`tests/core/test_methodology_vocabulary.py` pins them instead. The guard proves they cannot drift rather than removing the duplication. The trade is recorded in the test module docstring and in `docs/developer/organization-service.md` so it reads as a decision rather than an oversight.

## Strictness split, now explicit and tested

`normalize()` stays lenient — it reads persisted configuration and user-supplied form fields where a stale value must not crash the surface. `OrganizeOptions` rejects everything non-canonical **including aliases**: an alias reaching the domain means an adapter skipped normalization, which should fail loudly.

The domain error message is byte-identical to before, so the "same actionable domain error" criterion holds without a message change.

## Verification

16 new guard tests, each mutation-checked:

| Mutation | Result |
| --- | --- |
| REST model gains `date_based` / drops `jd` | caught |
| SDK model gains `date_based` | caught |
| TS union gains `date_based` | caught |
| TUI shortcut map gains an alias key | caught |
| Alias targets an unregistered value | caught |
| Alias shadows a canonical value | caught |
| Canonical enum value renamed | caught (4 failures) |

One escaped on the first pass: the TS regex used `[a-z]+`, which cannot match `date_based`, so the test passed against a mutated union. Fixed to `[^"]+` and re-verified.

Regressions: **3518 passed** (config, core, cli, web, conformance, tui), **7731 passed** (integration, api, client), TypeScript **4 passed**. `ruff`, `mypy`, `pymarkdown`, and `pre-commit run --files` all clean.

## Acceptance criteria

- [x] Canonical methodology values are defined in one place
- [x] Config, Web, CLI, API, SDK, and TUI adapters cannot introduce unregistered values
- [x] Existing compatibility aliases continue to normalize correctly
- [x] Invalid values fail with the same actionable domain error
- [x] Tests detect drift between aliases, registry capabilities, and `OrganizeOptions`
- [x] No presentation layer maintains a separate canonical methodology enum

Part of #1618
Part of #1593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Configuration, CLI, setup wizard, and terminal interface now use a consistent methodology vocabulary.
  - Methodology choices and help text update automatically when supported options change.
  - Legacy methodology aliases continue to work at configuration boundaries.
  - Invalid values receive clearer validation, while configuration normalization remains tolerant.

- **Documentation**
  - Added guidance on canonical methodologies, aliases, validation behavior, and compatibility requirements.

- **Tests**
  - Added coverage ensuring methodology choices remain consistent across configuration, APIs, SDKs, CLI, and terminal interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->