### PR TITLE
chore(parity): scope Pyre to its intended files and fix yamllint

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -2,11 +2,12 @@
   "source_directories": [
     "src"
   ],
+  "only_check_paths": [
+    "src/file_organizer/api/middleware.py",
+    "src/file_organizer/web/_helpers.py",
+    "src/file_organizer/web/csrf.py"
+  ],
   "search_path": [
     "stubs/pyre"
-  ],
-  "ignore_all_errors": [
-    "tests/.*",
-    "src/file_organizer/(?!api/middleware\\.py$|web/_helpers\\.py$|web/csrf\\.py$).*"
   ]
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,7 @@ nav:
   - Architecture:
       - Overview: architecture/architecture-overview.md
       - Module Diagrams: architecture/module-diagrams.md
-      - Cross-Surface Parity Execution: architecture/cross-surface-parity-execution.md
+      - Cross-Surface Parity: architecture/cross-surface-parity-execution.md
   - Admin Guide:
       - Overview: admin/index.md
       - Installation: admin/installation.md


### PR DESCRIPTION
Two deterministic pre-integration fixes for gates that run only against `main`. Both validated locally. Coverage floors were **removed from this PR** and deferred — see below.

## What's in

### Pyre config (#1649)
`ignore_all_errors` used a regex negative-lookahead Pyre doesn't support, so it scanned the whole package — 113 errors, none in the three files it intends to check. Replaced with `only_check_paths`. **Verified with a real pyre run:** 0 errors on the three files; injecting a type error into `web/csrf.py` is caught (mutation-tested).

### yamllint
`mkdocs.yml:128` shortened under 80 chars; `yamllint mkdocs.yml` exits 0.

## Why floors are deferred, not here

The coverage gate (a) runs only when a PR targets `main`, and (b) is **not** a required status check (only CodeQL + CodeRabbit + one review are). So:

- Missing floors do **not** block the integration PR from merging.
- The integration PR is the first context where the gate runs authoritatively, in the clean linux CI env. My local `[dev,search]` venv reads *lower* than CI for several files, so floors set now would be conservative guesses.

Setting floors from the real post-integration CI measurement is strictly more accurate. They land as a follow-up ratchet PR to `main` after integration.

## Still deferred to their own PRs (unchanged from prior note)

- **#1599 cross-adapter concurrency conformance** — the conformance harness isolates each driver's workspace by design; shared-state-across-adapters needs a new harness (the deferred #1606 step 5).
- **#1637** — platform-specific main-CI fixes, unvalidatable locally, straight to `main`.

Part of #1599
Part of #1593