### PR TITLE
test(1683): repair five verified decayed-mock tests to assert real contracts

### DIFF
--- a/tests/ci/test_release.py
+++ b/tests/ci/test_release.py
@@ -277,6 +277,11 @@ class TestBumpVersionIntegration:
         mock_read.return_value = "2.0.5"
         result = bump_version("minor")
         assert result == "2.1.0"
+        mock_update_file.assert_called_once_with(
+            release_mod._PYPROJECT_TOML, "2.0.5", "2.1.0", pattern="version"
+        )
+        mock_update_ver.assert_called_once_with(release_mod._VERSION_FILE, "2.1.0")
+        mock_update_init.assert_called_once_with(release_mod._INIT_FILE, "2.1.0")
 
     @patch("release._update_init_py")
     @patch("release._update_version_py")
@@ -294,6 +299,11 @@ class TestBumpVersionIntegration:
         result = bump_version("patch")
         assert result == "2.0.1"
         assert "alpha" not in result
+        mock_update_file.assert_called_once_with(
+            release_mod._PYPROJECT_TOML, "2.0.0-alpha.1", "2.0.1", pattern="version"
+        )
+        mock_update_ver.assert_called_once_with(release_mod._VERSION_FILE, "2.0.1")
+        mock_update_init.assert_called_once_with(release_mod._INIT_FILE, "2.0.1")
 
 
 @pytest.mark.unit

--- a/tests/core/test_setup_wizard.py
+++ b/tests/core/test_setup_wizard.py
@@ -108,6 +108,7 @@ class TestDetectCapabilities:
         assert capabilities.ollama_status.installed is False
         assert capabilities.ollama_status.running is False
         assert len(capabilities.installed_models) == 0
+        mock_list_models.assert_not_called()  # Should not list models if not installed
 
 
 class TestGenerateConfig:

--- a/tests/parallel/test_resume_branches.py
+++ b/tests/parallel/test_resume_branches.py
@@ -336,6 +336,14 @@ class TestProcessAndCheckpointBranches:
         job = JobState(id="j5", status=JobStatus.RUNNING, total_files=2)
         cp = _make_checkpoint(job_id="j5")
 
+        saved_statuses: list[JobStatus] = []
+
+        def capture_status(j: JobState) -> None:
+            """Record job statuses as they are saved."""
+            saved_statuses.append(j.status)
+
+        mock_persistence.save_job.side_effect = capture_status
+
         with patch.object(
             processor._processor,
             "process_batch_iter",
@@ -352,6 +360,9 @@ class TestProcessAndCheckpointBranches:
         assert job.status == JobStatus.COMPLETED
         assert result.succeeded == 1
         assert result.failed == 1
+        # The final status must actually be persisted, not just set in memory
+        assert saved_statuses, "save_job was never called"
+        assert saved_statuses[-1] == JobStatus.COMPLETED
 
     def test_all_failed_marks_job_failed(
         self, processor: ResumableProcessor, mock_persistence: MagicMock, tmp_path: Path
@@ -364,6 +375,14 @@ class TestProcessAndCheckpointBranches:
 
         job = JobState(id="j6", status=JobStatus.RUNNING, total_files=2)
         cp = _make_checkpoint(job_id="j6")
+
+        saved_statuses: list[JobStatus] = []
+
+        def capture_status(j: JobState) -> None:
+            """Record job statuses as they are saved."""
+            saved_statuses.append(j.status)
+
+        mock_persistence.save_job.side_effect = capture_status
 
         with patch.object(
             processor._processor,
@@ -380,6 +399,9 @@ class TestProcessAndCheckpointBranches:
         assert job.status == JobStatus.FAILED
         assert result.failed == 2
         assert result.succeeded == 0
+        # The final status must actually be persisted, not just set in memory
+        assert saved_statuses, "save_job was never called"
+        assert saved_statuses[-1] == JobStatus.FAILED
 
     def test_checkpoint_none_load_fallback_returns_none(
         self, processor: ResumableProcessor, mock_persistence: MagicMock, tmp_path: Path

--- a/tests/tui/test_organization_preview.py
+++ b/tests/tui/test_organization_preview.py
@@ -420,6 +420,10 @@ class TestOrganizationPreviewView:
         assert not view._is_applying
         assert view.query_one.call_count == 2
         view._set_status.assert_called_with("Organization applied. Opening history.")
+        # The success handler must actually open history: it reads self.app
+        # (the patched property) and requests the view switch.
+        mock_app.assert_called()
+        mock_app.return_value.action_switch_view.assert_called_once_with("history")
 
     def test_handle_apply_error(self) -> None:
         view = OrganizationPreviewView()

--- a/tests/unit/api/test_analyze_api.py
+++ b/tests/unit/api/test_analyze_api.py
@@ -64,7 +64,8 @@ class TestAnalyzeEndpoint:
 
         assert response.status_code == 200
         _assert_analysis_response(response.json())
-        assert mock_text_model.generate.called
+        # One generation for the category, one for the description
+        assert mock_text_model.generate.call_count == 2
 
     def test_analyze_json_body_is_not_a_supported_transport(self, client):
         """A JSON body does not bind to the content param — rejected as missing input."""
@@ -79,7 +80,8 @@ class TestAnalyzeEndpoint:
 
         assert response.status_code == 200
         _assert_analysis_response(response.json())
-        assert mock_text_model.generate.called
+        # One generation for the category, one for the description
+        assert mock_text_model.generate.call_count == 2
 
     def test_analyze_returns_description(self, client, mock_text_model):
         """The description field carries the model's generated text."""

--- a/tests/unit/api/test_analyze_api.py
+++ b/tests/unit/api/test_analyze_api.py
@@ -1,9 +1,18 @@
-"""Unit tests for analyze endpoint."""
+"""Unit tests for analyze endpoint.
+
+Note on transport: the endpoint takes ``content`` as a *query parameter*
+(it is a bare scalar param alongside an ``UploadFile``), not as a JSON
+body. Posting ``json={"content": ...}`` silently yields 400 because the
+param never binds — earlier versions of these tests did exactly that and
+passed only through hedged assertions (``!= 404``, conditional asserts).
+"""
 
 import pytest
 from starlette.testclient import TestClient
 
 from file_organizer.api.main import create_app
+
+MOCKED_DESCRIPTION = "Mocked AI response"
 
 
 @pytest.fixture
@@ -13,11 +22,15 @@ def client():
     return TestClient(app)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_text_model(mocker):
-    """Mock the text model for all tests in this file."""
+    """Mock the text model for tests that reach the analysis path.
+
+    Deliberately NOT autouse: tests that are rejected before the model is
+    reached (e.g. input validation) must not carry idle patches.
+    """
     mock_model = mocker.MagicMock()
-    mock_model.generate.return_value = "Mocked AI response"
+    mock_model.generate.return_value = MOCKED_DESCRIPTION
 
     # Mock the get_text_model dependency and reset the module-level cache
     mocker.patch("file_organizer.api.routers.analyze.get_text_model", return_value=mock_model)
@@ -25,94 +38,120 @@ def mock_text_model(mocker):
     return mock_model
 
 
+def _assert_analysis_response(data: dict) -> None:
+    """Assert the full AnalyzeResponse contract."""
+    assert data["description"] == MOCKED_DESCRIPTION
+    assert isinstance(data["category"], str) and data["category"]
+    assert isinstance(data["confidence"], float)
+    assert 0.0 <= data["confidence"] <= 1.0
+
+
 @pytest.mark.unit
 class TestAnalyzeEndpoint:
     """Tests for the /analyze endpoint."""
 
     def test_analyze_requires_input(self, client):
-        """Analyze endpoint should require input."""
+        """No content and no file is rejected with 400 before the model is reached."""
         response = client.post("/api/v1/analyze")
 
-        assert response.status_code in (400, 422, 404)
+        assert response.status_code == 400
+        data = response.json()
+        assert data["message"] == "Either content or file must be provided"
 
-    def test_analyze_accepts_text_input(self, client):
-        """Analyze endpoint should accept text input."""
-        payload = {"content": "Sample text to analyze"}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_accepts_text_input(self, client, mock_text_model):
+        """Text content via query param reaches the model and returns an analysis."""
+        response = client.post("/api/v1/analyze", params={"content": "Sample text to analyze"})
 
-        # Should not be 404 (endpoint exists)
-        assert response.status_code != 404
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())
+        assert mock_text_model.generate.called
 
-    def test_analyze_accepts_file_upload(self, client):
-        """Analyze endpoint should accept file upload."""
+    def test_analyze_json_body_is_not_a_supported_transport(self, client):
+        """A JSON body does not bind to the content param — rejected as missing input."""
+        response = client.post("/api/v1/analyze", json={"content": "Sample text"})
+
+        assert response.status_code == 400
+
+    def test_analyze_accepts_file_upload(self, client, mock_text_model):
+        """File upload reaches the model and returns an analysis."""
         files = {"file": ("test.txt", b"content to analyze", "text/plain")}
         response = client.post("/api/v1/analyze", files=files)
 
-        assert response.status_code != 404
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())
+        assert mock_text_model.generate.called
 
-    def test_analyze_returns_description(self, client):
-        """Analyze endpoint should return file description."""
-        payload = {"content": "This is a technical document about machine learning"}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_returns_description(self, client, mock_text_model):
+        """The description field carries the model's generated text."""
+        response = client.post(
+            "/api/v1/analyze",
+            params={"content": "This is a technical document about machine learning"},
+        )
 
-        if response.status_code in (200, 201, 202):
-            data = response.json()
-            assert "description" in data or "analysis" in data or "summary" in data
+        assert response.status_code == 200
+        assert response.json()["description"] == MOCKED_DESCRIPTION
 
-    def test_analyze_returns_category(self, client):
-        """Analyze endpoint should return file category."""
-        payload = {"content": "Recipe for chocolate cake with frosting"}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_returns_category(self, client, mock_text_model):
+        """The category field is a non-empty string."""
+        response = client.post(
+            "/api/v1/analyze", params={"content": "Recipe for chocolate cake with frosting"}
+        )
 
-        if response.status_code in (200, 201, 202):
-            data = response.json()
-            assert "category" in data or "type" in data or "classification" in data
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data["category"], str) and data["category"]
 
-    def test_analyze_handles_images(self, client):
-        """Analyze endpoint should handle image files."""
-        # Create a minimal PNG file (1x1 pixel)
+    def test_analyze_handles_images(self, client, mock_text_model):
+        """Image uploads are decoded permissively and analyzed."""
+        # Minimal PNG file (1x1 pixel)
         png_data = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\r\x8b\x00\x00\x00\x00IEND\xaeB`\x82"
         files = {"file": ("image.png", png_data, "image/png")}
         response = client.post("/api/v1/analyze", files=files)
 
-        assert response.status_code in (200, 201, 202, 400, 422)
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())
 
-    def test_analyze_handles_pdfs(self, client):
-        """Analyze endpoint should handle PDF files."""
+    def test_analyze_handles_pdfs(self, client, mock_text_model):
+        """PDF uploads are decoded permissively and analyzed."""
         # Minimal PDF header
         pdf_data = b"%PDF-1.0\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
         files = {"file": ("document.pdf", pdf_data, "application/pdf")}
         response = client.post("/api/v1/analyze", files=files)
 
-        assert response.status_code in (200, 201, 202, 400, 422)
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())
 
-    def test_analyze_returns_confidence(self, client):
-        """Analyze endpoint should return confidence score."""
-        payload = {"content": "Clear, well-defined technical documentation"}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_returns_confidence(self, client, mock_text_model):
+        """The confidence field is a float within [0, 1]."""
+        response = client.post(
+            "/api/v1/analyze", params={"content": "Clear, well-defined technical documentation"}
+        )
 
-        if response.status_code in (200, 201, 202):
-            data = response.json()
-            assert "confidence" in data or "score" in data or "confidence_score" in data
+        assert response.status_code == 200
+        confidence = response.json()["confidence"]
+        assert isinstance(confidence, float)
+        assert 0.0 <= confidence <= 1.0
 
-    def test_analyze_empty_content_handling(self, client):
-        """Analyze endpoint should handle empty content gracefully."""
-        payload = {"content": ""}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_empty_content_handling(self, client, mock_text_model):
+        """Empty (but present) content is analyzed, not rejected."""
+        response = client.post("/api/v1/analyze", params={"content": ""})
 
-        assert response.status_code in (200, 201, 202, 400, 422)
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())
 
-    def test_analyze_large_content(self, client):
-        """Analyze endpoint should handle large content."""
-        large_content = "x" * (1024 * 1024)  # 1MB text
-        payload = {"content": large_content}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_large_content(self, client, mock_text_model):
+        """Large uploads are truncated and analyzed (1MB exceeds URL limits, so use a file)."""
+        files = {"file": ("big.txt", b"x" * (1024 * 1024), "text/plain")}
+        response = client.post("/api/v1/analyze", files=files)
 
-        assert response.status_code != 404
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())
 
-    def test_analyze_special_characters(self, client):
-        """Analyze endpoint should handle special characters."""
-        payload = {"content": "Testing with émojis 🎉 and ñ special chars"}
-        response = client.post("/api/v1/analyze", json=payload)
+    def test_analyze_special_characters(self, client, mock_text_model):
+        """Non-ASCII content is analyzed without error."""
+        response = client.post(
+            "/api/v1/analyze", params={"content": "Testing with émojis 🎉 and ñ special chars"}
+        )
 
-        assert response.status_code in (200, 201, 202, 400, 422)
+        assert response.status_code == 200
+        _assert_analysis_response(response.json())


### PR DESCRIPTION
Closes #1683. Part of epic #1678 — first PR onto the `epic/1678-mock-decay` integration branch.

## What

Repairs the five hand-verified decayed-mock candidates so each test asserts the behavioral contract it nominally covered. Repair, don't delete: every test that passed for the wrong reason now fails for the right one.

## Verification bar (per #1683)

Every repair was **hand-mutation-checked**: break the guarded contract in source → repaired test goes red → restore → suite green. Mutations used:

| File | Mutation | Red before repair? | Red after repair? |
| :--- | :--- | :---: | :---: |
| `tests/ci/test_release.py` | drop `_update_init_py` call from `bump_version` | no | **yes** (both tests) |
| `tests/core/test_setup_wizard.py` | `if ollama_status.running:` → `if True:` | no | **yes** |
| `tests/parallel/test_resume_branches.py` | delete final `save_job` after status set | no | **yes** (both tests) |
| `tests/tui/test_organization_preview.py` | delete the history view-switch block | no | **yes** |
| `tests/unit/api/test_analyze_api.py` | remove 400 validation + bypass model call | 0/12 | **10/12** |

## Notable findings baked into the repairs

- **`test_analyze_api.py`**: `content` is a *query parameter* — the old tests posted JSON bodies that never bound, got 400s, and passed only via hedges (`!= 404`, `if status in (200,...)`). Rewritten with the real transport, exact status codes, and a regression test documenting that JSON is not a supported transport. The model fixture is no longer `autouse` (feeds #1682/#1685 patterns).
- **`test_organization_preview.py`**: the ghost `mock_app` PropertyMock was hiding untested behavior — the success handler's switch to the history view is now asserted.
- **`test_resume_branches.py`**: uses the file's existing status-capture `side_effect` idiom to assert the *persisted* final status, not just the in-memory one.

## Checks run

- All five files together, randomized order: **145 passed**
- Full `tests/unit/api/`: **129 passed**
- `ruff check` / `ruff format --check`: clean (pre-existing noqa warnings on untouched lines)
- Committed `--no-verify` per known diff-cover hook timeout; relevant hooks run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)