### PR TITLE
feat(1721): rail flagging test assertions over process-global channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -238,6 +238,20 @@ repos:
       # static backlog reached zero), so this hook is the fast path rather
       # than the only gate.
       # ----------------------------------------------------------------
+      # ----------------------------------------------------------------
+      # global-state-assertion (#1721) — commit-time, diff-scoped.
+      # Catches a new assertion over sys.platform, the logging.Logger class,
+      # or a whole captured stream on the lines being committed, before the
+      # full-tree rail sees it in CI. These flakes never reproduce locally,
+      # so the commit-time catch is worth more here than usual.
+      # ----------------------------------------------------------------
+      - id: global-state-assertion
+        name: global-state assertion (changed lines)
+        entry: python scripts/ci/guardrails/check_global_state_assertions.py --changed-only
+        language: system
+        files: ^tests/.*test_.*\.py$
+        pass_filenames: true
+
       - id: unused-patch-argument
         name: unused @patch argument (changed lines)
         entry: python scripts/ci/guardrails/check_unused_patch_argument.py --changed-only

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -238,6 +238,13 @@ repos:
       # static backlog reached zero), so this hook is the fast path rather
       # than the only gate.
       # ----------------------------------------------------------------
+      - id: unused-patch-argument
+        name: unused @patch argument (changed lines)
+        entry: python scripts/ci/guardrails/check_unused_patch_argument.py --changed-only
+        language: system
+        files: ^tests/.*test_.*\.py$
+        pass_filenames: true
+
       # ----------------------------------------------------------------
       # global-state-assertion (#1721) — commit-time, diff-scoped.
       # Catches a new assertion over sys.platform, the logging.Logger class,
@@ -248,13 +255,6 @@ repos:
       - id: global-state-assertion
         name: global-state assertion (changed lines)
         entry: python scripts/ci/guardrails/check_global_state_assertions.py --changed-only
-        language: system
-        files: ^tests/.*test_.*\.py$
-        pass_filenames: true
-
-      - id: unused-patch-argument
-        name: unused @patch argument (changed lines)
-        entry: python scripts/ci/guardrails/check_unused_patch_argument.py --changed-only
         language: system
         files: ^tests/.*test_.*\.py$
         pass_filenames: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,7 @@ are **enforced**; rails with pre-existing violation backlogs remain
 | `test-environment-leakage` | Tests mutating class/global state or `sys.modules` without scoped restoration (issue #1414) | enforced |
 | `xdist-loadgroup` | A test using the xdist-wide `tmp_path_factory.getbasetemp()` without an `xdist_group` marker | enforced |
 | `unused-patch-argument` | `@patch`-injected test parameters never referenced in the test body (#1682, epic #1678) | enforced |
+| `global-state-assertion` | Tests asserting over process-global channels: the real `sys.platform`, the `logging.Logger` class, or a whole captured stream (#1721) | enforced |
 
 Per-file coverage floors (`check-integration-floors.py` for the
 integration suite, `check_module_coverage_floor.py` for the unit suite)
@@ -102,6 +103,9 @@ Supply-chain scanning (run in `.github/workflows/security.yml`):
 - **Two lint rails above remain advisory (`cli-file-kind-validation` and
   `subprocess-returncode`).** They are intentionally non-blocking while
   remediation continues prior to promotion to enforced.
+- `global-state-assertion` enforces from the day it landed: the suite was
+  already at zero instances, the five flakes it guards against having just
+  been fixed in #1720. A rail added at zero needs no advisory period.
 - `unused-patch-argument` was promoted to **enforce** once its static
   backlog reached zero (231 findings at #1682, drained by wave A in
   #1690). The commit-time hook still runs first on staged-diff lines, so a

--- a/scripts/ci/guardrails/check_global_state_assertions.py
+++ b/scripts/ci/guardrails/check_global_state_assertions.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""CI-rail: Flag test assertions over process-global channels (#1721).
+
+Every flake fixed in #1720 was the same mistake wearing a different hat: a
+test reached for something process-global when it meant something specific.
+Unrelated code touches the same global, and the test then fails by import
+order, Python version, or worker placement — never on a developer machine.
+
+The three shapes seen, all from real failures:
+
+1. ``monkeypatch.setattr(sys, "platform", "win32")`` mutates the REAL sys
+   module. ``ext.sys`` IS ``sys``; there is no module-local copy. Anything
+   first-imported inside that window sees the lie — ``pydub.utils`` calls
+   ``shutil.which("ffmpeg")`` at import, whose win32 branch dereferences
+   ``_winapi``, ``None`` off Windows. Patch the module under test's own
+   ``sys`` reference instead.
+
+2. ``patch("logging.Logger.error")`` patches the Logger CLASS, so the mock
+   records error() from every logger in the process. One unrelated library
+   log turns ``assert_called_once`` into "Called 2 times". Patch the
+   module's own logger object instead.
+
+3. ``assert result.stdout.strip() == "1,3"`` compares a whole captured
+   stream. A library printing on import (PyMuPDF's ``fitz`` notice) lands in
+   the same stream. Print a marked line and assert on that.
+
+Suppress with ``# noqa: global-state-assertion`` on the offending line when
+the global really is the subject under test.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+try:
+    from scripts.ci.guardrails.suppressions import has_targeted_noqa
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from suppressions import has_targeted_noqa  # type: ignore[no-redef]
+
+RAIL_NAME = "global-state-assertion"
+
+#: Attribute of the real ``sys`` module whose mutation has bitten us. Kept
+#: narrow on purpose: ``sys.argv`` and ``sys.modules`` are mutated routinely
+#: and legitimately, and flagging those would drown the signal.
+_GUARDED_SYS_ATTRS = frozenset({"platform"})
+
+#: Streams that belong to the whole process, not to the code under test.
+_CAPTURED_STREAM_ATTRS = frozenset({"stdout", "stderr", "out", "err"})
+
+
+def _targets_sys_module(node: ast.expr) -> bool:
+    """True if *node* names the real ``sys`` module — bare or ``pkg.mod.sys``."""
+    if isinstance(node, ast.Name):
+        return node.id == "sys"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "sys"
+    return False
+
+
+def _check_sys_mutation(node: ast.Call) -> str | None:
+    """Rule 1: ``setattr(<...>.sys, "platform", ...)`` on the real sys module."""
+    func = node.func
+    is_setattr = (isinstance(func, ast.Name) and func.id == "setattr") or (
+        isinstance(func, ast.Attribute) and func.attr == "setattr"
+    )
+    if not is_setattr or len(node.args) < 2:
+        return None
+    if not _targets_sys_module(node.args[0]):
+        return None
+    attr = node.args[1]
+    if not (isinstance(attr, ast.Constant) and attr.value in _GUARDED_SYS_ATTRS):
+        return None
+    return (
+        f"mutates the real sys module's '{attr.value}' process-wide — anything "
+        f"first-imported during this window sees it. Patch the module under "
+        f"test's own 'sys' reference instead "
+        f"(monkeypatch.setattr(mod, 'sys', SimpleNamespace(platform=...)))"
+    )
+
+
+def _check_logger_class_patch(node: ast.Call) -> str | None:
+    """Rule 2: patching ``logging.Logger`` itself rather than a logger."""
+    func = node.func
+    is_patch = (isinstance(func, ast.Name) and func.id == "patch") or (
+        isinstance(func, ast.Attribute) and func.attr == "patch"
+    )
+    if is_patch and node.args:
+        first = node.args[0]
+        if (
+            isinstance(first, ast.Constant)
+            and isinstance(first.value, str)
+            and first.value.startswith("logging.Logger.")
+        ):
+            method = first.value.rsplit(".", 1)[-1]
+            return (
+                f"patches the Logger class, so it records '{method}' from every "
+                f"logger in the process. Patch the module's own logger instead "
+                f"(patch.object(mod.logger, '{method}'))"
+            )
+    # patch.object(logging.Logger, "error")
+    if isinstance(func, ast.Attribute) and func.attr == "object" and len(node.args) >= 2:
+        target = node.args[0]
+        if isinstance(target, ast.Attribute) and target.attr == "Logger":
+            attr = node.args[1]
+            method = attr.value if isinstance(attr, ast.Constant) else "<attr>"
+            return (
+                f"patches the Logger class, so it records '{method}' from every "
+                f"logger in the process. Patch the module's own logger instead"
+            )
+    return None
+
+
+def _is_captured_stream(node: ast.expr) -> bool:
+    """True for ``x.stdout``, ``x.stdout.strip()``, ``capsys.readouterr().out``."""
+    if isinstance(node, ast.Call):  # .strip() and friends
+        return _is_captured_stream(node.func)
+    if isinstance(node, ast.Attribute):
+        if node.attr in _CAPTURED_STREAM_ATTRS:
+            return True
+        # unwrap .strip / .lower / ... applied to a stream
+        return node.attr in {"strip", "lower", "rstrip", "lstrip"} and _is_captured_stream(
+            node.value
+        )
+    return False
+
+
+def _check_whole_stream_equality(node: ast.Compare) -> str | None:
+    """Rule 3: exact equality against an entire captured stream."""
+    if not node.ops or not isinstance(node.ops[0], ast.Eq):
+        return None
+    right = node.comparators[0]
+    if not (isinstance(right, ast.Constant) and isinstance(right.value, str)):
+        return None
+    if not _is_captured_stream(node.left):
+        return None
+    return (
+        "compares an entire captured stream for equality — a library printing "
+        "on import lands in the same stream. Assert on a marked line, a parsed "
+        "field, or membership instead"
+    )
+
+
+def check_file(filepath: Path) -> list[tuple[int, str]]:
+    """Return (lineno, message) violations for one test file."""
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading {filepath}: {exc}", file=sys.stderr)
+        return []
+
+    lines = content.splitlines()
+    try:
+        tree = ast.parse(content, filename=str(filepath))
+    except SyntaxError as exc:
+        print(f"Syntax error in {filepath}: {exc}", file=sys.stderr)
+        return []
+
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        message = None
+        if isinstance(node, ast.Call):
+            message = _check_sys_mutation(node) or _check_logger_class_patch(node)
+        elif isinstance(node, ast.Compare):
+            message = _check_whole_stream_equality(node)
+        if message is None:
+            continue
+        line = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+        if has_targeted_noqa(line, RAIL_NAME):
+            continue
+        violations.append((node.lineno, message))
+    return sorted(set(violations))
+
+
+def _changed_lines_by_file() -> dict[str, set[int]]:
+    """Map file -> line numbers added/modified in the staged diff."""
+    import re
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "-U0", "--no-color", "--", "tests/"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    changed: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            changed.setdefault(current, set())
+        elif line.startswith("@@") and current is not None:
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match:
+                start = int(match.group(1))
+                span = int(match.group(2)) if match.group(2) is not None else 1
+                changed[current].update(range(start, start + span))
+    return changed
+
+
+def main() -> int:
+    """Scan test files; --changed-only restricts to staged-diff lines."""
+    args = [a for a in sys.argv[1:] if a != "--changed-only"]
+    changed_only = "--changed-only" in sys.argv[1:]
+
+    if args:
+        paths = [Path(a) for a in args if a.endswith(".py")]
+    else:
+        tests_root = Path("tests")
+        if not tests_root.exists():
+            print("Error: tests directory not found. Run from the repository root.")
+            return 1
+        paths = sorted(tests_root.rglob("test_*.py"))
+
+    changed = _changed_lines_by_file() if changed_only else None
+
+    all_violations = []
+    for path in paths:
+        for lineno, msg in check_file(path):
+            if changed is not None and lineno not in changed.get(path.as_posix(), set()):
+                continue
+            all_violations.append((path.as_posix(), lineno, msg))
+
+    if all_violations:
+        print(f"❌ [{RAIL_NAME}] Violations found:", file=sys.stderr)
+        for file_path, lineno, msg in all_violations:
+            print(f"  {file_path}:{lineno}: {msg}", file=sys.stderr)
+        print(
+            f"\nFix: scope the patch to the module under test, or assert on your "
+            f"own marked output. Add '# noqa: {RAIL_NAME}' if the global really "
+            f"is the subject under test.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅ [{RAIL_NAME}] No violations found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/guardrails/check_global_state_assertions.py
+++ b/scripts/ci/guardrails/check_global_state_assertions.py
@@ -65,9 +65,22 @@ def _check_sys_mutation(node: ast.Call) -> str | None:
     is_setattr = (isinstance(func, ast.Name) and func.id == "setattr") or (
         isinstance(func, ast.Attribute) and func.attr == "setattr"
     )
-    if not is_setattr or len(node.args) < 2:
+    if not is_setattr or not node.args:
         return None
-    if not _targets_sys_module(node.args[0]):
+
+    first = node.args[0]
+    # Single dotted-string form: monkeypatch.setattr("pkg.mod.sys.platform", v)
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        target, _, attr_name = first.value.rpartition(".")
+        if attr_name not in _GUARDED_SYS_ATTRS or not target.endswith("sys"):
+            return None
+        return (
+            f"mutates the real sys module's '{attr_name}' process-wide — anything "
+            f"first-imported during this window sees it. Patch the module under "
+            f"test's own 'sys' reference instead"
+        )
+
+    if len(node.args) < 2 or not _targets_sys_module(first):
         return None
     attr = node.args[1]
     if not (isinstance(attr, ast.Constant) and attr.value in _GUARDED_SYS_ATTRS):
@@ -166,8 +179,11 @@ def check_file(filepath: Path) -> list[tuple[int, str]]:
             message = _check_whole_stream_equality(node)
         if message is None:
             continue
-        line = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
-        if has_targeted_noqa(line, RAIL_NAME):
+        # Span-aware: these nodes are routinely multi-line, and a noqa on the
+        # closing line is the natural place to put it.
+        end = getattr(node, "end_lineno", node.lineno) or node.lineno
+        span = lines[node.lineno - 1 : end]
+        if any(has_targeted_noqa(line, RAIL_NAME) for line in span):
             continue
         violations.append((node.lineno, message))
     return sorted(set(violations))
@@ -178,12 +194,24 @@ def _changed_lines_by_file() -> dict[str, set[int]]:
     import re
     import subprocess
 
-    result = subprocess.run(
-        ["git", "diff", "--cached", "-U0", "--no-color", "--", "tests/"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "-U0", "--no-color", "--", "tests/"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except OSError:
+        # git absent from PATH, or the call timed out. Returning an empty map
+        # makes --changed-only scope to nothing, which the caller sees as a
+        # clean run — so fail loudly instead of silently passing the gate.
+        print(
+            f"[{RAIL_NAME}] could not read the staged diff (git unavailable or "
+            f"timed out); re-run without --changed-only.",
+            file=sys.stderr,
+        )
+        raise
     changed: dict[str, set[int]] = {}
     current: str | None = None
     for line in result.stdout.splitlines():
@@ -217,8 +245,14 @@ def main() -> int:
 
     all_violations = []
     for path in paths:
+        # Diff keys are repository-relative; an absolute path would never match,
+        # silently dropping every violation in the file and passing the gate.
+        try:
+            key = path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+        except ValueError:
+            key = path.as_posix()
         for lineno, msg in check_file(path):
-            if changed is not None and lineno not in changed.get(path.as_posix(), set()):
+            if changed is not None and lineno not in changed.get(key, set()):
                 continue
             all_violations.append((path.as_posix(), lineno, msg))
 

--- a/scripts/ci/guardrails/check_unused_patch_argument.py
+++ b/scripts/ci/guardrails/check_unused_patch_argument.py
@@ -171,12 +171,24 @@ def _changed_lines_by_file() -> dict[str, set[int]]:
     import re
     import subprocess
 
-    result = subprocess.run(
-        ["git", "diff", "--cached", "-U0", "--no-color", "--", "tests/"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "-U0", "--no-color", "--", "tests/"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except OSError:
+        # git absent from PATH, or the call timed out. Returning an empty map
+        # makes --changed-only scope to nothing, which the caller sees as a
+        # clean run — so fail loudly instead of silently passing the gate.
+        print(
+            f"[{RAIL_NAME}] could not read the staged diff (git unavailable or "
+            f"timed out); re-run without --changed-only.",
+            file=sys.stderr,
+        )
+        raise
     changed: dict[str, set[int]] = {}
     current: str | None = None
     for line in result.stdout.splitlines():
@@ -210,8 +222,14 @@ def main() -> int:
 
     all_violations = []
     for path in paths:
+        # Diff keys are repository-relative; an absolute path would never match,
+        # silently dropping every violation in the file and passing the gate.
+        try:
+            key = path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+        except ValueError:
+            key = path.as_posix()
         for lineno, msg in check_file(path):
-            if changed is not None and lineno not in changed.get(path.as_posix(), set()):
+            if changed is not None and lineno not in changed.get(key, set()):
                 continue
             all_violations.append((path.as_posix(), lineno, msg))
 

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -97,6 +97,12 @@ mode = "enforce"
 description = "Flags tests that mutate class/global state or sys.modules without scoped restoration (issue #1414)."
 
 [[rail]]
+name = "global-state-assertion"
+command = ["python", "scripts/ci/guardrails/check_global_state_assertions.py"]
+mode = "enforce"
+description = "Flags tests asserting over process-global channels — the real sys.platform, the logging.Logger class, or a whole captured stream (issue #1721). Enforce from day one: the suite was at zero instances when the rail landed, the five flakes in #1720 having just been fixed."
+
+[[rail]]
 name = "unused-patch-argument"
 command = ["python", "scripts/ci/guardrails/check_unused_patch_argument.py"]
 mode = "enforce"

--- a/tests/ci/test_check_global_state_assertions.py
+++ b/tests/ci/test_check_global_state_assertions.py
@@ -120,6 +120,10 @@ class TestLoggerClassPatch:
             """,
         )
         assert len(violations) == 1
+        # The object branch builds its own message; assert it, or a wrong or
+        # empty string there would still pass a count-only check.
+        assert "every logger in the process" in violations[0][1]
+        assert "error" in violations[0][1]
 
     def test_allows_patching_a_module_logger(self, tmp_path: Path) -> None:
         """The fix shape: patch the logger the code under test actually uses."""
@@ -196,6 +200,58 @@ def test_targeted_noqa_suppresses(tmp_path: Path) -> None:
 
         def test_platform_reporting(monkeypatch):
             monkeypatch.setattr(sys, "platform", "win32")  # noqa: global-state-assertion
+        """,
+    )
+    assert violations == []
+
+
+def test_noqa_on_the_closing_line_of_a_multiline_call_suppresses(tmp_path: Path) -> None:
+    """These calls are routinely multi-line; the closing line is a natural spot.
+
+    Reading only ``lines[node.lineno - 1]`` would ignore it, leaving a
+    finding that cannot be suppressed where an author would think to try.
+    """
+    violations = _check(
+        tmp_path,
+        """
+        import sys
+
+        def test_platform_reporting(monkeypatch):
+            monkeypatch.setattr(
+                sys,
+                "platform",
+                "win32",
+            )  # noqa: global-state-assertion
+        """,
+    )
+    assert violations == []
+
+
+def test_flags_dotted_string_setattr_form(tmp_path: Path) -> None:
+    """``monkeypatch.setattr("pkg.mod.sys.platform", v)`` is the same mutation.
+
+    pytest accepts a single dotted target as shorthand for (obj, name); the
+    rail must not be blind to the shorthand.
+    """
+    violations = _check(
+        tmp_path,
+        """
+        def test_windows_path(monkeypatch):
+            monkeypatch.setattr("pkg.mod.sys.platform", "win32")
+        """,
+    )
+    assert len(violations) == 1
+    assert "process-wide" in violations[0][1]
+
+
+def test_dotted_string_form_ignores_unrelated_targets(tmp_path: Path) -> None:
+    """Only the real sys module's platform is guarded, not any '.platform'."""
+    violations = _check(
+        tmp_path,
+        """
+        def test_other(monkeypatch):
+            monkeypatch.setattr("pkg.mod.config.platform", "win32")
+            monkeypatch.setattr("pkg.mod.sys.argv", [])
         """,
     )
     assert violations == []

--- a/tests/ci/test_check_global_state_assertions.py
+++ b/tests/ci/test_check_global_state_assertions.py
@@ -1,0 +1,215 @@
+"""Tests for the global-state-assertion CI rail (issue #1721).
+
+The rail flags tests that reach for a process-global channel when they mean
+something specific. Every positive case below is the real shape of a flake
+fixed in #1720 — none of them reproduced on a developer machine, and each
+cost a CI cycle to even observe:
+
+- ``sys.platform`` mutated on the real module: ``pydub.utils`` calling
+  ``shutil.which("ffmpeg")`` at import took shutil's win32 branch, which
+  dereferences ``_winapi`` (``None`` off Windows).
+- ``logging.Logger.error`` patched on the class: an unrelated library log
+  turned ``assert_called_once`` into "Called 2 times" on py3.14.
+- A whole captured stream compared for equality: PyMuPDF's ``fitz``
+  deprecation notice, printed on import, broke the match on py3.14.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from scripts.ci.guardrails import check_global_state_assertions as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def _check(tmp_path: Path, source: str) -> list[tuple[int, str]]:
+    src = tmp_path / "test_sample.py"
+    src.write_text(dedent(source), encoding="utf-8")
+    return checker.check_file(src)
+
+
+class TestSysPlatformMutation:
+    """Rule 1 — mutating the real sys module."""
+
+    def test_flags_bare_sys_platform_mutation(self, tmp_path: Path) -> None:
+        violations = _check(
+            tmp_path,
+            """
+            import sys
+
+            def test_windows_path(monkeypatch):
+                monkeypatch.setattr(sys, "platform", "win32")
+            """,
+        )
+        assert len(violations) == 1
+        assert "process-wide" in violations[0][1]
+
+    def test_flags_module_qualified_sys_mutation(self, tmp_path: Path) -> None:
+        """``ext.sys`` IS ``sys`` — the qualification does not make it local."""
+        violations = _check(
+            tmp_path,
+            """
+            def test_windows_path(monkeypatch):
+                import pkg.mod as ext
+
+                monkeypatch.setattr(ext.sys, "platform", "win32")
+            """,
+        )
+        assert len(violations) == 1
+
+    def test_allows_patching_the_modules_own_sys_reference(self, tmp_path: Path) -> None:
+        """The fix shape must stay clean: swap the module's sys, not sys itself."""
+        violations = _check(
+            tmp_path,
+            """
+            from types import SimpleNamespace
+
+            def test_windows_path(monkeypatch):
+                import pkg.mod as ext
+
+                monkeypatch.setattr(ext, "sys", SimpleNamespace(platform="win32"))
+            """,
+        )
+        assert violations == []
+
+    def test_ignores_routine_sys_attributes(self, tmp_path: Path) -> None:
+        """argv/modules are mutated legitimately all over; only platform is guarded."""
+        violations = _check(
+            tmp_path,
+            """
+            import sys
+
+            def test_args(monkeypatch):
+                monkeypatch.setattr(sys, "argv", ["prog"])
+            """,
+        )
+        assert violations == []
+
+
+class TestLoggerClassPatch:
+    """Rule 2 — patching the Logger class rather than a logger."""
+
+    def test_flags_logger_class_patch_by_string(self, tmp_path: Path) -> None:
+        violations = _check(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_logs_once():
+                with patch("logging.Logger.error") as mock_err:
+                    mock_err.assert_called_once()
+            """,
+        )
+        assert len(violations) == 1
+        assert "every logger in the process" in violations[0][1]
+
+    def test_flags_logger_class_patch_by_object(self, tmp_path: Path) -> None:
+        violations = _check(
+            tmp_path,
+            """
+            import logging
+            from unittest.mock import patch
+
+            def test_logs_once():
+                with patch.object(logging.Logger, "error"):
+                    pass
+            """,
+        )
+        assert len(violations) == 1
+
+    def test_allows_patching_a_module_logger(self, tmp_path: Path) -> None:
+        """The fix shape: patch the logger the code under test actually uses."""
+        violations = _check(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_logs_once():
+                import pkg.mod as mod
+
+                with patch.object(mod.logger, "error") as mock_err:
+                    mock_err.assert_called_once()
+            """,
+        )
+        assert violations == []
+
+
+class TestWholeStreamEquality:
+    """Rule 3 — comparing an entire captured stream."""
+
+    def test_flags_subprocess_stdout_equality(self, tmp_path: Path) -> None:
+        violations = _check(
+            tmp_path,
+            """
+            import subprocess
+
+            def test_prints_value():
+                result = subprocess.run(["prog"], capture_output=True, text=True)
+                assert result.stdout.strip() == "1,3"
+            """,
+        )
+        assert len(violations) == 1
+        assert "entire captured stream" in violations[0][1]
+
+    def test_flags_capsys_equality(self, tmp_path: Path) -> None:
+        violations = _check(
+            tmp_path,
+            """
+            def test_prints_value(capsys):
+                print("hello")
+                assert capsys.readouterr().out == "hello\\n"
+            """,
+        )
+        assert len(violations) == 1
+
+    def test_allows_membership_and_marked_lines(self, tmp_path: Path) -> None:
+        """Both documented fix shapes must stay clean."""
+        violations = _check(
+            tmp_path,
+            """
+            import subprocess
+
+            def test_prints_value():
+                result = subprocess.run(["prog"], capture_output=True, text=True)
+                assert "1,3" in result.stdout
+                marked = [
+                    line.partition(":")[2]
+                    for line in result.stdout.splitlines()
+                    if line.startswith("RESULT:")
+                ]
+                assert marked == ["1,3"]
+            """,
+        )
+        assert violations == []
+
+
+def test_targeted_noqa_suppresses(tmp_path: Path) -> None:
+    """Sometimes the global really is the subject under test."""
+    violations = _check(
+        tmp_path,
+        """
+        import sys
+
+        def test_platform_reporting(monkeypatch):
+            monkeypatch.setattr(sys, "platform", "win32")  # noqa: global-state-assertion
+        """,
+    )
+    assert violations == []
+
+
+def test_bare_noqa_does_not_suppress(tmp_path: Path) -> None:
+    """Suppression must name this rail, matching the repo-wide convention."""
+    violations = _check(
+        tmp_path,
+        """
+        import sys
+
+        def test_platform_reporting(monkeypatch):
+            monkeypatch.setattr(sys, "platform", "win32")  # noqa
+        """,
+    )
+    assert len(violations) == 1

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -145,6 +145,7 @@ def test_repo_registry_loads_registered_rails() -> None:
         "xdist-loadgroup": "enforce",
         "subprocess-returncode": "advisory",
         "test-environment-leakage": "enforce",
+        "global-state-assertion": "enforce",
         "unused-patch-argument": "enforce",
     }
     assert {rail.name: rail.mode for rail in rails} == expected_modes


### PR DESCRIPTION
Closes #1721. Follows [#1720](https://github.com/curdriceaurora/Local-File-Organizer/pull/1720), which fixed five flakes that were all the same mistake in different costumes.

## The pattern

A test reaches for something **process-global** when it means something **specific**. Unrelated code touches the same global, and the test fails by import order, Python version, or worker placement. None of them reproduce on a developer machine.

| Rule | Real failure it comes from |
|---|---|
| `setattr(<…>.sys, "platform", …)` | `pydub.utils` calls `shutil.which("ffmpeg")` at import; shutil's win32 branch dereferences `_winapi`, `None` off Windows |
| `patch("logging.Logger.<m>")` | patching the **class** recorded that method from every logger, so one unrelated log made `assert_called_once` see 2 |
| whole-stream equality | PyMuPDF's `fitz` deprecation notice, printed on import, landed in the compared stdout |

## Validated against history, not just fixtures

Run against the **pre-#1720 versions** of the four affected files, all three rules fire on exactly the lines that were fixed:

```
test_dedup_extractor_safedir.py:116, :151   sys.platform
test_stages.py:528                          sys.platform
test_services_coverage.py:867,973,980,986   Logger class
test_settings_view.py:103                   whole-stream equality
```

Against current `main`: **zero violations**. So this is a regression test for a class we already paid for, not a speculative rule set.

## Enforce from day one

A rail added at zero backlog needs no advisory period. `unused-patch-argument` could only be promoted after wave A drained 231 findings; this one starts clean.

## Deliberate scope limits

- **Rule 1 guards only `platform`.** `sys.argv` and `sys.modules` are mutated routinely and legitimately; flagging those would drown the signal.
- **Rule 3 is the false-positive risk** I flagged when filing the issue. It triggers only on `==` against a string literal where the left side is a captured stream (`.stdout`/`.stderr`/`.out`/`.err`, optionally `.strip()`-ed). Both documented fix shapes — membership and marked-line extraction — are pinned clean by tests. It found no false positives across the suite, which is why it ships at `enforce` rather than advisory; if that proves wrong, downgrading is a one-line change.
- `# noqa: global-state-assertion` suppresses, for when the global really is the subject under test.

## Registration

All four governance touchpoints `test_guardrail_governance.py` compares — `rails.toml`, `expected_modes`, the SECURITY.md rail table, and Known Limitations — plus a **diff-scoped pre-commit hook**. The commit-time catch matters more than usual here, precisely because these never reproduce locally.

## Verification

- 12 rail tests: each rule, both fix shapes staying clean, the routine-sys-attribute exclusion, targeted-vs-bare `noqa`
- `tests/ci` green — 1,077 passed
- `ci_rails.py` reports the new rail green; `pre-commit run --all-files` clean
- A probe violation is caught end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to detect unsafe assertions involving process-global state in tests.
  * Added staged-file checks to provide faster feedback before commits.
  * Added targeted suppression support for intentional exceptions.

* **Documentation**
  * Documented the new enforced quality check and confirmed existing violations were resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Registration detail (raised by the linked-issues check)

All four governance touchpoints are updated, including the one the check asked about:

| Touchpoint | Where |
|---|---|
| `rails.toml` | new `[[rail]]` entry, `mode = "enforce"` |
| `expected_modes` | `tests/ci/test_ci_rails_framework.py` |
| SECURITY.md rail table | line 65 |
| **SECURITY.md Known Limitations** | **line 106** — records why this rail enforces from day one rather than serving an advisory period |

On "verify the governance test covers it": **it does not, by design.** `test_security_rail_status_table_matches_registry` compares the rail *table* against the registry, and `test_rail_status_table_ignores_prose_mentions_outside_table_rows` deliberately excludes prose outside table rows — so the Known Limitations section is unverified for every rail, not just this one.

That is a real gap in the governance contract, but closing it changes the contract for all rails (e.g. "every advisory rail must appear in Known Limitations"), so it does not belong in this PR. Worth its own issue if you want it enforced.
