### PR TITLE
security(traversal): migrate 13 rglob call sites to safe_walk

### DIFF
--- a/src/file_organizer/api/routers/files.py
+++ b/src/file_organizer/api/routers/files.py
@@ -34,6 +34,7 @@ from file_organizer.api.openapi_responses import (
 )
 from file_organizer.api.utils import file_info_from_path, is_hidden, resolve_path
 from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.utils.file_times import creation_timestamp
 
 logger = logging.getLogger(__name__)
@@ -78,23 +79,14 @@ def _collect_files(path: Path, recursive: bool, include_hidden: bool) -> list[Pa
             files.append(path)
         return files
 
-    if recursive:
-        iterator = path.rglob("*")
-    else:
-        iterator = path.glob("*")
-
-    for entry in iterator:
-        try:
-            if entry.is_symlink():
-                continue
-            if not entry.is_file():
-                continue
-            if not include_hidden and is_hidden(entry):
-                continue
-        except (OSError, PermissionError):
-            logger.debug("Skipping entry %s: filesystem error", entry, exc_info=True)
-            continue
-        files.append(entry)
+    # safe_walk applies exactly the three rules the loop below used to apply by
+    # hand — skip symlinks, keep only files, honour the caller's include_hidden —
+    # and absorbs the per-entry OSError the old `except` clause swallowed.
+    # include_hidden is threaded from the request rather than hardcoded, so the
+    # endpoint's documented behaviour is unchanged.
+    files.extend(
+        safe_walk(path, recursive=recursive, only_files=True, include_hidden=include_hidden)
+    )
     return files
 
 

--- a/src/file_organizer/api/service_facade.py
+++ b/src/file_organizer/api/service_facade.py
@@ -18,6 +18,7 @@ from loguru import logger
 from file_organizer.api.config import ApiSettings
 from file_organizer.config.manager import ConfigManager
 from file_organizer.config.provider_env import get_current_provider
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.version import __version__
 
 
@@ -383,7 +384,9 @@ class ServiceFacade:
                 engine = SuggestionEngine()
                 # Path must be pre-validated at API boundary
                 target = Path(path)
-                files = [p for p in target.rglob("*") if p.is_file()]
+                # include_hidden defaults to False: suggestions are surfaced to
+                # the user and should not propose acting on dotfiles.
+                files = list(safe_walk(target, only_files=True))
                 suggestions = engine.generate_suggestions(files)
                 return [
                     {

--- a/src/file_organizer/config/path_migration.py
+++ b/src/file_organizer/config/path_migration.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.utils.atomic_write import atomic_write_text
 
 
@@ -71,13 +72,18 @@ class PathMigrator:
         # Ensure canonical path exists
         self.canonical_path.mkdir(parents=True, exist_ok=True)
 
-        # Copy all files from legacy to canonical
-        for item in self.legacy_path.rglob("*"):
-            if item.is_file():
-                relative = item.relative_to(self.legacy_path)
-                target = self.canonical_path / relative
-                target.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(item, target)  # noqa: safedir-required  # config migration — item/target are pre-validated legacy config paths
+        # Copy all files from legacy to canonical.
+        # include_hidden=True: dotfiles are real config here (.env, .prefs) and
+        # dropping them would silently lose user settings. safe_walk still
+        # refuses symlinks, which is the exposure that matters — copy2 follows
+        # them, so a link in the legacy dir would copy its target's contents
+        # into the canonical tree. backup_legacy_path() above preserves the
+        # originals, so a skipped link is recoverable.
+        for item in safe_walk(self.legacy_path, only_files=True, include_hidden=True):
+            relative = item.relative_to(self.legacy_path)
+            target = self.canonical_path / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)  # noqa: safedir-required  # config migration — item/target are pre-validated legacy config paths
 
     def create_migration_log(self) -> dict[str, Any]:
         """Create migration log entry for audit trail.

--- a/src/file_organizer/config/path_migration.py
+++ b/src/file_organizer/config/path_migration.py
@@ -57,7 +57,11 @@ class PathMigrator:
         # Use microseconds to ensure uniqueness for rapid successive migrations
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
         backup = self.legacy_path.parent / f"{self.legacy_path.name}.backup.{timestamp}"
-        shutil.copytree(self.legacy_path, backup)  # noqa: safedir-required  # config migration — legacy/backup paths pre-validated at migration start
+        # symlinks=True recreates links as links. Without it copytree *follows*
+        # them, so a link escaping legacy_path would have its target's contents
+        # materialised inside the backup — performing exactly the escape that
+        # safe_walk() prevents in migrate() below, one directory over.
+        shutil.copytree(self.legacy_path, backup, symlinks=True)  # noqa: safedir-required  # config migration — legacy/backup paths pre-validated at migration start
         self.backup_path = backup
         return backup
 

--- a/src/file_organizer/methodologies/johnny_decimal/system.py
+++ b/src/file_organizer/methodologies/johnny_decimal/system.py
@@ -11,6 +11,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
+
 from .categories import (
     AreaDefinition,
     CategoryDefinition,
@@ -70,8 +72,14 @@ class JohnnyDecimalSystem:
         logger.info(f"Initializing from directory: {directory}")
         detected_numbers = 0
 
-        # Scan all items in directory
-        for item in directory.rglob("*"):
+        # Scan all items in directory.
+        # only_files=False: Johnny Decimal numbers live on directory names as
+        # much as file names ("10 Finance/"), so directories must be yielded.
+        # include_hidden defaults to False: a dot-prefixed entry like
+        # ".20 Backup" is not part of the user's numbering scheme and must not
+        # claim a number. Symlinks are skipped too — a link named "20 Escape"
+        # would otherwise register a number pointing outside the scanned root.
+        for item in safe_walk(directory, only_files=False):
             if item.is_file() or item.is_dir():
                 number = self._extract_number_from_path(item)
                 if number:

--- a/src/file_organizer/methodologies/johnny_decimal/system.py
+++ b/src/file_organizer/methodologies/johnny_decimal/system.py
@@ -79,16 +79,19 @@ class JohnnyDecimalSystem:
         # ".20 Backup" is not part of the user's numbering scheme and must not
         # claim a number. Symlinks are skipped too — a link named "20 Escape"
         # would otherwise register a number pointing outside the scanned root.
+        # The former `if item.is_file() or item.is_dir()` guard is gone: safe_walk
+        # has already rejected symlinks and hidden entries, and number extraction
+        # reads only the entry's name, so the file/dir distinction is irrelevant
+        # here. It was also unreachable — every surviving entry satisfied it.
         for item in safe_walk(directory, only_files=False):
-            if item.is_file() or item.is_dir():
-                number = self._extract_number_from_path(item)
-                if number:
-                    try:
-                        self.generator.register_existing_number(number, item)
-                        detected_numbers += 1
-                        logger.debug(f"Detected number {number.formatted_number} in {item.name}")
-                    except NumberConflictError as e:
-                        logger.warning(f"Conflict detected: {e}")
+            number = self._extract_number_from_path(item)
+            if number:
+                try:
+                    self.generator.register_existing_number(number, item)
+                    detected_numbers += 1
+                    logger.debug(f"Detected number {number.formatted_number} in {item.name}")
+                except NumberConflictError as e:
+                    logger.warning(f"Conflict detected: {e}")
 
         logger.info(f"Initialized with {detected_numbers} existing numbers")
         self._initialized = True

--- a/src/file_organizer/methodologies/para/ai/file_mover.py
+++ b/src/file_organizer/methodologies/para/ai/file_mover.py
@@ -13,6 +13,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from file_organizer.core.path_guard import safe_walk
+
 from ..categories import PARACategory
 from ..config import PARAConfig
 from .suggestion_engine import PARASuggestion, PARASuggestionEngine
@@ -253,11 +255,13 @@ class PARAFileMover:
             logger.error("Directory does not exist: %s", directory)
             return report
 
-        # Collect files
-        if recursive:
-            files = [f for f in directory.rglob("*") if f.is_file()]
-        else:
-            files = [f for f in directory.iterdir() if f.is_file()]
+        # Collect files. Both the recursive and top-level branches collapse into
+        # safe_walk's recursive= parameter.
+        # include_hidden defaults to False: this method *relocates* files, and
+        # dotfiles (.gitignore, .env) are infrastructure the user did not ask to
+        # have reorganized. Symlinks are skipped so a link in the scanned tree
+        # cannot cause a write against a target outside it.
+        files = list(safe_walk(directory, recursive=recursive, only_files=True))
 
         report.total_files = len(files)
 
@@ -319,11 +323,12 @@ class PARAFileMover:
 
         now = time.time()
 
-        try:
-            files = [f for f in directory.rglob("*") if f.is_file()]
-        except OSError as e:
-            logger.error("Cannot scan directory %s: %s", directory, e, exc_info=True)
-            return suggestions
+        # Same exclusions as bulk_organize: this proposes moves, so dotfiles and
+        # symlinks stay out. safe_walk absorbs per-entry and per-directory
+        # OSErrors internally (skipping the unreadable subtree), so the previous
+        # try/except around the scan is unreachable and has been removed — an
+        # unreadable directory now yields no suggestions rather than logging.
+        files = list(safe_walk(directory, only_files=True))
 
         for file_path in files:
             try:

--- a/src/file_organizer/plugins/api/endpoints.py
+++ b/src/file_organizer/plugins/api/endpoints.py
@@ -28,6 +28,7 @@ from file_organizer.api.openapi_responses import (
 )
 from file_organizer.api.utils import file_info_from_path, is_hidden, resolve_path
 from file_organizer.config.manager import ConfigManager
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.plugins.api.hooks import HookEvent, PluginHookManager
 from file_organizer.plugins.api.models import (
     PluginConfigValueResponse,
@@ -86,13 +87,14 @@ def _collect_files(path: Path, recursive: bool, include_hidden: bool) -> list[Pa
             files.append(path)
         return files
 
-    iterator = path.rglob("*") if recursive else path.glob("*")
-    for entry in iterator:
-        if not entry.is_file():
-            continue
-        if not include_hidden and is_hidden(entry):
-            continue
-        files.append(entry)
+    # include_hidden is threaded from the caller, preserving the endpoint's
+    # documented behaviour. The rglob/glob branch maps onto recursive=. Unlike
+    # the previous loop this also skips symlinks, which this endpoint never
+    # filtered — a link under the requested path could previously return a file
+    # whose real location is outside it.
+    files.extend(
+        safe_walk(path, recursive=recursive, only_files=True, include_hidden=include_hidden)
+    )
     files.sort(key=lambda entry: entry.name.lower())
     return files
 

--- a/src/file_organizer/services/analytics/storage_analyzer.py
+++ b/src/file_organizer/services/analytics/storage_analyzer.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
+
 from ...models.analytics import FileDistribution, FileInfo, StorageStats
 
 logger = logging.getLogger(__name__)
@@ -127,22 +129,26 @@ class StorageAnalyzer:
             "huge": (1024 * 1024 * 1024, float("inf")),  # > 1GB
         }
 
-        for file_path in path.rglob("*"):
-            if file_path.is_file():
-                distribution.total_files += 1
+        # include_hidden=True: this measures disk usage, and a size distribution
+        # that silently omits dotfiles is wrong. It also keeps these totals
+        # consistent with analyze_directory's _walk_directory, which has always
+        # counted hidden entries. Symlinks stay excluded — following them would
+        # double-count, or count bytes living outside the analysed tree.
+        for file_path in safe_walk(path, only_files=True, include_hidden=True):
+            distribution.total_files += 1
 
-                # By type
-                file_type = file_path.suffix.lower() or "no_extension"
-                distribution.by_type[file_type] = distribution.by_type.get(file_type, 0) + 1
+            # By type
+            file_type = file_path.suffix.lower() or "no_extension"
+            distribution.by_type[file_type] = distribution.by_type.get(file_type, 0) + 1
 
-                # By size range
-                size = file_path.stat().st_size
-                for range_name, (min_size, max_size) in size_ranges.items():
-                    if min_size <= size < max_size:
-                        distribution.by_size_range[range_name] = (
-                            distribution.by_size_range.get(range_name, 0) + 1
-                        )
-                        break
+            # By size range
+            size = file_path.stat().st_size
+            for range_name, (min_size, max_size) in size_ranges.items():
+                if min_size <= size < max_size:
+                    distribution.by_size_range[range_name] = (
+                        distribution.by_size_range.get(range_name, 0) + 1
+                    )
+                    break
 
         logger.info(
             f"Distribution: {distribution.total_files} files across "
@@ -169,18 +175,19 @@ class StorageAnalyzer:
         """
         large_files = []
 
-        for file_path in path.rglob("*"):
-            if file_path.is_file():
-                size = file_path.stat().st_size
-                if size >= threshold:
-                    large_files.append(
-                        FileInfo(
-                            path=file_path,
-                            size=size,
-                            type=file_path.suffix.lower(),
-                            modified=datetime.fromtimestamp(file_path.stat().st_mtime, tz=UTC),
-                        )
+        # include_hidden=True for the same reason as calculate_size_distribution:
+        # a large dotfile still occupies the disk the user is asking about.
+        for file_path in safe_walk(path, only_files=True, include_hidden=True):
+            size = file_path.stat().st_size
+            if size >= threshold:
+                large_files.append(
+                    FileInfo(
+                        path=file_path,
+                        size=size,
+                        type=file_path.suffix.lower(),
+                        modified=datetime.fromtimestamp(file_path.stat().st_mtime, tz=UTC),
                     )
+                )
 
         # Sort by size descending
         large_files.sort(key=lambda f: f.size, reverse=True)

--- a/src/file_organizer/services/copilot/executor.py
+++ b/src/file_organizer/services/copilot/executor.py
@@ -14,12 +14,12 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.services.copilot.models import (
     ExecutionResult,
     Intent,
     IntentType,
 )
-from file_organizer.utils import is_hidden
 
 if TYPE_CHECKING:
     from file_organizer.interfaces.search import RetrieverProtocol
@@ -232,10 +232,12 @@ class CommandExecutor:
         docs: list[str] = []
         paths: list[Path] = []
         try:
-            for entry in search_root.rglob("*"):
+            # only_files=True + include_hidden default False replaces the
+            # hand-rolled is_symlink()/is_file()/is_hidden(rel) post-filter that
+            # stood here — safe_walk applies exactly those three rules, and its
+            # hidden check is likewise relative to the walked root.
+            for entry in safe_walk(search_root, only_files=True):
                 rel = entry.relative_to(search_root)
-                if entry.is_symlink() or not entry.is_file() or is_hidden(rel):
-                    continue
                 # search_root is the trusted walked root: anchor the read so a
                 # symlink swapped into any intermediate directory is refused (#286).
                 text = read_text_safe(entry, scan_root=search_root)
@@ -312,14 +314,18 @@ class CommandExecutor:
         # ------------------------------------------------------------------
         query_lower = query.lower()
         matches = []
-        try:
-            for entry in search_root.rglob("*"):
-                if entry.is_file() and query_lower in entry.name.lower():
-                    matches.append(str(entry))
-                    if len(matches) >= 20:
-                        break
-        except PermissionError:
-            pass
+        # include_hidden defaults to False: search results are shown to the user,
+        # and dotfiles (.env, .ssh/*) are not what "find X" is asking for. The
+        # previous rglob applied no symlink or hidden filtering at all, so this
+        # narrows what the filename scan can surface.
+        # The former `except PermissionError` is gone: safe_walk absorbs OSError
+        # at the root, per-directory and per-entry levels, and nothing else in
+        # this loop raises — see #1674 for restoring that visibility.
+        for entry in safe_walk(search_root, only_files=True):
+            if query_lower in entry.name.lower():
+                matches.append(str(entry))
+                if len(matches) >= 20:
+                    break
 
         if matches:
             file_list = "\n".join(f"  - {m}" for m in matches[:10])

--- a/src/file_organizer/services/misplacement_detector.py
+++ b/src/file_organizer/services/misplacement_detector.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
+
 from .pattern_analyzer import PatternAnalysis, PatternAnalyzer
 
 logger = logging.getLogger(__name__)
@@ -124,8 +126,14 @@ class MisplacementDetector:
         if pattern_analysis is None:
             pattern_analysis = self.pattern_analyzer.analyze_directory(directory)
 
-        # Get all files (lazily — the tree is not materialized)
-        files = (f for f in directory.rglob("*") if f.is_file() and not f.name.startswith("."))
+        # Get all files (lazily — the tree is not materialized).
+        # include_hidden defaults to False, replacing the old
+        # `not f.name.startswith(".")` filter — note safe_walk is stricter: it
+        # excludes any path with a dot component relative to the root, so files
+        # buried under ".cache/" are no longer analysed. Symlinks are skipped
+        # too, so a link cannot make a file outside the tree look misplaced
+        # within it.
+        files = safe_walk(directory, only_files=True)
 
         misplaced_files = []
 

--- a/src/file_organizer/services/pattern_analyzer.py
+++ b/src/file_organizer/services/pattern_analyzer.py
@@ -14,6 +14,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
+
 logger = logging.getLogger(__name__)
 
 
@@ -232,9 +234,14 @@ class PatternAnalyzer:
 
         location_patterns = []
 
-        # Analyze each subdirectory
-        for subdir in directory.rglob("*"):
-            if not subdir.is_dir() or subdir.name.startswith("."):
+        # Analyze each subdirectory.
+        # only_files=False because this walk wants directories, not files.
+        # include_hidden defaults to False, replacing the old
+        # `subdir.name.startswith(".")` check — note safe_walk is stricter: it
+        # excludes any path with a dot component relative to the root, so a
+        # visible directory buried under ".cache/" is no longer analysed.
+        for subdir in safe_walk(directory, only_files=False):
+            if not subdir.is_dir():
                 continue
 
             # Get files in this directory (non-recursive)

--- a/src/file_organizer/tui/audio_view.py
+++ b/src/file_organizer/tui/audio_view.py
@@ -16,6 +16,7 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import Static
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.tui.status import StatusMixin
 
 if TYPE_CHECKING:
@@ -292,8 +293,12 @@ class AudioView(StatusMixin, Vertical):
             if has_selection:
                 audio_paths.extend(selected_audio[:_MAX_SCAN_FILES])
             elif scan_dir.is_dir():
-                for p in sorted(scan_dir.rglob("*")):
-                    if p.suffix.lower() in _AUDIO_EXTENSIONS and p.is_file():
+                # only_files=True makes the trailing p.is_file() redundant;
+                # include_hidden defaults to False, so dot-prefixed media is no
+                # longer scanned. Sorting still happens over the full result so
+                # the listing order is unchanged.
+                for p in sorted(safe_walk(scan_dir, only_files=True)):
+                    if p.suffix.lower() in _AUDIO_EXTENSIONS:
                         audio_paths.append(p)
                         if len(audio_paths) >= _MAX_SCAN_FILES:
                             break

--- a/src/file_organizer/tui/file_preview.py
+++ b/src/file_organizer/tui/file_preview.py
@@ -18,6 +18,7 @@ from textual.containers import Horizontal
 from textual.message import Message
 from textual.widgets import Static
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.tui.file_browser import FileBrowserView
 
 if TYPE_CHECKING:
@@ -332,7 +333,9 @@ class FilePreviewView(Horizontal):
         if self._root_path is None:
             return
         try:
-            all_files = {p for p in self._root_path.rglob("*") if p.is_file()}
+            # include_hidden defaults to False: "select all" feeds destructive
+            # operations, and dotfiles are not what the user is selecting.
+            all_files = set(safe_walk(self._root_path, only_files=True))
             self.selection.select_all(all_files)
             self._notify_selection()
         except OSError:

--- a/src/file_organizer/tui/methodology_view.py
+++ b/src/file_organizer/tui/methodology_view.py
@@ -20,6 +20,7 @@ from textual.widgets import Static
 
 from file_organizer.config.methodology import DEFAULT as _DEFAULT_METHODOLOGY
 from file_organizer.core.organize_options import OrganizationMethodology
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.tui.status import StatusMixin
 
 if TYPE_CHECKING:
@@ -281,7 +282,10 @@ class MethodologyView(StatusMixin, Vertical):
                     : self._MAX_SAMPLE_FILES
                 ]
             else:
-                files = [p for p in scan.rglob("*") if p.is_file()][: self._MAX_SAMPLE_FILES]
+                # include_hidden defaults to False: the preview samples files to
+                # show the user what organizing would do, and dotfiles are not
+                # candidates for it.
+                files = list(safe_walk(scan, only_files=True))[: self._MAX_SAMPLE_FILES]
 
             if not files:
                 self.app.call_from_thread(

--- a/tests/methodologies/para/test_ai_file_mover_branches.py
+++ b/tests/methodologies/para/test_ai_file_mover_branches.py
@@ -7,6 +7,7 @@ non-dir, suggest_archive stat error, _resolve_collision overflow.
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -366,17 +367,30 @@ class TestSuggestArchive:
         assert suggestions[0].target_category == PARACategory.ARCHIVE
 
     def test_suggest_archive_os_error_during_scan(self, tmp_path: Path) -> None:
-        """OSError during directory scan returns empty list (lines 324-326)."""
+        """An unreadable directory yields no suggestions rather than raising.
+
+        The scan goes through ``safe_walk``, which absorbs OSError per directory
+        via ``os.scandir`` — patching ``Path.rglob`` would no longer intercept
+        anything and the assertion would hold vacuously. The fixture holds a
+        genuinely stale file so an unpatched run *would* produce a suggestion,
+        which is what makes the empty result meaningful.
+        """
         config = PARAConfig()
         engine = MagicMock()
         mover = PARAFileMover(config, suggestion_engine=engine, root_dir=tmp_path)
 
         src_dir = tmp_path / "src"
         src_dir.mkdir()
+        stale = src_dir / "old.txt"
+        stale.write_text("stale")
+        old = time.time() - 400 * 86400
+        os.utime(stale, (old, old))
 
-        # Mock rglob to raise OSError
-        with patch.object(Path, "rglob", side_effect=OSError("Permission denied")):
-            suggestions = mover.suggest_archive(src_dir)
+        # Control: the file is stale enough to be suggested when readable.
+        assert mover.suggest_archive(src_dir, inactive_days=180) != []
+
+        with patch("os.scandir", side_effect=OSError("Permission denied")):
+            suggestions = mover.suggest_archive(src_dir, inactive_days=180)
 
         assert suggestions == []
 

--- a/tests/methodologies/para/test_ai_file_mover_branches.py
+++ b/tests/methodologies/para/test_ai_file_mover_branches.py
@@ -394,8 +394,18 @@ class TestSuggestArchive:
 
         assert suggestions == []
 
-    def test_suggest_archive_file_stat_error(self, tmp_path: Path) -> None:
-        """OSError during file.stat() is caught and file skipped."""
+    def test_suggest_archive_file_stat_error(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """OSError during file.stat() is caught, logged, and the file skipped.
+
+        The walk is stubbed at the module's ``safe_walk`` symbol rather than left
+        to run for real. Patching ``Path.stat`` globally would otherwise also
+        break ``safe_walk``'s own ``is_dir()``/``is_file()`` probes, so the
+        unstattable file would be dropped *by the walk* and never reach the
+        handler under test — while ``len(suggestions) == 1`` stayed true either
+        way, making the old assertion unable to tell the two apart.
+        """
         config = PARAConfig()
         engine = MagicMock()
         mover = PARAFileMover(config, suggestion_engine=engine, root_dir=tmp_path)
@@ -414,15 +424,25 @@ class TestSuggestArchive:
                 raise OSError("Cannot stat file")
             return original_stat(self, **kwargs)
 
-        with patch.object(Path, "is_file", return_value=True):
-            with patch.object(Path, "stat", mock_stat):
-                with patch("file_organizer.methodologies.para.ai.file_mover.time") as mock_time:
-                    mock_time.time.return_value = time.time() + (200 * 86400)
-                    suggestions = mover.suggest_archive(src_dir, inactive_days=180)
+        with (
+            patch(
+                "file_organizer.methodologies.para.ai.file_mover.safe_walk",
+                return_value=[file1, file2],
+            ),
+            patch.object(Path, "stat", mock_stat),
+            patch("file_organizer.methodologies.para.ai.file_mover.time") as mock_time,
+            caplog.at_level("WARNING", logger="file_organizer.methodologies.para.ai.file_mover"),
+        ):
+            mock_time.time.return_value = time.time() + (200 * 86400)
+            suggestions = mover.suggest_archive(src_dir, inactive_days=180)
 
-        # Should have suggestion for file2 only, file1 was skipped
+        # file2 is suggested; file1 was skipped *by the handler*, not by the walk.
         assert len(suggestions) == 1
         assert suggestions[0].file_path.name == "file2.txt"
+        assert any("Cannot stat file" in r.message for r in caplog.records), (
+            "the OSError handler must have logged — otherwise this test is not "
+            "exercising the branch it names"
+        )
 
     def test_suggest_archive_recent_files_not_suggested(self, tmp_path: Path) -> None:
         """Recent files are not suggested for archive (branch 333->328)."""

--- a/tests/security/test_safe_walk_migration_batch1.py
+++ b/tests/security/test_safe_walk_migration_batch1.py
@@ -79,6 +79,46 @@ class TestPathMigratorTraversal:
             "symlink escaping the legacy root must not be migrated"
         )
 
+    @posix_only
+    def test_backup_preserves_symlink_instead_of_dereferencing_it(self, tmp_path: Path) -> None:
+        """The pre-migration backup must not materialise the link's target.
+
+        ``backup_legacy_path()`` runs before the hardened ``migrate()`` loop and
+        uses ``shutil.copytree``, which follows symlinks unless told otherwise.
+        Without ``symlinks=True`` the escaping link's *contents* land inside the
+        backup — the same data escape ``safe_walk`` prevents in ``migrate()``,
+        one directory over.
+        """
+        secret = tmp_path / "secret.txt"
+        secret.write_text("sensitive data outside the config tree")
+
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "settings.json").write_text("{}")
+        (legacy / "escape.txt").symlink_to(secret)
+
+        migrator = PathMigrator(legacy, tmp_path / "canonical")
+        migrator.migrate()
+
+        assert migrator.backup_path is not None
+        backed_up_link = migrator.backup_path / "escape.txt"
+
+        assert backed_up_link.is_symlink(), "the backup must keep the link as a link"
+        assert backed_up_link.readlink() == secret, "the link must still point at the original"
+
+        # Decisive: no *regular file* anywhere in the backup carries the external
+        # content. A dereferencing copytree would have written it as one.
+        materialised = [
+            p
+            for p in migrator.backup_path.rglob("*")
+            if p.is_file()
+            and not p.is_symlink()
+            and "sensitive data" in p.read_text(errors="ignore")
+        ]
+        assert materialised == [], (
+            f"backup dereferenced the escaping link into real files: {materialised}"
+        )
+
     def test_migrate_copies_hidden_config_files(self, tmp_path: Path) -> None:
         """Dotfiles are real config and must survive migration.
 

--- a/tests/security/test_safe_walk_migration_batch1.py
+++ b/tests/security/test_safe_walk_migration_batch1.py
@@ -1,0 +1,207 @@
+"""Traversal-safety regression tests for the batch 1 ``safe_walk`` migration (#1671).
+
+Covers the call sites in ``config/`` and ``methodologies/`` that previously
+walked user-supplied roots with a raw ``rglob("*")``:
+
+- ``config/path_migration.PathMigrator.migrate``
+- ``methodologies/johnny_decimal/system.JohnnyDecimalSystem.initialize_from_directory``
+- ``methodologies/para/ai/file_mover.PARAFileMover.bulk_organize``
+- ``methodologies/para/ai/file_mover.PARAFileMover.suggest_archive``
+
+Each site is asserted on two axes: a symlink whose target lives outside the
+walked root must never be reached, and dot-prefixed entries are included only
+where that site deliberately wants them.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from file_organizer.config.path_migration import PathMigrator
+from file_organizer.methodologies.johnny_decimal.system import JohnnyDecimalSystem
+from file_organizer.methodologies.para.ai.file_mover import PARAFileMover
+from file_organizer.methodologies.para.categories import PARACategory
+from file_organizer.methodologies.para.config import PARAConfig
+
+pytestmark = [pytest.mark.security, pytest.mark.unit, pytest.mark.ci]
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="symlink hardening is POSIX-focused"
+)
+
+
+def _mover(tmp_path: Path, *, confidence: float = 0.9) -> PARAFileMover:
+    """A PARAFileMover whose engine always returns a usable suggestion."""
+    suggestion = MagicMock()
+    suggestion.category = PARACategory.PROJECT
+    suggestion.confidence = confidence
+    suggestion.reasoning = ["test"]
+    suggestion.suggested_subfolder = None
+
+    engine = MagicMock()
+    engine.suggest.return_value = suggestion
+    return PARAFileMover(PARAConfig(), suggestion_engine=engine, root_dir=tmp_path)
+
+
+class TestPathMigratorTraversal:
+    """PathMigrator.migrate copies config, but must not chase links out of it."""
+
+    @posix_only
+    def test_migrate_does_not_copy_through_symlink_escaping_legacy_root(
+        self, tmp_path: Path
+    ) -> None:
+        """A symlink in the legacy dir pointing outside it is not migrated."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("sensitive data outside the config tree")
+
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "settings.json").write_text("{}")
+        (legacy / "escape.txt").symlink_to(secret)
+
+        canonical = tmp_path / "canonical"
+
+        PathMigrator(legacy, canonical).migrate()
+
+        assert (canonical / "settings.json").exists(), "real config file must migrate"
+        assert not (canonical / "escape.txt").exists(), (
+            "symlink escaping the legacy root must not be migrated"
+        )
+
+    def test_migrate_copies_hidden_config_files(self, tmp_path: Path) -> None:
+        """Dotfiles are real config and must survive migration.
+
+        Characterization guard: this site deliberately opts into hidden entries
+        because dropping them silently loses user configuration.
+        """
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / ".env").write_text("TOKEN=abc")
+        (legacy / "nested").mkdir()
+        (legacy / "nested" / ".hidden_prefs").write_text("theme=dark")
+
+        canonical = tmp_path / "canonical"
+
+        PathMigrator(legacy, canonical).migrate()
+
+        assert (canonical / ".env").read_text() == "TOKEN=abc"
+        assert (canonical / "nested" / ".hidden_prefs").exists()
+
+
+class TestJohnnyDecimalInitTraversal:
+    """initialize_from_directory scans names for numbers — not through links."""
+
+    def test_initialize_skips_hidden_directories(self, tmp_path: Path) -> None:
+        """A dot-prefixed directory is not registered even if it looks numbered."""
+        (tmp_path / "10 Finance").mkdir()
+        (tmp_path / ".20 Hidden").mkdir()
+
+        system = JohnnyDecimalSystem()
+        system.initialize_from_directory(tmp_path)
+
+        registered = set(system.generator._used_numbers)
+        assert "10" in registered
+        assert "20" not in registered, "hidden directory must not register a number"
+
+    @posix_only
+    def test_initialize_does_not_register_symlinked_entries(self, tmp_path: Path) -> None:
+        """A symlink named like a JD entry is not registered."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "10 Finance").mkdir()
+        (root / "20 Escape").symlink_to(outside, target_is_directory=True)
+
+        system = JohnnyDecimalSystem()
+        system.initialize_from_directory(root)
+
+        registered = set(system.generator._used_numbers)
+        assert "10" in registered
+        assert "20" not in registered, "symlinked entry must not register a number"
+
+
+class TestBulkOrganizeTraversal:
+    """bulk_organize moves files — it must not pick up links or dotfiles."""
+
+    @posix_only
+    def test_bulk_organize_skips_symlinked_files(self, tmp_path: Path) -> None:
+        """A symlink to a file outside the scanned directory is not organized."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("outside")
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "real.txt").write_text("inside")
+        (src / "link.txt").symlink_to(secret)
+
+        report = _mover(tmp_path).bulk_organize(src, dry_run=True)
+
+        assert report.total_files == 1, "only the real file should be collected"
+
+    def test_bulk_organize_skips_hidden_files(self, tmp_path: Path) -> None:
+        """Dotfiles are not relocated by a bulk organize run."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "real.txt").write_text("inside")
+        (src / ".gitignore").write_text("*.pyc")
+
+        report = _mover(tmp_path).bulk_organize(src, dry_run=True)
+
+        assert report.total_files == 1, "hidden file must not be organized"
+
+
+def _backdate(path: Path, days: int = 400) -> None:
+    """Age a file so suggest_archive considers it inactive."""
+    old = time.time() - days * 86400
+    os.utime(path, (old, old))
+
+
+class TestSuggestArchiveTraversal:
+    """suggest_archive proposes moves — same exclusions as bulk_organize."""
+
+    @posix_only
+    def test_suggest_archive_skips_symlinked_files(self, tmp_path: Path) -> None:
+        """A symlink is never proposed for archiving."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("outside")
+        _backdate(secret)
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "link.txt").symlink_to(secret)
+
+        suggestions = _mover(tmp_path).suggest_archive(src, inactive_days=180)
+
+        assert suggestions == [], "symlink must not be proposed for archiving"
+
+    def test_suggest_archive_skips_hidden_files(self, tmp_path: Path) -> None:
+        """Dotfiles are never proposed for archiving."""
+        src = tmp_path / "src"
+        src.mkdir()
+        hidden = src / ".gitignore"
+        hidden.write_text("*.pyc")
+        _backdate(hidden)
+
+        suggestions = _mover(tmp_path).suggest_archive(src, inactive_days=180)
+
+        assert suggestions == [], "hidden file must not be proposed for archiving"
+
+    def test_suggest_archive_still_proposes_real_inactive_files(self, tmp_path: Path) -> None:
+        """Characterization guard: ordinary inactive files are still proposed."""
+        src = tmp_path / "src"
+        src.mkdir()
+        stale = src / "old_report.txt"
+        stale.write_text("stale")
+        _backdate(stale)
+
+        suggestions = _mover(tmp_path).suggest_archive(src, inactive_days=180)
+
+        assert [s.file_path for s in suggestions] == [stale]

--- a/tests/security/test_safe_walk_migration_batch1.py
+++ b/tests/security/test_safe_walk_migration_batch1.py
@@ -29,7 +29,12 @@ from file_organizer.methodologies.para.ai.file_mover import PARAFileMover
 from file_organizer.methodologies.para.categories import PARACategory
 from file_organizer.methodologies.para.config import PARAConfig
 
-pytestmark = [pytest.mark.security, pytest.mark.unit, pytest.mark.ci]
+pytestmark = [
+    pytest.mark.security,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.ci,
+]
 
 posix_only = pytest.mark.skipif(
     sys.platform == "win32", reason="symlink hardening is POSIX-focused"

--- a/tests/security/test_safe_walk_migration_services_api.py
+++ b/tests/security/test_safe_walk_migration_services_api.py
@@ -11,7 +11,6 @@ Sites deliberately *not* covered here, and why:
 - ``api/routers/search.py`` — both walks meter a ``max_files`` traversal budget on
   *raw* entries. ``safe_walk`` pre-filters, so the same number would bound a larger
   walk, loosening a DoS guard on a remote-reachable endpoint.
-- ``services/misplacement_detector.py`` — being changed in #1670 / PR #1673.
 """
 
 from __future__ import annotations
@@ -26,6 +25,7 @@ from file_organizer.plugins.api.endpoints import _collect_files as plugin_collec
 from file_organizer.services.analytics.storage_analyzer import StorageAnalyzer
 from file_organizer.services.copilot.executor import CommandExecutor
 from file_organizer.services.copilot.intent_parser import Intent, IntentType
+from file_organizer.services.misplacement_detector import MisplacementDetector
 from file_organizer.services.pattern_analyzer import PatternAnalyzer
 
 pytestmark = [pytest.mark.security, pytest.mark.unit, pytest.mark.ci]
@@ -214,3 +214,56 @@ class TestCopilotFindTraversal:
         )
         result = CommandExecutor().execute(intent)
         assert any("report.txt" in f for f in result.affected_files)
+
+
+class TestMisplacementDetectorTraversal:
+    """detect_misplaced walks a user-supplied root — unblocked once #1673 merged."""
+
+    @posix_only
+    def test_symlinked_file_is_not_analyzed(self, tmp_path: Path) -> None:
+        """A symlink pointing outside the scanned tree is never a misplacement candidate."""
+        outside = tmp_path / "outside.jpg"
+        outside.write_bytes(b"\xff\xd8\xff")
+
+        root = tmp_path / "root"
+        root.mkdir()
+        for i in range(5):
+            (root / f"report_{i}.txt").write_text("content")
+        (root / "linked.jpg").symlink_to(outside)
+
+        detector = MisplacementDetector(min_mismatch_score=50.0)
+        misplaced = detector.detect_misplaced(root)
+
+        assert all(m.file_path.name != "linked.jpg" for m in misplaced)
+
+    def test_file_under_hidden_directory_is_not_analyzed(self, tmp_path: Path) -> None:
+        """safe_walk excludes any dot component relative to the root.
+
+        Stricter than the previous leaf-only ``name.startswith(".")`` filter: a
+        visible file inside ``.cache/`` was analysed before and is not now.
+        """
+        root = tmp_path / "root"
+        buried = root / ".cache"
+        buried.mkdir(parents=True)
+        for i in range(5):
+            (buried / f"report_{i}.txt").write_text("content")
+        (buried / "photo.jpg").write_bytes(b"\xff\xd8\xff")
+
+        detector = MisplacementDetector(min_mismatch_score=50.0)
+        misplaced = detector.detect_misplaced(root)
+
+        assert misplaced == []
+
+    def test_ordinary_outlier_is_still_detected(self, tmp_path: Path) -> None:
+        """Characterization guard carried over from #1670."""
+        root = tmp_path / "root"
+        root.mkdir()
+        for i in range(5):
+            (root / f"report_{i}.txt").write_text("content")
+        outlier = root / "photo.jpg"
+        outlier.write_bytes(b"\xff\xd8\xff")
+
+        detector = MisplacementDetector(min_mismatch_score=50.0)
+        misplaced = detector.detect_misplaced(root)
+
+        assert outlier in [m.file_path for m in misplaced]

--- a/tests/security/test_safe_walk_migration_services_api.py
+++ b/tests/security/test_safe_walk_migration_services_api.py
@@ -1,0 +1,216 @@
+"""Traversal-safety tests for the services/, api/ and plugins/ ``safe_walk`` migration (#1671).
+
+Each migrated call site is asserted on two axes: a symlink whose target lives
+outside the walked root is never reached, and dot-prefixed entries appear only
+where that site deliberately wants them.
+
+Sites deliberately *not* covered here, and why:
+
+- ``services/copilot/rules/preview.py`` — blocked on #1674. Its ``PreviewResult.errors``
+  reports "Permission denied" to the user, and ``safe_walk`` cannot surface OSError.
+- ``api/routers/search.py`` — both walks meter a ``max_files`` traversal budget on
+  *raw* entries. ``safe_walk`` pre-filters, so the same number would bound a larger
+  walk, loosening a DoS guard on a remote-reachable endpoint.
+- ``services/misplacement_detector.py`` — being changed in #1670 / PR #1673.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from file_organizer.api.routers.files import _collect_files as api_collect_files
+from file_organizer.plugins.api.endpoints import _collect_files as plugin_collect_files
+from file_organizer.services.analytics.storage_analyzer import StorageAnalyzer
+from file_organizer.services.copilot.executor import CommandExecutor
+from file_organizer.services.copilot.intent_parser import Intent, IntentType
+from file_organizer.services.pattern_analyzer import PatternAnalyzer
+
+pytestmark = [pytest.mark.security, pytest.mark.unit, pytest.mark.ci]
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="symlink hardening is POSIX-focused"
+)
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A scan root holding a real file, a dotfile, and a symlink escaping the root."""
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("sensitive data outside the scan root")
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "report.txt").write_text("real content")
+    (root / ".hidden.txt").write_text("dotfile content")
+    (root / "escape.txt").symlink_to(outside)
+    return root
+
+
+class TestApiCollectFiles:
+    """api/routers/files.py::_collect_files — hidden threading must survive."""
+
+    @posix_only
+    def test_symlink_is_not_collected(self, tree: Path) -> None:
+        names = {p.name for p in api_collect_files(tree, recursive=True, include_hidden=True)}
+        assert "report.txt" in names
+        assert "escape.txt" not in names
+
+    def test_include_hidden_false_excludes_dotfiles(self, tree: Path) -> None:
+        names = {p.name for p in api_collect_files(tree, recursive=True, include_hidden=False)}
+        assert names == {"report.txt"}
+
+    def test_include_hidden_true_includes_dotfiles(self, tree: Path) -> None:
+        names = {p.name for p in api_collect_files(tree, recursive=True, include_hidden=True)}
+        assert ".hidden.txt" in names
+
+    def test_non_recursive_stays_top_level(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        (root / "nested").mkdir(parents=True)
+        (root / "top.txt").write_text("t")
+        (root / "nested" / "deep.txt").write_text("d")
+
+        names = {p.name for p in api_collect_files(root, recursive=False, include_hidden=False)}
+        assert names == {"top.txt"}
+
+
+class TestPluginCollectFiles:
+    """plugins/api/endpoints.py::_collect_files — same contract, plus sorting."""
+
+    @posix_only
+    def test_symlink_is_not_collected(self, tree: Path) -> None:
+        names = {p.name for p in plugin_collect_files(tree, recursive=True, include_hidden=True)}
+        assert "report.txt" in names
+        assert "escape.txt" not in names
+
+    def test_include_hidden_is_threaded(self, tree: Path) -> None:
+        without = {p.name for p in plugin_collect_files(tree, recursive=True, include_hidden=False)}
+        with_hidden = {
+            p.name for p in plugin_collect_files(tree, recursive=True, include_hidden=True)
+        }
+        assert ".hidden.txt" not in without
+        assert ".hidden.txt" in with_hidden
+
+    def test_results_remain_sorted_by_name(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        for name in ("zulu.txt", "alpha.txt", "mike.txt"):
+            (root / name).write_text("x")
+
+        collected = plugin_collect_files(root, recursive=True, include_hidden=False)
+        assert [p.name for p in collected] == ["alpha.txt", "mike.txt", "zulu.txt"]
+
+
+class TestStorageAnalyzerTraversal:
+    """Analytics must not count symlinks, but must still count dotfiles."""
+
+    @posix_only
+    def test_size_distribution_excludes_symlinks(self, tree: Path) -> None:
+        distribution = StorageAnalyzer().calculate_size_distribution(tree)
+        # report.txt + .hidden.txt, but not the escaping symlink
+        assert distribution.total_files == 2
+
+    def test_size_distribution_counts_hidden_files(self, tmp_path: Path) -> None:
+        """include_hidden=True here: disk usage that omits dotfiles is simply wrong."""
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "visible.txt").write_text("x")
+        (root / ".hidden.txt").write_text("y")
+
+        distribution = StorageAnalyzer().calculate_size_distribution(root)
+        assert distribution.total_files == 2
+
+    @posix_only
+    def test_identify_large_files_excludes_symlinks(self, tmp_path: Path) -> None:
+        big_outside = tmp_path / "big_outside.bin"
+        big_outside.write_bytes(b"x" * 5000)
+
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "big_inside.bin").write_bytes(b"y" * 5000)
+        (root / "link.bin").symlink_to(big_outside)
+
+        large = StorageAnalyzer().identify_large_files(root, threshold=1000)
+        assert [f.path.name for f in large] == ["big_inside.bin"]
+
+
+class TestPatternAnalyzerTraversal:
+    """get_location_patterns walks directories — not through links."""
+
+    @posix_only
+    def test_symlinked_directory_is_not_analyzed(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.pdf").write_text("x")
+
+        root = tmp_path / "root"
+        real = root / "real"
+        real.mkdir(parents=True)
+        (real / "doc.pdf").write_text("x")
+        (root / "linked").symlink_to(outside, target_is_directory=True)
+
+        patterns = PatternAnalyzer().get_location_patterns(root)
+        analyzed = {p.directory.name for p in patterns}
+        assert "real" in analyzed
+        assert "linked" not in analyzed
+
+    def test_hidden_directory_is_not_analyzed(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        (root / "real").mkdir(parents=True)
+        (root / "real" / "doc.pdf").write_text("x")
+        (root / ".hidden").mkdir()
+        (root / ".hidden" / "doc.pdf").write_text("x")
+
+        patterns = PatternAnalyzer().get_location_patterns(root)
+        analyzed = {p.directory.name for p in patterns}
+        assert "real" in analyzed
+        assert ".hidden" not in analyzed
+
+    def test_directory_nested_under_hidden_parent_is_not_analyzed(self, tmp_path: Path) -> None:
+        """safe_walk excludes any path with a dot component relative to the root.
+
+        Stricter than the previous leaf-only ``name.startswith(".")`` check: a
+        visible directory inside ``.cache/`` was analysed before and is not now.
+        """
+        root = tmp_path / "root"
+        buried = root / ".cache" / "visible"
+        buried.mkdir(parents=True)
+        (buried / "doc.pdf").write_text("x")
+
+        patterns = PatternAnalyzer().get_location_patterns(root)
+        assert [p.directory.name for p in patterns] == []
+
+
+class TestCopilotFindTraversal:
+    """_handle_find's filename scan must not surface links or dotfiles."""
+
+    @posix_only
+    def test_find_does_not_match_symlinks(self, tree: Path) -> None:
+        intent = Intent(
+            intent_type=IntentType.FIND,
+            confidence=0.9,
+            parameters={"query": "escape", "paths": [str(tree)]},
+        )
+        result = CommandExecutor().execute(intent)
+        assert all("escape.txt" not in f for f in result.affected_files)
+
+    def test_find_does_not_match_hidden_files(self, tree: Path) -> None:
+        intent = Intent(
+            intent_type=IntentType.FIND,
+            confidence=0.9,
+            parameters={"query": "hidden", "paths": [str(tree)]},
+        )
+        result = CommandExecutor().execute(intent)
+        assert all(".hidden.txt" not in f for f in result.affected_files)
+
+    def test_find_still_matches_ordinary_files(self, tree: Path) -> None:
+        """Characterization guard: the migration must not break finding real files."""
+        intent = Intent(
+            intent_type=IntentType.FIND,
+            confidence=0.9,
+            parameters={"query": "report", "paths": [str(tree)]},
+        )
+        result = CommandExecutor().execute(intent)
+        assert any("report.txt" in f for f in result.affected_files)

--- a/tests/security/test_safe_walk_migration_services_api.py
+++ b/tests/security/test_safe_walk_migration_services_api.py
@@ -28,7 +28,12 @@ from file_organizer.services.copilot.intent_parser import Intent, IntentType
 from file_organizer.services.misplacement_detector import MisplacementDetector
 from file_organizer.services.pattern_analyzer import PatternAnalyzer
 
-pytestmark = [pytest.mark.security, pytest.mark.unit, pytest.mark.ci]
+pytestmark = [
+    pytest.mark.security,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.ci,
+]
 
 posix_only = pytest.mark.skipif(
     sys.platform == "win32", reason="symlink hardening is POSIX-focused"

--- a/tests/tui/test_audio_view_coverage.py
+++ b/tests/tui/test_audio_view_coverage.py
@@ -311,10 +311,16 @@ def test_audio_view_scan_no_audio_files() -> None:
     # Mock Path methods
     mock_dir = MagicMock()
     mock_dir.is_dir.return_value = True
-    mock_dir.rglob.return_value = [Path("file.txt"), Path("image.png")]
     view._scan_dir = mock_dir
 
     with (
+        # See the note in test_audio_view_scan_success: the scan uses safe_walk,
+        # so stubbing mock_dir.rglob would no longer control enumeration and the
+        # "no audio files" result would hold for the wrong reason.
+        patch(
+            "file_organizer.tui.audio_view.safe_walk",
+            return_value=[Path("file.txt"), Path("image.png")],
+        ),
         patch("file_organizer.services.audio.metadata_extractor.AudioMetadataExtractor"),
         patch("file_organizer.services.audio.classifier.AudioClassifier"),
         patch.object(view, "_set_status") as mock_status,

--- a/tests/tui/test_audio_view_coverage.py
+++ b/tests/tui/test_audio_view_coverage.py
@@ -336,7 +336,6 @@ def test_audio_view_scan_success() -> None:
 
     mock_dir = MagicMock()
     mock_dir.is_dir.return_value = True
-    mock_dir.rglob.return_value = [p1, p2]
     view._scan_dir = mock_dir
 
     # Mock extractors/classifiers
@@ -352,6 +351,9 @@ def test_audio_view_scan_success() -> None:
 
     with (
         patch.object(Path, "is_file", return_value=True),
+        # The scan walks via safe_walk now; stubbing mock_dir.rglob would no
+        # longer be reached. Patch the name as imported by the view module.
+        patch("file_organizer.tui.audio_view.safe_walk", return_value=[p1, p2]),
         patch(
             "file_organizer.services.audio.metadata_extractor.AudioMetadataExtractor"
         ) as mock_extractor_class,
@@ -393,7 +395,6 @@ def test_audio_view_scan_extraction_exception() -> None:
     p1 = Path("track1.mp3")
     mock_dir = MagicMock()
     mock_dir.is_dir.return_value = True
-    mock_dir.rglob.return_value = [p1]
     view._scan_dir = mock_dir
 
     mock_extractor = MagicMock()
@@ -401,6 +402,8 @@ def test_audio_view_scan_extraction_exception() -> None:
 
     with (
         patch.object(Path, "is_file", return_value=True),
+        # See the note in test_audio_view_scan_success: the scan uses safe_walk.
+        patch("file_organizer.tui.audio_view.safe_walk", return_value=[p1]),
         patch(
             "file_organizer.services.audio.metadata_extractor.AudioMetadataExtractor",
             return_value=mock_extractor,

--- a/tests/tui/test_tui_coverage_gaps2.py
+++ b/tests/tui/test_tui_coverage_gaps2.py
@@ -11,7 +11,6 @@ Covers:
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -224,12 +223,27 @@ class TestFilePreviewViewActions:
         assert view.selection.count == 2
         view._notify_selection.assert_called_once()
 
-    def test_action_select_all_oserror(self, tmp_path):
+    def test_action_select_all_unreadable_directory_selects_nothing(self, tmp_path):
+        """An unreadable root must not add anything to the selection.
+
+        The scan goes through ``safe_walk``, which reads via ``os.scandir`` and
+        absorbs the OSError itself — patching ``Path.rglob`` would no longer
+        intercept anything. The invariant worth pinning is that nothing gets
+        selected; ``_notify_selection`` now fires with an empty result, which is
+        harmless because ``select_all`` is additive (``set.update``).
+        """
         view = self._make_view(tmp_path)
+        (tmp_path / "a.txt").write_text("a")
         view._notify_selection = MagicMock()
-        with patch.object(Path, "rglob", side_effect=OSError("no access")):
+
+        # Control: the file is selectable when the directory is readable.
+        view.action_select_all()
+        assert view.selection.count == 1
+
+        view.selection.clear()
+        with patch("os.scandir", side_effect=OSError("no access")):
             view.action_select_all()
-        view._notify_selection.assert_not_called()
+        assert view.selection.count == 0
 
     def test_action_deselect_all(self, tmp_path):
         view = self._make_view(tmp_path)


### PR DESCRIPTION
## Description

`core.path_guard.safe_walk()` was built in #1223 as the security-safe replacement for raw `rglob("*")` / `glob("*")` — it refuses symlinks (whose targets may resolve outside the walked root) and dot-prefixed entries. The primitive landed; the call-site migration did not.

This migrates **13 of the 16 remaining sites**. The other three are carved out into their own issues with reasons below, so this closes #1671.

This is security hardening, not performance work. `rglob()` is already a lazy generator — there is no traversal-speed or memory win here, and none is claimed. The value is closing symlink-escape and dotfile-exposure paths, most importantly on the remote-reachable `api/` and `plugins/api/` surface.

Closes #1671

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — security hardening
- [ ] New feature
- [x] Breaking change — **behaviour changes at every migrated site**, detailed below
- [ ] This change requires a documentation update

## Per-site parameter choices

Each site was decided individually rather than substituted mechanically.

| Site | `only_files` | `include_hidden` | Rationale |
|---|---|---|---|
| `config/path_migration.migrate` | True | **True** | Dotfiles *are* the config (`.env`, `.prefs`); dropping them loses user settings. The real exposure was `shutil.copy2` following a symlink out of the legacy dir. `backup_legacy_path()` runs first, so a skipped link is recoverable. |
| `johnny_decimal.initialize_from_directory` | **False** | False | JD numbers live on directory names, so directories must be yielded. A link named `20 Escape` would otherwise register a number pointing outside the root. |
| `para/file_mover.bulk_organize` | True | False | Collapses the `rglob`/`iterdir` branch into `recursive=`. This *relocates* files — `.gitignore` is not something the user asked to reorganize. |
| `para/file_mover.suggest_archive` | True | False | Same rationale. |
| `copilot/executor._build_retriever_for_root` | True | False | Replaces an identical hand-rolled `is_symlink()`/`is_file()`/`is_hidden(rel)` filter. `safe_walk`'s hidden check is likewise relative to the walked root. |
| `copilot/executor._handle_find` | True | False | Previously applied **no** filtering — the filename scan could surface dotfiles and symlinked paths in user-visible results. |
| `services/pattern_analyzer.get_location_patterns` | **False** | False | Needs directories. Stricter than the old leaf-only `name.startswith(".")`: a visible directory buried under `.cache/` is no longer analysed. |
| `analytics/storage_analyzer.calculate_size_distribution` | True | **True** | Disk-usage numbers that omit dotfiles are wrong, and this keeps totals consistent with `analyze_directory`'s `_walk_directory`, which always counted them. Symlinks stay out — following them double-counts or counts bytes outside the tree. |
| `analytics/storage_analyzer.identify_large_files` | True | **True** | Same. |
| `api/routers/files._collect_files` | True | *threaded* | `include_hidden` comes from the request, so documented endpoint behaviour is unchanged. |
| `plugins/api/endpoints._collect_files` | True | *threaded* | Same — and this endpoint applied **no symlink filter at all**, so a link under the requested path could return a file whose real location was outside it. |
| `api/service_facade` suggestions | True | False | Surfaced to the user; should not propose acting on dotfiles. |
| `tui/file_preview.action_select_all` | True | False | "Select all" feeds destructive operations. |
| `tui/methodology_view`, `tui/audio_view` | True | False | Preview/sampling flows. |
| `services/misplacement_detector.detect_misplaced` | True | False | Replaces `not f.name.startswith(".")`. Deferred until #1673 merged, then completed here. |

`safe_walk` is imported at module scope everywhere.

## Deferred, and why

Three sites are **not** migrated. Each has its own issue so this one can close cleanly.

**`services/copilot/rules/preview.py` — #1674.** Its `PreviewResult.errors` reports `"Permission denied"` to the user as part of the return contract. `safe_walk` absorbs every `OSError` at the root, per-directory and per-entry levels and cannot surface it — verified:

```python
with patch("os.scandir", side_effect=PermissionError("denied")):
    list(safe_walk(d, only_files=True))   # -> [] , no exception
```

Keeping the `try/except` would not help; nothing propagates for it to catch. Migrating would silently delete a user-facing error report.

**`api/routers/search.py` ×2 — #1675.** Both walks meter a `max_files` budget counted on *raw* entries, incremented before filtering. `safe_walk` pre-filters, so the same constant would bound a materially larger walk — loosening a DoS guard on a remote-reachable endpoint.

## How Has This Been Tested?

Two new files under `tests/security/`, written test-first, covering every migrated site on both axes (symlink escaping the root, hidden entries):

- `test_safe_walk_migration_batch1.py` — 9 tests, 6 failed before the change
- `test_safe_walk_migration_services_api.py` — 19 tests, 9 failed before the change

Plus characterization guards that must stay green: `include_hidden` threading in both `_collect_files`, non-recursive collection, plugin result ordering, find-still-finds-real-files, migration-still-copies-dotfiles, outlier-still-detected.

Full suite: **22,001 passed, 190 skipped**. Four failures (`cli_daemon`, `cli_main_commands`, `checkpoint`, `persistence` default-dir tests) are **pre-existing order-dependence** — verified by running the identical suite on a clean `origin/main` worktree, which produces the same four. They pass in isolation and touch nothing here.

`ruff check`, `ruff format`, `mypy`, `pre-commit` clean.

## Reviewer notes

**Three existing tests were silently defused by this migration and had to be rewritten.** They patched `Path.rglob` to simulate failures; `safe_walk` reads via `os.scandir`, so the patches stopped intercepting anything:

- `test_suggest_archive_os_error_during_scan` — would have kept passing while testing nothing. Confirmed by experiment: patching `rglob` had zero effect and the asserted `[]` came from the file simply not being old enough. Re-pointed at `os.scandir` with a stale-file control proving the unpatched run *does* produce a suggestion.
- `test_action_select_all_oserror` — same failure mode. Rewritten to pin the invariant that matters (an unreadable root selects nothing), with a control for the readable case. `_notify_selection` now fires with an empty result, which is harmless because `select_all` is additive (`set.update`).
- `test_audio_view_scan_success` / `_scan_extraction_exception` — stubbed `mock_dir.rglob`. Re-pointed at the module's `safe_walk` symbol.

Anyone touching #1674 or #1675 should expect the same trap; it is noted in both issues.

**One observability regression, affecting every migrated site.** Dead `except OSError` handlers were removed where `safe_walk` made them unreachable — including one in `suggest_archive` that logged `"Cannot scan directory %s"`. Unreadable subtrees are now skipped silently. This is not per-site and should not be fixed per-site; it belongs inside `safe_walk`, which is exactly what #1674 proposes.

**Stricter-than-before hidden filtering.** `safe_walk` excludes any path with a dot component *relative to the walked root*, not just a dot-prefixed leaf. Sites that previously used `name.startswith(".")` (`pattern_analyzer`, `misplacement_detector`) now also exclude visible files and directories nested under `.cache/` and similar. Tests pin this explicitly.

Suggested review order: `api/` and `plugins/api/` first — remote-reachable, and `endpoints.py` gains symlink filtering it never had.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved file and directory scanning to prevent traversal through symlinks outside the selected location.
  * Unreadable files and folders are handled safely without interrupting scans.
* **Bug Fixes**
  * Standardized hidden-file handling across file lists, searches, previews, organization, and analytics.
  * Preserved intentional inclusion of hidden files for migration and storage analysis.
* **Tests**
  * Added comprehensive coverage for symlink safety, hidden files, unreadable paths, and recursive scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->