### PR TITLE
fix(1678): correct the liveness plugin's xdist detection; document a blind spot

### DIFF
--- a/tests/_plugins/patch_liveness.py
+++ b/tests/_plugins/patch_liveness.py
@@ -51,6 +51,7 @@ _state: dict[str, Any] = {
     "current": None,  # (nodeid, file, line) of the running test
     "records": [],
     "findings": [],
+    "worker": None,  # xdist worker id, from pytest config (never the env)
 }
 
 
@@ -97,6 +98,11 @@ def pytest_configure(config: pytest.Config) -> None:
     if _state["enabled"]:  # already installed (defensive: nested sessions)
         return
     _state["enabled"] = True
+    # Ask pytest, not the environment, whether this session is an xdist
+    # worker. ``PYTEST_XDIST_WORKER`` is inherited by any subprocess a test
+    # spawns, so a nested session would otherwise believe it is a worker and
+    # write its report to a suffixed path nobody reads.
+    _state["worker"] = getattr(config, "workerinput", {}).get("workerid")
     _state["orig_enter"] = _MockPatch.__enter__
     _MockPatch.__enter__ = _tracking_enter
 
@@ -107,6 +113,7 @@ def pytest_unconfigure(config: pytest.Config) -> None:
         _MockPatch.__enter__ = _state["orig_enter"]
         _state["enabled"] = False
         _state["orig_enter"] = None
+        _state["worker"] = None
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:
@@ -146,7 +153,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if not _state["enabled"] or not _state["findings"]:
         return
     path = os.environ[ENV_VAR]
-    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    worker = _state["worker"]
     if worker:
         path = f"{path}.{worker}"
     with open(path, "a", encoding="utf-8") as fh:

--- a/tests/unit/plugins/test_patch_liveness.py
+++ b/tests/unit/plugins/test_patch_liveness.py
@@ -103,6 +103,41 @@ class TestClassifyMock:
 
 
 @pytest.mark.unit
+class TestClassifyMockKnownLimitations:
+    """Documented blind spots in access counting.
+
+    These are not aspirations — they are the current, verified behaviour.
+    They exist because ``classify_mock`` infers access from ``mock_calls``
+    and ``_mock_children``, both of which are populated by ``__getattr__``
+    and ``__call__``. An attribute the *test* assigns lands in the mock's
+    ``__dict__``, so a later read by the code under test goes straight there
+    and is never observed.
+    """
+
+    def test_preset_attribute_read_is_misreported_as_dead(self) -> None:
+        """FALSE NEGATIVE: ``mock.attr = v`` then a read reports dead.
+
+        This is the ``mock_sys.platform = "darwin"`` shape, which is common,
+        so a share of "dead" findings are patches that are genuinely load
+        bearing. Triage must probe before treating such a row as decay.
+        """
+        mock = MagicMock()
+        mock.ITEM_DOCUMENT = 9  # the test pre-sets it
+        assert mock.ITEM_DOCUMENT == 9  # the code under test reads it
+
+        assert classify_mock(mock) == ("dead", 0)
+
+    def test_attribute_read_without_preset_is_live(self) -> None:
+        """The same read IS observed when the test does not pre-set it."""
+        mock = MagicMock()
+        _ = mock.SOME_CONSTANT
+
+        status, count = classify_mock(mock)
+        assert status == "live"
+        assert count == 1
+
+
+@pytest.mark.unit
 class TestReportFlow:
     """End-to-end: hooks record dead patches and write the JSONL report."""
 
@@ -165,6 +200,47 @@ class TestReportFlow:
 
         # The live patch must not be reported at all
         assert not any("test_live_patch" in e["nodeid"] for e in entries)
+
+    def test_inherited_worker_env_does_not_suffix_the_report(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A nested session must not be mistaken for an xdist worker.
+
+        ``PYTEST_XDIST_WORKER`` is inherited by every subprocess a test
+        spawns. The plugin used to read it at sessionfinish, so whenever the
+        outer suite ran under xdist this nested session wrote its report to
+        ``<path>.gwN`` and the caller — which only knows ``<path>`` — saw
+        nothing. The worker id must come from pytest's own config instead.
+        """
+        self._install_plugin(pytester)
+        pytester.makepyfile(
+            target_mod="""
+            def helper():
+                return "real"
+
+            def entry():
+                return "no helper call"
+            """,
+            test_sample="""
+            from unittest.mock import patch
+            import target_mod
+
+            @patch("target_mod.helper")
+            def test_dead_patch(mock_helper):
+                assert target_mod.entry() == "no helper call"
+            """,
+        )
+        report = pytester.path / "liveness.jsonl"
+        monkeypatch.setenv(ENV_VAR, str(report))
+        # Pretend an xdist worker spawned us, which is exactly what happens
+        # when the outer suite runs with -n auto.
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw7")
+
+        result = pytester.runpytest_subprocess("-p", "no:randomly")
+        result.assert_outcomes(passed=1)
+
+        assert report.exists(), "report went to a worker-suffixed path"
+        assert not (pytester.path / "liveness.jsonl.gw7").exists()
 
     def test_disabled_without_env_var(
         self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Part of #1678. Fixes the detector this epic depends on, before the wave-4 enforcement flip leans on its output.

## 1. Real bug — nested sessions were mistaken for xdist workers

`pytest_sessionfinish` decided whether the session was an xdist worker by reading **`PYTEST_XDIST_WORKER` from the environment**. That variable is inherited by every subprocess a test spawns, so any nested pytest session believed it was a worker and wrote its report to `<path>.gwN` while the caller watched `<path>`.

This is why `test_patch_liveness.py`'s two report-flow tests failed whenever the suite ran under `-n auto` — and why they passed in isolation, which is what made them look like flakes. Confirmed by finding the stray artifact:

```
.../popen-gw14/test_dead_patch_is_reported_and_suite_stays_green0/liveness.jsonl.gw14
```

**Fix:** take the worker id from pytest's own `config.workerinput`, captured at configure time. Real workers still suffix (verified — a `-n 2` run produces `.gw0`/`.gw1`); nested sessions no longer do.

Added a regression test that sets `PYTEST_XDIST_WORKER` explicitly and asserts the unsuffixed path is written. It fails with the fix reverted.

| | |
|---|---|
| `tests/unit` + `tests/cli` under `-n auto`, before | 2 failed, 1,664 passed |
| after | **1,669 passed** |

## 2. Documented blind spot — not fixed here

`classify_mock` infers access from `mock_calls` and `_mock_children`, both populated via `__getattr__`/`__call__`. An attribute the **test** assigns lands in the mock's `__dict__`, so a later read by the code under test is never observed:

| Interaction | Classified |
|---|---|
| `mock.attr = 9`, then code reads `mock.attr` | **`("dead", 0)`** ← false negative |
| code reads `mock.attr` never pre-set | `("live", 1)` |
| code calls the mock | `("live", n)` |

That is the `mock_sys.platform = "darwin"` shape — common enough that **a share of "dead" findings are patches that are genuinely load-bearing**. `test_read_ebook_file_max_chars` is a confirmed instance: I proved the patch live during wave-B triage by swapping in a sentinel value, and the test still passed.

Pinned as two characterisation tests so the limitation is tracked rather than rediscovered.

**Why not fix it here:** doing so means instrumenting attribute reads — a Mock subclass recording `__getattribute__` — which changes the plugin's design and would re-baseline every wave's row counts. That deserves its own decision, and it should be made before enforcement depends on these counts.

## Consequence for the epic

Wave B triage found roughly half its rows were already-asserted intentional suppressors, plus two confirmed false negatives. Combined with the blind spot above, **raw row counts are not a sound basis for the enforcement flip** — the curated allowlist is.

Verified: `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)