### PR TITLE
fix(para): stop suggest_archive dividing by a non-positive inactive_days

### DIFF
--- a/src/file_organizer/methodologies/para/ai/file_mover.py
+++ b/src/file_organizer/methodologies/para/ai/file_mover.py
@@ -337,7 +337,11 @@ class PARAFileMover:
                 stat = file_path.stat()
                 days_inactive = (now - stat.st_mtime) / 86400.0
 
-                if days_inactive >= inactive_days:
+                # A non-positive threshold selects every file, including one
+                # whose mtime is in the future (clock skew, an archive extracted
+                # with a bogus timestamp): its negative days_inactive would fail
+                # the age comparison.
+                if inactive_days <= 0 or days_inactive >= inactive_days:
                     target_path = self._compute_target_path_for_category(
                         file_path,
                         PARACategory.ARCHIVE,
@@ -357,7 +361,9 @@ class PARAFileMover:
                             target_path=target_path,
                             confidence=confidence,
                             reasoning=[
-                                f"File has not been modified in {int(days_inactive)} days "
+                                # Clamped: a future mtime yields negative days,
+                                # which reads as nonsense in the reasoning.
+                                f"File has not been modified in {max(0, int(days_inactive))} days "
                                 f"(threshold: {inactive_days} days)",
                             ],
                         )

--- a/src/file_organizer/methodologies/para/ai/file_mover.py
+++ b/src/file_organizer/methodologies/para/ai/file_mover.py
@@ -307,7 +307,9 @@ class PARAFileMover:
         Args:
             directory: Directory to scan for inactive files.
             inactive_days: Number of days without modification to consider
-                a file inactive. Defaults to 180.
+                a file inactive. Defaults to 180. A value of 0 or less means
+                "archive everything regardless of age": every file matches
+                and is suggested at the maximum confidence of 0.95.
 
         Returns:
             List of MoveSuggestion objects for files that should be archived.
@@ -335,7 +337,13 @@ class PARAFileMover:
                         file_path,
                         PARACategory.ARCHIVE,
                     )
-                    confidence = min(0.95, 0.5 + (days_inactive / (inactive_days * 3)))
+                    # A non-positive threshold selects every file, so the age
+                    # ratio carries no signal: saturate instead of dividing by
+                    # zero (or by a negative, which would invert confidence).
+                    if inactive_days > 0:
+                        confidence = min(0.95, 0.5 + (days_inactive / (inactive_days * 3)))
+                    else:
+                        confidence = 0.95
 
                     suggestions.append(
                         MoveSuggestion(

--- a/tests/integration/test_para_file_mover.py
+++ b/tests/integration/test_para_file_mover.py
@@ -514,3 +514,24 @@ class TestPARAFileMover:
         assert suggestions[0].target_category == PARACategory.ARCHIVE
         # Age carries no signal at a non-positive threshold: confidence saturates.
         assert suggestions[0].confidence == pytest.approx(0.95)
+
+    def test_suggest_archive_zero_threshold_includes_future_dated_file(
+        self, tmp_path: Path
+    ) -> None:
+        """A future mtime does not escape the zero threshold."""
+        import os
+        import time
+
+        mover = _make_mover(tmp_path)
+
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        skewed = scan_dir / "clock_skew.txt"
+        skewed.write_text("stamped ahead of now")
+        future_mtime = time.time() + (30 * 86400)
+        os.utime(skewed, (future_mtime, future_mtime))
+
+        suggestions = mover.suggest_archive(scan_dir, inactive_days=0)
+
+        assert [s.file_path for s in suggestions] == [skewed]
+        assert "in 0 days" in suggestions[0].reasoning[0]

--- a/tests/integration/test_para_file_mover.py
+++ b/tests/integration/test_para_file_mover.py
@@ -497,3 +497,20 @@ class TestPARAFileMover:
         s = suggestions[0]
         assert len(s.reasoning) >= 1
         assert "days" in s.reasoning[0]
+
+    def test_suggest_archive_zero_threshold_archives_every_file(self, tmp_path: Path) -> None:
+        """inactive_days=0 means "archive everything" rather than dividing by zero."""
+        from file_organizer.methodologies.para.categories import PARACategory
+
+        mover = _make_mover(tmp_path)
+
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        (scan_dir / "fresh.md").write_text("written just now")
+
+        suggestions = mover.suggest_archive(scan_dir, inactive_days=0)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].target_category == PARACategory.ARCHIVE
+        # Age carries no signal at a non-positive threshold: confidence saturates.
+        assert suggestions[0].confidence == pytest.approx(0.95)

--- a/tests/methodologies/para/test_file_mover.py
+++ b/tests/methodologies/para/test_file_mover.py
@@ -492,6 +492,10 @@ class TestSuggestArchive:
         assert len(suggestions) >= 1
         assert any("days" in r for r in suggestions[0].reasoning)
 
+    # Marked ``ci`` so the PR suite (-m "ci and not benchmark") exercises the
+    # non-positive-threshold branch — that run generates the coverage.xml the
+    # diff-coverage gate reads.
+    @pytest.mark.ci
     def test_zero_inactive_days_archives_everything(
         self,
         mover: PARAFileMover,
@@ -512,6 +516,7 @@ class TestSuggestArchive:
         assert suggestions[0].target_category == PARACategory.ARCHIVE
         assert suggestions[0].confidence == pytest.approx(0.95)
 
+    @pytest.mark.ci
     def test_negative_inactive_days_archives_everything(
         self,
         mover: PARAFileMover,

--- a/tests/methodologies/para/test_file_mover.py
+++ b/tests/methodologies/para/test_file_mover.py
@@ -6,6 +6,7 @@ bulk organization, archive suggestions, and collision handling.
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -490,6 +491,48 @@ class TestSuggestArchive:
         suggestions = mover.suggest_archive(src, inactive_days=180)
         assert len(suggestions) >= 1
         assert any("days" in r for r in suggestions[0].reasoning)
+
+    def test_zero_inactive_days_archives_everything(
+        self,
+        mover: PARAFileMover,
+        tmp_path: Path,
+    ) -> None:
+        """inactive_days=0 archives every file at saturated confidence.
+
+        Regression: the confidence formula divided by ``inactive_days * 3``
+        and raised ZeroDivisionError for the "archive everything" threshold.
+        """
+        src = tmp_path / "everything"
+        src.mkdir()
+        (src / "brand_new.txt").write_text("fresh")
+
+        suggestions = mover.suggest_archive(src, inactive_days=0)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].target_category == PARACategory.ARCHIVE
+        assert suggestions[0].confidence == pytest.approx(0.95)
+
+    def test_negative_inactive_days_archives_everything(
+        self,
+        mover: PARAFileMover,
+        tmp_path: Path,
+    ) -> None:
+        """A negative threshold behaves like 0 rather than inverting confidence.
+
+        Regression: a negative divisor drove confidence below 0.0, which
+        MoveSuggestion rejects with ValueError.
+        """
+        src = tmp_path / "negative"
+        src.mkdir()
+        f = src / "ancient.txt"
+        f.write_text("old")
+        old_time = time.time() - (300 * 86400)
+        os.utime(f, (old_time, old_time))
+
+        suggestions = mover.suggest_archive(src, inactive_days=-1)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].confidence == pytest.approx(0.95)
 
 
 # =========================================================================

--- a/tests/methodologies/para/test_file_mover.py
+++ b/tests/methodologies/para/test_file_mover.py
@@ -539,6 +539,35 @@ class TestSuggestArchive:
         assert len(suggestions) == 1
         assert suggestions[0].confidence == pytest.approx(0.95)
 
+    @pytest.mark.ci
+    @pytest.mark.parametrize("threshold", [0, -1])
+    def test_future_mtime_still_archived_at_non_positive_threshold(
+        self,
+        mover: PARAFileMover,
+        tmp_path: Path,
+        threshold: int,
+    ) -> None:
+        """A future mtime does not escape a non-positive threshold.
+
+        Clock skew or an archive extracted with a bogus timestamp makes
+        days_inactive negative, which failed the ``>= inactive_days`` age
+        comparison and silently excluded the file despite "archive everything".
+        """
+        src = tmp_path / "future"
+        src.mkdir()
+        f = src / "tomorrow.txt"
+        f.write_text("dated ahead")
+        future_time = time.time() + (30 * 86400)
+        os.utime(f, (future_time, future_time))
+
+        suggestions = mover.suggest_archive(src, inactive_days=threshold)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].file_path == f
+        assert suggestions[0].confidence == pytest.approx(0.95)
+        # Negative day counts are clamped rather than surfaced as "-30 days".
+        assert "in 0 days" in suggestions[0].reasoning[0]
+
 
 # =========================================================================
 # Additional coverage tests


### PR DESCRIPTION
## Description

`PARAFileMover.suggest_archive` computed archive confidence as:

```python
confidence = min(0.95, 0.5 + (days_inactive / (inactive_days * 3)))
```

`inactive_days` is an unvalidated `int`, and `inactive_days=0` is a reasonable
caller intent — "archive everything regardless of age". It raised
`ZeroDivisionError: float division by zero`.

Negative thresholds were broken too, in a second way: `days_inactive >= inactive_days`
passes for every file, then the negative divisor drives confidence below zero and
`MoveSuggestion.__post_init__` rejects it
(`ValueError: confidence must be between 0.0 and 1.0, got -99.5` for a 300-day-old
file at `inactive_days=-1`).

**Fix:** saturate confidence at 0.95 when `inactive_days <= 0`. A non-positive
threshold selects every file, so the age ratio carries no signal; one branch covers
both failure modes without adding a new error path. The docstring now states that
`0` or less means "archive everything regardless of age" at maximum confidence.

**Why not reject `inactive_days < 1` with `ValueError`:** an existing test already
calls `suggest_archive(src, inactive_days=0)`
(`tests/methodologies/para/test_file_mover.py`, `test_file_stat_error`) and only
escapes the crash because it monkeypatches `stat` to raise. The suite already treats
`0` as a legitimate call, and saturating preserves the "archive everything" intent.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Two regression tests added to `TestSuggestArchive` in
      `tests/methodologies/para/test_file_mover.py`:
      `test_zero_inactive_days_archives_everything` and
      `test_negative_inactive_days_archives_everything`. Both were written first and
      confirmed failing against the previous code with exactly the two errors above.
- [x] `pytest tests/methodologies/para/ tests/integration/test_para_file_mover.py`
      — 702 passed.
- [x] `ruff check`, `ruff format --check`, `mypy` clean on both changed files.
- [x] `pre-commit run --files <both files>` — all hooks pass. `diff-cover` was
      skipped locally (it runs the full suite single-threaded and times out); both
      new branches are directly exercised by the tests above, and CI runs the gate.

## Notes for the reviewer

- **No production callers.** `suggest_archive` is referenced only inside its own
  module and in tests (grepped `.py`/`.md`/`.json`/`.yaml`/`.toml` repo-wide), so
  nothing currently passes a computed or user-supplied threshold. This is a public
  library API whose contract is now safe across the full `int` range.
- **The `safe_walk` migration has not landed for this file.** The scan on line ~323
  is still `directory.rglob("*")` on `main` (`f72ffd74`); `core.path_guard.safe_walk`
  adoption for the PARA movers is in flight in #1676. This change is independent of
  which scan API is used and should not conflict beyond trivial context.
- The reasoning string reads `File has not been modified in 0 days (threshold: 0 days)`
  at the saturated threshold, which seemed accurate enough to leave as-is.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstring `Args`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive suggestions now handle zero or negative inactivity thresholds correctly.
  * Files are selected for archiving with a confidence score of 0.95 when the threshold is non-positive.

* **Tests**
  * Added coverage for zero and negative inactivity thresholds, including integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->