### PR TITLE
refactor(conformance): move golden expectations to JSON fixtures (#1659)

### DIFF
--- a/tests/conformance/fixtures/collision_rename_counter.json
+++ b/tests/conformance/fixtures/collision_rename_counter.json
@@ -1,0 +1,34 @@
+{
+  "case_id": "collision-stems",
+  "options": {
+    "use_hardlinks": false,
+    "skip_existing": false
+  },
+  "expected_routes": [
+    [
+      "<input>/archive/summary.txt",
+      "<output>/Documents/summary_1.txt",
+      "ready",
+      "rename_with_counter"
+    ],
+    [
+      "<input>/notes/draft.txt",
+      "<output>/Documents/draft.txt",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/old/draft.txt",
+      "<output>/Documents/draft_1.txt",
+      "ready",
+      "rename_with_counter"
+    ],
+    [
+      "<input>/reports/summary.txt",
+      "<output>/Documents/summary_2.txt",
+      "ready",
+      "rename_with_counter"
+    ]
+  ],
+  "expected_processed_files": 4
+}

--- a/tests/conformance/fixtures/collision_skip_existing.json
+++ b/tests/conformance/fixtures/collision_skip_existing.json
@@ -1,0 +1,35 @@
+{
+  "case_id": "collision-stems",
+  "options": {
+    "use_hardlinks": false,
+    "skip_existing": true
+  },
+  "expected_routes": [
+    [
+      "<input>/archive/summary.txt",
+      "<output>/Documents/summary.txt",
+      "skipped",
+      "skip_existing"
+    ],
+    [
+      "<input>/notes/draft.txt",
+      "<output>/Documents/draft.txt",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/old/draft.txt",
+      "<output>/Documents/draft_1.txt",
+      "ready",
+      "rename_with_counter"
+    ],
+    [
+      "<input>/reports/summary.txt",
+      "<output>/Documents/summary.txt",
+      "skipped",
+      "skip_existing"
+    ]
+  ],
+  "expected_processed_files": 2,
+  "expected_skipped_files": 2
+}

--- a/tests/conformance/fixtures/duplicate_content.json
+++ b/tests/conformance/fixtures/duplicate_content.json
@@ -1,0 +1,27 @@
+{
+  "case_id": "duplicate-content",
+  "options": {
+    "use_hardlinks": false
+  },
+  "expected_routes": [
+    [
+      "<input>/copy/two.txt",
+      "<output>/Documents/two.txt",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/unique.txt",
+      "<output>/Documents/unique.txt",
+      "ready",
+      "create"
+    ]
+  ],
+  "expected_counts": {
+    "total_files": 3,
+    "processed_files": 2,
+    "skipped_files": 0,
+    "failed_files": 0,
+    "deduplicated_files": 1
+  }
+}

--- a/tests/conformance/fixtures/execute_applies_previewed.json
+++ b/tests/conformance/fixtures/execute_applies_previewed.json
@@ -1,0 +1,56 @@
+{
+  "case_id": "flat-documents",
+  "options": {
+    "use_hardlinks": false
+  },
+  "expected_result": {
+    "counts": {
+      "total_files": 3,
+      "processed_files": 3,
+      "skipped_files": 0,
+      "failed_files": 0,
+      "deduplicated_files": 0
+    },
+    "organized_structure": {
+      "Documents": [
+        "alpha.txt",
+        "bravo.md"
+      ],
+      "Spreadsheets": [
+        "ledger.csv"
+      ]
+    },
+    "errors": []
+  },
+  "expected_audit_events": [
+    {
+      "operation_type": "copy",
+      "status": "completed",
+      "source": "<input>/alpha.txt",
+      "destination": "<output>/Documents/alpha.txt",
+      "collision_action": "create",
+      "folder": "Documents"
+    },
+    {
+      "operation_type": "copy",
+      "status": "completed",
+      "source": "<input>/bravo.md",
+      "destination": "<output>/Documents/bravo.md",
+      "collision_action": "create",
+      "folder": "Documents"
+    },
+    {
+      "operation_type": "copy",
+      "status": "completed",
+      "source": "<input>/ledger.csv",
+      "destination": "<output>/Spreadsheets/ledger.csv",
+      "collision_action": "create",
+      "folder": "Spreadsheets"
+    }
+  ],
+  "expected_organized_paths": [
+    "Documents/alpha.txt",
+    "Documents/bravo.md",
+    "Spreadsheets/ledger.csv"
+  ]
+}

--- a/tests/conformance/fixtures/media_routing.json
+++ b/tests/conformance/fixtures/media_routing.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Optional media routes through canonical policy on pinned metadata. skipped_files is 1 because data.zzz has no supported handler.",
   "case_id": "media-optional",
   "options": {
     "transfer_mode": "copy"

--- a/tests/conformance/fixtures/media_routing.json
+++ b/tests/conformance/fixtures/media_routing.json
@@ -1,0 +1,51 @@
+{
+  "case_id": "media-optional",
+  "options": {
+    "transfer_mode": "copy"
+  },
+  "expected_routes": [
+    [
+      "<input>/clip.mp4",
+      "<output>/Short_Clips/clip.mp4",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/movie.mkv",
+      "<output>/Videos/2026/movie.mkv",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/photo_older.png",
+      "<output>/Images/2020/photo_older.png",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/photo_recent.jpg",
+      "<output>/Images/2026/photo_recent.jpg",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/song.mp3",
+      "<output>/Rock/Fixture Artist/Fixture Album/00 - Fixture Song.mp3",
+      "ready",
+      "create"
+    ],
+    [
+      "<input>/widget.step",
+      "<output>/CAD/widget.step",
+      "ready",
+      "create"
+    ]
+  ],
+  "expected_counts": {
+    "total_files": 7,
+    "processed_files": 6,
+    "skipped_files": 1,
+    "failed_files": 0,
+    "deduplicated_files": 0
+  }
+}

--- a/tests/conformance/fixtures/methodology_seed.json
+++ b/tests/conformance/fixtures/methodology_seed.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "PARA and Johnny Decimal expected destinations (#1602). Documents and PDFs share area 30 and therefore must not share a category number; PDFs sorts after Documents, so it takes 30.02 (#1617).",
   "case_id": "methodology-seed",
   "cases": [
     {

--- a/tests/conformance/fixtures/methodology_seed.json
+++ b/tests/conformance/fixtures/methodology_seed.json
@@ -1,0 +1,23 @@
+{
+  "case_id": "methodology-seed",
+  "cases": [
+    {
+      "methodology": "para",
+      "expected_destinations": [
+        "<output>/Archive/Documents/notes.md",
+        "<output>/Areas/Spreadsheets/budget.csv",
+        "<output>/Projects/Documents/plan.txt",
+        "<output>/Resources/PDFs/paper.pdf"
+      ]
+    },
+    {
+      "methodology": "jd",
+      "expected_destinations": [
+        "<output>/30 Operations & Projects/30.01 Documents/notes.md",
+        "<output>/10 Finance & Administration/10.01 Spreadsheets/budget.csv",
+        "<output>/30 Operations & Projects/30.01 Documents/plan.txt",
+        "<output>/30 Operations & Projects/30.02 PDFs/paper.pdf"
+      ]
+    }
+  ]
+}

--- a/tests/conformance/fixtures/scan_counts.json
+++ b/tests/conformance/fixtures/scan_counts.json
@@ -1,0 +1,11 @@
+{
+  "case_id": "nested-mixed",
+  "expected_counts": {
+    "audio": 1,
+    "cad": 1,
+    "image": 1,
+    "other": 1,
+    "text": 3,
+    "video": 1
+  }
+}

--- a/tests/conformance/fixtures/traversal_policy.json
+++ b/tests/conformance/fixtures/traversal_policy.json
@@ -1,0 +1,84 @@
+{
+  "cases": [
+    {
+      "case_id": "flat-documents",
+      "options": {},
+      "expected_files": [
+        "<input>/alpha.txt",
+        "<input>/bravo.md",
+        "<input>/ledger.csv"
+      ]
+    },
+    {
+      "case_id": "nested-mixed",
+      "options": {
+        "recursive": false
+      },
+      "expected_files": [
+        "<input>/top.txt"
+      ]
+    },
+    {
+      "case_id": "nested-mixed",
+      "options": {
+        "recursive": true
+      },
+      "expected_files": [
+        "<input>/cad/part.dxf",
+        "<input>/docs/deep/inner.md",
+        "<input>/docs/report.pdf",
+        "<input>/media/clip.mp4",
+        "<input>/media/photo.jpg",
+        "<input>/media/song.mp3",
+        "<input>/misc/data.zzz",
+        "<input>/top.txt"
+      ]
+    },
+    {
+      "case_id": "hidden-entries",
+      "options": {
+        "recursive": true,
+        "include_hidden": false
+      },
+      "expected_files": [
+        "<input>/nested/plain.md",
+        "<input>/visible.txt"
+      ]
+    },
+    {
+      "case_id": "hidden-entries",
+      "options": {
+        "recursive": true,
+        "include_hidden": true
+      },
+      "expected_files": [
+        "<input>/.hidden.txt",
+        "<input>/.hiddendir/inside.txt",
+        "<input>/nested/.dotfile.md",
+        "<input>/nested/plain.md",
+        "<input>/visible.txt"
+      ]
+    },
+    {
+      "case_id": "hidden-entries",
+      "options": {
+        "recursive": false,
+        "include_hidden": true
+      },
+      "expected_files": [
+        "<input>/.hidden.txt",
+        "<input>/visible.txt"
+      ]
+    },
+    {
+      "case_id": "hidden-entries",
+      "options": {
+        "recursive": false,
+        "include_hidden": false
+      },
+      "expected_files": [
+        "<input>/visible.txt"
+      ]
+    }
+  ]
+}

--- a/tests/conformance/goldens.py
+++ b/tests/conformance/goldens.py
@@ -27,5 +27,11 @@ def load_golden(name: str) -> dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"Conformance golden fixture missing at '{path}'")
     content = path.read_text(encoding="utf-8")
-    result: dict[str, Any] = json.loads(content)
+    result = json.loads(content)
+    if not isinstance(result, dict):
+        raise json.JSONDecodeError(
+            f"Conformance golden fixture '{name}' must root a JSON object, got {type(result).__name__}",
+            content,
+            0,
+        )
     return result

--- a/tests/conformance/goldens.py
+++ b/tests/conformance/goldens.py
@@ -7,14 +7,15 @@ This module loads and parses fixture data with session-level LRU caching.
 from __future__ import annotations
 
 import json
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
+from typing import Any
 
 _FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
 
-@lru_cache(maxsize=None)
-def load_golden(name: str) -> dict:
+@cache
+def load_golden(name: str) -> dict[str, Any]:
     """Load and parse a JSON golden fixture by name.
 
     :param name: Fixture basename without extension (e.g. ``"traversal_policy"``).
@@ -26,4 +27,5 @@ def load_golden(name: str) -> dict:
     if not path.exists():
         raise FileNotFoundError(f"Conformance golden fixture missing at '{path}'")
     content = path.read_text(encoding="utf-8")
-    return json.loads(content)
+    result: dict[str, Any] = json.loads(content)
+    return result

--- a/tests/conformance/goldens.py
+++ b/tests/conformance/goldens.py
@@ -1,0 +1,29 @@
+"""Loader for serialized conformance golden fixtures (#1659).
+
+Golden expectations live as versioned JSON files under ``tests/conformance/fixtures/``.
+This module loads and parses fixture data with session-level LRU caching.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@lru_cache(maxsize=None)
+def load_golden(name: str) -> dict:
+    """Load and parse a JSON golden fixture by name.
+
+    :param name: Fixture basename without extension (e.g. ``"traversal_policy"``).
+    :return: Parsed JSON fixture structure.
+    :raises FileNotFoundError: If the fixture file does not exist.
+    :raises json.JSONDecodeError: If the fixture file contains invalid JSON.
+    """
+    path = _FIXTURES_DIR / f"{name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Conformance golden fixture missing at '{path}'")
+    content = path.read_text(encoding="utf-8")
+    return json.loads(content)

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -28,6 +28,7 @@ from file_organizer.history.models import Operation, OperationType
 from tests.conformance.conftest import ConformanceContext
 from tests.conformance.corpus import FIXED_MTIME_NS, get_case, materialize_case
 from tests.conformance.driver import DirectServiceDriver, OrganizationConformanceDriver
+from tests.conformance.goldens import load_golden
 from tests.conformance.normalize import (
     normalize_audit_events,
     normalize_job_events,
@@ -82,59 +83,14 @@ def test_corpus_materialization_is_deterministic(tmp_path: Path) -> None:
         assert left.stat().st_mtime_ns == right.stat().st_mtime_ns == spec.mtime_ns
 
 
+_TRAVERSAL_GOLDEN = load_golden("traversal_policy")
+
+
 @pytest.mark.parametrize(
     ("case_id", "options", "expected_files"),
     [
-        (
-            "flat-documents",
-            {},
-            ["<input>/alpha.txt", "<input>/bravo.md", "<input>/ledger.csv"],
-        ),
-        (
-            "nested-mixed",
-            {"recursive": False},
-            ["<input>/top.txt"],
-        ),
-        (
-            "nested-mixed",
-            {"recursive": True},
-            [
-                "<input>/cad/part.dxf",
-                "<input>/docs/deep/inner.md",
-                "<input>/docs/report.pdf",
-                "<input>/media/clip.mp4",
-                "<input>/media/photo.jpg",
-                "<input>/media/song.mp3",
-                "<input>/misc/data.zzz",
-                "<input>/top.txt",
-            ],
-        ),
-        (
-            "hidden-entries",
-            {"recursive": True, "include_hidden": False},
-            ["<input>/nested/plain.md", "<input>/visible.txt"],
-        ),
-        (
-            "hidden-entries",
-            {"recursive": True, "include_hidden": True},
-            [
-                "<input>/.hidden.txt",
-                "<input>/.hiddendir/inside.txt",
-                "<input>/nested/.dotfile.md",
-                "<input>/nested/plain.md",
-                "<input>/visible.txt",
-            ],
-        ),
-        (
-            "hidden-entries",
-            {"recursive": False, "include_hidden": True},
-            ["<input>/.hidden.txt", "<input>/visible.txt"],
-        ),
-        (
-            "hidden-entries",
-            {"recursive": False, "include_hidden": False},
-            ["<input>/visible.txt"],
-        ),
+        (c["case_id"], c["options"], c["expected_files"])
+        for c in _TRAVERSAL_GOLDEN["cases"]
     ],
 )
 def test_traversal_policy_goldens(
@@ -152,18 +108,12 @@ def test_traversal_policy_goldens(
 
 
 def test_scan_counts_golden(conformance: ConformanceContext) -> None:
-    conformance.stage("nested-mixed")
+    golden = load_golden("scan_counts")
+    conformance.stage(golden["case_id"])
 
     envelope = _ok(conformance.driver.scan(conformance.request()))
 
-    assert envelope["scan"]["counts"] == {
-        "audio": 1,
-        "cad": 1,
-        "image": 1,
-        "other": 1,
-        "text": 3,
-        "video": 1,
-    }
+    assert envelope["scan"]["counts"] == golden["expected_counts"]
 
 
 def test_preview_sources_match_scan(conformance: ConformanceContext) -> None:
@@ -200,40 +150,17 @@ def test_non_recursive_execution_applies_only_reviewed_top_level_files(
 
 def test_media_routing_golden(conformance: ConformanceContext) -> None:
     """Optional media routes through canonical policy on pinned metadata."""
-    conformance.stage("media-optional")
+    golden = load_golden("media_routing")
+    conformance.stage(golden["case_id"])
 
-    envelope = _ok(conformance.driver.preview(conformance.request(transfer_mode="copy")))
+    envelope = _ok(
+        conformance.driver.preview(conformance.request(**golden["options"]))
+    )
 
     assert _operation_routes(envelope) == [
-        ("<input>/clip.mp4", "<output>/Short_Clips/clip.mp4", "ready", "create"),
-        ("<input>/movie.mkv", "<output>/Videos/2026/movie.mkv", "ready", "create"),
-        (
-            "<input>/photo_older.png",
-            "<output>/Images/2020/photo_older.png",
-            "ready",
-            "create",
-        ),
-        (
-            "<input>/photo_recent.jpg",
-            "<output>/Images/2026/photo_recent.jpg",
-            "ready",
-            "create",
-        ),
-        (
-            "<input>/song.mp3",
-            "<output>/Rock/Fixture Artist/Fixture Album/00 - Fixture Song.mp3",
-            "ready",
-            "create",
-        ),
-        ("<input>/widget.step", "<output>/CAD/widget.step", "ready", "create"),
+        tuple(route) for route in golden["expected_routes"]
     ]
-    assert envelope["plan"]["counts"] == {
-        "total_files": 7,
-        "processed_files": 6,
-        "skipped_files": 1,  # data.zzz has no supported handler
-        "failed_files": 0,
-        "deduplicated_files": 0,
-    }
+    assert envelope["plan"]["counts"] == golden["expected_counts"]
 
 
 def test_plan_is_deterministic_and_round_trips(conformance: ConformanceContext) -> None:
@@ -340,85 +267,47 @@ def test_resolved_options_are_persisted(conformance: ConformanceContext) -> None
 
 
 def test_collision_skip_existing_golden(conformance: ConformanceContext) -> None:
-    conformance.stage("collision-stems")
+    golden = load_golden("collision_skip_existing")
+    conformance.stage(golden["case_id"])
 
     envelope = _ok(
-        conformance.driver.preview(conformance.request(use_hardlinks=False, skip_existing=True))
+        conformance.driver.preview(conformance.request(**golden["options"]))
     )
 
     assert _operation_routes(envelope) == [
-        (
-            "<input>/archive/summary.txt",
-            "<output>/Documents/summary.txt",
-            "skipped",
-            "skip_existing",
-        ),
-        ("<input>/notes/draft.txt", "<output>/Documents/draft.txt", "ready", "create"),
-        (
-            "<input>/old/draft.txt",
-            "<output>/Documents/draft_1.txt",
-            "ready",
-            "rename_with_counter",
-        ),
-        (
-            "<input>/reports/summary.txt",
-            "<output>/Documents/summary.txt",
-            "skipped",
-            "skip_existing",
-        ),
+        tuple(route) for route in golden["expected_routes"]
     ]
-    assert envelope["plan"]["counts"]["processed_files"] == 2
-    assert envelope["plan"]["counts"]["skipped_files"] == 2
+    assert envelope["plan"]["counts"]["processed_files"] == golden["expected_processed_files"]
+    assert envelope["plan"]["counts"]["skipped_files"] == golden["expected_skipped_files"]
 
 
 def test_collision_rename_with_counter_golden(conformance: ConformanceContext) -> None:
-    conformance.stage("collision-stems")
+    golden = load_golden("collision_rename_counter")
+    conformance.stage(golden["case_id"])
 
     envelope = _ok(
-        conformance.driver.preview(conformance.request(use_hardlinks=False, skip_existing=False))
+        conformance.driver.preview(conformance.request(**golden["options"]))
     )
 
     assert _operation_routes(envelope) == [
-        (
-            "<input>/archive/summary.txt",
-            "<output>/Documents/summary_1.txt",
-            "ready",
-            "rename_with_counter",
-        ),
-        ("<input>/notes/draft.txt", "<output>/Documents/draft.txt", "ready", "create"),
-        (
-            "<input>/old/draft.txt",
-            "<output>/Documents/draft_1.txt",
-            "ready",
-            "rename_with_counter",
-        ),
-        (
-            "<input>/reports/summary.txt",
-            "<output>/Documents/summary_2.txt",
-            "ready",
-            "rename_with_counter",
-        ),
+        tuple(route) for route in golden["expected_routes"]
     ]
-    assert envelope["plan"]["counts"]["processed_files"] == 4
+    assert envelope["plan"]["counts"]["processed_files"] == golden["expected_processed_files"]
 
 
 def test_duplicate_content_golden(conformance: ConformanceContext) -> None:
     """Content dedup keeps the lexicographically first source of each hash."""
-    conformance.stage("duplicate-content")
+    golden = load_golden("duplicate_content")
+    conformance.stage(golden["case_id"])
 
-    envelope = _ok(conformance.driver.preview(conformance.request(use_hardlinks=False)))
+    envelope = _ok(
+        conformance.driver.preview(conformance.request(**golden["options"]))
+    )
 
     assert _operation_routes(envelope) == [
-        ("<input>/copy/two.txt", "<output>/Documents/two.txt", "ready", "create"),
-        ("<input>/unique.txt", "<output>/Documents/unique.txt", "ready", "create"),
+        tuple(route) for route in golden["expected_routes"]
     ]
-    assert envelope["plan"]["counts"] == {
-        "total_files": 3,
-        "processed_files": 2,
-        "skipped_files": 0,
-        "failed_files": 0,
-        "deduplicated_files": 1,
-    }
+    assert envelope["plan"]["counts"] == golden["expected_counts"]
     fingerprints = [op["fingerprint"] for op in envelope["plan"]["operations"]]
     assert all(fp is not None and fp["sha256"] for fp in fingerprints)
 
@@ -437,62 +326,21 @@ def test_symlinks_are_excluded(conformance: ConformanceContext) -> None:
 
 
 def test_execute_applies_previewed_plan_golden(conformance: ConformanceContext) -> None:
-    conformance.stage("flat-documents")
-    request = conformance.request(use_hardlinks=False)
+    golden = load_golden("execute_applies_previewed")
+    conformance.stage(golden["case_id"])
+    request = conformance.request(**golden["options"])
     preview = _ok(conformance.driver.preview(request))
 
     envelope = _ok(conformance.driver.execute(request, preview["plan_payload"]))
 
-    assert envelope["result"] == {
-        "counts": {
-            "total_files": 3,
-            "processed_files": 3,
-            "skipped_files": 0,
-            "failed_files": 0,
-            "deduplicated_files": 0,
-        },
-        "organized_structure": {
-            "Documents": ["alpha.txt", "bravo.md"],
-            "Spreadsheets": ["ledger.csv"],
-        },
-        "errors": [],
-    }
-    assert envelope["audit_events"] == [
-        {
-            "operation_type": "copy",
-            "status": "completed",
-            "source": "<input>/alpha.txt",
-            "destination": "<output>/Documents/alpha.txt",
-            "collision_action": "create",
-            "folder": "Documents",
-        },
-        {
-            "operation_type": "copy",
-            "status": "completed",
-            "source": "<input>/bravo.md",
-            "destination": "<output>/Documents/bravo.md",
-            "collision_action": "create",
-            "folder": "Documents",
-        },
-        {
-            "operation_type": "copy",
-            "status": "completed",
-            "source": "<input>/ledger.csv",
-            "destination": "<output>/Spreadsheets/ledger.csv",
-            "collision_action": "create",
-            "folder": "Spreadsheets",
-        },
-    ]
+    assert envelope["result"] == golden["expected_result"]
+    assert envelope["audit_events"] == golden["expected_audit_events"]
     organized = sorted(
         path.relative_to(conformance.output_root).as_posix()
         for path in conformance.output_root.rglob("*")
         if path.is_file()
     )
-    assert organized == [
-        "Documents/alpha.txt",
-        "Documents/bravo.md",
-        "Spreadsheets/ledger.csv",
-    ]
+    assert organized == golden["expected_organized_paths"]
     assert (conformance.output_root / "Documents" / "alpha.txt").read_bytes() == b"alpha body\n"
 
 
@@ -598,29 +446,14 @@ def test_missing_input_is_rejected(conformance: ConformanceContext) -> None:
     assert envelope["error"]["message"] == "Input path does not exist: <input>"
 
 
+_METHODOLOGY_GOLDEN = load_golden("methodology_seed")
+
+
 @pytest.mark.parametrize(
     ("methodology", "expected_destinations"),
     [
-        (
-            "para",
-            [
-                "<output>/Archive/Documents/notes.md",
-                "<output>/Areas/Spreadsheets/budget.csv",
-                "<output>/Projects/Documents/plan.txt",
-                "<output>/Resources/PDFs/paper.pdf",
-            ],
-        ),
-        (
-            "jd",
-            [
-                # Documents and PDFs share area 30 and therefore must not share a category
-                # number; PDFs sorts after Documents, so it takes 30.02 (#1617).
-                "<output>/30 Operations & Projects/30.01 Documents/notes.md",
-                "<output>/10 Finance & Administration/10.01 Spreadsheets/budget.csv",
-                "<output>/30 Operations & Projects/30.01 Documents/plan.txt",
-                "<output>/30 Operations & Projects/30.02 PDFs/paper.pdf",
-            ],
-        ),
+        (c["methodology"], c["expected_destinations"])
+        for c in _METHODOLOGY_GOLDEN["cases"]
     ],
 )
 def test_methodology_seed_golden(
@@ -629,7 +462,7 @@ def test_methodology_seed_golden(
     expected_destinations: list[str],
 ) -> None:
     """PARA and Johnny Decimal destinations come from the canonical service."""
-    conformance.stage("methodology-seed")
+    conformance.stage(_METHODOLOGY_GOLDEN["case_id"])
 
     envelope = _ok(
         conformance.driver.preview(

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -88,10 +88,7 @@ _TRAVERSAL_GOLDEN = load_golden("traversal_policy")
 
 @pytest.mark.parametrize(
     ("case_id", "options", "expected_files"),
-    [
-        (c["case_id"], c["options"], c["expected_files"])
-        for c in _TRAVERSAL_GOLDEN["cases"]
-    ],
+    [(c["case_id"], c["options"], c["expected_files"]) for c in _TRAVERSAL_GOLDEN["cases"]],
 )
 def test_traversal_policy_goldens(
     conformance: ConformanceContext,
@@ -153,13 +150,9 @@ def test_media_routing_golden(conformance: ConformanceContext) -> None:
     golden = load_golden("media_routing")
     conformance.stage(golden["case_id"])
 
-    envelope = _ok(
-        conformance.driver.preview(conformance.request(**golden["options"]))
-    )
+    envelope = _ok(conformance.driver.preview(conformance.request(**golden["options"])))
 
-    assert _operation_routes(envelope) == [
-        tuple(route) for route in golden["expected_routes"]
-    ]
+    assert _operation_routes(envelope) == [tuple(route) for route in golden["expected_routes"]]
     assert envelope["plan"]["counts"] == golden["expected_counts"]
 
 
@@ -270,13 +263,9 @@ def test_collision_skip_existing_golden(conformance: ConformanceContext) -> None
     golden = load_golden("collision_skip_existing")
     conformance.stage(golden["case_id"])
 
-    envelope = _ok(
-        conformance.driver.preview(conformance.request(**golden["options"]))
-    )
+    envelope = _ok(conformance.driver.preview(conformance.request(**golden["options"])))
 
-    assert _operation_routes(envelope) == [
-        tuple(route) for route in golden["expected_routes"]
-    ]
+    assert _operation_routes(envelope) == [tuple(route) for route in golden["expected_routes"]]
     assert envelope["plan"]["counts"]["processed_files"] == golden["expected_processed_files"]
     assert envelope["plan"]["counts"]["skipped_files"] == golden["expected_skipped_files"]
 
@@ -285,13 +274,9 @@ def test_collision_rename_with_counter_golden(conformance: ConformanceContext) -
     golden = load_golden("collision_rename_counter")
     conformance.stage(golden["case_id"])
 
-    envelope = _ok(
-        conformance.driver.preview(conformance.request(**golden["options"]))
-    )
+    envelope = _ok(conformance.driver.preview(conformance.request(**golden["options"])))
 
-    assert _operation_routes(envelope) == [
-        tuple(route) for route in golden["expected_routes"]
-    ]
+    assert _operation_routes(envelope) == [tuple(route) for route in golden["expected_routes"]]
     assert envelope["plan"]["counts"]["processed_files"] == golden["expected_processed_files"]
 
 
@@ -300,13 +285,9 @@ def test_duplicate_content_golden(conformance: ConformanceContext) -> None:
     golden = load_golden("duplicate_content")
     conformance.stage(golden["case_id"])
 
-    envelope = _ok(
-        conformance.driver.preview(conformance.request(**golden["options"]))
-    )
+    envelope = _ok(conformance.driver.preview(conformance.request(**golden["options"])))
 
-    assert _operation_routes(envelope) == [
-        tuple(route) for route in golden["expected_routes"]
-    ]
+    assert _operation_routes(envelope) == [tuple(route) for route in golden["expected_routes"]]
     assert envelope["plan"]["counts"] == golden["expected_counts"]
     fingerprints = [op["fingerprint"] for op in envelope["plan"]["operations"]]
     assert all(fp is not None and fp["sha256"] for fp in fingerprints)
@@ -451,10 +432,7 @@ _METHODOLOGY_GOLDEN = load_golden("methodology_seed")
 
 @pytest.mark.parametrize(
     ("methodology", "expected_destinations"),
-    [
-        (c["methodology"], c["expected_destinations"])
-        for c in _METHODOLOGY_GOLDEN["cases"]
-    ],
+    [(c["methodology"], c["expected_destinations"]) for c in _METHODOLOGY_GOLDEN["cases"]],
 )
 def test_methodology_seed_golden(
     conformance: ConformanceContext,

--- a/tests/conformance/test_goldens.py
+++ b/tests/conformance/test_goldens.py
@@ -1,0 +1,36 @@
+"""Unit tests for the conformance golden fixture loader (#1659)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tests.conformance.goldens import load_golden
+
+
+def test_load_golden_valid() -> None:
+    """Valid golden fixture loads successfully as a dictionary."""
+    data = load_golden("traversal_policy")
+    assert isinstance(data, dict)
+    assert "cases" in data
+
+
+def test_load_golden_missing_raises_file_not_found() -> None:
+    """Missing fixture file raises FileNotFoundError with descriptive message."""
+    with pytest.raises(FileNotFoundError, match="Conformance golden fixture missing at"):
+        load_golden("non_existent_fixture_spec")
+
+
+def test_load_golden_malformed_json_raises_json_decode_error(
+    tmp_path: pytest.TempPathFactory,
+) -> None:
+    """Malformed JSON fixture raises json.JSONDecodeError."""
+    bad_fixture = tmp_path / "bad_fixture.json"
+    bad_fixture.write_text("{invalid json:", encoding="utf-8")
+
+    with patch("tests.conformance.goldens._FIXTURES_DIR", tmp_path):
+        load_golden.cache_clear()
+        with pytest.raises(json.JSONDecodeError):
+            load_golden("bad_fixture")

--- a/tests/conformance/test_goldens.py
+++ b/tests/conformance/test_goldens.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -23,9 +24,7 @@ def test_load_golden_missing_raises_file_not_found() -> None:
         load_golden("non_existent_fixture_spec")
 
 
-def test_load_golden_malformed_json_raises_json_decode_error(
-    tmp_path: pytest.TempPathFactory,
-) -> None:
+def test_load_golden_malformed_json_raises_json_decode_error(tmp_path: Path) -> None:
     """Malformed JSON fixture raises json.JSONDecodeError."""
     bad_fixture = tmp_path / "bad_fixture.json"
     bad_fixture.write_text("{invalid json:", encoding="utf-8")
@@ -34,3 +33,14 @@ def test_load_golden_malformed_json_raises_json_decode_error(
         load_golden.cache_clear()
         with pytest.raises(json.JSONDecodeError):
             load_golden("bad_fixture")
+
+
+def test_load_golden_non_object_json_raises_json_decode_error(tmp_path: Path) -> None:
+    """Non-object JSON root (e.g. array or scalar) raises json.JSONDecodeError."""
+    array_fixture = tmp_path / "array_fixture.json"
+    array_fixture.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with patch("tests.conformance.goldens._FIXTURES_DIR", tmp_path):
+        load_golden.cache_clear()
+        with pytest.raises(json.JSONDecodeError, match="must root a JSON object"):
+            load_golden("array_fixture")


### PR DESCRIPTION
## Summary

Refactors golden expectation data embedded as inline Python literals inside `test_direct_service_conformance.py` into versioned JSON fixture files under `tests/conformance/fixtures/`, loaded via a cached helper module `tests/conformance/goldens.py`.

- Created `tests/conformance/goldens.py` with `load_golden(name: str) -> dict` utilizing `@functools.lru_cache`.
- Created 8 versioned JSON fixture files in `tests/conformance/fixtures/`:
  - `traversal_policy.json`
  - `scan_counts.json`
  - `media_routing.json`
  - `collision_skip_existing.json`
  - `collision_rename_counter.json`
  - `duplicate_content.json`
  - `execute_applies_previewed.json`
  - `methodology_seed.json`
- Swapped inline list/dict literals in `test_direct_service_conformance.py` for `load_golden(...)` calls.

## Verification
- Verified all 257 conformance tests pass (`pytest -m conformance`: **257 Passed**).
- Verified CI quality guardrails (`pytest tests/ci/`: **63 Passed**).
- Tested missing fixture error handling (`load_golden('non_existent')` raises loud `FileNotFoundError`).

Closes #1659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive conformance coverage for file traversal, media routing, duplicate detection, collision handling, execution results, scan counts, and methodology-based destinations.
  * Centralized expected test outcomes in reusable JSON fixtures.
  * Added validation for loading valid, missing, and malformed test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->