### PR TITLE
fix(tui): add per-request model-provider override; document resolution order and add round-trip test

### DIFF
--- a/docs/developer/organization-service.md
+++ b/docs/developer/organization-service.md
@@ -39,6 +39,28 @@ controls. Defaults are validated once before work begins. The direct service res
 text and vision model names/providers before placing the options in a plan, so a plan records the
 behavioral inputs used to produce it rather than an unstable “current default.”
 
+### Model config resolution order
+
+`text_provider`, `vision_provider`, `text_model`, and `vision_model` resolve through a four-step
+cascade, highest priority first:
+
+1. **Per-request explicit option** — `OrganizeOptions.text_provider`/`vision_provider` set by the
+   calling surface (CLI `--text-provider`/`--vision-provider` flags, REST/Web JSON body or form
+   field, TUI session settings).
+2. **Environment variable** — `FO_PROVIDER` and its per-provider siblings (`FO_OPENAI_*`,
+   `FO_LLAMA_CPP_*`, `FO_MLX_*`, `FO_CLAUDE_*`), read by
+   `file_organizer.config.provider_env.get_model_configs_from_env`.
+3. **Persisted config profile** — `AppConfig.models` (`config.models.framework`), loaded via
+   `ConfigManager` when no `FO_PROVIDER` override is set.
+4. **Hardcoded default** — `ollama`, applied when nothing above resolves a value.
+
+Steps 2–4 are resolved once, at `OrganizationService` construction, by
+`config/provider_env.py::get_model_configs()` (see that module's docstring for the full
+env-var/profile/default cascade); `OrganizationService._resolve_options` then applies step 1 on
+top of that resolved baseline for every request. A plan always records the resolved values, never
+an unstable "current default" — the same rule the rest of this section describes for other
+options.
+
 `transfer_mode` is the canonical transfer selector and supports `copy` and `hardlink`.
 `use_hardlinks` remains an input-only compatibility alias and is not emitted in canonical options.
 

--- a/src/file_organizer/tui/settings_view.py
+++ b/src/file_organizer/tui/settings_view.py
@@ -281,6 +281,10 @@ class SettingsView(StatusMixin, Vertical):
         self._methodology: str = "none"
         self._text_model: str = DEFAULT_TEXT_MODEL
         self._provider: str = _DEFAULT_PROVIDER
+        # True once the user explicitly cycles the provider control this session;
+        # until then the persisted value is display-only and is never written into
+        # session options, so it can never silently outrank FO_PROVIDER (#1660).
+        self._provider_overridden: bool = False
         self._check_updates: bool = True
         self._include_prereleases: bool = False
         options = workspace.options if workspace is not None else None
@@ -297,11 +301,7 @@ class SettingsView(StatusMixin, Vertical):
             self._output_dir = str(workspace.output_root or "")
             self._methodology = workspace.options.effective_methodology.value
             self._text_model = workspace.options.text_model or DEFAULT_TEXT_MODEL
-            self._provider = (
-                workspace.options.text_provider
-                if workspace.options.text_provider in _PROVIDER_ORDER
-                else _DEFAULT_PROVIDER
-            )
+            self._provider = self._load_persisted_provider()
             self._max_workers = workspace.options.parallel_workers
             self._prefetch_depth = workspace.options.prefetch_depth
 
@@ -427,6 +427,7 @@ class SettingsView(StatusMixin, Vertical):
         except ValueError:
             index = -1
         self._provider = _PROVIDER_ORDER[(index + 1) % len(_PROVIDER_ORDER)]
+        self._provider_overridden = True
         self._set_status(f"Provider: {self._provider}")
         self._sync_workspace_options()
         self._refresh_panel()
@@ -550,6 +551,7 @@ class SettingsView(StatusMixin, Vertical):
         self._methodology = loaded.methodology
         self._text_model = loaded.text_model
         self._provider = loaded.provider
+        self._provider_overridden = False
         self._check_updates = loaded.check_updates_on_startup
         self._include_prereleases = loaded.include_prereleases
         self._sync_dir_inputs()
@@ -581,20 +583,33 @@ class SettingsView(StatusMixin, Vertical):
         """Apply behavior controls immediately without persisting path edits."""
         if self._workspace is None:
             return
-        self._workspace.set_options(
-            recursive=self._recursive,
-            include_hidden=self._include_hidden,
-            skip_existing=self._skip_existing,
-            transfer_mode=self._transfer_mode,
-            methodology=self._methodology,
-            enable_vision=self._enable_vision,
-            transcribe_audio=self._transcribe_audio,
-            parallel_workers=self._max_workers,
-            prefetch_depth=self._prefetch_depth,
-            text_model=self._text_model,
-            text_provider=self._provider,
-            vision_provider=self._provider,
-        )
+        changes: dict[str, Any] = {
+            "recursive": self._recursive,
+            "include_hidden": self._include_hidden,
+            "skip_existing": self._skip_existing,
+            "transfer_mode": self._transfer_mode,
+            "methodology": self._methodology,
+            "enable_vision": self._enable_vision,
+            "transcribe_audio": self._transcribe_audio,
+            "parallel_workers": self._max_workers,
+            "prefetch_depth": self._prefetch_depth,
+            "text_model": self._text_model,
+        }
+        if self._provider_overridden:
+            # Only write the provider into session options once the user has
+            # explicitly chosen it here; otherwise leave it unset so FO_PROVIDER
+            # and the persisted config profile resolve it in documented order
+            # instead of being silently outranked by a display-only default (#1660).
+            changes["text_provider"] = self._provider
+            changes["vision_provider"] = self._provider
+        self._workspace.set_options(**changes)
+
+    def _load_persisted_provider(self) -> str:
+        """Read the persisted provider for display only, without touching options."""
+        try:
+            return load_workflow_settings(profile=self._profile).provider
+        except Exception:
+            return _DEFAULT_PROVIDER
 
     def _text_model_options(self) -> list[str]:
         """Return cycle options, prepending any persisted custom model."""

--- a/src/file_organizer/tui/settings_view.py
+++ b/src/file_organizer/tui/settings_view.py
@@ -8,6 +8,7 @@ is a one-stop configuration surface:
 - default input/output directories (pre-filled for organize runs)
 - organization methodology (none, PARA, Johnny Decimal)
 - text model choice (cycles through curated Ollama presets)
+- model provider (ollama, openai, llama_cpp, mlx, claude) for both text and vision
 - update / privacy toggles (check-on-startup, include pre-releases)
 
 Every value is persisted through :class:`ConfigManager` onto the canonical
@@ -52,6 +53,12 @@ _TEXT_MODEL_PRESETS = (
     "gemma2:2b-instruct-q4_K_M",
 )
 
+# Supported model providers cycled through with the "f" binding. One provider
+# drives both text_provider and vision_provider (#1660) — the config schema's
+# models.framework field is likewise a single value for both.
+_PROVIDER_ORDER = ("ollama", "openai", "llama_cpp", "mlx", "claude")
+_DEFAULT_PROVIDER = "ollama"
+
 
 @dataclass(frozen=True)
 class ParallelRuntimeSettings:
@@ -74,6 +81,7 @@ class WorkflowSettings:
     default_output_dir: str
     methodology: str
     text_model: str
+    provider: str
     check_updates_on_startup: bool
     include_prereleases: bool
 
@@ -169,11 +177,15 @@ def load_workflow_settings(
     config = resolved_manager.load(profile=profile)
 
     text_model = config.models.text_model.strip() or DEFAULT_TEXT_MODEL
+    provider = (
+        config.models.framework if config.models.framework in _PROVIDER_ORDER else _DEFAULT_PROVIDER
+    )
     return WorkflowSettings(
         default_input_dir=config.default_input_dir or "",
         default_output_dir=config.default_output_dir or "",
         methodology=_normalize_methodology(config.default_methodology),
         text_model=text_model,
+        provider=provider,
         check_updates_on_startup=bool(config.updates.check_on_startup),
         include_prereleases=bool(config.updates.include_prereleases),
     )
@@ -193,6 +205,9 @@ def save_workflow_settings(
     config.default_output_dir = settings.default_output_dir.strip()
     config.default_methodology = _normalize_methodology(settings.methodology)
     config.models.text_model = settings.text_model.strip() or DEFAULT_TEXT_MODEL
+    config.models.framework = (
+        settings.provider if settings.provider in _PROVIDER_ORDER else _DEFAULT_PROVIDER
+    )
     config.updates.check_on_startup = bool(settings.check_updates_on_startup)
     config.updates.include_prereleases = bool(settings.include_prereleases)
 
@@ -229,6 +244,7 @@ class SettingsView(StatusMixin, Vertical):
         Binding("a", "toggle_auto_workers", "Auto Workers", show=True),
         Binding("m", "cycle_methodology", "Methodology", show=True),
         Binding("t", "cycle_text_model", "Model", show=True),
+        Binding("f", "cycle_provider", "Provider", show=True),
         Binding("u", "toggle_update_check", "Updates", show=True),
         Binding("p", "toggle_prereleases", "Pre-releases", show=True),
         Binding("c", "toggle_recursive", "Recursive", show=False),
@@ -264,6 +280,7 @@ class SettingsView(StatusMixin, Vertical):
         self._output_dir: str = ""
         self._methodology: str = "none"
         self._text_model: str = DEFAULT_TEXT_MODEL
+        self._provider: str = _DEFAULT_PROVIDER
         self._check_updates: bool = True
         self._include_prereleases: bool = False
         options = workspace.options if workspace is not None else None
@@ -280,6 +297,11 @@ class SettingsView(StatusMixin, Vertical):
             self._output_dir = str(workspace.output_root or "")
             self._methodology = workspace.options.effective_methodology.value
             self._text_model = workspace.options.text_model or DEFAULT_TEXT_MODEL
+            self._provider = (
+                workspace.options.text_provider
+                if workspace.options.text_provider in _PROVIDER_ORDER
+                else _DEFAULT_PROVIDER
+            )
             self._max_workers = workspace.options.parallel_workers
             self._prefetch_depth = workspace.options.prefetch_depth
 
@@ -395,6 +417,17 @@ class SettingsView(StatusMixin, Vertical):
             index = -1
         self._text_model = options[(index + 1) % len(options)]
         self._set_status(f"Text model: {self._text_model}")
+        self._sync_workspace_options()
+        self._refresh_panel()
+
+    def action_cycle_provider(self) -> None:
+        """Cycle the model provider used for both text and vision inference."""
+        try:
+            index = _PROVIDER_ORDER.index(self._provider)
+        except ValueError:
+            index = -1
+        self._provider = _PROVIDER_ORDER[(index + 1) % len(_PROVIDER_ORDER)]
+        self._set_status(f"Provider: {self._provider}")
         self._sync_workspace_options()
         self._refresh_panel()
 
@@ -516,6 +549,7 @@ class SettingsView(StatusMixin, Vertical):
         self._output_dir = loaded.default_output_dir
         self._methodology = loaded.methodology
         self._text_model = loaded.text_model
+        self._provider = loaded.provider
         self._check_updates = loaded.check_updates_on_startup
         self._include_prereleases = loaded.include_prereleases
         self._sync_dir_inputs()
@@ -531,6 +565,7 @@ class SettingsView(StatusMixin, Vertical):
             default_output_dir=self._output_dir,
             methodology=self._methodology,
             text_model=self._text_model,
+            provider=self._provider,
             check_updates_on_startup=self._check_updates,
             include_prereleases=self._include_prereleases,
         )
@@ -557,6 +592,8 @@ class SettingsView(StatusMixin, Vertical):
             parallel_workers=self._max_workers,
             prefetch_depth=self._prefetch_depth,
             text_model=self._text_model,
+            text_provider=self._provider,
+            vision_provider=self._provider,
         )
 
     def _text_model_options(self) -> list[str]:
@@ -609,6 +646,7 @@ class SettingsView(StatusMixin, Vertical):
             f"  output dir    : {output_text}\n"
             f"  methodology   : {_METHODOLOGY_LABELS[self._methodology]}\n"
             f"  text model    : {self._text_model}\n"
+            f"  provider      : {self._provider}\n"
             f"  recursive     : {recursive_text}\n"
             f"  hidden files  : {hidden_text}\n"
             f"  transfer mode : {self._transfer_mode}\n"
@@ -622,7 +660,8 @@ class SettingsView(StatusMixin, Vertical):
             f"  prefetch_depth: {self._prefetch_depth}\n"
             f"  sequential    : {sequential_text}\n\n"
             "[dim]Arrows: workers/prefetch · s: sequential · a: auto workers[/dim]\n"
-            "[dim]m: methodology · t: model · u: update check · p: pre-releases[/dim]\n"
+            "[dim]m: methodology · t: model · f: provider · u: update check · "
+            "p: pre-releases[/dim]\n"
             "[dim]c: recursive · h: hidden · x: transfer · k: collisions · "
             "v: vision · d: transcription[/dim]\n"
             "[dim]Type in the fields below to set directories · Enter: save · r: reload[/dim]"

--- a/src/file_organizer/tui/workspace.py
+++ b/src/file_organizer/tui/workspace.py
@@ -10,7 +10,7 @@ from file_organizer.config.manager import ConfigManager
 from file_organizer.core.capabilities import Surface, get_capability_registry
 from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.lifecycle import JobSnapshot
-from file_organizer.core.organize_options import ModelProvider, OrganizeOptions, OrganizeRequest
+from file_organizer.core.organize_options import OrganizeOptions, OrganizeRequest
 from file_organizer.core.plan import OrganizationPlan
 from file_organizer.core.types import OrganizationResult
 
@@ -46,18 +46,21 @@ class TUIWorkspace:
         parallel = config.parallel or {}
         workers = parallel.get("max_workers")
         prefetch_depth = parallel.get("prefetch_depth", 2)
-        provider = config.models.framework
-        supported_providers = {"ollama", "openai", "llama_cpp", "mlx", "claude"}
-        model_provider = cast(ModelProvider, provider) if provider in supported_providers else None
         try:
+            # text_provider/vision_provider are deliberately left unset here (#1660):
+            # a request-level OrganizeOptions field outranks FO_PROVIDER in
+            # OrganizationService._resolve_options, so eagerly copying the persisted
+            # config.models.framework value in would make it silently beat the
+            # environment variable on every session, before the user ever makes an
+            # explicit choice. Settings still displays the persisted value (seeded
+            # from config, not from these options) and only writes it into session
+            # options once the user explicitly cycles the provider control.
             options = OrganizeOptions(
                 methodology=config.default_methodology,
                 parallel_workers=workers,
                 prefetch_depth=prefetch_depth,
                 text_model=config.models.text_model,
                 vision_model=config.models.vision_model,
-                text_provider=model_provider,
-                vision_provider=model_provider,
             )
         except (TypeError, ValueError):
             options = OrganizeOptions()

--- a/tests/conformance/fixtures/provider_override.json
+++ b/tests/conformance/fixtures/provider_override.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "flat-documents",
+  "options": {
+    "use_hardlinks": false,
+    "text_provider": "openai",
+    "vision_provider": "openai"
+  },
+  "expected_text_provider": "openai",
+  "expected_vision_provider": "openai"
+}

--- a/tests/conformance/test_direct_service_conformance.py
+++ b/tests/conformance/test_direct_service_conformance.py
@@ -259,6 +259,19 @@ def test_resolved_options_are_persisted(conformance: ConformanceContext) -> None
     assert envelope["plan"]["schema_version"] == 3
 
 
+def test_explicit_provider_override_round_trips_golden(
+    conformance: ConformanceContext,
+) -> None:
+    """An explicit non-default provider reaches resolved options on every surface (#1660)."""
+    golden = load_golden("provider_override")
+    conformance.stage(golden["case_id"])
+
+    envelope = _ok(conformance.driver.preview(conformance.request(**golden["options"])))
+
+    assert envelope["plan"]["options"]["text_provider"] == golden["expected_text_provider"]
+    assert envelope["plan"]["options"]["vision_provider"] == golden["expected_vision_provider"]
+
+
 def test_collision_skip_existing_golden(conformance: ConformanceContext) -> None:
     golden = load_golden("collision_skip_existing")
     conformance.stage(golden["case_id"])

--- a/tests/tui/test_settings_view.py
+++ b/tests/tui/test_settings_view.py
@@ -210,6 +210,7 @@ def test_settings_view_reload_action_handles_load_failure() -> None:
                 default_output_dir="",
                 methodology="none",
                 text_model="qwen2.5:3b-instruct-q4_K_M",
+                provider="ollama",
                 check_updates_on_startup=True,
                 include_prereleases=False,
             ),
@@ -306,6 +307,7 @@ def test_save_workflow_settings_persists_values() -> None:
             default_output_dir="/data/out",
             methodology="jd",
             text_model="  gemma2:2b-instruct-q4_K_M  ",
+            provider="openai",
             check_updates_on_startup=False,
             include_prereleases=True,
         ),
@@ -316,6 +318,7 @@ def test_save_workflow_settings_persists_values() -> None:
     assert config.default_output_dir == "/data/out"
     assert config.default_methodology == "jd"
     assert config.models.text_model == "gemma2:2b-instruct-q4_K_M"  # trimmed
+    assert config.models.framework == "openai"
     assert config.updates.check_on_startup is False
     assert config.updates.include_prereleases is True
     mock_manager.save.assert_called_once_with(config, profile="default")
@@ -333,6 +336,7 @@ def test_save_workflow_settings_empty_model_falls_back_to_default() -> None:
             default_output_dir="",
             methodology="none",
             text_model="   ",
+            provider="ollama",
             check_updates_on_startup=True,
             include_prereleases=False,
         ),
@@ -340,6 +344,28 @@ def test_save_workflow_settings_empty_model_falls_back_to_default() -> None:
     )
 
     assert config.models.text_model == "qwen2.5:3b-instruct-q4_K_M"
+
+
+def test_save_workflow_settings_unknown_provider_falls_back_to_default() -> None:
+    """An out-of-range provider value should be replaced with the ollama default."""
+    mock_manager = MagicMock()
+    config = AppConfig()
+    mock_manager.load.return_value = config
+
+    save_workflow_settings(
+        WorkflowSettings(
+            default_input_dir="",
+            default_output_dir="",
+            methodology="none",
+            text_model="qwen2.5:3b-instruct-q4_K_M",
+            provider="not-a-real-provider",
+            check_updates_on_startup=True,
+            include_prereleases=False,
+        ),
+        manager=mock_manager,
+    )
+
+    assert config.models.framework == "ollama"
 
 
 def test_settings_view_cycle_methodology_round_trips() -> None:
@@ -376,6 +402,39 @@ def test_settings_view_cycle_text_model_preserves_custom_value() -> None:
         # Custom value is prepended; first cycle moves to the first preset.
         view.action_cycle_text_model()
         assert view._text_model == "qwen2.5:3b-instruct-q4_K_M"
+
+
+def test_settings_view_cycle_provider_round_trips() -> None:
+    """Cycling provider should advance through all five supported providers and wrap (#1660)."""
+    view = SettingsView()
+    view._provider = "ollama"
+
+    with patch.object(view, "_refresh_panel"), patch.object(view, "_set_status"):
+        view.action_cycle_provider()
+        assert view._provider == "openai"
+        view.action_cycle_provider()
+        assert view._provider == "llama_cpp"
+        view.action_cycle_provider()
+        assert view._provider == "mlx"
+        view.action_cycle_provider()
+        assert view._provider == "claude"
+        view.action_cycle_provider()
+        assert view._provider == "ollama"
+
+
+def test_settings_view_cycle_provider_syncs_to_workspace() -> None:
+    """Cycling provider should immediately update both workspace model providers (#1660)."""
+    from file_organizer.tui.workspace import TUIWorkspace
+
+    workspace = TUIWorkspace()
+    view = SettingsView(workspace=workspace)
+    view._provider = "ollama"
+
+    with patch.object(view, "_refresh_panel"), patch.object(view, "_set_status"):
+        view.action_cycle_provider()
+
+    assert workspace.options.text_provider == "openai"
+    assert workspace.options.vision_provider == "openai"
 
 
 def test_settings_view_toggle_update_check() -> None:
@@ -556,6 +615,7 @@ async def test_settings_view_mounted_end_to_end(monkeypatch) -> None:
             default_output_dir="/seed/out",
             methodology="para",
             text_model="qwen2.5:7b-instruct-q4_K_M",
+            provider="ollama",
             check_updates_on_startup=False,
             include_prereleases=True,
         ),

--- a/tests/tui/test_workspace_parity.py
+++ b/tests/tui/test_workspace_parity.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from file_organizer.config.schema import AppConfig
 from file_organizer.core.errors import DomainError, DomainErrorCode
 from file_organizer.core.organize_options import OrganizeOptions
 from file_organizer.core.plan import build_plan_from_processed
@@ -112,6 +113,25 @@ def test_config_load_failure_is_retained_as_workspace_error() -> None:
     assert workspace.last_error.message == "config unreadable"
 
 
+def test_from_config_never_lets_persisted_provider_outrank_environment() -> None:
+    """A persisted provider must not become a request-level override on startup.
+
+    ``OrganizationService._resolve_options`` treats an ``OrganizeOptions.text_provider``
+    value as the highest-priority source, above ``FO_PROVIDER``. If ``from_config``
+    copied ``config.models.framework`` in here, a saved "openai" would silently beat
+    ``FO_PROVIDER=ollama`` on every session before the user ever chose anything (#1660).
+    """
+    config = AppConfig()
+    config.models.framework = "openai"
+    manager = MagicMock()
+    manager.load.return_value = config
+
+    workspace = TUIWorkspace.from_config(manager)
+
+    assert workspace.options.text_provider is None
+    assert workspace.options.vision_provider is None
+
+
 def test_selection_persists_across_file_views(tmp_path: Path) -> None:
     selected = tmp_path / "selected.txt"
     selected.write_text("selected")
@@ -150,6 +170,7 @@ def test_settings_map_losslessly_to_canonical_options(tmp_path: Path) -> None:
     view._prefetch_depth = 3
     view._text_model = "custom-text"
     view._provider = "openai"
+    view._provider_overridden = True
 
     view._sync_workspace()
 

--- a/tests/tui/test_workspace_parity.py
+++ b/tests/tui/test_workspace_parity.py
@@ -149,6 +149,7 @@ def test_settings_map_losslessly_to_canonical_options(tmp_path: Path) -> None:
     view._max_workers = 5
     view._prefetch_depth = 3
     view._text_model = "custom-text"
+    view._provider = "openai"
 
     view._sync_workspace()
 
@@ -164,6 +165,8 @@ def test_settings_map_losslessly_to_canonical_options(tmp_path: Path) -> None:
         "parallel_workers": 5,
         "prefetch_depth": 3,
         "text_model": "custom-text",
+        "text_provider": "openai",
+        "vision_provider": "openai",
     }
 
 


### PR DESCRIPTION
## Summary

Closes #1660, re-scoped after verifying the issue's premise against `main` (see the issue-comment history / edited issue body for the investigation). The two REST/Web bugs the issue originally described no longer exist; this PR addresses the three items that are still genuinely open.

- **TUI provider override** — `SettingsView` had no control at all for `text_provider`/`vision_provider`; it was fixed at whatever `config.models.framework` held at session start. Added a `provider` cycle control (`f` binding), following the exact same pattern already used for methodology/text-model: immediate session sync via `_sync_workspace_options`, persisted to `config.models.framework` on save. One provider drives both text and vision, matching the existing config schema (a single `framework` field).
- **Documented the real resolution order** — the issue assumed a 3-step cascade (explicit option → env var → hard default). The actual cascade, verified in `OrganizationService._resolve_options` and `config/provider_env.py`, is 4 steps: per-request option → env var (`FO_PROVIDER`) → persisted config profile → hardcoded default. Added a "Model config resolution order" section to `docs/developer/organization-service.md` documenting this accurately.
- **Cross-surface round-trip test** — added a golden-fixture-backed conformance test (`provider_override.json` + `test_explicit_provider_override_round_trips_golden`) that submits an explicit non-default provider (`openai`) and asserts it survives to resolved options. Runs automatically across all 9 conformance drivers (CLI, REST, Web form, TUI adapter, both SDKs, etc.) via the existing `conformance` fixture. Confirmed the underlying transport plumbing (CLI flags, REST/SDK JSON body, web form fields, TUI workspace sync) already carried providers correctly on every surface — this was purely a missing-test gap, not a defect.

## Verification

- `pytest -m conformance`: 266 passed (was 257; +9 = the new test × 9 drivers)
- `pytest tests/tui/`: 731 passed (plus updated an existing parity test — `test_settings_map_losslessly_to_canonical_options` — which enumerated the full expected options dict and needed the new provider field added)
- `pytest tests/ci/`: all guardrails pass
- `pre-commit run --all-files` (locally, via the git commit hook): all 22 applicable hooks passed, including mypy, ruff, diff-cover (80%), and pytest smoke/guardrail suites

## Test plan

- [x] Conformance suite green across all drivers
- [x] TUI settings test suite green, including new `action_cycle_provider` tests
- [x] Manual read-through of `_sync_workspace_options` / `WorkflowSettings` round-trip for the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Settings control for selecting and cycling through supported model providers.
  - Provider selections now apply consistently to both text and vision processing.
  - Added persistence and validation for the selected provider.

- **Documentation**
  - Documented the model configuration resolution order, including request-level overrides and saved settings.

- **Bug Fixes**
  - Ensured explicit provider selections are preserved in resolved plans.

- **Tests**
  - Expanded coverage for provider selection, persistence, synchronization, and configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->