### PR TITLE
perf(misplacement): list each directory once instead of once per file

### DIFF
--- a/src/file_organizer/services/misplacement_detector.py
+++ b/src/file_organizer/services/misplacement_detector.py
@@ -124,15 +124,17 @@ class MisplacementDetector:
         if pattern_analysis is None:
             pattern_analysis = self.pattern_analyzer.analyze_directory(directory)
 
-        # Get all files
-        files = list(directory.rglob("*"))
-        files = [f for f in files if f.is_file() and not f.name.startswith(".")]
+        # Get all files (lazily — the tree is not materialized)
+        files = (f for f in directory.rglob("*") if f.is_file() and not f.name.startswith("."))
 
         misplaced_files = []
 
+        # One directory listing per directory, shared by every file inside it.
+        directory_cache: dict[Path, list[Path]] = {}
+
         for file_path in files:
             # Analyze context
-            context = self.analyze_context(file_path)
+            context = self.analyze_context(file_path, directory_cache)
 
             # Calculate mismatch score
             mismatch_score = self.calculate_mismatch_score(file_path, context, pattern_analysis)
@@ -173,11 +175,25 @@ class MisplacementDetector:
         logger.info(f"Detected {len(misplaced_files)} misplaced files")
         return misplaced_files
 
-    def analyze_context(self, file_path: Path) -> ContextAnalysis:
+    def _list_directory_files(self, directory: Path) -> list[Path]:
+        """Return every file directly inside `directory`, or [] if it can't be read."""
+        try:
+            return [f for f in directory.iterdir() if f.is_file()]
+        except OSError:
+            return []
+
+    def analyze_context(
+        self, file_path: Path, directory_cache: dict[Path, list[Path]] | None = None
+    ) -> ContextAnalysis:
         """Analyze the context of a file.
 
         Args:
             file_path: File to analyze
+            directory_cache: Optional directory -> file-listing cache, populated on
+                miss. Passing the same cache across files in one directory replaces
+                a listing per file with a listing per directory. It holds only raw
+                listings: `sibling_files`, `sibling_types` and `naming_patterns`
+                stay derived per file so each still excludes `file_path` itself.
 
         Returns:
             ContextAnalysis with context information
@@ -195,10 +211,16 @@ class MisplacementDetector:
             size = 0
 
         # Get sibling files
-        try:
-            sibling_files = [f for f in directory.iterdir() if f.is_file() and f != file_path]
-        except OSError:
-            sibling_files = []
+        if directory_cache is None:
+            entries = self._list_directory_files(directory)
+        else:
+            cached = directory_cache.get(directory)
+            if cached is None:
+                cached = self._list_directory_files(directory)
+                directory_cache[directory] = cached
+            entries = cached
+
+        sibling_files = [f for f in entries if f != file_path]
         sibling_types = {f.suffix.lower() for f in sibling_files if f.suffix}
 
         # Infer parent category

--- a/tests/services/test_misplacement_detector.py
+++ b/tests/services/test_misplacement_detector.py
@@ -323,3 +323,127 @@ class TestEdgeCases:
 
             with pytest.raises(ValueError, match="Invalid directory"):
                 detector.detect_misplaced(file_path)
+
+
+class TestDirectorySiblingCache:
+    """Sibling listings are cached per directory without changing analysis results.
+
+    ``analyze_context`` derives ``sibling_files``, ``sibling_types`` and
+    ``naming_patterns`` from the file's directory *excluding the file itself*.
+    Caching must preserve that exclusion: a cache holding directory-wide derived
+    values would leak the analysed file's own suffix into ``sibling_types``,
+    which silently collapses the type-mismatch score and hides every outlier.
+    """
+
+    @staticmethod
+    def _make_outlier_tree(root: Path) -> Path:
+        """Create a directory of five .txt files plus one .jpg outlier."""
+        docs = root / "docs"
+        docs.mkdir()
+        for i in range(5):
+            (docs / f"report_{i}.txt").write_text("content")
+        outlier = docs / "photo.jpg"
+        outlier.write_bytes(b"\xff\xd8\xff")
+        return outlier
+
+    def test_detect_misplaced_lists_each_directory_once(self, monkeypatch):
+        """detect_misplaced issues one iterdir per directory, not one per file."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            outlier = self._make_outlier_tree(tmppath)
+            docs = outlier.parent
+
+            calls: list[Path] = []
+            original_iterdir = Path.iterdir
+
+            def counting_iterdir(self: Path):
+                calls.append(self)
+                return original_iterdir(self)
+
+            monkeypatch.setattr(Path, "iterdir", counting_iterdir)
+
+            analyzer = PatternAnalyzer()
+            pattern_analysis = analyzer.analyze_directory(tmppath)
+            calls.clear()  # only count the detector's own sibling scanning
+
+            detector = MisplacementDetector()
+            detector.detect_misplaced(tmppath, pattern_analysis)
+
+            assert calls.count(docs) == 1, (
+                f"expected docs/ to be listed once for its 6 files, got {calls.count(docs)}"
+            )
+
+    def test_cached_analyze_context_matches_uncached(self):
+        """A cache-backed analyze_context returns exactly what the plain call returns."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            outlier = self._make_outlier_tree(tmppath)
+
+            detector = MisplacementDetector()
+            uncached = detector.analyze_context(outlier)
+
+            cache: dict[Path, list[Path]] = {}
+            cached = detector.analyze_context(outlier, cache)
+
+            assert sorted(cached.sibling_files) == sorted(uncached.sibling_files)
+            assert cached.sibling_types == uncached.sibling_types
+            assert cached.naming_patterns == uncached.naming_patterns
+            assert cached.parent_category == uncached.parent_category
+
+    def test_cache_is_populated_and_reused_across_files(self):
+        """The second file in a directory reuses the first file's cached listing."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            outlier = self._make_outlier_tree(tmppath)
+            docs = outlier.parent
+
+            detector = MisplacementDetector()
+            cache: dict[Path, list[Path]] = {}
+
+            detector.analyze_context(outlier, cache)
+            assert docs in cache, "analyze_context should populate the cache it is given"
+
+            sibling = docs / "report_0.txt"
+            context = detector.analyze_context(sibling, cache)
+
+            # Derived per file from the shared listing, still excluding self.
+            assert sibling not in context.sibling_files
+            assert outlier in context.sibling_files
+
+    def test_cached_path_excludes_own_suffix_from_sibling_types(self):
+        """The analysed file's own extension never appears in its sibling types.
+
+        Guards the failure mode where caching directory-wide derived values makes
+        ``file_type in sibling_types`` unconditionally true, dropping
+        ``_calculate_type_mismatch`` from 80.0 to 10.0 and zeroing out detection.
+        """
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            outlier = self._make_outlier_tree(tmppath)
+
+            detector = MisplacementDetector()
+            cache: dict[Path, list[Path]] = {}
+            context = detector.analyze_context(outlier, cache)
+
+            assert context.sibling_types == {".txt"}
+            assert detector._calculate_type_mismatch(context) == 80.0
+
+    def test_outlier_still_detected_end_to_end(self):
+        """The .jpg among .txt files is still reported as misplaced.
+
+        The outlier scores 56.5 on this fixture, so the threshold is lowered to
+        50.0 to bring it into range. Leaking the file's own suffix into
+        ``sibling_types`` costs 24.5 points (type mismatch 80.0 -> 10.0 at 35%
+        weight), dropping it to 32.0 — below the threshold, and undetected.
+        """
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            outlier = self._make_outlier_tree(tmppath)
+
+            analyzer = PatternAnalyzer()
+            pattern_analysis = analyzer.analyze_directory(tmppath)
+
+            detector = MisplacementDetector(min_mismatch_score=50.0)
+            misplaced = detector.detect_misplaced(tmppath, pattern_analysis)
+
+            assert outlier in [m.file_path for m in misplaced]


### PR DESCRIPTION
## Description

`MisplacementDetector.detect_misplaced()` called `analyze_context()` once per file, and every one of those calls re-listed the file's parent directory from disk. For a directory holding `M` files that is `M` full `iterdir()` scans all returning the same `M` entries.

This adds an optional `directory -> file-listing` cache to `analyze_context()`, populated on miss, and shares one across a `detect_misplaced()` run. `detect_misplaced()` also stops materialising the whole tree (`list(directory.rglob("*"))` -> generator).

**The cache holds only raw listings.** `sibling_files`, `sibling_types` and `naming_patterns` stay derived per file, so each still excludes the file being analysed. That is the whole design constraint — see "Reviewer notes" below.

Benchmark, one directory, `detect_misplaced()` with a precomputed `PatternAnalysis`:

| files | `iterdir()` calls | wall clock | speedup |
|------:|------------------:|-----------:|--------:|
|   500 | 500 → **1**       | 0.844s → **0.160s** | 5.3× |
|  1000 | 1000 → **1**      | 3.486s → **0.628s** | 5.6× |
|  2000 | 2000 → **1**      | 14.391s → **2.367s** | 6.1× |

Reproduce: `scripts` not added — the benchmark is a throwaway that monkeypatches `Path.iterdir` to count calls and times `detect_misplaced()` on a synthetic directory. Happy to add it under `tests/benchmarks/` if that is preferred.

Refs #1670

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — performance fix, no behaviour change
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

`analyze_context()` gains an optional keyword-style second parameter. Existing single-argument callers are unaffected.

## How Has This Been Tested?

New `TestDirectorySiblingCache` class in `tests/services/test_misplacement_detector.py`, written test-first:

- [x] `test_detect_misplaced_lists_each_directory_once` — monkeypatches `Path.iterdir` and asserts exactly one listing per directory. Failed at `6 == 1` before the change.
- [x] `test_cached_analyze_context_matches_uncached` — cached and uncached calls agree on `sibling_files`, `sibling_types`, `naming_patterns`, `parent_category`. Failed with `TypeError` before the change.
- [x] `test_cache_is_populated_and_reused_across_files` — the cache is filled on first use and the second file in the directory derives from it, still excluding itself.
- [x] `test_cached_path_excludes_own_suffix_from_sibling_types` — asserts `sibling_types == {".txt"}` and `_calculate_type_mismatch() == 80.0` for a `.jpg` among `.txt` files.
- [x] `test_outlier_still_detected_end_to_end` — characterization guard. Passes on `main` and stays green here.

Full runs (all green):

- `tests/services/test_misplacement_detector.py`
- `tests/services/test_misplacement_detector_coverage.py`
- `tests/services/test_smart_suggestions.py`
- `tests/integration/test_plugins_dedup_batch4.py`

230 passed, 13 skipped. `ruff check`, `ruff format --check`, `mypy`, and `pre-commit` (excluding the slow pytest/diff-cover hooks, which CI runs) all clean.

## Reviewer notes

**The one thing to check in review:** whether anything caches *derived* values directory-wide rather than the raw listing.

`_calculate_type_mismatch()` returns `10.0` (low mismatch) whenever `file_type in sibling_types`. If the cache stores `sibling_types` computed over the directory listing *including* the analysed file, that branch becomes unconditionally true for any file with an extension. Type mismatch carries 35% weight, so the score drops 24.5 points and the detector silently reports **zero** misplaced files. It fails quiet — no exception, no log, just an empty result.

That is exactly how the previous attempt at this optimisation (#1664) regressed; verified there that `sibling_types` went from `{'.txt'}` (score 80.0) to `{'.jpg', '.txt'}` (score 10.0) and `test_smart_suggestions.py::test_end_to_end_workflow` failed `assert 0 >= 1`. Two of the tests above exist specifically to catch it.

**Two things this deliberately does not do:**

1. **No cache eviction.** The cache holds one list per directory, not per file, and lives only for the duration of a single `detect_misplaced()` call. A size cap was not added because nothing measured justifies one; a wholesale `.clear()` at an arbitrary threshold would be worse than no cap at all.
2. **Residual quadratic left alone.** Rebuilding the self-excluded `sibling_files` list per file is still `O(M²)`, as is `_detect_local_patterns()` over it. Both are in-memory with no syscalls — visible in the benchmark, which still roughly quadruples per doubling. This PR removes the I/O term only. Making the rest linear means incremental suffix counters and aggregate pattern counts, which is a larger change and a separate call.

**Scope caveat, stated plainly:** `MisplacementDetector` is exported from `services/__init__.py` but has **no callers in `src/`** — only tests use it today. This is a correctness-preserving fix to public API, not a win on a live code path. Worth knowing before weighing the review cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved file scanning efficiency by processing directories lazily.
  * Reduced repeated directory listings when analyzing files in the same folder.
  * Preserved existing context analysis and misplaced-file detection results.

* **Bug Fixes**
  * Ensured analyzed files are excluded from sibling comparisons.
  * Maintained accurate file-type mismatch detection when using cached directory information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->