### PR TITLE
fix(1677): remove three flake mechanisms; widen two timing margins

### DIFF
--- a/tests/integration/test_services_coverage.py
+++ b/tests/integration/test_services_coverage.py
@@ -43,6 +43,7 @@ from file_organizer.services.audio.transcriber import (
 from file_organizer.services.audio.transcriber import (
     TranscriptionOptions as ServiceTranscriptionOptions,
 )
+from file_organizer.services.deduplication import embedder as _embedder_mod
 from file_organizer.services.deduplication.embedder import DocumentEmbedder
 from file_organizer.services.video.scene_detector import (
     DetectionMethod,
@@ -864,7 +865,7 @@ class TestDocumentEmbedder:
         assert emb1.shape == (5,)
 
         # Cache hit
-        with patch("logging.Logger.debug") as mock_debug:
+        with patch.object(_embedder_mod.logger, "debug") as mock_debug:
             emb2 = embedder.transform(doc)
             assert np.array_equal(emb1, emb2)
             # Verify cache hit log message
@@ -970,20 +971,20 @@ class TestDocumentEmbedder:
 
         # 4. save_model on unfitted vectorizer
         unfitted = DocumentEmbedder(max_features=5)
-        with patch("logging.Logger.warning") as mock_warn:
+        with patch.object(_embedder_mod.logger, "warning") as mock_warn:
             unfitted.save_model(tmp_path / "unfitted.pkl")
             mock_warn.assert_called_with("Cannot save unfitted vectorizer")
 
         # 5. save_model raising pickling errors
         embedder.is_fitted = True
         with patch("builtins.open", side_effect=OSError("Save failed")):
-            with patch("logging.Logger.error") as mock_err:
+            with patch.object(_embedder_mod.logger, "error") as mock_err:
                 embedder.save_model(tmp_path / "fail.pkl")
                 mock_err.assert_called_once()
 
         # 6. load_model raising unpickling errors
         with patch("builtins.open", side_effect=OSError("Load failed")):
-            with patch("logging.Logger.error") as mock_err:
+            with patch.object(_embedder_mod.logger, "error") as mock_err:
                 with pytest.raises(OSError, match="Load failed"):
                     embedder.load_model(tmp_path / "fail.pkl")
                 mock_err.assert_called_once()
@@ -995,14 +996,14 @@ class TestDocumentEmbedder:
         # 8. _save_cache raising pickling errors
         embedder.cache_path = tmp_path / "cache_fail.pkl"
         with patch("builtins.open", side_effect=OSError("Cache save failed")):
-            with patch("logging.Logger.error") as mock_err:
+            with patch.object(_embedder_mod.logger, "error") as mock_err:
                 embedder._save_cache()
                 mock_err.assert_called_once()
 
         # 9. _load_cache raising unpickling errors
         embedder.cache_path = tmp_path / "cache_fail.pkl"
         embedder.cache_path.write_bytes(b"corrupted pickle data")
-        with patch("logging.Logger.error") as mock_err:
+        with patch.object(_embedder_mod.logger, "error") as mock_err:
             embedder._load_cache()
             mock_err.assert_called_once()
 

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -285,21 +285,28 @@ class TestConcurrencyFixes(unittest.TestCase):
         measure *continuous no-progress* time — reset on every healthy
         completion — so it does NOT fire here and ALL files complete.
         """
-        timeout = 0.2
+        # Two constraints shape these numbers:
+        #   1. total drain time must exceed 2 x timeout, or the scenario the
+        #      test exists for (a queued file aging past the guard while the
+        #      pool progresses) never arises: n * work > 2 * timeout.
+        #   2. each task must stay comfortably under timeout on a loaded CI
+        #      runner, or a healthy task is misread as a hung one.
+        # The original 6 tasks at 0.5 x timeout satisfied (1) with only a 2x
+        # margin on (2), and a 2x slowdown is routine on shared runners — this
+        # test failed that way on macOS/py3.12 CI. More tasks buy margin:
+        # 20 x 0.2 = 4 x timeout for (1), while leaving a 5x margin on (2).
+        timeout = 0.5
+        work_time = timeout * 0.2
         config = ParallelConfig(
             max_workers=1,
             timeout_per_file=timeout,
             retry_count=0,
         )
         processor = ParallelProcessor(config=config)
-        # Six files drained one-at-a-time: total ≈ 6 x 0.1s = 0.6s. Without the
-        # per-completion reset, the last queued file would age well past
-        # 2xtimeout (0.4s) and false-trip saturation before it ever runs.
-        paths = [Path(f"slow_progress_{i}") for i in range(6)]
+        paths = [Path(f"slow_progress_{i}") for i in range(20)]
 
         def slow_but_completes(_path: Path) -> str:
-            # Completes in ~half the timeout, so each task is healthy.
-            threading.Event().wait(timeout=timeout * 0.5)
+            threading.Event().wait(timeout=work_time)
             return "ok"
 
         results = processor.process_batch(paths, slow_but_completes)

--- a/tests/pipeline/test_prefetch.py
+++ b/tests/pipeline/test_prefetch.py
@@ -134,20 +134,27 @@ class TestPrefetchPerformance:
         files: list[Path],
         io_delay: float,
         compute_delay: float,
-        iterations: int = 7,
+        iterations: int = 8,
     ) -> tuple[float, float]:
         """Median time for depth=0 and depth=2, sampled interleaved.
 
-        Timing all baseline runs and then all prefetch runs biases the ratio
-        by whatever the machine was doing between the two blocks — a CI
-        runner that gets busier mid-test makes prefetch look slower than it
-        is. Alternating the two configurations exposes both to the same
-        drift, which is what this comparison needs to mean anything.
+        Two biases to remove, not one:
+
+        - Timing all baseline runs and then all prefetch runs lets drift
+          between the two blocks drive the ratio — a runner that gets busier
+          mid-test makes prefetch look slower than it is. Hence pairing.
+        - Within a pair, always running depth=0 first hands depth=2 a warm
+          page cache every single time, which flatters prefetch. Seven
+          medians do not cancel a systematic order bias. Hence alternating,
+          over an even iteration count so each order runs equally often.
         """
         baseline: list[float] = []
         prefetched: list[float] = []
-        for _ in range(iterations):
-            for depth, bucket in ((0, baseline), (2, prefetched)):
+        for iteration in range(iterations):
+            runs = ((0, baseline), (2, prefetched))
+            if iteration % 2:
+                runs = ((2, prefetched), (0, baseline))
+            for depth, bucket in runs:
                 orchestrator = PipelineOrchestrator(
                     stages=[
                         _SlowIOStage(delay_s=io_delay),

--- a/tests/pipeline/test_prefetch.py
+++ b/tests/pipeline/test_prefetch.py
@@ -129,28 +129,37 @@ def _make_files(tmp_path: Path, count: int, size_bytes: int, seed: int = 42) -> 
 class TestPrefetchPerformance:
     """Verify prefetch gives >= 20% wall-clock speedup on a 10-file batch."""
 
-    def _median_batch_time(
+    def _paired_medians(
         self,
         files: list[Path],
-        prefetch_depth: int,
         io_delay: float,
         compute_delay: float,
-        iterations: int = 5,
-    ) -> float:
-        times: list[float] = []
+        iterations: int = 7,
+    ) -> tuple[float, float]:
+        """Median time for depth=0 and depth=2, sampled interleaved.
+
+        Timing all baseline runs and then all prefetch runs biases the ratio
+        by whatever the machine was doing between the two blocks — a CI
+        runner that gets busier mid-test makes prefetch look slower than it
+        is. Alternating the two configurations exposes both to the same
+        drift, which is what this comparison needs to mean anything.
+        """
+        baseline: list[float] = []
+        prefetched: list[float] = []
         for _ in range(iterations):
-            orchestrator = PipelineOrchestrator(
-                stages=[
-                    _SlowIOStage(delay_s=io_delay),
-                    _SlowComputeStage(delay_s=compute_delay),
-                ],
-                prefetch_depth=prefetch_depth,
-                prefetch_stages=1,
-            )
-            t0 = time.monotonic()
-            orchestrator.process_batch(files)
-            times.append(time.monotonic() - t0)
-        return statistics.median(times)
+            for depth, bucket in ((0, baseline), (2, prefetched)):
+                orchestrator = PipelineOrchestrator(
+                    stages=[
+                        _SlowIOStage(delay_s=io_delay),
+                        _SlowComputeStage(delay_s=compute_delay),
+                    ],
+                    prefetch_depth=depth,
+                    prefetch_stages=1,
+                )
+                t0 = time.monotonic()
+                orchestrator.process_batch(files)
+                bucket.append(time.monotonic() - t0)
+        return statistics.median(baseline), statistics.median(prefetched)
 
     def test_prefetch_faster_than_sequential(self, tmp_path: Path) -> None:
         """Prefetch depth=2 must be >= 20% faster than no-prefetch baseline.
@@ -165,11 +174,8 @@ class TestPrefetchPerformance:
         io_delay = 0.015  # 15 ms  — simulates file-read latency
         compute_delay = 0.04  # 40 ms  — simulates LLM inference
 
-        baseline = self._median_batch_time(
-            files, prefetch_depth=0, io_delay=io_delay, compute_delay=compute_delay
-        )
-        with_prefetch = self._median_batch_time(
-            files, prefetch_depth=2, io_delay=io_delay, compute_delay=compute_delay
+        baseline, with_prefetch = self._paired_medians(
+            files, io_delay=io_delay, compute_delay=compute_delay
         )
 
         speedup = (baseline - with_prefetch) / baseline

--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -523,9 +523,14 @@ class TestWriterStage:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Verify that when sys.platform is mocked as win32, the writer falls back to shutil.copy2."""
-        import sys
+        from types import SimpleNamespace
 
-        monkeypatch.setattr(sys, "platform", "win32")
+        from file_organizer.utils import safe_copy as _safe_copy
+
+        # Scope the fake to the module that branches on it. Patching the real
+        # sys.platform is process-wide and makes any first-import during the
+        # window take a Windows path it cannot survive off Windows.
+        monkeypatch.setattr(_safe_copy, "sys", SimpleNamespace(platform="win32"))
 
         src = tmp_path / "src.txt"
         src.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/services/deduplication/test_dedup_extractor_safedir.py
+++ b/tests/services/deduplication/test_dedup_extractor_safedir.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import sys
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -113,7 +114,13 @@ class TestAnchoredScanRoot:
         enforced on every platform (#1269)."""
         import file_organizer.services.deduplication.extractor as ext
 
-        monkeypatch.setattr(ext.sys, "platform", "win32")
+        # Give the module its own sys stand-in. ``ext.sys`` IS the real sys
+        # module, so setattr on it fakes the platform process-wide: anything
+        # first-importing during the window sees the lie. pydub.utils calls
+        # shutil.which("ffmpeg") at import, and shutil.which's win32 branch
+        # dereferences _winapi, which is None off Windows — an AttributeError
+        # whose appearance depends purely on which tests imported pydub first.
+        monkeypatch.setattr(ext, "sys", SimpleNamespace(platform="win32"))
 
         root = tmp_path / "root"
         root.mkdir()
@@ -148,7 +155,13 @@ class TestAnchoredScanRoot:
         except OSError:
             pytest.skip("symlink creation not supported")
 
-        monkeypatch.setattr(ext.sys, "platform", "win32")
+        # Give the module its own sys stand-in. ``ext.sys`` IS the real sys
+        # module, so setattr on it fakes the platform process-wide: anything
+        # first-importing during the window sees the lie. pydub.utils calls
+        # shutil.which("ffmpeg") at import, and shutil.which's win32 branch
+        # dereferences _winapi, which is None off Windows — an AttributeError
+        # whose appearance depends purely on which tests imported pydub first.
+        monkeypatch.setattr(ext, "sys", SimpleNamespace(platform="win32"))
         victim = root / "link" / "doc.txt"
         # Lexically victim is under root, but it resolves outside → refused ("").
         assert DocumentExtractor().extract_text(victim, scan_root=root) == ""

--- a/tests/tui/test_settings_view.py
+++ b/tests/tui/test_settings_view.py
@@ -84,7 +84,11 @@ with patch("os.cpu_count", return_value=None):
     importlib.reload(settings_view_module)
     settings = settings_view_module.load_parallel_runtime_settings(manager=mock_manager)
 
-    print(f"{settings.max_workers},{settings.prefetch_depth}")
+    # Sentinel-prefixed: the subprocess imports the whole package, and
+    # libraries print to stdout on import (PyMuPDF emits a `fitz` deprecation
+    # notice, which broke an exact-match assertion here on py3.14). Assert on
+    # our own marked line rather than on the entire shared stream.
+    print(f"PARALLEL_SETTINGS:{settings.max_workers},{settings.prefetch_depth}")
 """
     src_root = Path(__file__).resolve().parents[2] / "src"
     existing_pythonpath = os.environ.get("PYTHONPATH", "")
@@ -100,7 +104,12 @@ with patch("os.cpu_count", return_value=None):
         text=True,
     )
 
-    assert result.stdout.strip() == "1,3"
+    marked = [
+        line.partition(":")[2]
+        for line in result.stdout.splitlines()
+        if line.startswith("PARALLEL_SETTINGS:")
+    ]
+    assert marked == ["1,3"], f"stdout was: {result.stdout!r}"
 
 
 def test_save_parallel_runtime_settings_persists_values() -> None:


### PR DESCRIPTION
Part of #1677. All the flakes seen on `main` at `75c0c91b` in one PR.

**These do not surface on a developer machine** — they are CI-runner and Python-version dependent. So the evidence differs per fix, and this table says which is which rather than blurring them together.

| # | Flake | Evidence |
|---|---|---|
| 1 | global `sys.platform` mutation | **Reproduced here; fix verified** |
| 2 | global `logging.Logger.error` patch | Mechanism reproduced by injection; py3.14 trigger not |
| 3 | 0.2 s concurrency deadline | **Reasoned only** — not reproduced |
| 4 | prefetch speedup comparison | **Reasoned only** — not reproduced |

## 1. Global `sys.platform` mutation — reproduced

`monkeypatch.setattr(ext.sys, "platform", "win32")` mutates the **real `sys` module process-wide**; `ext.sys` *is* `sys`. Anything first-imported inside that window sees the lie — and `pydub.utils` calls `shutil.which("ffmpeg")` at import, whose win32 branch dereferences `_winapi`, `None` off Windows:

```
AttributeError: 'NoneType' object has no attribute 'NeedCurrentDirectoryForExePath'
```

Whether pydub was already imported depends on which files ran first in that worker — that is the order dependence.

This one **did** reproduce locally: running `tests/desktop`, `tests/methodologies`, `tests/services/deduplication` and `test_deduplication_core.py` together failed 2 tests every time. Each patch is now scoped to the module that branches on it (`extractor`, `safe_copy`), and the same command passes twice.

Three sites; these were the only global platform mutations in the suite.

## 2. Global `logging.Logger.error` patch — mechanism reproduced

Patching the **`Logger` class** intercepts every logger in the process, so an unrelated error log inside the window inflates the count (`Called 2 times` on py3.14). Six sites scoped to the module's own logger.

Injecting an unrelated error log *inside* the window: **fails with the global patch, passes with the scoped one.** py3.14's specific second log is not reproduced here.

## 3. Concurrency deadline — reasoned, not reproduced

Each task slept `0.5 × timeout`, so only a **2× slowdown** fails it — routine on a shared runner. The scenario requires total drain > 2×timeout, which caps headroom at 3× with 6 tasks, so more margin means more tasks: **20 tasks at 0.2 × timeout** keeps 4×timeout of drain while leaving a **5× margin**.

**Worth knowing:** mutating away the per-completion saturation reset that this test documents leaves it **green** — with both old and new parameters. The test does not guard the contract in its docstring. Widening did not neuter it; it was already toothless for that mutation. Not fixed here — that is #1288's contract, not a flake.

## 4. Prefetch speedup — reasoned, not reproduced

The test timed **all baseline runs, then all prefetch runs**, and compared medians. Load drift between the two blocks biases the ratio directly. Now interleaved so both configurations see the same drift, 7 pairs instead of 5+5. Dead `_median_batch_time` helper removed.

## Not changed

Two further one-off failures this session — `test_executable_plan_review_regressions` and `test_checkpoint::test_default_dir` — did not reappear across repeated full-suite runs and have no identified mechanism. Nothing is changed for them rather than guessing.

## Verification

- `pipeline`, `parallel`, `deduplication`, `services_coverage` green — 1,332 passed
- Previously-reliable 4-directory reproduction now passes twice
- `pre-commit run --all-files` clean

For 3 and 4 the real test is CI over the next few nightly runs, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for logging, concurrency, performance timing, and simulated Windows behavior.
  * Isolated platform-specific test patches to prevent unintended system-wide changes.
  * Updated subprocess output checks to ignore unrelated startup messages.
  * Refined prefetch performance comparisons using paired timing runs and median results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->