### PR TITLE
ci(coverage): count conformance toward the integration coverage gate (#1599)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,11 @@ jobs:
         # 2026-06-25: 75.7% combined (ratchet after ebook, document, audio, video and model coverage updates; actual 75.77%)
         # 2026-07-19: 76.0% combined (ratchet after genuine integration tests for the JD migrator, dedupe CLI, and deploy scaling/monitoring/compose modules; issue #1582)
         # 2026-07-19: 76.5% combined (ratchet after genuine integration tests for the updater check→install→rollback cycle, desktop launcher daemon boot, and TUI Pilot view transitions; issue #1582)
-        run: pytest tests/ -m "integration" --strict-markers --cov=file_organizer --cov-branch --cov-fail-under=76.5 --cov-report=term-missing --cov-report=xml --cov-report=json:.coverage-integration.json --timeout=60 --override-ini="addopts="
+        # 2026-07-23: count the conformance suite (#1599 parity slice). It drives the canonical
+        #   service and every adapter end to end, so it is integration-level evidence for the new
+        #   core/tui/methodology modules; it stays separately gated by the Conformance workflow. The
+        #   floor is regenerated from this pool and ratchets in the same PR (#1628 coverage follow-up).
+        run: pytest tests/ -m "integration or conformance" --strict-markers --cov=file_organizer --cov-branch --cov-fail-under=76.5 --cov-report=term-missing --cov-report=xml --cov-report=json:.coverage-integration.json --timeout=60 --override-ini="addopts="
 
       - name: Check per-file integration coverage floors
         run: python scripts/coverage/check-integration-floors.py

--- a/scripts/coverage/measure-integration-coverage.sh
+++ b/scripts/coverage/measure-integration-coverage.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 uv pip install -e ".[search]" --quiet
 
 coverage erase
-pytest tests/ -m "integration" \
+# Conformance is integration-level: it drives the canonical service and every adapter end to end.
+# It carries its own `conformance` marker for the required Conformance workflow, so counting it here
+# keeps the integration coverage measurement honest for the new canonical modules it exercises.
+pytest tests/ -m "integration or conformance" \
     --strict-markers \
     --cov=file_organizer \
     --cov-branch \


### PR DESCRIPTION
## Why

The canonical modules this epic added are exercised end to end by the conformance suite, but that suite carries only the `conformance` marker while the integration coverage gate runs `-m integration` — so conformance evidence was excluded from the measurement.

The distortion, from the #1645 CI run:

| Module (new this epic) | Unit | Integration (gate) |
| --- | --- | --- |
| `methodologies/organization.py` | 94.1% | **22.5%** |
| `tui/organization_adapter.py` | 79.6% | **30.6%** |
| `tui/workspace.py` | 91.8% | 63.9% |
| `core/organize_options.py` | 92.3% | 73.5% |
| `core/capabilities.py` | 87.6% | 70.9% |
| `core/lifecycle.py` | 85.7% | 75.7% |

The gate was measuring the wrong denominator for exactly the modules conformance was built to cover.

## Change

Count `-m "integration or conformance"` in the integration coverage gate (`ci.yml`) and the local measure script. Conformance only ever adds covered lines, so the aggregate can only rise — the 76.5% floor is safe. Conformance stays separately gated by the Conformance workflow for pass/fail.

## This PR is not green on its own — it is the measurement step

Folding conformance in raises the eight new modules' measured coverage, but they still have **no per-file floor entries**, so `check-integration-floors.py` still reports MISSING FLOOR. This draft exists so CI (clean env) produces the authoritative `.coverage-integration.json`. Next commits, from that artifact:

1. `generate-integration-floors.py` → write floor entries
2. Read the regenerated floors → identify modules still genuinely low after conformance is counted
3. Add real integration tests only for those, so we don't duplicate conformance

Local measurement is blocked by a torch/ctranslate2 import clash on the dev box, so the numbers must come from CI.

## Scope note

This is integration-readiness work, not a parity slice. Filed under #1599, whose acceptance also still needs the cross-adapter concurrent-mutation conformance scenario (the deferred #1606 step 5) before it can close.

Part of #1599
Part of #1593