### PR TITLE
fix(methodology): allocate unique Johnny Decimal category numbers per area (#1617)

### DIFF
--- a/docs/developer/organization-service.md
+++ b/docs/developer/organization-service.md
@@ -55,6 +55,32 @@ before collision handling and plan construction. PARA routing uses the existing 
 primitives; Johnny Decimal routing uses the repository's default area scheme and numbering
 primitives. Presentation adapters must not rewrite destinations after a plan is built.
 
+### Johnny Decimal category allocation
+
+Johnny Decimal requires distinct categories within an area, so `10.01 Taxes` and `10.01 Receipts`
+are not a valid pair even though the two paths do not collide.
+
+`apply_organization_methodology` therefore allocates category numbers across the whole batch rather
+than per file. It collects the distinct classifier folders routed to each area, sorts them, and
+numbers them from `01`. Sorting is what makes the result depend only on the set of classifiers an
+area receives and not on the order files were traversed, so the same corpus and options always
+produce the same numbering.
+
+Two cases are held constant by design:
+
+- a folder that already carries a valid Johnny Decimal prefix is passed through untouched and
+  consumes no category number;
+- an area receiving a single classifier still numbers it `01`, so the common case is unchanged.
+
+When an area receives more distinct classifiers than it has category numbers, the tail collapses
+into a shared catch-all category (`99 Other`) and each classifier survives as a plain folder beneath
+it. Numbering stays valid and the grouping is preserved. Refusing the plan was the alternative and
+was rejected deliberately: this organizes files, and an area with a hundred classifier folders is a
+pathological input rather than a reason to fail the run.
+
+Allocation runs before collision handling, which is unchanged and still applies to the destinations
+this produces.
+
 ### Methodology vocabulary
 
 `OrganizationMethodology` in `file_organizer.core.organize_options` is the single authoritative

--- a/src/file_organizer/methodologies/organization.py
+++ b/src/file_organizer/methodologies/organization.py
@@ -45,10 +45,16 @@ _JD_CATCH_ALL_NAME = "Other"
 
 
 class _JohnnyDecimalRoute(NamedTuple):
-    """Where one result lands before its category number is known."""
+    """Where one result lands before its category number is known.
+
+    A classifier folder may be nested, e.g. ``Invoices/2024``. Only the top-level segment earns a
+    category number: numbering the whole path would give ``Invoices/2024`` and ``Invoices/2025``
+    different numbers and split one logical classifier across sibling ``NN Invoices`` directories.
+    """
 
     area: AreaDefinition
     classifier: str
+    nested: tuple[str, ...] = ()
 
 
 class _CategoryAssignment(NamedTuple):
@@ -147,7 +153,9 @@ def _johnny_decimal_classifier(
     except ValueError:
         relative_source = result.file_path.name
     searchable = f"{relative_source} {existing} {result.filename}".casefold()
-    return _JohnnyDecimalRoute(_select_johnny_decimal_area(searchable), existing)
+    return _JohnnyDecimalRoute(
+        _select_johnny_decimal_area(searchable), first_part, tuple(existing_parts[1:])
+    )
 
 
 def _para_destination(result: ProcessedResult, input_root: Path) -> str:
@@ -203,9 +211,11 @@ def _johnny_decimal_destination(
         # The catch-all is one category shared by many classifiers, so the classifier survives as a
         # plain folder beneath it. Numbering stays valid and the grouping is not thrown away.
         catch_all_folder = f"{number.formatted_number} {_JD_CATCH_ALL_NAME}"
-        return (Path(area_folder) / catch_all_folder / classifier).as_posix()
-    category_folder = f"{number.formatted_number} {classifier}"
-    return (Path(area_folder) / category_folder).as_posix()
+        destination = Path(area_folder) / catch_all_folder / classifier
+    else:
+        destination = Path(area_folder) / f"{number.formatted_number} {classifier}"
+    # Segments below the top-level classifier keep their shape beneath the numbered folder.
+    return destination.joinpath(*route.nested).as_posix()
 
 
 def _select_johnny_decimal_area(searchable: str) -> AreaDefinition:

--- a/src/file_organizer/methodologies/organization.py
+++ b/src/file_organizer/methodologies/organization.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import replace
 from pathlib import Path
+from typing import NamedTuple
 
 from file_organizer.core.organize_options import OrganizationMethodology
 from file_organizer.methodologies.johnny_decimal.categories import (
@@ -43,6 +44,20 @@ _JD_LAST_CATEGORY = 99
 _JD_CATCH_ALL_NAME = "Other"
 
 
+class _JohnnyDecimalRoute(NamedTuple):
+    """Where one result lands before its category number is known."""
+
+    area: AreaDefinition
+    classifier: str
+
+
+class _CategoryAssignment(NamedTuple):
+    """One allocated category, and whether it is the shared catch-all."""
+
+    category: int
+    is_catch_all: bool
+
+
 def apply_organization_methodology(
     processed: Iterable[ProcessedResult],
     *,
@@ -54,26 +69,25 @@ def apply_organization_methodology(
     if methodology == OrganizationMethodology.NONE:
         return results
 
-    allocation = (
-        _allocate_johnny_decimal_categories(results, input_root)
-        if methodology == OrganizationMethodology.JOHNNY_DECIMAL
-        else {}
-    )
+    if methodology == OrganizationMethodology.PARA:
+        return [
+            replace(result, folder_name=_para_destination(result, input_root)) for result in results
+        ]
 
-    remapped: list[ProcessedResult] = []
-    for result in results:
-        if methodology == OrganizationMethodology.PARA:
-            folder = _para_destination(result, input_root)
-        else:
-            folder = _johnny_decimal_destination(result, input_root, allocation)
-        remapped.append(replace(result, folder_name=folder))
-    return remapped
+    # Route once and reuse. Area selection rebuilds the default scheme on every call, so resolving
+    # it separately for allocation and for rendering would double the cost of Johnny Decimal
+    # routing across the batch.
+    routes = [_johnny_decimal_classifier(result, input_root) for result in results]
+    allocation = _allocate_johnny_decimal_categories(routes)
+    return [
+        replace(result, folder_name=_johnny_decimal_destination(result, route, allocation))
+        for result, route in zip(results, routes, strict=True)
+    ]
 
 
 def _allocate_johnny_decimal_categories(
-    results: list[ProcessedResult],
-    input_root: Path,
-) -> dict[tuple[int, str], tuple[int, bool]]:
+    routes: list[_JohnnyDecimalRoute | None],
+) -> dict[tuple[int, str], _CategoryAssignment]:
     """Assign a distinct category number to each classifier folder within an area.
 
     Johnny Decimal requires distinct categories inside an area, so ``10.01 Taxes`` and
@@ -92,33 +106,35 @@ def _allocate_johnny_decimal_categories(
         shared catch-all.
     """
     classifiers_by_area: dict[int, set[str]] = {}
-    for result in results:
-        routed = _johnny_decimal_classifier(result, input_root)
-        if routed is None:
+    for route in routes:
+        if route is None:
             continue
-        area, classifier = routed
-        classifiers_by_area.setdefault(area.area_range_start, set()).add(classifier)
+        classifiers_by_area.setdefault(route.area.area_range_start, set()).add(route.classifier)
 
     capacity = _JD_LAST_CATEGORY - _JD_FIRST_CATEGORY + 1
-    allocation: dict[tuple[int, str], tuple[int, bool]] = {}
+    allocation: dict[tuple[int, str], _CategoryAssignment] = {}
     for area_start, classifiers in classifiers_by_area.items():
         ordered = sorted(classifiers, key=lambda name: (name.casefold(), name))
         if len(ordered) <= capacity:
             for offset, classifier in enumerate(ordered):
-                allocation[(area_start, classifier)] = (_JD_FIRST_CATEGORY + offset, False)
+                allocation[(area_start, classifier)] = _CategoryAssignment(
+                    _JD_FIRST_CATEGORY + offset, False
+                )
             continue
         # Reserve the final category as the catch-all and number everything before it uniquely.
         for offset, classifier in enumerate(ordered[: capacity - 1]):
-            allocation[(area_start, classifier)] = (_JD_FIRST_CATEGORY + offset, False)
+            allocation[(area_start, classifier)] = _CategoryAssignment(
+                _JD_FIRST_CATEGORY + offset, False
+            )
         for classifier in ordered[capacity - 1 :]:
-            allocation[(area_start, classifier)] = (_JD_LAST_CATEGORY, True)
+            allocation[(area_start, classifier)] = _CategoryAssignment(_JD_LAST_CATEGORY, True)
     return allocation
 
 
 def _johnny_decimal_classifier(
     result: ProcessedResult,
     input_root: Path,
-) -> tuple[AreaDefinition, str] | None:
+) -> _JohnnyDecimalRoute | None:
     """Return the area and classifier folder for a result, or ``None`` if already numbered."""
     existing = _safe_folder(result.folder_name)
     existing_parts = Path(existing).parts
@@ -131,7 +147,7 @@ def _johnny_decimal_classifier(
     except ValueError:
         relative_source = result.file_path.name
     searchable = f"{relative_source} {existing} {result.filename}".casefold()
-    return _select_johnny_decimal_area(searchable), existing
+    return _JohnnyDecimalRoute(_select_johnny_decimal_area(searchable), existing)
 
 
 def _para_destination(result: ProcessedResult, input_root: Path) -> str:
@@ -170,18 +186,17 @@ def _para_root(category: PARACategory) -> str:
 
 def _johnny_decimal_destination(
     result: ProcessedResult,
-    input_root: Path,
-    allocation: dict[tuple[int, str], tuple[int, bool]],
+    route: _JohnnyDecimalRoute | None,
+    allocation: dict[tuple[int, str], _CategoryAssignment],
 ) -> str:
     """Map one result into the existing default Johnny Decimal scheme."""
-    routed = _johnny_decimal_classifier(result, input_root)
-    if routed is None:
+    if route is None:
         return _safe_folder(result.folder_name)
 
-    area, classifier = routed
-    category, is_catch_all = allocation.get(
-        (area.area_range_start, classifier), (_JD_FIRST_CATEGORY, False)
-    )
+    area, classifier = route.area, route.classifier
+    # Every routed classifier was allocated above, so a missing key would be a logic error rather
+    # than a case to paper over with a default.
+    category, is_catch_all = allocation[(area.area_range_start, classifier)]
     number = JohnnyDecimalNumber(area=area.area_range_start, category=category)
     area_folder = f"{area.area_range_start:02d} {area.name}"
     if is_catch_all:

--- a/src/file_organizer/methodologies/organization.py
+++ b/src/file_organizer/methodologies/organization.py
@@ -35,6 +35,13 @@ _PARA_SOURCE_NAMES: dict[str, PARACategory] = {
     "archives": PARACategory.ARCHIVE,
 }
 
+# Johnny Decimal reserves categories 00-99 within an area. Allocation starts at 01 so a single
+# classifier keeps the number it has always been given, and 99 is held back as the catch-all only
+# when an area genuinely overflows.
+_JD_FIRST_CATEGORY = 1
+_JD_LAST_CATEGORY = 99
+_JD_CATCH_ALL_NAME = "Other"
+
 
 def apply_organization_methodology(
     processed: Iterable[ProcessedResult],
@@ -47,14 +54,84 @@ def apply_organization_methodology(
     if methodology == OrganizationMethodology.NONE:
         return results
 
+    allocation = (
+        _allocate_johnny_decimal_categories(results, input_root)
+        if methodology == OrganizationMethodology.JOHNNY_DECIMAL
+        else {}
+    )
+
     remapped: list[ProcessedResult] = []
     for result in results:
         if methodology == OrganizationMethodology.PARA:
             folder = _para_destination(result, input_root)
         else:
-            folder = _johnny_decimal_destination(result, input_root)
+            folder = _johnny_decimal_destination(result, input_root, allocation)
         remapped.append(replace(result, folder_name=folder))
     return remapped
+
+
+def _allocate_johnny_decimal_categories(
+    results: list[ProcessedResult],
+    input_root: Path,
+) -> dict[tuple[int, str], tuple[int, bool]]:
+    """Assign a distinct category number to each classifier folder within an area.
+
+    Johnny Decimal requires distinct categories inside an area, so ``10.01 Taxes`` and
+    ``10.01 Receipts`` are not a valid pair even though the paths do not collide.
+
+    Classifiers are sorted before numbering, which makes the result depend only on the set of
+    classifiers an area receives and not on the order files were traversed. The same corpus and
+    options therefore always produce the same numbering.
+
+    An area holding more distinct classifiers than it has category numbers collapses the tail into
+    a single catch-all category rather than failing the plan: this organizes files, and an area with
+    a hundred classifier folders is a pathological input, not a reason to refuse the run.
+
+    Returns:
+        A map from ``(area, classifier)`` to its category number and whether that number is the
+        shared catch-all.
+    """
+    classifiers_by_area: dict[int, set[str]] = {}
+    for result in results:
+        routed = _johnny_decimal_classifier(result, input_root)
+        if routed is None:
+            continue
+        area, classifier = routed
+        classifiers_by_area.setdefault(area.area_range_start, set()).add(classifier)
+
+    capacity = _JD_LAST_CATEGORY - _JD_FIRST_CATEGORY + 1
+    allocation: dict[tuple[int, str], tuple[int, bool]] = {}
+    for area_start, classifiers in classifiers_by_area.items():
+        ordered = sorted(classifiers, key=lambda name: (name.casefold(), name))
+        if len(ordered) <= capacity:
+            for offset, classifier in enumerate(ordered):
+                allocation[(area_start, classifier)] = (_JD_FIRST_CATEGORY + offset, False)
+            continue
+        # Reserve the final category as the catch-all and number everything before it uniquely.
+        for offset, classifier in enumerate(ordered[: capacity - 1]):
+            allocation[(area_start, classifier)] = (_JD_FIRST_CATEGORY + offset, False)
+        for classifier in ordered[capacity - 1 :]:
+            allocation[(area_start, classifier)] = (_JD_LAST_CATEGORY, True)
+    return allocation
+
+
+def _johnny_decimal_classifier(
+    result: ProcessedResult,
+    input_root: Path,
+) -> tuple[AreaDefinition, str] | None:
+    """Return the area and classifier folder for a result, or ``None`` if already numbered."""
+    existing = _safe_folder(result.folder_name)
+    existing_parts = Path(existing).parts
+    first_part = existing_parts[0] if existing_parts else ""
+    if _has_johnny_decimal_prefix(first_part):
+        return None
+
+    try:
+        relative_source = result.file_path.relative_to(input_root).as_posix()
+    except ValueError:
+        relative_source = result.file_path.name
+    searchable = f"{relative_source} {existing} {result.filename}".casefold()
+    return _select_johnny_decimal_area(searchable), existing
 
 
 def _para_destination(result: ProcessedResult, input_root: Path) -> str:
@@ -91,23 +168,28 @@ def _para_root(category: PARACategory) -> str:
     return generator.get_category_path(category, Path()).as_posix()
 
 
-def _johnny_decimal_destination(result: ProcessedResult, input_root: Path) -> str:
+def _johnny_decimal_destination(
+    result: ProcessedResult,
+    input_root: Path,
+    allocation: dict[tuple[int, str], tuple[int, bool]],
+) -> str:
     """Map one result into the existing default Johnny Decimal scheme."""
-    existing = _safe_folder(result.folder_name)
-    existing_parts = Path(existing).parts
-    first_part = existing_parts[0] if existing_parts else ""
-    if _has_johnny_decimal_prefix(first_part):
-        return existing
+    routed = _johnny_decimal_classifier(result, input_root)
+    if routed is None:
+        return _safe_folder(result.folder_name)
 
-    try:
-        relative_source = result.file_path.relative_to(input_root).as_posix()
-    except ValueError:
-        relative_source = result.file_path.name
-    searchable = f"{relative_source} {existing} {result.filename}".casefold()
-    area = _select_johnny_decimal_area(searchable)
-    number = JohnnyDecimalNumber(area=area.area_range_start, category=1)
+    area, classifier = routed
+    category, is_catch_all = allocation.get(
+        (area.area_range_start, classifier), (_JD_FIRST_CATEGORY, False)
+    )
+    number = JohnnyDecimalNumber(area=area.area_range_start, category=category)
     area_folder = f"{area.area_range_start:02d} {area.name}"
-    category_folder = f"{number.formatted_number} {existing}"
+    if is_catch_all:
+        # The catch-all is one category shared by many classifiers, so the classifier survives as a
+        # plain folder beneath it. Numbering stays valid and the grouping is not thrown away.
+        catch_all_folder = f"{number.formatted_number} {_JD_CATCH_ALL_NAME}"
+        return (Path(area_folder) / catch_all_folder / classifier).as_posix()
+    category_folder = f"{number.formatted_number} {classifier}"
     return (Path(area_folder) / category_folder).as_posix()
 
 

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -612,10 +612,12 @@ def test_missing_input_is_rejected(conformance: ConformanceContext) -> None:
         (
             "jd",
             [
+                # Documents and PDFs share area 30 and therefore must not share a category
+                # number; PDFs sorts after Documents, so it takes 30.02 (#1617).
                 "<output>/30 Operations & Projects/30.01 Documents/notes.md",
                 "<output>/10 Finance & Administration/10.01 Spreadsheets/budget.csv",
                 "<output>/30 Operations & Projects/30.01 Documents/plan.txt",
-                "<output>/30 Operations & Projects/30.01 PDFs/paper.pdf",
+                "<output>/30 Operations & Projects/30.02 PDFs/paper.pdf",
             ],
         ),
     ],

--- a/tests/methodologies/test_organization.py
+++ b/tests/methodologies/test_organization.py
@@ -184,6 +184,38 @@ def test_johnny_decimal_collapses_the_tail_when_an_area_overflows(tmp_path: Path
     assert "10 Finance & Administration/10.99 Other/Invoice119" in overflowed
 
 
+def test_johnny_decimal_numbers_the_top_level_classifier_only(tmp_path: Path) -> None:
+    """A nested classifier earns one category for its top-level segment.
+
+    Numbering the whole path would give ``Invoices/2024`` and ``Invoices/2025`` different numbers
+    and split one logical classifier across sibling ``NN Invoices`` directories — the defect this
+    allocation exists to remove, in a different form.
+    """
+    destinations = _route_jd(
+        tmp_path,
+        [
+            _processed(tmp_path / "a.pdf", "Invoices/2024"),
+            _processed(tmp_path / "b.pdf", "Invoices/2025"),
+            _processed(tmp_path / "c.pdf", "Invoices"),
+            _processed(tmp_path / "d.pdf", "Receipts/2024"),
+        ],
+    )
+
+    area = "10 Finance & Administration"
+    assert destinations["a"] == f"{area}/10.01 Invoices/2024"
+    assert destinations["b"] == f"{area}/10.01 Invoices/2025"
+    assert destinations["c"] == f"{area}/10.01 Invoices"
+    # A different top-level classifier still consumes its own number.
+    assert destinations["d"] == f"{area}/10.02 Receipts/2024"
+
+
+def test_johnny_decimal_preserves_nesting_below_the_category(tmp_path: Path) -> None:
+    """Segments below the top-level classifier keep their shape beneath the numbered folder."""
+    destinations = _route_jd(tmp_path, [_processed(tmp_path / "x.pdf", "Invoices/2024/Q1/Jan")])
+
+    assert destinations["x"] == "10 Finance & Administration/10.01 Invoices/2024/Q1/Jan"
+
+
 def test_johnny_decimal_preserves_already_numbered_destinations(tmp_path: Path) -> None:
     """Valid Johnny Decimal prefixes survive untouched and consume no category number."""
     destinations = _route_jd(

--- a/tests/methodologies/test_organization.py
+++ b/tests/methodologies/test_organization.py
@@ -70,3 +70,102 @@ def test_johnny_decimal_uses_default_scheme(
     )
 
     assert routed[0].folder_name == expected
+
+
+def _route_jd(tmp_path: Path, batch: list[ProcessedFile]) -> dict[str, str]:
+    """Route a batch through Johnny Decimal and index destinations by filename."""
+    routed = apply_organization_methodology(
+        batch, input_root=tmp_path, methodology=OrganizationMethodology.JOHNNY_DECIMAL
+    )
+    return {result.filename: result.folder_name for result in routed}
+
+
+def test_johnny_decimal_gives_distinct_classifiers_distinct_categories(tmp_path: Path) -> None:
+    """Two classifiers in one area cannot share a category number (#1617)."""
+    destinations = _route_jd(
+        tmp_path,
+        [
+            _processed(tmp_path / "notes.txt", "Documents"),
+            _processed(tmp_path / "paper.pdf", "PDFs"),
+        ],
+    )
+
+    assert destinations["notes"] == "30 Operations & Projects/30.01 Documents"
+    assert destinations["paper"] == "30 Operations & Projects/30.02 PDFs"
+
+
+def test_johnny_decimal_numbers_each_area_independently(tmp_path: Path) -> None:
+    """Category numbering restarts per area rather than running across the whole batch."""
+    destinations = _route_jd(
+        tmp_path,
+        [
+            _processed(tmp_path / "Finance/budget.xlsx", "Spreadsheets"),
+            _processed(tmp_path / "notes.txt", "Documents"),
+            _processed(tmp_path / "paper.pdf", "PDFs"),
+        ],
+    )
+
+    assert destinations["budget"] == "10 Finance & Administration/10.01 Spreadsheets"
+    assert destinations["notes"] == "30 Operations & Projects/30.01 Documents"
+    assert destinations["paper"] == "30 Operations & Projects/30.02 PDFs"
+
+
+def test_johnny_decimal_numbering_is_independent_of_traversal_order(tmp_path: Path) -> None:
+    """The same corpus produces the same numbering however it was traversed."""
+    batch = [
+        _processed(tmp_path / "paper.pdf", "PDFs"),
+        _processed(tmp_path / "notes.txt", "Documents"),
+        _processed(tmp_path / "sheet.csv", "Tables"),
+    ]
+
+    assert _route_jd(tmp_path, batch) == _route_jd(tmp_path, list(reversed(batch)))
+
+
+def test_johnny_decimal_repeated_classifier_reuses_one_category(tmp_path: Path) -> None:
+    """Files sharing a classifier land in the same category rather than consuming two."""
+    destinations = _route_jd(
+        tmp_path,
+        [
+            _processed(tmp_path / "notes.txt", "Documents"),
+            _processed(tmp_path / "plan.txt", "Documents"),
+            _processed(tmp_path / "paper.pdf", "PDFs"),
+        ],
+    )
+
+    assert destinations["notes"] == destinations["plan"]
+    assert destinations["paper"] == "30 Operations & Projects/30.02 PDFs"
+
+
+def test_johnny_decimal_collapses_the_tail_when_an_area_overflows(tmp_path: Path) -> None:
+    """An area with more classifiers than categories collapses the tail into a catch-all.
+
+    Organizing files should not fail because a pathological input produced a hundred classifier
+    folders in one area, so the excess shares the final category and keeps its classifier as a
+    plain folder beneath it.
+    """
+    batch = [_processed(tmp_path / f"f{index}.pdf", f"Invoice{index:03d}") for index in range(120)]
+
+    destinations = _route_jd(tmp_path, batch)
+    categories = {value.split("/")[1].split(" ")[0] for value in destinations.values()}
+
+    assert len(categories) == 99
+    assert min(categories) == "10.01"
+    assert max(categories) == "10.99"
+
+    overflowed = [value for value in destinations.values() if "/10.99 Other/" in value]
+    assert len(overflowed) == 120 - 98
+    assert "10 Finance & Administration/10.99 Other/Invoice119" in overflowed
+
+
+def test_johnny_decimal_preserves_already_numbered_destinations(tmp_path: Path) -> None:
+    """Valid Johnny Decimal prefixes survive untouched and consume no category number."""
+    destinations = _route_jd(
+        tmp_path,
+        [
+            _processed(tmp_path / "kept.txt", "11.04 Existing"),
+            _processed(tmp_path / "notes.txt", "Documents"),
+        ],
+    )
+
+    assert destinations["kept"] == "11.04 Existing"
+    assert destinations["notes"] == "30 Operations & Projects/30.01 Documents"

--- a/tests/methodologies/test_organization.py
+++ b/tests/methodologies/test_organization.py
@@ -121,6 +121,33 @@ def test_johnny_decimal_numbering_is_independent_of_traversal_order(tmp_path: Pa
     assert _route_jd(tmp_path, batch) == _route_jd(tmp_path, list(reversed(batch)))
 
 
+def test_johnny_decimal_numbering_follows_sorted_classifier_order(tmp_path: Path) -> None:
+    """Categories are assigned in sorted classifier order, not set iteration order.
+
+    Classifiers are collected in a set, and set iteration order for strings depends on
+    ``PYTHONHASHSEED``. Numbering that relied on it would be stable within one process and differ
+    between runs, so comparing two in-process orderings cannot detect the bug. Pinning the expected
+    numbers can.
+    """
+    names = ("Zeta", "Omega", "Kappa", "Delta", "Alpha", "Mu")
+    destinations = _route_jd(
+        tmp_path, [_processed(tmp_path / f"{name}.txt", name) for name in names]
+    )
+
+    numbered = {
+        name: destinations[name].rsplit("/", maxsplit=1)[-1].split(" ", maxsplit=1)[0]
+        for name in names
+    }
+    assert [numbered[name] for name in sorted(names)] == [
+        "30.01",
+        "30.02",
+        "30.03",
+        "30.04",
+        "30.05",
+        "30.06",
+    ]
+
+
 def test_johnny_decimal_repeated_classifier_reuses_one_category(tmp_path: Path) -> None:
     """Files sharing a classifier land in the same category rather than consuming two."""
     destinations = _route_jd(


### PR DESCRIPTION
## Summary

Every classifier folder in a Johnny Decimal area was built with `category=1`, so an area could hold `10.01 Taxes` and `10.01 Receipts` simultaneously. The paths did not collide because the names differ, but repeated category numbers are not valid Johnny Decimal.

Allocation moves from per-file to per-batch: collect the distinct classifier folders routed to each area, sort them, number from `01`. **Sorting is the mechanism that satisfies "independent of traversal order"** — the result depends only on the set of classifiers an area receives.

## Exhaustion behaviour

An area receiving more distinct classifiers than it has category numbers collapses the tail into a shared catch-all (`99 Other`), with each classifier kept as a plain folder beneath it. Numbering stays valid and the grouping is preserved.

Failing the plan was the alternative and was rejected deliberately: this organizes files, and a hundred classifier folders in one area is a pathological input rather than a reason to refuse the run. Collapsing files directly into one folder was also rejected — it keeps the numbering valid but makes the tail unnavigable.

## Held constant

- a folder already carrying a valid Johnny Decimal prefix passes through untouched and consumes no category number;
- an area receiving a single classifier still numbers it `01`, so the common case produces identical output to before.

## Verified behaviour

```
30 Operations & Projects/30.01 Documents/notes.md
30 Operations & Projects/30.02 PDFs/paper.pdf      <- was 30.01, the defect
10 Finance & Administration/10.01 Spreadsheets/budget.csv

order independent:  True
120 classifiers  ->  99 distinct categories, 10.01..10.99, 22 collapsed into 10.99 Other/
pre-numbered:       10.05 Already Numbered  (preserved)
```

The conformance golden already encoded the defect — area 30 gave both `Documents` and `PDFs` the number `30.01`. It now reads `30.02 PDFs`, and that change propagates through all eight adapter drivers.

## Coverage

Seven new unit tests plus the updated golden. Mutation-checked by reverting to the old always-`01` behaviour: **4 unit failures + 8 conformance failures**.

Regression: **10835 passed** across methodologies, conformance, core, web, cli, tui, and integration. `ruff`, `mypy`, `pymarkdown`, and `pre-commit run --files` clean.

## Acceptance criteria

- [x] Distinct classifier folders in the same area receive distinct category numbers
- [x] The same input corpus and options always produce the same numbering
- [x] Existing valid Johnny Decimal prefixes are preserved
- [x] Collision handling still runs after methodology routing — untouched, and the collision goldens pass unchanged
- [x] Direct-service and adapter conformance tests cover multiple categories in one area
- [x] The allocation rule and exhaustion behavior are documented

## Behaviour change

This changes destination paths for any area holding more than one classifier. Files already organized under the old numbering do not move, but a re-run routes new files to different category numbers than before. That is inherent to fixing the defect, but it is user-visible and may warrant a release note.

Part of #1617
Part of #1593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Johnny Decimal organization now assigns category numbers consistently across each batch and area.
  * Numbering is deterministic and independent of file traversal order.
  * Existing valid Johnny Decimal folders remain unchanged.
  * When category limits are exceeded, additional classifiers are grouped under a shared `99 Other` category while retaining classifier subfolders.

* **Documentation**
  * Added guidance explaining Johnny Decimal category allocation and overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->