### PR TITLE
fix(api): stop SQLite lock contention breaking auth requests

### DIFF
--- a/src/file_organizer/api/auth_db.py
+++ b/src/file_organizer/api/auth_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from functools import cache
 
 from sqlalchemy.engine import Engine
@@ -35,6 +36,10 @@ def _ensure_default_auth_db_dir() -> None:
     get_config_dir().mkdir(parents=True, exist_ok=True)
 
 
+#: Serializes schema creation. See ``get_engine``.
+_SCHEMA_LOCK = threading.Lock()
+
+
 @cache
 def get_engine(db_path: str) -> Engine:
     """Return a cached SQLAlchemy engine for the auth database."""
@@ -49,7 +54,13 @@ def get_engine(db_path: str) -> Engine:
         pool_pre_ping=True,
         pool_recycle_seconds=1800,
     )
-    Base.metadata.create_all(engine)
+    # ``functools.cache`` memoizes the *result*, it does not serialize the
+    # call: every thread that arrives before the first one returns runs this
+    # body too. ``create_all(checkfirst=True)`` is a non-atomic
+    # check-then-CREATE, so unserialized first callers raced to CREATE TABLE
+    # against the same file and the losers got "table users already exists".
+    with _SCHEMA_LOCK:
+        Base.metadata.create_all(engine)
     return engine
 
 

--- a/src/file_organizer/api/database.py
+++ b/src/file_organizer/api/database.py
@@ -14,12 +14,18 @@ from __future__ import annotations
 from functools import lru_cache
 from re import compile as re_compile
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool, StaticPool
 
 _URL_SCHEME_RE = re_compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+
+#: How long a blocked SQLite statement waits for a lock before giving up.
+#: pysqlite defaults to 5 s, which a contended CI runner blows through: a
+#: schema read then dies with "database is locked" mid-request instead of
+#: waiting out the writer.
+SQLITE_BUSY_TIMEOUT_MS = 30_000
 
 
 def resolve_database_url(database: str) -> str:
@@ -65,6 +71,28 @@ def _is_sqlite_url(url: str) -> bool:
     return url.startswith("sqlite")
 
 
+def _apply_file_sqlite_pragmas(engine: Engine) -> None:
+    """Give a file-backed SQLite engine a usable lock timeout.
+
+    In SQLite's default rollback-journal mode a committing writer holds an
+    EXCLUSIVE lock that blocks readers too, and pysqlite gives up after 5 s.
+    That is short enough for a contended machine to blow through, so a
+    routine schema reflection (``PRAGMA main.table_info(...)``) failed
+    mid-request with "database is locked". Waiting longer is the fix: the
+    lock is held for milliseconds in the normal case.
+
+    Set per pooled connection, since ``busy_timeout`` is connection state.
+    """
+
+    @event.listens_for(engine, "connect")
+    def _set_pragmas(dbapi_connection, _connection_record) -> None:  # type: ignore[no-untyped-def]
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+        finally:
+            cursor.close()
+
+
 @lru_cache(maxsize=64)
 def get_engine(
     database: str,
@@ -94,7 +122,7 @@ def get_engine(
         )
 
     if _is_sqlite_url(url):
-        return create_engine(
+        engine = create_engine(
             url,
             connect_args={"check_same_thread": False},
             poolclass=QueuePool,
@@ -104,6 +132,10 @@ def get_engine(
             pool_recycle=max(1, pool_recycle_seconds),
             **base_kwargs,
         )
+        # File-backed only: ``:memory:`` is handled above and cannot contend
+        # with another process for a file lock.
+        _apply_file_sqlite_pragmas(engine)
+        return engine
 
     return create_engine(
         url,

--- a/tests/api/test_auth_db.py
+++ b/tests/api/test_auth_db.py
@@ -1,0 +1,79 @@
+"""Tests for file_organizer.api.auth_db."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect
+
+from file_organizer.api import auth_db, database
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Clear the engine/session caches on both layers around each test."""
+    caches = (
+        auth_db.get_engine,
+        auth_db.get_session_factory,
+        database.get_engine,
+        database.get_session_factory,
+    )
+    for cache in caches:
+        cache.cache_clear()
+    yield
+    for cache in caches:
+        cache.cache_clear()
+
+
+class TestGetEngineConcurrency:
+    """``get_engine`` runs ``create_all`` in its body, so it must serialize.
+
+    ``functools.cache`` guards the *result*, not the call: every thread that
+    arrives before the first one returns executes the body too. That let N
+    threads issue ``CREATE TABLE`` against the same file-backed SQLite DB,
+    which is the concurrent writer behind the Playwright
+    ``database is locked`` flake, and which fails outright as
+    ``table users already exists`` when the loser gets that far.
+    """
+
+    def test_concurrent_first_touch_does_not_race_on_ddl(self, tmp_path: Path) -> None:
+        db_path = str(tmp_path / "auth.db")
+        threads = 12
+        barrier = threading.Barrier(threads)
+        errors: list[BaseException] = []
+
+        def _first_touch(_: int) -> None:
+            barrier.wait(timeout=30)
+            try:
+                auth_db.get_engine(db_path)
+            except BaseException as exc:  # collecting every failure for the assertion
+                errors.append(exc)
+
+        with ThreadPoolExecutor(max_workers=threads) as pool:
+            list(pool.map(_first_touch, range(threads)))
+
+        assert not errors, f"{len(errors)}/{threads} concurrent callers failed: {errors[0]!r}"
+
+    def test_concurrent_first_touch_creates_schema(self, tmp_path: Path) -> None:
+        """Serializing must still leave a usable schema behind, not skip it."""
+        db_path = str(tmp_path / "auth.db")
+        threads = 8
+        barrier = threading.Barrier(threads)
+
+        def _first_touch(_: int) -> None:
+            barrier.wait(timeout=30)
+            auth_db.get_engine(db_path)
+
+        with ThreadPoolExecutor(max_workers=threads) as pool:
+            list(pool.map(_first_touch, range(threads)))
+
+        assert "users" in inspect(auth_db.get_engine(db_path)).get_table_names()
+
+    def test_engine_is_cached_per_path(self, tmp_path: Path) -> None:
+        db_path = str(tmp_path / "auth.db")
+        assert auth_db.get_engine(db_path) is auth_db.get_engine(db_path)

--- a/tests/api/test_database.py
+++ b/tests/api/test_database.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
 import pytest
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
 from file_organizer.api.database import (
+    SQLITE_BUSY_TIMEOUT_MS,
     create_session,
     get_engine,
     get_session_factory,
@@ -103,6 +109,94 @@ class TestGetEngine:
         engine = get_engine(":memory:", echo=True)
         assert engine.echo is True
         get_engine.cache_clear()
+
+
+class TestSqliteBusyTimeout:
+    """File-backed SQLite must wait for a lock instead of giving up.
+
+    Regression cover for the Playwright E2E flake where
+    ``POST /api/v1/auth/register`` died with
+    ``sqlite3.OperationalError: database is locked`` on
+    ``PRAGMA main.table_info("users")``: the reflection read was blocked by a
+    concurrent writer and hit pysqlite's 5 s default timeout.
+    """
+
+    def test_file_engine_sets_busy_timeout(self, tmp_path: Path) -> None:
+        engine = get_engine(str(tmp_path / "app.db"))
+        with engine.connect() as conn:
+            busy_ms = conn.exec_driver_sql("PRAGMA busy_timeout").scalar()
+        # Must exceed pysqlite's 5 s default, which the flake blew through.
+        assert int(busy_ms) > 5_000
+
+    def test_memory_engine_left_at_default(self) -> None:
+        """The pragma is for file-lock contention, which :memory: cannot have.
+
+        5000 ms is pysqlite's own default, from ``connect(timeout=5.0)`` -- the
+        very timeout the flake blew through on a file-backed database. Seeing it
+        here confirms the listener is file-only rather than global.
+        """
+        engine = get_engine(":memory:")
+        with engine.connect() as conn:
+            busy_ms = conn.exec_driver_sql("PRAGMA busy_timeout").scalar()
+        assert int(busy_ms) == 5_000
+        assert int(busy_ms) != SQLITE_BUSY_TIMEOUT_MS
+
+    def test_reader_waits_out_a_writer_past_the_default_timeout(self, tmp_path: Path) -> None:
+        """A schema read must survive a writer holding the lock over 5 s.
+
+        This is the exact CI failure: ``PRAGMA main.table_info(...)`` raising
+        "database is locked" after pysqlite's 5 s default. The read is still
+        blocked — rollback-journal mode blocks readers behind an EXCLUSIVE
+        lock — but it now waits for the writer rather than giving up.
+        """
+        db_path = tmp_path / "app.db"
+        engine = get_engine(str(db_path))
+        with engine.begin() as conn:
+            conn.exec_driver_sql("CREATE TABLE users (id INTEGER PRIMARY KEY)")
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def _hold_write_lock() -> None:
+            conn = sqlite3.connect(str(db_path), timeout=30.0, isolation_level=None)
+            try:
+                # EXCLUSIVE, not IMMEDIATE: a RESERVED lock never blocks readers,
+                # so IMMEDIATE would pass even in rollback-journal mode and prove
+                # nothing. EXCLUSIVE is what a committing writer holds.
+                conn.execute("BEGIN EXCLUSIVE")
+                conn.execute("INSERT INTO users (id) VALUES (1)")
+                holding.set()
+                release.wait(timeout=30)
+                conn.execute("COMMIT")
+            finally:
+                conn.close()
+
+        # Long enough to blow through pysqlite's 5 s default, short enough to
+        # stay well inside the configured timeout.
+        hold_seconds = 6.0
+
+        writer = threading.Thread(target=_hold_write_lock, daemon=True)
+        writer.start()
+        try:
+            assert holding.wait(timeout=10), "writer never acquired the lock"
+            timer = threading.Timer(hold_seconds, release.set)
+            timer.daemon = True
+            timer.start()
+            started = time.monotonic()
+            with engine.connect() as conn:
+                rows = conn.exec_driver_sql('PRAGMA main.table_info("users")').fetchall()
+            elapsed = time.monotonic() - started
+            timer.cancel()
+        finally:
+            release.set()
+            writer.join(timeout=30)
+
+        assert rows, "reflection returned no columns for the users table"
+        # It must have genuinely waited past the 5 s default rather than
+        # squeezing in early -- otherwise the test would pass without the
+        # pragma and prove nothing.
+        assert elapsed > 5.0, f"read completed in {elapsed:.1f}s, before the old timeout"
+        assert elapsed < SQLITE_BUSY_TIMEOUT_MS / 1000, "read consumed the whole timeout"
 
 
 class TestGetSessionFactory:


### PR DESCRIPTION
Fixes the recurring Playwright E2E flake where `tests/playwright/test_marketplace_lifecycle.py::test_install_uninstall_round_trip` errored at **setup**: the fixture's `POST /api/v1/auth/register` raised `sqlite3.OperationalError: database is locked` on `PRAGMA main.table_info("users")` and never answered, so the client hit its 60 s read timeout. Two reruns didn't shake it off. First seen on run 30185404416 (webkit).

Root cause turned out to be **two independent defects**, both reproduced deterministically against unmodified code before anything was changed.

## 1. Lock timeout too short for a contended machine

File-backed engines relied on pysqlite's 5 s default. In SQLite's default rollback-journal mode a committing writer holds an EXCLUSIVE lock that blocks **readers** too — so a routine schema reflection gave up mid-request instead of waiting out a lock normally held for milliseconds.

Reproduced exactly, no app changes, just holding a write lock for 6 s:

```
FAILED after 5.3s (lock held 6.0s)
  OperationalError: (sqlite3.OperationalError) database is locked
  [SQL: PRAGMA main.table_info("users")]
```

Same statement, same error as CI; the 5.3 s is the default timing out.

**Fix:** `PRAGMA busy_timeout=30000` per connection, file-backed SQLite only (`:memory:` untouched — it has no file lock to contend for).

## 2. `create_all` racing inside a `@cache`d function

`auth_db.get_engine` runs `Base.metadata.create_all` in its body. `functools.cache` memoizes the *result*, not the *call* — every thread arriving before the first returns runs the body too. `create_all(checkfirst=True)` is a non-atomic check-then-CREATE, so concurrent first callers raced:

```
threads=12 rounds=15 failing_rounds=15/15
  round 0: 5/12 -> OperationalError: table users already exists
```

Deterministic, and a live defect in its own right — this is *also* the concurrent writer behind defect #1. Fix #1 alone did **not** resolve it.

**Fix:** serialize schema creation so the check-then-CREATE is atomic.

## Deliberately not changed

- **`journal_mode`.** WAL would stop readers blocking on writers entirely, but it isn't needed for either defect — verified: `busy_timeout` alone survives the 6 s lock — and it rewrites the on-disk format of existing user databases irreversibly, adding `-wal`/`-shm` sidecars any external backup step would need to know about. Too big a call to ride along on a flake fix; it deserves its own change decided on its own merits.
- **Client timeout and rerun count.** They masked this; they didn't cause it.
- **Session handling** — already correct, `get_db` closes in a `finally`.
- **Per-worker DB files** — already in place via `tmp_path_factory`.

Net diff is ~15 lines of source across two files.

## Verification

| Check | Result |
|---|---|
| 4 new regression tests | fail with either fix disabled, pass with both |
| Both standalone repro scripts | deterministic failure → clean |
| Full Playwright suite, randomized order | green ×6 (52 tests) |
| `tests/api` + `tests/web` + `tests/integration` | 8,357 passed, 6 skipped |
| `pre-commit run --all-files` | clean |

The regression tests assert the mechanism, not just the outcome. `test_reader_waits_out_a_writer_past_the_default_timeout` reproduces the CI error in-suite and asserts the read took **longer than 5 s** — if it completed sooner it never actually crossed the old timeout, and would pass without the fix. It uses `BEGIN EXCLUSIVE` on purpose: `BEGIN IMMEDIATE` only takes a RESERVED lock, which never blocks readers, so an earlier draft of this test passed pre-fix and proved nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes or threads initialize the database simultaneously.
  * Reduced SQLite lock-related failures by allowing file-backed databases to wait longer for busy connections.
  * Preserved existing in-memory database timeout behavior.

* **Tests**
  * Added coverage for concurrent database initialization, schema creation, engine caching, and SQLite lock handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->