### PR TITLE
test(parity): guard OrganizationOptionsPayload/OrganizeOptions field parity (#1628)

### DIFF
--- a/tests/client/test_endpoint_inventory.py
+++ b/tests/client/test_endpoint_inventory.py
@@ -1,4 +1,4 @@
-"""Fail CI when public REST operations and official SDKs drift apart."""
+"""Fail CI when public REST operations, official SDKs, or option-field parity drift apart."""
 
 from __future__ import annotations
 
@@ -9,10 +9,13 @@ import pytest
 
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.main import create_app
+from file_organizer.api.models import OrganizationOptionsPayload as RestOptionsPayload
 from file_organizer.client.async_client import AsyncFileOrganizerClient
 from file_organizer.client.endpoint_spec import INTENTIONAL_EXCLUSIONS, PUBLIC_ENDPOINTS
+from file_organizer.client.models import OrganizationOptionsPayload as SdkOptionsPayload
 from file_organizer.client.sync_client import FileOrganizerClient
 from file_organizer.core.capabilities import Surface, get_capability_registry
+from file_organizer.core.organize_options import OrganizeOptions
 from tests._route_inventory import iter_effective_routes
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
@@ -92,3 +95,87 @@ def test_single_file_suggestion_is_not_owned_by_plan_execution() -> None:
     )
 
     assert suggestion.capability_ids == ("organization.suggest",)
+
+
+# ---------------------------------------------------------------------------
+# Option-field parity: guard the _merge_remote_plan_options round-trip
+# ---------------------------------------------------------------------------
+#
+# ``cli/api.py::_merge_remote_plan_options`` round-trips between the transport
+# payload and the canonical contract:
+#
+#   OrganizationOptionsPayload  ->  OrganizeOptions.from_dict(...)
+#                               ->  _merge_explicit_plan_options(...)
+#                               ->  OrganizationOptionsPayload.model_validate(merged.to_dict())
+#
+# This only works because:
+#   1. every payload field is consumable by OrganizeOptions.from_dict (subset);
+#   2. OrganizeOptions.to_dict() output validates against the payload model.
+#
+# ``use_hardlinks`` is the sole intentional asymmetry: it lives on OrganizeOptions
+# as a legacy input-only alias and is stripped by to_dict().
+
+
+def test_rest_payload_fields_are_subset_of_canonical_options() -> None:
+    """Every REST transport field must be consumable by OrganizeOptions.from_dict."""
+    payload_fields = set(RestOptionsPayload.model_fields)
+    option_fields = set(OrganizeOptions.__dataclass_fields__)
+    extra = payload_fields - option_fields
+    assert not extra, (
+        f"REST OrganizationOptionsPayload has fields not present on OrganizeOptions: {extra}. "
+        "OrganizeOptions.from_dict() will reject them, breaking _merge_remote_plan_options."
+    )
+
+
+def test_sdk_payload_fields_are_subset_of_canonical_options() -> None:
+    """Every SDK transport field must be consumable by OrganizeOptions.from_dict."""
+    payload_fields = set(SdkOptionsPayload.model_fields)
+    option_fields = set(OrganizeOptions.__dataclass_fields__)
+    extra = payload_fields - option_fields
+    assert not extra, (
+        f"SDK OrganizationOptionsPayload has fields not present on OrganizeOptions: {extra}. "
+        "OrganizeOptions.from_dict() will reject them, breaking _merge_remote_plan_options."
+    )
+
+
+def test_canonical_options_to_dict_validates_against_rest_payload() -> None:
+    """OrganizeOptions().to_dict() must validate back to the REST transport model."""
+    canonical = OrganizeOptions().to_dict()
+    payload = RestOptionsPayload.model_validate(canonical)
+    # Assert every canonical field survives the round-trip, not just spot-checks.
+    for field in RestOptionsPayload.model_fields:
+        assert getattr(payload, field) == canonical[field], (
+            f"REST payload field {field!r} diverges: model={getattr(payload, field)!r} "
+            f"vs canonical={canonical[field]!r}"
+        )
+
+
+def test_canonical_options_to_dict_validates_against_sdk_payload() -> None:
+    """OrganizeOptions().to_dict() must validate back to the SDK transport model."""
+    canonical = OrganizeOptions().to_dict()
+    payload = SdkOptionsPayload.model_validate(canonical)
+    for field in SdkOptionsPayload.model_fields:
+        assert getattr(payload, field) == canonical[field], (
+            f"SDK payload field {field!r} diverges: model={getattr(payload, field)!r} "
+            f"vs canonical={canonical[field]!r}"
+        )
+
+
+def test_to_dict_drops_use_hardlinks_legacy_alias() -> None:
+    """The legacy ``use_hardlinks`` field must not leak into the canonical serialization.
+
+    ``OrganizationOptionsPayload`` defines ``transfer_mode`` instead, so emitting
+    ``use_hardlinks`` would cause ``model_validate`` to reject the dict as an extra field.
+    """
+    canonical = OrganizeOptions().to_dict()
+    assert "use_hardlinks" not in canonical
+
+
+def test_rest_and_sdk_payloads_declare_identical_fields() -> None:
+    """The REST and SDK payload models must agree on exactly which fields exist."""
+    rest = set(RestOptionsPayload.model_fields)
+    sdk = set(SdkOptionsPayload.model_fields)
+    assert rest == sdk, (
+        f"REST-only: {rest - sdk}, SDK-only: {sdk - rest}. "
+        "The REST and SDK OrganizationOptionsPayload models must declare the same fields."
+    )

--- a/tests/client/test_endpoint_inventory.py
+++ b/tests/client/test_endpoint_inventory.py
@@ -138,9 +138,19 @@ def test_sdk_payload_fields_are_subset_of_canonical_options() -> None:
     )
 
 
-def test_canonical_options_to_dict_validates_against_rest_payload() -> None:
+@pytest.mark.parametrize(
+    "options",
+    [
+        OrganizeOptions(),
+        OrganizeOptions(transfer_mode="copy", methodology="para", recursive=False),
+        OrganizeOptions(transfer_mode="hardlink", methodology="jd", prefetch_depth=5),
+    ],
+)
+def test_canonical_options_to_dict_validates_against_rest_payload(
+    options: OrganizeOptions,
+) -> None:
     """OrganizeOptions().to_dict() must validate back to the REST transport model."""
-    canonical = OrganizeOptions().to_dict()
+    canonical = options.to_dict()
     payload = RestOptionsPayload.model_validate(canonical)
     # Assert every canonical field survives the round-trip, not just spot-checks.
     for field in RestOptionsPayload.model_fields:
@@ -150,9 +160,19 @@ def test_canonical_options_to_dict_validates_against_rest_payload() -> None:
         )
 
 
-def test_canonical_options_to_dict_validates_against_sdk_payload() -> None:
+@pytest.mark.parametrize(
+    "options",
+    [
+        OrganizeOptions(),
+        OrganizeOptions(transfer_mode="copy", methodology="para", recursive=False),
+        OrganizeOptions(transfer_mode="hardlink", methodology="jd", prefetch_depth=5),
+    ],
+)
+def test_canonical_options_to_dict_validates_against_sdk_payload(
+    options: OrganizeOptions,
+) -> None:
     """OrganizeOptions().to_dict() must validate back to the SDK transport model."""
-    canonical = OrganizeOptions().to_dict()
+    canonical = options.to_dict()
     payload = SdkOptionsPayload.model_validate(canonical)
     for field in SdkOptionsPayload.model_fields:
         assert getattr(payload, field) == canonical[field], (

--- a/tests/client/test_endpoint_inventory.py
+++ b/tests/client/test_endpoint_inventory.py
@@ -109,11 +109,15 @@ def test_single_file_suggestion_is_not_owned_by_plan_execution() -> None:
 #                               ->  OrganizationOptionsPayload.model_validate(merged.to_dict())
 #
 # This only works because:
-#   1. every payload field is consumable by OrganizeOptions.from_dict (subset);
+#   1. every payload field is consumable by OrganizeOptions.from_dict (payload ⊆ dataclass);
 #   2. OrganizeOptions.to_dict() output validates against the payload model.
 #
-# ``use_hardlinks`` is the sole intentional asymmetry: it lives on OrganizeOptions
-# as a legacy input-only alias and is stripped by to_dict().
+# Note on Pydantic extra="ignore" behavior:
+#   Payload models default to ``extra="ignore"``, so extra fields in ``to_dict()`` are silently
+#   dropped rather than rejected. ``use_hardlinks`` is stripped by ``to_dict()`` as a redundant
+#   legacy alias, while ``transfer_mode`` carries the authoritative mode.
+#   Coverage boundary: If ``OrganizeOptions`` ever gains a new domain-only field omitted from
+#   ``OrganizationOptionsPayload``, ``model_validate`` will silently drop it on remote plan merges.
 
 
 def test_rest_payload_fields_are_subset_of_canonical_options() -> None:
@@ -152,7 +156,7 @@ def test_canonical_options_to_dict_validates_against_rest_payload(
     """OrganizeOptions().to_dict() must validate back to the REST transport model."""
     canonical = options.to_dict()
     payload = RestOptionsPayload.model_validate(canonical)
-    # Assert every canonical field survives the round-trip, not just spot-checks.
+    # Assert every payload field survives the round-trip, not just spot-checks.
     for field in RestOptionsPayload.model_fields:
         assert getattr(payload, field) == canonical[field], (
             f"REST payload field {field!r} diverges: model={getattr(payload, field)!r} "
@@ -184,8 +188,9 @@ def test_canonical_options_to_dict_validates_against_sdk_payload(
 def test_to_dict_drops_use_hardlinks_legacy_alias() -> None:
     """The legacy ``use_hardlinks`` field must not leak into the canonical serialization.
 
-    ``OrganizationOptionsPayload`` defines ``transfer_mode`` instead, so emitting
-    ``use_hardlinks`` would cause ``model_validate`` to reject the dict as an extra field.
+    ``OrganizationOptionsPayload`` defines ``transfer_mode`` instead. While Pydantic payload
+    models default to ``extra="ignore"`` (silently dropping unrecognized fields), keeping
+    ``to_dict()`` clean ensures redundant input-only aliases are omitted from serialized state.
     """
     canonical = OrganizeOptions().to_dict()
     assert "use_hardlinks" not in canonical

--- a/tests/core/test_methodology_vocabulary.py
+++ b/tests/core/test_methodology_vocabulary.py
@@ -88,7 +88,7 @@ def test_unrecognized_values_are_lenient_at_the_boundary_and_strict_in_the_domai
 def test_domain_error_lists_exactly_the_canonical_vocabulary() -> None:
     # Asserted through the public failure path rather than the private renderer, so the guard
     # pins the message a caller actually sees.
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="methodology must be") as exc_info:
         OrganizeOptions(methodology="date_based")
 
     assert re.findall(r"'([^']+)'", str(exc_info.value)) == list(CANONICAL)


### PR DESCRIPTION
## Summary

`_merge_remote_plan_options` in `src/file_organizer/cli/api.py` round-trips between `OrganizationOptionsPayload` and `OrganizeOptions` to reuse the CLI's plan overlay helper:

```
OrganizationOptionsPayload  ->  OrganizeOptions.from_dict(...)
                            ->  _merge_explicit_plan_options(...)
                            ->  OrganizationOptionsPayload.model_validate(merged.to_dict())
```

This PR adds field-parity guards to `tests/client/test_endpoint_inventory.py` asserting the preconditions required for this round-trip to succeed:
1. Every field in REST/SDK `OrganizationOptionsPayload` must be present on `OrganizeOptions` so `OrganizeOptions.from_dict()` does not reject unknown option fields.
2. `OrganizeOptions.to_dict()` must validate back into `OrganizationOptionsPayload` across default and non-default option configurations.
3. `use_hardlinks` is verified to be stripped during `to_dict()` serialization so it does not leak into transport payloads.
4. REST and SDK `OrganizationOptionsPayload` models are asserted to declare identical field sets.

Also resolves a `pytest-raises-hygiene` lint rule violation in `tests/core/test_methodology_vocabulary.py`.

## Verification

- **32 unit tests passed**: `pytest tests/client/test_endpoint_inventory.py tests/core/test_methodology_vocabulary.py`
- **Mutation testing verified**:
  - REST/SDK models gaining unknown fields -> CAUGHT
  - `to_dict()` leaking `use_hardlinks` -> CAUGHT
  - REST/SDK field set divergence -> CAUGHT
- **Linting clean**: `ruff check` and `ruff format` passed.

Closes #1628
Part of #1593