### PR TITLE
feat(1684): mutation-testing pilot with measured floors

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -53,7 +53,11 @@ jobs:
       - name: Run the mutation pilot
         env:
           PROFILE: ${{ inputs.profile }}
-          ENFORCE: ${{ inputs.enforce == false && 'no' || 'yes' }}
+          # The `inputs` context is empty on a schedule trigger, and GitHub's
+          # loose equality makes `inputs.enforce == false` TRUE when it is
+          # null — so keying off that alone silently disabled enforcement on
+          # exactly the run that matters. Branch on the event first.
+          ENFORCE: ${{ github.event_name != 'workflow_dispatch' && 'yes' || (inputs.enforce && 'yes' || 'no') }}
         run: |
           set -euo pipefail
           args=()

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,69 @@
+name: Mutation Pilot
+
+# Mutation testing for epic #1678's pilot modules (#1684).
+#
+# Nightly and on demand only — never on a PR. Mutation runtime is test runtime
+# multiplied by mutant count, and this suite is ~22.5k tests; the pilot keeps
+# that tractable by mutating three small modules and running only the tests
+# that exercise them.
+on:
+  schedule:
+    - cron: "0 4 * * *"  # daily at 04:00 UTC, ahead of the ci-full matrix at 06:00
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: "Single profile to run (blank = all)"
+        required: false
+        default: ""
+      enforce:
+        description: "Fail the job when a profile is below its floor"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    name: Mutation pilot
+    runs-on: ubuntu-latest
+    # Generous: a profile is a full mutant sweep, and the point of the nightly
+    # slot is that it can take its time. Kept finite so a hung fork cannot burn
+    # a runner indefinitely.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      # --no-deps is required, not an optimisation. mutmut declares
+      # textual>=1.0; this project pins textual~=0.50 for the TUI, and letting
+      # pip resolve mutmut's dependencies silently upgrades textual and breaks
+      # the TUI suite. mutmut's `run`/`results`/`export-cicd-stats` all work
+      # against the pinned version — only `browse` needs the newer API.
+      - name: Install mutmut without its dependency closure
+        run: pip install --no-deps "mutmut==3.7.0" libcst
+      # The dispatch inputs go through the environment, never interpolated
+      # straight into the shell: `${{ inputs.profile }}` inline would let
+      # anyone who can dispatch this workflow run arbitrary commands here.
+      - name: Run the mutation pilot
+        env:
+          PROFILE: ${{ inputs.profile }}
+          ENFORCE: ${{ inputs.enforce == false && 'no' || 'yes' }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ -n "${PROFILE}" ]; then args+=("${PROFILE}"); fi
+          if [ "${ENFORCE}" = "yes" ]; then args+=(--enforce); fi
+          python scripts/ci/mutation_pilot.py "${args[@]}" --report mutation-report.json
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: mutation-report
+          path: mutation-report.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,9 @@ coverage.json
 pallet_inventory_estimate.py
 Pallet_Inventory_Estimate.xlsx
 .~lock.Pallet_Inventory_Estimate.xlsx#
+
+# Mutation testing (#1684). `mutants/` is mutmut's working copy of the tree;
+# `setup.cfg` is generated per profile by scripts/ci/mutation_pilot.py and
+# removed after each run — neither belongs in the repo.
+mutants/
+/setup.cfg

--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -16,7 +16,7 @@ anything".
 ```bash
 pip install --no-deps "mutmut==3.7.0" libcst
 python scripts/ci/mutation_pilot.py --list          # show profiles
-python scripts/ci/mutation_pilot.py optimization    # one profile
+python scripts/ci/mutation_pilot.py batch-sizer     # one profile
 python scripts/ci/mutation_pilot.py                 # all of them
 ```
 
@@ -32,7 +32,7 @@ accepts a manual dispatch. It never runs on a pull request.
 ## Reading the output
 
 ```text
--- optimization: mutating 3 module(s)
+-- batch-sizer: mutating 1 module(s)
    killed  129  survived   65  no-tests    0  score 66.5%
 ```
 
@@ -70,9 +70,9 @@ two distinct ways:
 - *Segfaults.* Broad test paths drag in ~240 native extension modules (torch,
   av, scipy) and the fork crashes. mutmut records the crash as a mutant
   verdict, so a profile can report a perfect score built entirely on
-  corpses — the pilot's own first run showed `optimization` and `organizer`
-  at 100% with 268 and 432 mutants segfaulted. The driver treats any
-  `segfault` in the stats as a hard error.
+  corpses — the pilot's own first run showed the grouped optimization profile
+  and `organizer` at 100% with 268 and 432 mutants segfaulted. The driver
+  treats any `segfault` in the stats as a hard error.
 - *Deadlocks.* Thread-heavy test files (for example
   `tests/parallel/test_processor_thread_safety.py`) make the forked children
   sit asleep forever, consuming no CPU. mutmut's own per-mutant timeout never
@@ -116,11 +116,11 @@ problem further, since `test_processor_thread_safety.py` and
 `test_concurrency_fixes.py` — the tests most worth mutating — are exactly the
 ones that trigger the hang.
 
-**`organizer` segfaults.** `core/organizer.py` imports the audio and video
-metadata extractors at module scope, so every fork loads av/torch and 432
-mutants crash. Making those imports lazy would unblock it, and would be worth
-doing: this is the module where `organize()`'s AI path was once deletable
-with all 126 tests still passing.
+**`organizer` segfaults.** `src/file_organizer/core/organizer.py` imports the
+audio and video metadata extractors at module scope, so every fork loads
+av/torch and 432 mutants crash. Making those imports lazy would unblock it,
+and would be worth doing: this is the module where `organize()`'s AI path was
+once deletable with all 126 tests still passing.
 
 ## Validating the harness before trusting a score
 
@@ -130,7 +130,7 @@ something and confirm the number moves:
 
 ```bash
 # neuter the assertions in a profile's test file, rerun, and compare
-python scripts/ci/mutation_pilot.py optimization
+python scripts/ci/mutation_pilot.py batch-sizer
 ```
 
 On the `batch_sizer` baseline, replacing every `assert X` with `_ = X` moved

--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -1,0 +1,146 @@
+# Mutation Testing
+
+Mutation testing changes the source, reruns the tests, and asks whether
+anything noticed. A test suite can have high coverage and still assert
+nothing; a surviving mutant is proof of exactly that, found without knowing
+the failure mode in advance.
+
+This is a **pilot** (#1684, epic #1678), not suite-wide adoption. Mutation
+runtime is test runtime multiplied by mutant count, and this suite is ~22.5k
+tests. Three small modules are covered — the ones the epic's repair waves
+touched most, so the score answers "did those repairs actually catch
+anything".
+
+## Running it
+
+```bash
+pip install --no-deps "mutmut==3.7.0" libcst
+python scripts/ci/mutation_pilot.py --list          # show profiles
+python scripts/ci/mutation_pilot.py optimization    # one profile
+python scripts/ci/mutation_pilot.py                 # all of them
+```
+
+`--no-deps` is required. mutmut declares `textual>=1.0` and this project pins
+`textual~=0.50` for the TUI; letting pip resolve mutmut's dependencies
+upgrades textual and breaks the TUI suite. `run`, `results` and
+`export-cicd-stats` all work against the pinned version — only `mutmut browse`
+needs the newer API, so use `mutmut results` instead.
+
+In CI this runs nightly via `.github/workflows/mutation.yml`, which also
+accepts a manual dispatch. It never runs on a pull request.
+
+## Reading the output
+
+```text
+-- optimization: mutating 3 module(s)
+   killed  129  survived   65  no-tests    0  score 66.5%
+```
+
+- **killed** — the mutant broke a test. Good.
+- **survived** — the source changed and every test still passed. Either a
+  missing assertion or an equivalent mutant.
+- **no-tests** — no test exercises that line at all. That is a coverage
+  question, gated separately, and it is excluded from the score so a coverage
+  change cannot move the mutation number on its own.
+
+Score is `killed / (killed + survived)`.
+
+!!! warning "mutmut's emoji legend is easy to invert"
+    In the live progress line `🙁` is **survived** and `🫥` is **no tests**.
+    Reading them the other way round turns a 66.5% score into a reported
+    100%. Prefer the driver script's wording, or
+    `mutmut export-cicd-stats`, over the progress bar.
+
+## Three things that make the numbers meaningless if you skip them
+
+These are encoded in `scripts/ci/mutation_pilot.py`. They are recorded here
+because each one fails quietly, producing a confident number that measures
+the wrong thing.
+
+**1. Coverage must be off.** The project's pytest `addopts` carry
+`--cov-fail-under=93`. Under mutation that gate fails for nearly every mutant,
+pytest exits non-zero, and mutmut reads a non-zero exit as "the suite caught
+it". Leaving coverage on reports a ~100% mutation score that reflects the
+coverage gate and nothing else.
+
+**2. Test selection must be narrow, and one module per profile.** mutmut
+forks a process per mutant, and forking this test environment is fragile in
+two distinct ways:
+
+- *Segfaults.* Broad test paths drag in ~240 native extension modules (torch,
+  av, scipy) and the fork crashes. mutmut records the crash as a mutant
+  verdict, so a profile can report a perfect score built entirely on
+  corpses — the pilot's own first run showed `optimization` and `organizer`
+  at 100% with 268 and 432 mutants segfaulted. The driver treats any
+  `segfault` in the stats as a hard error.
+- *Deadlocks.* Thread-heavy test files (for example
+  `tests/parallel/test_processor_thread_safety.py`) make the forked children
+  sit asleep forever, consuming no CPU. mutmut's own per-mutant timeout never
+  fires because the child never starts. The driver imposes a per-profile
+  wall-clock `--timeout` and reaps the strays.
+
+Both are why profiles are one module with its own test files, rather than one
+profile per package. Grouping three optimization modules with the whole
+`tests/optimization` directory segfaulted; splitting them into three profiles
+of one module and two test files each runs clean.
+
+**3. Config lives in a generated `setup.cfg`.** mutmut reads `[tool.mutmut]`
+from `pyproject.toml` when that section exists and only falls back to
+`setup.cfg` otherwise. Keeping `pyproject.toml` free of it is what lets the
+driver vary `only_mutate` and test paths per profile. The generated file is
+temporary and removed after each run — do not commit one.
+
+## Baselines
+
+Measured 2026-08-08. Floors sit ~3 points below the baseline: scores here are
+deterministic (`pytest-randomly` is disabled for these runs), so the margin
+absorbs test additions changing the denominator, not run-to-run noise.
+
+| Profile | Killed | Survived | Score | Floor |
+| :--- | ---: | ---: | ---: | ---: |
+| `batch-sizer` | 129 | 65 | 66.5% | 63% |
+| `memory-limiter` | 67 | 17 | 79.8% | 76% |
+| `memory-profiler` | 96 | 23 | 80.7% | 77% |
+| `parallel` | 233 | 291 | 44.5% | blocked |
+| `organizer` | — | — | blocked | — |
+
+Two of the five targets are blocked, for different reasons. Blocked profiles
+are skipped in a default run — announced, never silently — and still run when
+named explicitly, so progress on the blocker stays measurable.
+
+**`parallel` deadlocks intermittently.** It completed twice (44.5% against
+`test_processor.py` alone) and hung twice, forked children asleep at zero CPU
+until `--timeout` reaped them. A gate that hangs half the time is worse than
+no gate. Its 44.5% is also the weakest score in the pilot and understates the
+problem further, since `test_processor_thread_safety.py` and
+`test_concurrency_fixes.py` — the tests most worth mutating — are exactly the
+ones that trigger the hang.
+
+**`organizer` segfaults.** `core/organizer.py` imports the audio and video
+metadata extractors at module scope, so every fork loads av/torch and 432
+mutants crash. Making those imports lazy would unblock it, and would be worth
+doing: this is the module where `organize()`'s AI path was once deletable
+with all 126 tests still passing.
+
+## Validating the harness before trusting a score
+
+A mutation score is only evidence if the harness can tell killed from
+survived. Check it the same way you would check any other guard — break
+something and confirm the number moves:
+
+```bash
+# neuter the assertions in a profile's test file, rerun, and compare
+python scripts/ci/mutation_pilot.py optimization
+```
+
+On the `batch_sizer` baseline, replacing every `assert X` with `_ = X` moved
+16 mutants from killed to survived (66.5% → 58.2%). A harness that reports the
+same score either way is measuring nothing, and that is the failure mode this
+whole page exists to prevent.
+
+## Adding a profile
+
+Add a `Profile` to `PROFILES` in `scripts/ci/mutation_pilot.py` with the
+modules to mutate and the test files that exercise them. Leave `floor` as
+`None` until there is a measured baseline — a floor invented before the first
+run is a number people route around rather than a bar they clear.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
       - API Clients: developer/api-clients.md
       - Contributing: developer/contributing.md
       - Testing: developer/testing.md
+      - Mutation Testing: developer/mutation-testing.md
   - Configuration & Migration:
       - Configuration Guide: CONFIGURATION.md
       - Path Standardization & Migration: config/path-standardization.md

--- a/scripts/ci/mutation_pilot.py
+++ b/scripts/ci/mutation_pilot.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Mutation-testing pilot driver (#1684, epic #1678).
+
+Runs ``mutmut`` over a small set of per-module profiles and reports a
+mutation score for each. Pilot scope only — the modules epic #1678's repair
+waves touched most, so the score answers "did the repairs actually catch
+anything". This is deliberately NOT suite-wide: mutation runtime is test
+runtime multiplied by mutant count, and the suite is ~22.5k tests.
+
+Usage::
+
+    python scripts/ci/mutation_pilot.py                 # run every profile
+    python scripts/ci/mutation_pilot.py optimization    # run one
+    python scripts/ci/mutation_pilot.py --enforce       # fail below floors
+    python scripts/ci/mutation_pilot.py --list          # show profiles
+
+Three things about this harness are load bearing. Each of them, left alone,
+produces a confident number that means nothing:
+
+1. ``--no-cov``. The project's pytest ``addopts`` carry
+   ``--cov-fail-under=93``. Under mutation that gate fails for nearly every
+   mutant, pytest exits non-zero, and mutmut reads a non-zero exit as "the
+   suite caught it" — reporting a ~100% score that measures the coverage
+   gate rather than the tests.
+
+2. **Narrow test selection.** mutmut forks per mutant. Pointed at broad test
+   paths it drags in ~240 native extension modules (torch, av, scipy) and
+   segfaults, which mutmut records as a mutant verdict. Each profile names
+   only the test files that exercise its modules. ``segfault`` in the stats
+   is treated as a hard error here, not as a result.
+
+3. **Config lives in ``setup.cfg``, written per profile.** mutmut reads
+   ``[tool.mutmut]`` from ``pyproject.toml`` when present and only falls back
+   to ``setup.cfg`` otherwise. Keeping pyproject free of that section is what
+   lets this script vary ``only_mutate``/test paths per profile without
+   rewriting a tracked file.
+
+``mutmut browse`` is unavailable: it needs ``textual>=1.0`` and this project
+pins ``textual~=0.50``. Install mutmut with ``--no-deps``; ``run``, ``results``
+and ``export-cicd-stats`` all work against the pinned version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_CFG = REPO_ROOT / "setup.cfg"
+MUTANTS_DIR = REPO_ROOT / "mutants"
+STATS_FILE = MUTANTS_DIR / "mutmut-cicd-stats.json"
+
+#: Pytest arguments shared by every profile. `--no-cov` is not optional; see
+#: the module docstring.
+BASE_PYTEST_ARGS = ["--no-cov", "-p", "no:randomly", "-p", "no:cacheprovider"]
+
+
+@dataclass(frozen=True)
+class Profile:
+    """One pilot target: what to mutate, and what to run against it."""
+
+    name: str
+    only_mutate: list[str]
+    tests: list[str]
+    #: Minimum mutation score, as a percentage, enforced under `--enforce`.
+    #: `None` means "measured but not yet gated" — a floor is only meaningful
+    #: once there is a baseline to set it from.
+    floor: float | None = None
+    notes: str = ""
+    #: Why this profile cannot run. Blocked profiles are skipped in a default
+    #: run — loudly, never silently — but still run when named explicitly, so
+    #: anyone attempting a fix can measure it.
+    blocked: str | None = None
+    extra_pytest_args: list[str] = field(default_factory=list)
+
+
+PROFILES: tuple[Profile, ...] = (
+    Profile(
+        name="batch-sizer",
+        only_mutate=["*/optimization/batch_sizer.py"],
+        tests=[
+            "tests/optimization/test_batch_sizer.py",
+            "tests/optimization/test_batch_sizer_coverage.py",
+        ],
+        floor=63.0,  # measured 66.5%
+        notes="Absorbed the most wave-A/B repairs; the epic's own premise under test.",
+    ),
+    Profile(
+        name="memory-limiter",
+        only_mutate=["*/optimization/memory_limiter.py"],
+        tests=[
+            "tests/optimization/test_memory_limiter.py",
+            "tests/optimization/test_memory_limiter_coverage.py",
+        ],
+        floor=76.0,  # measured 79.8%
+    ),
+    Profile(
+        name="memory-profiler",
+        only_mutate=["*/optimization/memory_profiler.py"],
+        tests=[
+            "tests/optimization/test_memory_profiler.py",
+            "tests/optimization/test_memory_profiler_coverage.py",
+        ],
+        floor=77.0,  # measured 80.7%
+    ),
+    Profile(
+        name="parallel",
+        only_mutate=["*/parallel/processor.py"],
+        tests=["tests/parallel/test_processor.py"],
+        # test_processor_thread_safety.py and test_concurrency_fixes.py are
+        # excluded: including them made mutmut deadlock intermittently (forked
+        # children asleep, no CPU, no progress). They are the tests most worth
+        # mutating, so this is a known gap, not a preference -- see
+        # docs/developer/mutation-testing.md.
+        notes="Wave-B repairs plus the resume/persistence assertions.",
+        blocked=(
+            "deadlocks intermittently: forked children go to sleep and never "
+            "resume, so the run hangs until --timeout reaps it. Measured 44.5% "
+            "(233 killed / 291 survived) on the runs that did complete, but an "
+            "intermittent hang cannot gate a nightly."
+        ),
+    ),
+    Profile(
+        name="organizer",
+        only_mutate=["*/core/organizer.py"],
+        tests=[
+            "tests/core/test_organizer.py",
+            "tests/core/test_organizer_coverage.py",
+            "tests/core/test_organizer_sha256_safedir.py",
+        ],
+        # test_audio_video_integration.py is deliberately excluded: it imports
+        # av/torch, and those native extensions are what make mutmut's fork
+        # segfault (see the module docstring).
+        notes="organize()'s AI path was deletable with all 126 tests passing.",
+        blocked=(
+            "432 mutants segfault: organizer.py imports the audio/video metadata "
+            "extractors at module scope, so every fork loads av/torch. Needs those "
+            "imports made lazy, or a non-forking runner."
+        ),
+    ),
+)
+
+
+def write_config(profile: Profile) -> None:
+    """Write the mutmut config for *profile* to ``setup.cfg``."""
+    pytest_args = BASE_PYTEST_ARGS + profile.extra_pytest_args + profile.tests
+    lines = [
+        "# Generated by scripts/ci/mutation_pilot.py -- do not edit, do not commit.",
+        "[mutmut]",
+        "source_paths=src/file_organizer",
+        "only_mutate=" + "".join(f"\n    {p}" for p in profile.only_mutate),
+        "also_copy=\n    tests/\n    pyproject.toml",
+        "pytest_add_cli_args=" + "".join(f"\n    {a}" for a in pytest_args),
+        "",
+    ]
+    SETUP_CFG.write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_profile(profile: Profile, max_children: int, timeout: int) -> dict[str, int]:
+    """Run mutmut for *profile* and return its raw stats."""
+    shutil.rmtree(MUTANTS_DIR, ignore_errors=True)
+    write_config(profile)
+    try:
+        try:
+            run = subprocess.run(
+                [sys.executable, "-m", "mutmut", "run", "--max-children", str(max_children)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            # mutmut forks per mutant, and a fork taken while the parent holds
+            # a lock in a thread can deadlock: the children sit in sleep with
+            # no CPU and mutmut's own per-mutant timeout never fires because
+            # the child never starts running. Observed intermittently on
+            # thread-heavy test files. Fail loudly rather than let a nightly
+            # job hang until the runner is reaped.
+            _kill_stragglers()
+            raise RuntimeError(
+                f"{profile.name}: mutmut hung for >{timeout}s (deadlocked fork). "
+                "Narrow this profile's test selection."
+            ) from None
+        if run.returncode not in (0, 1):  # 1 == some mutants survived
+            raise RuntimeError(f"mutmut run failed ({run.returncode}):\n{run.stdout[-3000:]}")
+        export = subprocess.run(
+            [sys.executable, "-m", "mutmut", "export-cicd-stats"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if not STATS_FILE.exists():
+            raise RuntimeError(f"no stats produced for {profile.name}:\n{export.stdout}")
+        return json.loads(STATS_FILE.read_text(encoding="utf-8"))
+    finally:
+        SETUP_CFG.unlink(missing_ok=True)
+
+
+def _kill_stragglers() -> None:
+    """Reap mutmut children left behind by a deadlocked fork.
+
+    ``subprocess`` kills the process it started; the forked grandchildren are
+    not in that tree and would otherwise sit around holding the sandbox.
+    """
+    subprocess.run(["pkill", "-f", "mutmut run"], check=False, capture_output=True)
+
+
+def score_of(stats: dict[str, int]) -> float | None:
+    """Mutation score: killed / (killed + survived), as a percentage.
+
+    Mutants with no covering test are excluded from the denominator — they
+    measure coverage, which the project already gates separately, and folding
+    them in would let a coverage change move the mutation score on its own.
+    """
+    decided = stats.get("killed", 0) + stats.get("survived", 0)
+    if not decided:
+        return None
+    return stats["killed"] / decided * 100
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profiles", nargs="*", help="profiles to run (default: all)")
+    parser.add_argument("--enforce", action="store_true", help="exit non-zero below a floor")
+    parser.add_argument("--max-children", type=int, default=4)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=1800,
+        help="per-profile wall-clock limit; a deadlocked fork never self-clears",
+    )
+    parser.add_argument("--report", type=Path, help="write the JSON report here")
+    parser.add_argument("--list", action="store_true", help="list profiles and exit")
+    args = parser.parse_args()
+
+    by_name = {p.name: p for p in PROFILES}
+    if args.list:
+        for p in PROFILES:
+            floor = f"{p.floor:.0f}%" if p.floor is not None else "not gated"
+            status = f"BLOCKED — {p.blocked}" if p.blocked else p.notes
+            print(f"{p.name:16s} floor={floor:10s} {status}")
+        return 0
+
+    unknown = set(args.profiles) - set(by_name)
+    if unknown:
+        print(f"unknown profile(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+        return 2
+    if args.profiles:
+        # Named explicitly: run it even if blocked, so anyone working on the
+        # blocker can measure whether they have fixed it.
+        selected = [by_name[n] for n in args.profiles]
+    else:
+        selected = [p for p in PROFILES if not p.blocked]
+        for skipped in (p for p in PROFILES if p.blocked):
+            # Announce every exclusion. A pilot that quietly drops a target
+            # reads as "we measured everything" when it did not.
+            print(f"-- {skipped.name}: SKIPPED — {skipped.blocked}", flush=True)
+
+    report: dict[str, dict] = {}
+    failures: list[str] = []
+    for profile in selected:
+        print(f"-- {profile.name}: mutating {len(profile.only_mutate)} module(s)", flush=True)
+        stats = run_profile(profile, args.max_children, args.timeout)
+
+        # A segfault is a broken harness, not a surviving mutant. Reporting a
+        # score over crashed runs is how this pilot would start lying.
+        if stats.get("segfault"):
+            failures.append(f"{profile.name}: {stats['segfault']} mutant(s) segfaulted")
+
+        score = score_of(stats)
+        report[profile.name] = {"stats": stats, "score": score, "floor": profile.floor}
+        shown = "n/a" if score is None else f"{score:.1f}%"
+        print(
+            f"   killed {stats.get('killed', 0):4d}  survived {stats.get('survived', 0):4d}"
+            f"  no-tests {stats.get('no_tests', 0):4d}  score {shown}",
+            flush=True,
+        )
+        if (
+            args.enforce
+            and profile.floor is not None
+            and score is not None
+            and score < profile.floor
+        ):
+            failures.append(f"{profile.name}: {score:.1f}% below floor {profile.floor:.0f}%")
+
+    if args.report:
+        args.report.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+        print(f"\nwrote {args.report}")
+
+    if failures:
+        print("\n".join(["", "FAILED:", *(f"  {f}" for f in failures)]), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/mutation_pilot.py
+++ b/scripts/ci/mutation_pilot.py
@@ -10,7 +10,7 @@ runtime multiplied by mutant count, and the suite is ~22.5k tests.
 Usage::
 
     python scripts/ci/mutation_pilot.py                 # run every profile
-    python scripts/ci/mutation_pilot.py optimization    # run one
+    python scripts/ci/mutation_pilot.py batch-sizer     # run one
     python scripts/ci/mutation_pilot.py --enforce       # fail below floors
     python scripts/ci/mutation_pilot.py --list          # show profiles
 
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -58,6 +59,10 @@ STATS_FILE = MUTANTS_DIR / "mutmut-cicd-stats.json"
 #: Pytest arguments shared by every profile. `--no-cov` is not optional; see
 #: the module docstring.
 BASE_PYTEST_ARGS = ["--no-cov", "-p", "no:randomly", "-p", "no:cacheprovider"]
+
+#: Reading already-written meta files should take seconds. Bounded anyway, so
+#: a wedged export cannot hang the nightly the way a wedged run would.
+EXPORT_TIMEOUT = 300
 
 
 @dataclass(frozen=True)
@@ -187,15 +192,30 @@ def run_profile(profile: Profile, max_children: int, timeout: int) -> dict[str, 
                 "Narrow this profile's test selection."
             ) from None
         if run.returncode not in (0, 1):  # 1 == some mutants survived
-            raise RuntimeError(f"mutmut run failed ({run.returncode}):\n{run.stdout[-3000:]}")
-        export = subprocess.run(
-            [sys.executable, "-m", "mutmut", "export-cicd-stats"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-        )
+            raise RuntimeError(
+                f"mutmut run failed ({run.returncode}):\n{run.stdout[-3000:]}\n{run.stderr[-3000:]}"
+            )
+        try:
+            export = subprocess.run(
+                [sys.executable, "-m", "mutmut", "export-cicd-stats"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=EXPORT_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError(
+                f"{profile.name}: export-cicd-stats hung for >{EXPORT_TIMEOUT}s"
+            ) from None
+        if export.returncode != 0:
+            raise RuntimeError(
+                f"{profile.name}: export-cicd-stats failed ({export.returncode}):\n"
+                f"{export.stdout[-2000:]}\n{export.stderr[-2000:]}"
+            )
         if not STATS_FILE.exists():
-            raise RuntimeError(f"no stats produced for {profile.name}:\n{export.stdout}")
+            raise RuntimeError(
+                f"no stats produced for {profile.name}:\n{export.stdout}\n{export.stderr}"
+            )
         return json.loads(STATS_FILE.read_text(encoding="utf-8"))
     finally:
         SETUP_CFG.unlink(missing_ok=True)
@@ -206,8 +226,21 @@ def _kill_stragglers() -> None:
 
     ``subprocess`` kills the process it started; the forked grandchildren are
     not in that tree and would otherwise sit around holding the sandbox.
+
+    Scoped to the current user so a shared runner — or a second profile
+    running in another shell — does not lose its processes to this. ``pkill``
+    is absent on some platforms, and raising ``FileNotFoundError`` here would
+    mask the timeout error this is called from.
     """
-    subprocess.run(["pkill", "-f", "mutmut run"], check=False, capture_output=True)
+    pkill = shutil.which("pkill")
+    if pkill is None:
+        print("pkill unavailable; mutmut children may still be running", file=sys.stderr)
+        return
+    subprocess.run(
+        [pkill, "-u", str(os.getuid()), "-f", "mutmut run"],
+        check=False,
+        capture_output=True,
+    )
 
 
 def score_of(stats: dict[str, int]) -> float | None:
@@ -217,10 +250,11 @@ def score_of(stats: dict[str, int]) -> float | None:
     measure coverage, which the project already gates separately, and folding
     them in would let a coverage change move the mutation score on its own.
     """
-    decided = stats.get("killed", 0) + stats.get("survived", 0)
+    killed = stats.get("killed", 0)
+    decided = killed + stats.get("survived", 0)
     if not decided:
         return None
-    return stats["killed"] / decided * 100
+    return killed / decided * 100
 
 
 def main() -> int:
@@ -266,7 +300,22 @@ def main() -> int:
     failures: list[str] = []
     for profile in selected:
         print(f"-- {profile.name}: mutating {len(profile.only_mutate)} module(s)", flush=True)
-        stats = run_profile(profile, args.max_children, args.timeout)
+        try:
+            stats = run_profile(profile, args.max_children, args.timeout)
+        except RuntimeError as exc:
+            # One wedged profile must not cost the others their results. Left
+            # to propagate, a hang in the first profile meant no report file,
+            # so the nightly's artifact upload had nothing to publish and the
+            # run looked like an infrastructure failure rather than a finding.
+            print(f"   ERROR: {exc}", file=sys.stderr, flush=True)
+            failures.append(f"{profile.name}: {exc}")
+            report[profile.name] = {
+                "stats": None,
+                "score": None,
+                "floor": profile.floor,
+                "error": str(exc),
+            }
+            continue
 
         # A segfault is a broken harness, not a surviving mutant. Reporting a
         # score over crashed runs is how this pilot would start lying.
@@ -281,13 +330,17 @@ def main() -> int:
             f"  no-tests {stats.get('no_tests', 0):4d}  score {shown}",
             flush=True,
         )
-        if (
-            args.enforce
-            and profile.floor is not None
-            and score is not None
-            and score < profile.floor
-        ):
-            failures.append(f"{profile.name}: {score:.1f}% below floor {profile.floor:.0f}%")
+        if args.enforce and profile.floor is not None:
+            if score is None:
+                # "No score" must not read as "floor cleared". Every mutant
+                # landing in `no_tests`, or empty stats, would otherwise pass
+                # a gated profile in silence — the precise shape of failure
+                # this pilot exists to detect.
+                failures.append(
+                    f"{profile.name}: produced no score, cannot check floor {profile.floor:.0f}%"
+                )
+            elif score < profile.floor:
+                failures.append(f"{profile.name}: {score:.1f}% below floor {profile.floor:.0f}%")
 
     if args.report:
         args.report.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")

--- a/tests/ci/test_mutation_pilot.py
+++ b/tests/ci/test_mutation_pilot.py
@@ -9,15 +9,17 @@ that never produced a score.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "mutation_pilot.py"
 
 
-def _load_module():
+def _load_module() -> ModuleType:
     """Import the driver by path; scripts/ is not an importable package."""
     spec = importlib.util.spec_from_file_location("mutation_pilot", _SCRIPT)
     assert spec and spec.loader
@@ -34,12 +36,12 @@ mutation_pilot = _load_module()
 class TestScoreOf:
     """The score's denominator is the whole argument."""
 
-    def test_score_is_killed_over_decided_mutants(self):
+    def test_score_is_killed_over_decided_mutants(self) -> None:
         stats = {"killed": 129, "survived": 65}
 
         assert mutation_pilot.score_of(stats) == pytest.approx(66.49, abs=0.01)
 
-    def test_uncovered_mutants_do_not_move_the_score(self):
+    def test_uncovered_mutants_do_not_move_the_score(self) -> None:
         """`no_tests` is a coverage fact, gated elsewhere.
 
         Folding it into the denominator would let a coverage change shift the
@@ -51,11 +53,11 @@ class TestScoreOf:
 
         assert without == with_uncovered == 80.0
 
-    def test_no_decided_mutants_scores_none_not_zero(self):
+    def test_no_decided_mutants_scores_none_not_zero(self) -> None:
         """Zero decided mutants is "unknown", and must not read as a failure."""
         assert mutation_pilot.score_of({"killed": 0, "survived": 0, "no_tests": 12}) is None
 
-    def test_every_mutant_surviving_is_zero_not_none(self):
+    def test_every_mutant_surviving_is_zero_not_none(self) -> None:
         assert mutation_pilot.score_of({"killed": 0, "survived": 40}) == 0.0
 
 
@@ -63,12 +65,12 @@ class TestScoreOf:
 class TestProfiles:
     """Profile definitions are the pilot's scope; keep them honest."""
 
-    def test_profile_names_are_unique(self):
+    def test_profile_names_are_unique(self) -> None:
         names = [p.name for p in mutation_pilot.PROFILES]
 
         assert len(names) == len(set(names))
 
-    def test_every_profile_names_its_own_tests(self):
+    def test_every_profile_names_its_own_tests(self) -> None:
         """A profile with no test selector silently falls back to the suite.
 
         That is the ~22.5k-test run this pilot exists to avoid, and it is
@@ -78,7 +80,7 @@ class TestProfiles:
             assert profile.tests, f"{profile.name} has no test selection"
             assert profile.only_mutate, f"{profile.name} mutates nothing"
 
-    def test_coverage_is_disabled_for_every_run(self):
+    def test_coverage_is_disabled_for_every_run(self) -> None:
         """`--no-cov` is what stops the coverage gate faking a 100% score.
 
         With coverage on, `--cov-fail-under=93` fails for nearly every
@@ -86,7 +88,7 @@ class TestProfiles:
         """
         assert "--no-cov" in mutation_pilot.BASE_PYTEST_ARGS
 
-    def test_generated_config_carries_the_profile_selection(self, tmp_path, monkeypatch):
+    def test_generated_config_carries_the_profile_selection(self, tmp_path, monkeypatch) -> None:
         """The written config must actually contain what the profile declared."""
         cfg = tmp_path / "setup.cfg"
         monkeypatch.setattr(mutation_pilot, "SETUP_CFG", cfg)
@@ -113,7 +115,7 @@ class TestSegfaultHandling:
     reported 100% while 268 and 432 mutants had segfaulted.
     """
 
-    def test_segfaults_fail_the_run_even_at_a_perfect_score(self, monkeypatch, capsys):
+    def test_segfaults_fail_the_run_even_at_a_perfect_score(self, monkeypatch, capsys) -> None:
         stats = {"killed": 222, "survived": 0, "no_tests": 7, "segfault": 432}
         monkeypatch.setattr(
             mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
@@ -125,7 +127,7 @@ class TestSegfaultHandling:
         assert exit_code == 1, "a segfaulting run must not pass"
         assert "segfault" in capsys.readouterr().err
 
-    def test_clean_run_below_no_floor_still_passes(self, monkeypatch):
+    def test_clean_run_below_no_floor_still_passes(self, monkeypatch) -> None:
         """Ungated profiles are measured, not enforced."""
         stats = {"killed": 1, "survived": 99, "no_tests": 0, "segfault": 0}
         monkeypatch.setattr(
@@ -140,7 +142,7 @@ class TestSegfaultHandling:
 
         assert mutation_pilot.main() == 0
 
-    def test_score_below_floor_fails_under_enforce(self, monkeypatch, capsys):
+    def test_score_below_floor_fails_under_enforce(self, monkeypatch, capsys) -> None:
         stats = {"killed": 50, "survived": 50, "no_tests": 0, "segfault": 0}
         monkeypatch.setattr(
             mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
@@ -155,7 +157,7 @@ class TestSegfaultHandling:
         assert mutation_pilot.main() == 1
         assert "below floor" in capsys.readouterr().err
 
-    def test_the_same_score_passes_without_enforce(self, monkeypatch):
+    def test_the_same_score_passes_without_enforce(self, monkeypatch) -> None:
         """Reporting mode never fails, so a nightly can still publish a report."""
         stats = {"killed": 50, "survived": 50, "no_tests": 0, "segfault": 0}
         monkeypatch.setattr(
@@ -170,7 +172,7 @@ class TestSegfaultHandling:
 
         assert mutation_pilot.main() == 0
 
-    def test_blocked_profile_is_skipped_but_announced(self, monkeypatch, capsys):
+    def test_blocked_profile_is_skipped_but_announced(self, monkeypatch, capsys) -> None:
         """A dropped target must never read as a clean sweep."""
         called: list[str] = []
         monkeypatch.setattr(
@@ -193,7 +195,7 @@ class TestSegfaultHandling:
         assert called == [], "a blocked profile must not be run by default"
         assert "SKIPPED" in capsys.readouterr().out
 
-    def test_blocked_profile_still_runs_when_named(self, monkeypatch):
+    def test_blocked_profile_still_runs_when_named(self, monkeypatch) -> None:
         """So whoever is fixing the blocker can measure their progress."""
         called: list[str] = []
         stats = {"killed": 1, "survived": 0, "no_tests": 0, "segfault": 0}
@@ -216,7 +218,62 @@ class TestSegfaultHandling:
         assert mutation_pilot.main() == 0
         assert called == ["wedged"]
 
-    def test_unknown_profile_is_rejected(self, monkeypatch):
+    def test_gated_profile_with_no_score_fails_rather_than_passing(
+        self, monkeypatch, capsys
+    ) -> None:
+        """ "No score" must never read as "floor cleared".
+
+        Every mutant landing in `no_tests`, or mutmut emitting empty stats,
+        leaves `score_of` returning None. Skipping the floor check there
+        passes a gated profile in silence — exactly the shape of failure this
+        pilot exists to detect.
+        """
+        stats = {"killed": 0, "survived": 0, "no_tests": 400, "segfault": 0}
+        monkeypatch.setattr(
+            mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (mutation_pilot.Profile(name="gated", only_mutate=["*"], tests=["t"], floor=75.0),),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "--enforce"])
+
+        assert mutation_pilot.main() == 1
+        assert "no score" in capsys.readouterr().err
+
+    def test_one_profile_failing_does_not_abort_the_others(self, monkeypatch, tmp_path) -> None:
+        """A wedged profile must not cost the rest their results.
+
+        Left to propagate, a hang in the first profile meant no report file
+        was written at all, so the nightly's artifact upload had nothing to
+        publish.
+        """
+        report = tmp_path / "report.json"
+
+        def fake_run(profile, max_children, timeout):
+            if profile.name == "wedged":
+                raise RuntimeError("hung for >1800s")
+            return {"killed": 9, "survived": 1, "no_tests": 0, "segfault": 0}
+
+        monkeypatch.setattr(mutation_pilot, "run_profile", fake_run)
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (
+                mutation_pilot.Profile(name="wedged", only_mutate=["*"], tests=["t"]),
+                mutation_pilot.Profile(name="healthy", only_mutate=["*"], tests=["t"]),
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "--report", str(report)])
+
+        assert mutation_pilot.main() == 1, "the wedged profile must still fail the run"
+
+        written = json.loads(report.read_text(encoding="utf-8"))
+        assert "hung" in written["wedged"]["error"]
+        assert written["healthy"]["score"] == 90.0, "the healthy profile still ran and reported"
+
+    def test_unknown_profile_is_rejected(self, monkeypatch) -> None:
         monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "no-such-profile"])
 
         assert mutation_pilot.main() == 2

--- a/tests/ci/test_mutation_pilot.py
+++ b/tests/ci/test_mutation_pilot.py
@@ -1,0 +1,222 @@
+"""Tests for the mutation-testing pilot driver (#1684, epic #1678).
+
+The driver's job is to turn mutmut's output into a number people will trust,
+so these tests concentrate on the ways that number could lie: a crashed run
+scored as a result, coverage left on, or a floor enforced against a profile
+that never produced a score.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "mutation_pilot.py"
+
+
+def _load_module():
+    """Import the driver by path; scripts/ is not an importable package."""
+    spec = importlib.util.spec_from_file_location("mutation_pilot", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["mutation_pilot"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mutation_pilot = _load_module()
+
+
+@pytest.mark.unit
+class TestScoreOf:
+    """The score's denominator is the whole argument."""
+
+    def test_score_is_killed_over_decided_mutants(self):
+        stats = {"killed": 129, "survived": 65}
+
+        assert mutation_pilot.score_of(stats) == pytest.approx(66.49, abs=0.01)
+
+    def test_uncovered_mutants_do_not_move_the_score(self):
+        """`no_tests` is a coverage fact, gated elsewhere.
+
+        Folding it into the denominator would let a coverage change shift the
+        mutation score on its own, which makes the number unreadable as a
+        statement about assertion strength.
+        """
+        without = mutation_pilot.score_of({"killed": 8, "survived": 2})
+        with_uncovered = mutation_pilot.score_of({"killed": 8, "survived": 2, "no_tests": 500})
+
+        assert without == with_uncovered == 80.0
+
+    def test_no_decided_mutants_scores_none_not_zero(self):
+        """Zero decided mutants is "unknown", and must not read as a failure."""
+        assert mutation_pilot.score_of({"killed": 0, "survived": 0, "no_tests": 12}) is None
+
+    def test_every_mutant_surviving_is_zero_not_none(self):
+        assert mutation_pilot.score_of({"killed": 0, "survived": 40}) == 0.0
+
+
+@pytest.mark.unit
+class TestProfiles:
+    """Profile definitions are the pilot's scope; keep them honest."""
+
+    def test_profile_names_are_unique(self):
+        names = [p.name for p in mutation_pilot.PROFILES]
+
+        assert len(names) == len(set(names))
+
+    def test_every_profile_names_its_own_tests(self):
+        """A profile with no test selector silently falls back to the suite.
+
+        That is the ~22.5k-test run this pilot exists to avoid, and it is
+        also what makes mutmut's fork segfault.
+        """
+        for profile in mutation_pilot.PROFILES:
+            assert profile.tests, f"{profile.name} has no test selection"
+            assert profile.only_mutate, f"{profile.name} mutates nothing"
+
+    def test_coverage_is_disabled_for_every_run(self):
+        """`--no-cov` is what stops the coverage gate faking a 100% score.
+
+        With coverage on, `--cov-fail-under=93` fails for nearly every
+        mutant, pytest exits non-zero, and mutmut reads that as "killed".
+        """
+        assert "--no-cov" in mutation_pilot.BASE_PYTEST_ARGS
+
+    def test_generated_config_carries_the_profile_selection(self, tmp_path, monkeypatch):
+        """The written config must actually contain what the profile declared."""
+        cfg = tmp_path / "setup.cfg"
+        monkeypatch.setattr(mutation_pilot, "SETUP_CFG", cfg)
+        profile = mutation_pilot.Profile(
+            name="probe",
+            only_mutate=["*/some/module.py"],
+            tests=["tests/some/test_module.py"],
+        )
+
+        mutation_pilot.write_config(profile)
+        written = cfg.read_text(encoding="utf-8")
+
+        assert "[mutmut]" in written
+        assert "*/some/module.py" in written
+        assert "tests/some/test_module.py" in written
+        assert "--no-cov" in written
+
+
+@pytest.mark.unit
+class TestSegfaultHandling:
+    """A crashed run is not a result.
+
+    This is the guard that caught the pilot's own first numbers: two profiles
+    reported 100% while 268 and 432 mutants had segfaulted.
+    """
+
+    def test_segfaults_fail_the_run_even_at_a_perfect_score(self, monkeypatch, capsys):
+        stats = {"killed": 222, "survived": 0, "no_tests": 7, "segfault": 432}
+        monkeypatch.setattr(
+            mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "organizer"])
+
+        exit_code = mutation_pilot.main()
+
+        assert exit_code == 1, "a segfaulting run must not pass"
+        assert "segfault" in capsys.readouterr().err
+
+    def test_clean_run_below_no_floor_still_passes(self, monkeypatch):
+        """Ungated profiles are measured, not enforced."""
+        stats = {"killed": 1, "survived": 99, "no_tests": 0, "segfault": 0}
+        monkeypatch.setattr(
+            mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (mutation_pilot.Profile(name="ungated", only_mutate=["*"], tests=["t"], floor=None),),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "--enforce"])
+
+        assert mutation_pilot.main() == 0
+
+    def test_score_below_floor_fails_under_enforce(self, monkeypatch, capsys):
+        stats = {"killed": 50, "survived": 50, "no_tests": 0, "segfault": 0}
+        monkeypatch.setattr(
+            mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (mutation_pilot.Profile(name="gated", only_mutate=["*"], tests=["t"], floor=75.0),),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "--enforce"])
+
+        assert mutation_pilot.main() == 1
+        assert "below floor" in capsys.readouterr().err
+
+    def test_the_same_score_passes_without_enforce(self, monkeypatch):
+        """Reporting mode never fails, so a nightly can still publish a report."""
+        stats = {"killed": 50, "survived": 50, "no_tests": 0, "segfault": 0}
+        monkeypatch.setattr(
+            mutation_pilot, "run_profile", lambda profile, max_children, timeout: stats
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (mutation_pilot.Profile(name="gated", only_mutate=["*"], tests=["t"], floor=75.0),),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py"])
+
+        assert mutation_pilot.main() == 0
+
+    def test_blocked_profile_is_skipped_but_announced(self, monkeypatch, capsys):
+        """A dropped target must never read as a clean sweep."""
+        called: list[str] = []
+        monkeypatch.setattr(
+            mutation_pilot,
+            "run_profile",
+            lambda profile, max_children, timeout: called.append(profile.name) or {},
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (
+                mutation_pilot.Profile(
+                    name="wedged", only_mutate=["*"], tests=["t"], blocked="segfaults"
+                ),
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "--enforce"])
+
+        assert mutation_pilot.main() == 0
+        assert called == [], "a blocked profile must not be run by default"
+        assert "SKIPPED" in capsys.readouterr().out
+
+    def test_blocked_profile_still_runs_when_named(self, monkeypatch):
+        """So whoever is fixing the blocker can measure their progress."""
+        called: list[str] = []
+        stats = {"killed": 1, "survived": 0, "no_tests": 0, "segfault": 0}
+        monkeypatch.setattr(
+            mutation_pilot,
+            "run_profile",
+            lambda profile, max_children, timeout: (called.append(profile.name), stats)[1],
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (
+                mutation_pilot.Profile(
+                    name="wedged", only_mutate=["*"], tests=["t"], blocked="segfaults"
+                ),
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "wedged"])
+
+        assert mutation_pilot.main() == 0
+        assert called == ["wedged"]
+
+    def test_unknown_profile_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "no-such-profile"])
+
+        assert mutation_pilot.main() == 2


### PR DESCRIPTION
Closes #1684 — the last open piece of epic #1678.

Mutation testing is the only technique in this repo that finds "this test
proves nothing" without knowing the failure mode in advance. That makes it the
outside check on the epic's 417 repairs: it does not use the detectors that
produced them.

## Baselines

Measured 2026-08-08, reproduced **identically across four runs**.
`pytest-randomly` is disabled for these, so scores are deterministic — which is
what makes a floor meaningful rather than decorative.

| Profile | Killed | Survived | Score | Floor |
| :--- | ---: | ---: | ---: | ---: |
| `batch-sizer` | 129 | 65 | 66.5% | 63% |
| `memory-limiter` | 67 | 17 | 79.8% | 76% |
| `memory-profiler` | 96 | 23 | 80.7% | 77% |
| `parallel` | 233 | 291 | 44.5% | blocked |
| `organizer` | — | — | blocked | — |

Floors sit ~3 points below baseline: margin for test additions changing the
denominator, not for noise.

You asked for a **failing threshold** rather than report-only. I set the floors
from measured data instead of picking a number up front — an invented floor is
one people route around. `--enforce` exits non-zero below a floor; the nightly
passes it by default and a manual dispatch can turn it off.

## What ships

- `scripts/ci/mutation_pilot.py` — per-module profiles, scoring, floor
  enforcement, JSON report.
- `.github/workflows/mutation.yml` — nightly 04:00 UTC plus manual dispatch.
  Never on a PR.
- `docs/developer/mutation-testing.md` — how to run it, how to read it, and
  every trap below.
- `tests/ci/test_mutation_pilot.py` — 15 tests, concentrated on the ways the
  score could lie.

## Three traps, each of which produces a confident wrong number

I hit all three. They are why this took measuring rather than configuring.

**1. The coverage gate fakes a perfect score.** The project's pytest `addopts`
carry `--cov-fail-under=93`. Under mutation that gate fails for nearly every
mutant, pytest exits non-zero, and mutmut reads non-zero as "the suite caught
it". Leaving coverage on reports ~100% while measuring the coverage gate and
nothing else. `--no-cov` is load bearing.

**2. Segfaults get recorded as mutant verdicts.** mutmut forks per mutant, and
broad test paths drag in ~240 native extension modules (torch, av, scipy) and
crash the fork. The pilot's own first run reported `optimization` and
`organizer` at **100%** — built entirely on 268 and 432 segfaults. The driver
now treats any `segfault` as a hard error rather than a result, and that guard
is what caught it.

**3. A deadlocked fork never self-clears.** Children go to sleep at zero CPU
and mutmut's per-mutant timeout never fires, because the child never starts.
Hence a per-profile `--timeout` and straggler reaping.

I also had **mutmut's emoji legend backwards** at first (`🙁` is *survived*,
`🫥` is *no tests*), which is a fourth way to read 66.5% as 100%. The docs call
this out.

## Verification

The number is only evidence if the harness can tell killed from survived, so I
checked it the way I'd check any guard — broke something and confirmed the
score moved. Replacing every `assert X` with `_ = X` in `test_batch_sizer.py`
moved 16 mutants from killed to survived (66.5% → 58.2%). A harness that
reports the same score either way is measuring nothing.

## Two blocked targets, announced rather than dropped

The driver prints every skip. A pilot that quietly shrinks its sweep reads as
"we measured everything".

- **`parallel`** deadlocks intermittently — completed twice, hung twice. Its
  44.5% is real but ungated: a gate that hangs half the time is worse than no
  gate. It is also the weakest score here, and understated, since the
  thread-safety and concurrency tests (the ones most worth mutating) are
  exactly what triggers the hang.
- **`organizer`** segfaults 432 mutants because `core/organizer.py` imports the
  audio/video metadata extractors at module scope, so every fork loads
  av/torch. Making those imports lazy would unblock it — worth doing, since
  this is the module where `organize()`'s AI path was once deletable with all
  126 tests passing.

I'll file both as follow-ups.

## Packaging note

mutmut cannot go in the `dev` extra: it declares `textual>=1.0` against this
project's `textual~=0.50` pin, and letting pip resolve it upgrades textual and
breaks the TUI suite (733 tests). CI installs with `--no-deps`; `run`,
`results` and `export-cicd-stats` all work against the pinned version, only
`browse` needs the newer API.

The `workflow_dispatch` inputs are passed through the environment rather than
interpolated into the `run:` block, so dispatch access is not command
execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mutation-testing pilot with configurable profiles, score reporting, enforcement thresholds, timeouts, and JSON output.
  * Added scheduled and manually triggered CI runs with report uploads.
* **Documentation**
  * Added developer guidance covering setup, execution, results, profiles, and troubleshooting.
  * Added the guide to the Developer documentation navigation.
* **Tests**
  * Added comprehensive validation for scoring, configuration, failures, reporting, and profile selection.
* **Chores**
  * Ignored generated mutation-testing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->