### PR TITLE
fix: pypdf CVEs, alembic logger poisoning, and the real cause of the mutation blockers

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,7 +16,13 @@ from file_organizer.api.database import resolve_database_url
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # `disable_existing_loggers=False` is load bearing, not a preference.
+    # The default is True, which disables every logger not named in
+    # alembic.ini — i.e. all of `file_organizer.*` — for the rest of the
+    # process. Alembic ships the True default because it assumes it owns a
+    # short-lived CLI process; here migrations also run in-process, so the
+    # default silently switches application logging off (#1677).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -132,7 +132,7 @@ same root cause as `parallel`'s hang — one surfaces as a crash, the other as a
 deadlock — so neither is fixable by narrowing imports or tuning workers. It
 needs a non-forking runner (#1726).
 
-An earlier version of this page blamed `core/organizer.py`'s module-scope
+An earlier version of this page blamed the organizer module's module-scope
 `av`/`torch` imports. That was wrong: making them lazy cut the module's import
 from 2,839 to 1,665 modules and removed av/torch entirely, and the segfault
 count did not move by one.

--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -65,7 +65,9 @@ coverage gate and nothing else.
 
 **2. Test selection must be narrow, and one module per profile.** mutmut
 forks a process per mutant, and forking this test environment is fragile in
-two distinct ways:
+two distinct ways. Both are properties of the **test files** selected, not of
+the module being mutated — adding one thread-using test file to an otherwise
+clean profile is enough to break it:
 
 - *Segfaults.* Broad test paths drag in ~240 native extension modules (torch,
   av, scipy) and the fork crashes. mutmut records the crash as a mutant
@@ -116,11 +118,24 @@ problem further, since `test_processor_thread_safety.py` and
 `test_concurrency_fixes.py` — the tests most worth mutating — are exactly the
 ones that trigger the hang.
 
-**`organizer` segfaults.** `src/file_organizer/core/organizer.py` imports the
-audio and video metadata extractors at module scope, so every fork loads
-av/torch and 432 mutants crash. Making those imports lazy would unblock it,
-and would be worth doing: this is the module where `organize()`'s AI path was
-once deletable with all 126 tests still passing.
+**`organizer` segfaults**, 432 mutants — and the cause is the *test files*,
+not the module. Two controlled runs establish it:
+
+- Mutating the known-clean `batch_sizer.py` while merely adding
+  `tests/core/test_organizer.py` to the selection produces 42 segfaults, where
+  that profile is otherwise 129 killed / 65 survived / 0 crashed.
+- `--max-children 1` changes nothing (42 either way), so it is the fork
+  itself, not concurrency between children.
+
+Those tests create threads, and mutmut forks a process per mutant. This is the
+same root cause as `parallel`'s hang — one surfaces as a crash, the other as a
+deadlock — so neither is fixable by narrowing imports or tuning workers. It
+needs a non-forking runner (#1726).
+
+An earlier version of this page blamed `core/organizer.py`'s module-scope
+`av`/`torch` imports. That was wrong: making them lazy cut the module's import
+from 2,839 to 1,665 modules and removed av/torch entirely, and the segfault
+count did not move by one.
 
 ## Validating the harness before trusting a score
 

--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -69,10 +69,9 @@ two distinct ways. Both are properties of the **test files** selected, not of
 the module being mutated — adding one thread-using test file to an otherwise
 clean profile is enough to break it:
 
-- *Segfaults.* Broad test paths drag in ~240 native extension modules (torch,
-  av, scipy) and the fork crashes. mutmut records the crash as a mutant
-  verdict, so a profile can report a perfect score built entirely on
-  corpses — the pilot's own first run showed the grouped optimization profile
+- *Segfaults.* The fork crashes, and mutmut records the crash as a mutant
+  verdict — so a profile can report a perfect score built entirely on
+  corpses. The pilot's own first run showed the grouped optimization profile
   and `organizer` at 100% with 268 and 432 mutants segfaulted. The driver
   treats any `segfault` in the stats as a hard error.
 - *Deadlocks.* Thread-heavy test files (for example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,11 @@ dedup = [
     # round-trips. Validated continuously by the ci-extras matrix.
     "imagededup>=0.3.0",  # 0.x — unstable API, keep >=; Image similarity and duplicate detection
     "scikit-learn~=1.4",  # ML-based text similarity for deduplication
-    "pypdf>=4,<7",  # PDF text extraction fallback in dedup extractor
+    # 6.15.0 fixes GHSA-fwg2-594c-jp42 (unbounded runtime/memory on large CID
+    # font width ranges) and GHSA-fp3f-mc75-235c (large /ToUnicode streams).
+    # Both are resource exhaustion reachable from a malformed PDF, and this
+    # extractor runs over user-supplied files, so the floor is a real bound.
+    "pypdf>=6.15.0,<7",  # PDF text extraction fallback in dedup extractor
     "striprtf>=0.0.26",  # 0.x — unstable API, keep >=; RTF file text extraction in dedup extractor
 ]
 

--- a/scripts/ci/mutation_pilot.py
+++ b/scripts/ci/mutation_pilot.py
@@ -125,9 +125,11 @@ PROFILES: tuple[Profile, ...] = (
         notes="Wave-B repairs plus the resume/persistence assertions.",
         blocked=(
             "deadlocks intermittently: forked children go to sleep and never "
-            "resume, so the run hangs until --timeout reaps it. Measured 44.5% "
-            "(233 killed / 291 survived) on the runs that did complete, but an "
-            "intermittent hang cannot gate a nightly."
+            "resume, so the run hangs until --timeout reaps it. Same root cause "
+            "as the organizer profile — thread-creating tests plus fork-per-mutant "
+            "— surfacing as a hang rather than a crash. Measured 44.5% (233 killed "
+            "/ 291 survived) on the runs that completed, but an intermittent hang "
+            "cannot gate a nightly (#1726)."
         ),
     ),
     Profile(
@@ -143,9 +145,12 @@ PROFILES: tuple[Profile, ...] = (
         # segfault (see the module docstring).
         notes="organize()'s AI path was deletable with all 126 tests passing.",
         blocked=(
-            "432 mutants segfault: organizer.py imports the audio/video metadata "
-            "extractors at module scope, so every fork loads av/torch. Needs those "
-            "imports made lazy, or a non-forking runner."
+            "432 mutants segfault. Cause is the TEST files, not this module: "
+            "mutating the known-clean batch_sizer.py while merely adding "
+            "tests/core/test_organizer.py to the selection produces 42 segfaults. "
+            "Those tests create threads, and mutmut forks per mutant. Unaffected "
+            "by --max-children 1, so it is the fork itself. Needs a non-forking "
+            "runner (#1726)."
         ),
     ),
 )

--- a/scripts/ci/mutation_pilot.py
+++ b/scripts/ci/mutation_pilot.py
@@ -23,11 +23,13 @@ produces a confident number that means nothing:
    suite caught it" — reporting a ~100% score that measures the coverage
    gate rather than the tests.
 
-2. **Narrow test selection.** mutmut forks per mutant. Pointed at broad test
-   paths it drags in ~240 native extension modules (torch, av, scipy) and
-   segfaults, which mutmut records as a mutant verdict. Each profile names
-   only the test files that exercise its modules. ``segfault`` in the stats
-   is treated as a hard error here, not as a result.
+2. **Narrow test selection.** mutmut forks per mutant, and forks taken while
+   the parent has threads running crash or hang. This is a property of the
+   *test files* selected, not of the module being mutated: adding one
+   thread-creating test file to an otherwise clean profile produces
+   segfaults, which mutmut then records as mutant verdicts. Each profile
+   names only the test files that exercise its modules, and ``segfault`` in
+   the stats is treated as a hard error here rather than as a result.
 
 3. **Config lives in ``setup.cfg``, written per profile.** mutmut reads
    ``[tool.mutmut]`` from ``pyproject.toml`` when present and only falls back
@@ -140,9 +142,14 @@ PROFILES: tuple[Profile, ...] = (
             "tests/core/test_organizer_coverage.py",
             "tests/core/test_organizer_sha256_safedir.py",
         ],
-        # test_audio_video_integration.py is deliberately excluded: it imports
-        # av/torch, and those native extensions are what make mutmut's fork
-        # segfault (see the module docstring).
+        # test_audio_video_integration.py is excluded, but the reason it was
+        # excluded turned out to be wrong: it was av/torch native extensions,
+        # and that explanation is retracted (see the `blocked` note below and
+        # docs/developer/mutation-testing.md). There is no separate evidence
+        # that this file is unsafe to fork. It stays out only because the
+        # profile is blocked outright and the selection is therefore untested
+        # — re-derive it when #1726 unblocks this profile rather than
+        # inheriting this list.
         notes="organize()'s AI path was deletable with all 126 tests passing.",
         blocked=(
             "432 mutants segfault. Cause is the TEST files, not this module: "

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -45,8 +45,6 @@ from file_organizer.models.base import ModelConfig
 from file_organizer.parallel.config import ExecutorType, ParallelConfig
 from file_organizer.parallel.processor import ParallelProcessor
 from file_organizer.services import ProcessedFile, ProcessedImage, TextProcessor, VisionProcessor
-from file_organizer.services.audio.metadata_extractor import AudioMetadataExtractor
-from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
 from file_organizer.undo import UndoManager
 from file_organizer.utils.safedir import SafeDir, SymlinkRejected
 
@@ -792,6 +790,17 @@ class FileOrganizer:
                     "Falling back to metadata-only categorization.[/yellow]"
                 )
 
+        # Imported here, not at module scope: this and its video counterpart
+        # pull in `av` and `torch`, taking this module's import from 1,665 to
+        # 2,839 modules for every invocation, including ones that never touch
+        # media. They are the only heavy dependency unique to this module —
+        # everything else already arrives via `file_organizer.services`.
+        #
+        # This does NOT make the module mutation-testable, which was #1725's
+        # premise. The segfaults come from the test files, not this import;
+        # see docs/developer/mutation-testing.md.
+        from file_organizer.services.audio.metadata_extractor import AudioMetadataExtractor
+
         return dispatcher.process_audio_files(
             files,
             extractor_cls=AudioMetadataExtractor,
@@ -801,4 +810,7 @@ class FileOrganizer:
 
     def _process_video_files(self, files: list[Path]) -> list[ProcessedFile]:
         """Classify video files and append results to the plan."""
+        # Lazy for the same reason as the audio extractor above.
+        from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
+
         return dispatcher.process_video_files(files, extractor_cls=VideoMetadataExtractor)

--- a/src/file_organizer/methodologies/para/ai/feedback.py
+++ b/src/file_organizer/methodologies/para/ai/feedback.py
@@ -22,10 +22,19 @@ from ..config import HeuristicWeights
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_FEEDBACK_DIR = resolve_legacy_path(
-    get_config_dir() / "feedback",
-    Path.home() / ".config" / "file-organizer" / "feedback",
-)
+
+def _default_feedback_dir() -> Path:
+    """Resolve the default feedback directory at call time.
+
+    Deliberately not a module-level constant: ``get_config_dir()`` and
+    ``Path.home()`` both read the environment, so computing this at import
+    time pins it to whatever the environment was when the module was first
+    imported and ignores any later repointing (see #1677).
+    """
+    return resolve_legacy_path(
+        get_config_dir() / "feedback",
+        Path.home() / ".config" / "file-organizer" / "feedback",
+    )
 
 
 @dataclass
@@ -152,7 +161,7 @@ class FeedbackCollector:
             storage_dir: Directory for storing feedback JSON. Uses default
                 ~/.config/file-organizer/feedback if not specified.
         """
-        self._storage_dir = storage_dir or _DEFAULT_FEEDBACK_DIR
+        self._storage_dir = storage_dir or _default_feedback_dir()
         self._feedback_file = self._storage_dir / "feedback_events.json"
         self._events: list[FeedbackEvent] = []
         self._loaded = False

--- a/src/file_organizer/services/copilot/rules/rule_manager.py
+++ b/src/file_organizer/services/copilot/rules/rule_manager.py
@@ -16,10 +16,19 @@ from file_organizer.config.path_migration import resolve_legacy_path
 from file_organizer.services.copilot.rules.models import Rule, RuleSet
 from file_organizer.utils.atomic_write import atomic_write_text
 
-_DEFAULT_RULES_DIR = resolve_legacy_path(
-    get_config_dir() / "rules",
-    Path.home() / ".config" / "file-organizer" / "rules",
-)
+
+def _default_rules_dir() -> Path:
+    """Resolve the default rules directory at call time.
+
+    Deliberately not a module-level constant: ``get_config_dir()`` and
+    ``Path.home()`` both read the environment, so computing this at import
+    time pins it to whatever the environment was when the module was first
+    imported and ignores any later repointing (see #1677).
+    """
+    return resolve_legacy_path(
+        get_config_dir() / "rules",
+        Path.home() / ".config" / "file-organizer" / "rules",
+    )
 
 
 class RuleManager:
@@ -31,7 +40,7 @@ class RuleManager:
 
     def __init__(self, rules_dir: str | Path | None = None) -> None:
         """Initialize RuleManager."""
-        self._rules_dir = Path(rules_dir) if rules_dir else _DEFAULT_RULES_DIR
+        self._rules_dir = Path(rules_dir) if rules_dir else _default_rules_dir()
 
     @property
     def rules_dir(self) -> Path:

--- a/tests/core/test_audio_video_integration.py
+++ b/tests/core/test_audio_video_integration.py
@@ -80,7 +80,7 @@ class TestProcessAudioFiles:
         organizer = FileOrganizer()
 
         with patch(
-            "file_organizer.core.organizer.AudioMetadataExtractor.extract",
+            "file_organizer.services.audio.metadata_extractor.AudioMetadataExtractor.extract",
             side_effect=RuntimeError("bad file"),
         ):
             results = organizer._process_audio_files([audio])
@@ -94,7 +94,7 @@ class TestProcessAudioFiles:
         organizer = FileOrganizer()
 
         with patch(
-            "file_organizer.core.organizer.AudioMetadataExtractor.extract",
+            "file_organizer.services.audio.metadata_extractor.AudioMetadataExtractor.extract",
             side_effect=RuntimeError("bad"),
         ):
             results = organizer._process_audio_files([audio])
@@ -196,7 +196,7 @@ class TestProcessVideoFiles:
         organizer = FileOrganizer()
 
         with patch(
-            "file_organizer.core.organizer.VideoMetadataExtractor.extract",
+            "file_organizer.services.video.metadata_extractor.VideoMetadataExtractor.extract",
             side_effect=RuntimeError("corrupt"),
         ):
             results = organizer._process_video_files([video])

--- a/tests/history/test_db_migrations.py
+++ b/tests/history/test_db_migrations.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
+import pytest
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect
 
@@ -34,3 +36,35 @@ def test_alembic_upgrade_head_creates_expected_tables(tmp_path: Path) -> None:
         "file_metadata",
     }
     assert expected.issubset(tables)
+
+
+@pytest.mark.unit
+def test_running_migrations_does_not_disable_application_loggers(tmp_path: Path) -> None:
+    """Migrations must not switch off the rest of the process's logging.
+
+    Regression for #1677. ``alembic/env.py`` calls ``fileConfig()``, whose
+    ``disable_existing_loggers`` default is True — that disables every logger
+    not named in ``alembic.ini``, which is all of ``file_organizer.*``, for
+    the remaining life of the process. Alembic ships that default assuming a
+    short-lived CLI process; these migrations also run in-process.
+
+    The visible symptom was two unrelated tests failing only in full-suite
+    runs, because their ``caplog`` assertions saw nothing once this module had
+    run: ``test_cli_daemon.py::test_log_helper_emits_on_delta`` and
+    ``test_cli_main_commands.py::test_durable_move_sweep_failure_is_logged_not_raised``.
+
+    Asserted on ``logger.disabled`` rather than through ``caplog``, because
+    ``fileConfig`` also replaces the root handlers — which detaches caplog's
+    own handler for the rest of *this* test. That is harmless across tests,
+    since the fixture re-attaches per test, and it is not what broke them.
+    """
+    logger = logging.getLogger("file_organizer.probe_after_migration")
+    assert not logger.disabled, "premise: the probe logger starts enabled"
+    project_root = Path(__file__).resolve().parents[2]
+
+    config = Config(str(project_root / "alembic.ini"))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{tmp_path / 'probe.db'}")
+    command.upgrade(config, "head")
+
+    assert not logger.disabled, "migrations disabled an application logger"

--- a/tests/integration/test_para_feedback_collector.py
+++ b/tests/integration/test_para_feedback_collector.py
@@ -638,6 +638,7 @@ class TestDefaultStorageDirResolution:
         under its per-file integration coverage floor when the module-level
         constant became a function.
         """
+        from file_organizer.config.path_manager import get_config_dir
         from file_organizer.methodologies.para.ai.feedback import FeedbackCollector
 
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
@@ -645,7 +646,13 @@ class TestDefaultStorageDirResolution:
 
         collector = FeedbackCollector()
 
-        assert tmp_path in collector._storage_dir.parents or collector._storage_dir == tmp_path
+        # Compared against `get_config_dir()` resolved AFTER the patch, not
+        # against `tmp_path`. The conftest already points HOME and
+        # XDG_CONFIG_HOME at subdirectories of this same tmp_path, so
+        # "is it under tmp_path" is true whether or not the default follows
+        # the repointed environment — a vacuous assertion that passed against
+        # a deliberately frozen constant.
+        assert collector._storage_dir == get_config_dir() / "feedback"
 
 
 class TestFeedbackStoreDegradesInsteadOfRaising:

--- a/tests/integration/test_para_feedback_collector.py
+++ b/tests/integration/test_para_feedback_collector.py
@@ -623,3 +623,63 @@ class TestPatternLearner:
         total = weights.temporal + weights.content + weights.structural + weights.ai
 
         assert abs(total - 1.0) < 1e-6
+
+
+class TestDefaultStorageDirResolution:
+    """The default storage directory is resolved per call, not at import (#1677)."""
+
+    def test_collector_without_storage_dir_follows_the_config_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exercises the default branch, which every other test bypasses.
+
+        Integration tests all pass an explicit ``storage_dir``, so the default
+        path is otherwise never taken here — which is what dropped this module
+        under its per-file integration coverage floor when the module-level
+        constant became a function.
+        """
+        from file_organizer.methodologies.para.ai.feedback import FeedbackCollector
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        collector = FeedbackCollector()
+
+        assert tmp_path in collector._storage_dir.parents or collector._storage_dir == tmp_path
+
+
+class TestFeedbackStoreDegradesInsteadOfRaising:
+    """The store swallows I/O and parse errors by design; pin that it does.
+
+    These paths return an empty list or simply log, so a regression that
+    started raising would surface as a crash in the suggestion flow rather
+    than as a failure here. They were also the module's only untested
+    branches.
+    """
+
+    def test_corrupt_feedback_file_yields_no_events_rather_than_raising(
+        self, tmp_path: Path
+    ) -> None:
+        from file_organizer.methodologies.para.ai.feedback import FeedbackCollector
+
+        collector = FeedbackCollector(storage_dir=tmp_path)
+        collector._feedback_file.write_text("{not json at all", encoding="utf-8")
+
+        collector._ensure_loaded()
+
+        assert collector._events == []
+
+    def test_unwritable_storage_does_not_raise_on_save(self, tmp_path: Path) -> None:
+        from file_organizer.methodologies.para.ai.feedback import FeedbackCollector
+
+        collector = FeedbackCollector(storage_dir=tmp_path)
+        collector._loaded = True
+
+        with patch(
+            "file_organizer.methodologies.para.ai.feedback.open",
+            side_effect=OSError("disk full"),
+            create=True,
+        ) as mock_open:
+            collector._save_events()
+
+        mock_open.assert_called_once()

--- a/tests/methodologies/para/test_feedback.py
+++ b/tests/methodologies/para/test_feedback.py
@@ -513,3 +513,28 @@ class TestPatternLearner:
         assert weights.structural <= 0.30  # Should be reduced
         total = weights.temporal + weights.content + weights.structural + weights.ai
         assert 0.99 <= total <= 1.01
+
+
+@pytest.mark.unit
+class TestDefaultStorageDirResolution:
+    """The default feedback directory must track the environment (#1677)."""
+
+    def test_default_dir_follows_a_repointed_config_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolved per call, not frozen at import.
+
+        ``_DEFAULT_FEEDBACK_DIR`` used to be a module-level constant, so the
+        directory was pinned to whatever the environment was when this module
+        was first imported — in a test session, whichever test imported it
+        first. Same shape as the ``parallel/checkpoint.py`` defect that made
+        four tests order-dependent.
+        """
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        collector = FeedbackCollector()
+
+        assert tmp_path in collector._storage_dir.parents or collector._storage_dir == tmp_path, (
+            f"feedback dir {collector._storage_dir} ignored the repointed config dir {tmp_path}"
+        )

--- a/tests/methodologies/para/test_feedback.py
+++ b/tests/methodologies/para/test_feedback.py
@@ -533,8 +533,11 @@ class TestDefaultStorageDirResolution:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.setenv("HOME", str(tmp_path))
 
+        from file_organizer.config.path_manager import get_config_dir
+
         collector = FeedbackCollector()
 
-        assert tmp_path in collector._storage_dir.parents or collector._storage_dir == tmp_path, (
-            f"feedback dir {collector._storage_dir} ignored the repointed config dir {tmp_path}"
+        expected = get_config_dir() / "feedback"
+        assert collector._storage_dir == expected, (
+            f"feedback dir {collector._storage_dir} ignored the repointed config dir"
         )

--- a/tests/services/copilot/test_rule_manager.py
+++ b/tests/services/copilot/test_rule_manager.py
@@ -733,8 +733,11 @@ class TestDefaultRulesDirResolution:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.setenv("HOME", str(tmp_path))
 
+        from file_organizer.config.path_manager import get_config_dir
+
         manager = RuleManager()
 
-        assert tmp_path in manager._rules_dir.parents or manager._rules_dir == tmp_path, (
-            f"rules dir {manager._rules_dir} ignored the repointed config dir {tmp_path}"
+        expected = get_config_dir() / "rules"
+        assert manager._rules_dir == expected, (
+            f"rules dir {manager._rules_dir} ignored the repointed config dir"
         )

--- a/tests/services/copilot/test_rule_manager.py
+++ b/tests/services/copilot/test_rule_manager.py
@@ -715,3 +715,26 @@ class TestRuleManagerIntegration:
 
         archive_rule = manager.get_rule("archive", "pdf_rule")
         assert archive_rule.enabled is True
+
+
+@pytest.mark.unit
+class TestDefaultRulesDirResolution:
+    """The default rules directory must track the environment (#1677)."""
+
+    def test_default_dir_follows_a_repointed_config_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolved per call, not frozen at import.
+
+        ``_DEFAULT_RULES_DIR`` used to be a module-level constant, pinning the
+        directory to the environment present when this module was first
+        imported. Same defect shape as ``parallel/checkpoint.py`` in #1677.
+        """
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        manager = RuleManager()
+
+        assert tmp_path in manager._rules_dir.parents or manager._rules_dir == tmp_path, (
+            f"rules dir {manager._rules_dir} ignored the repointed config dir {tmp_path}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2488,7 +2488,7 @@ requires-dist = [
     { name = "pymarkdownlnt", marker = "extra == 'dev'", specifier = ">=0.9.25" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = "~=11.0" },
     { name = "pymupdf", marker = "extra == 'parsers'", specifier = "~=1.23" },
-    { name = "pypdf", marker = "extra == 'dedup'", specifier = ">=4,<7" },
+    { name = "pypdf", marker = "extra == 'dedup'", specifier = ">=6.15.0,<7" },
     { name = "pyqt6", marker = "extra == 'gui'", specifier = "~=6.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "~=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "~=1.4" },
@@ -3032,13 +3032,13 @@ name = "mlx-lm"
 version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
+    { name = "jinja2", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "sentencepiece" },
-    { name = "transformers" },
+    { name = "numpy", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "protobuf", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "pyyaml", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "sentencepiece", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "transformers", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
@@ -4386,11 +4386,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]
@@ -5681,15 +5681,15 @@ name = "transformers"
 version = "5.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "safetensors" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-    { name = "typer" },
+    { name = "huggingface-hub", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "numpy", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "packaging", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "pyyaml", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "regex", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "safetensors", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "tokenizers", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "tqdm", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "typer", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
 wheels = [


### PR DESCRIPTION
Closes #1677. Addresses #1725 and #1726 — but not by fixing them: by finding
that their stated cause was wrong. Plus two Dependabot alerts.

## Security — pypdf 6.15.0

[Alert 92](https://github.com/curdriceaurora/Local-File-Organizer/security/dependabot/92)
(GHSA-fwg2-594c-jp42, unbounded runtime/memory on large CID font width ranges)
and [alert 93](https://github.com/curdriceaurora/Local-File-Organizer/security/dependabot/93)
(GHSA-fp3f-mc75-235c, large `/ToUnicode` streams). Both are resource
exhaustion reachable from a malformed PDF, and the dedup extractor runs over
user-supplied files, so this floor is a real bound rather than hygiene.
`uv lock` moved pypdf 6.14.2 → 6.15.0; 36 PDF tests pass on it.

⚠️ The lock diff also carries incidental marker normalisation on the
transformers/sentencepiece groups, from my local uv (0.11.3) re-resolving.
Semantically it gates deps of packages already excluded on Windows ARM64. I
flagged rather than hand-reverted it, since surgically editing lock hunks
risks an internally inconsistent file — worth a look before merge.

## #1677 — bisected to a product bug in `alembic/env.py`

Cluster A (the two default-dir tests) is fixed and stays fixed: verified under
the issue's exact acceptance command.

Cluster B I bisected properly rather than guessing. My first instinct — grep
for tests mutating logging state — produced three candidates and **none of
them reproduced**. Directory-level bisection found `tests/history/`, then
`test_db_migrations.py`, and the mechanism turned out to be in product code:

`alembic/env.py` calls `fileConfig(config.config_file_name)`. That parameter's
`disable_existing_loggers` default is **True**, so it disables every logger
not named in `alembic.ini` — all of `file_organizer.*` — for the rest of the
process. Alembic ships that default assuming a short-lived CLI process; these
migrations also run in-process, so **any in-process migration silently
switches application logging off**. The two failing tests were the visible
symptom, not the problem.

The regression test asserts `logger.disabled` rather than going through
caplog, and explains why: `fileConfig` *also* replaces the root handlers,
detaching caplog's own handler for the remainder of that test. Asserting
through caplog would have tested the wrong thing. Mutation-checked — restoring
the default makes it fail.

### The remaining acceptance criterion

An AST sweep for module-scope `get_data_dir`/`get_config_dir`/
`resolve_legacy_path`/`Path.home()` found five more import-time captures:

| Site | Disposition |
| :--- | :--- |
| `para/ai/feedback.py::_DEFAULT_FEEDBACK_DIR` | **converted** — no test coupling |
| `copilot/rules/rule_manager.py::_DEFAULT_RULES_DIR` | **converted** — no test coupling |
| `config/manager.py::DEFAULT_CONFIG_DIR` | left — 9 test files import and pass it directly |
| `web/profile_routes.py::_SETTINGS_DIR` | left — 28 test references patch it as a constant |
| `web/settings_routes.py::_SETTINGS_DIR` | left — same |

Both conversions are mutation-checked. The three left are justified rather
than churned: those tests patch the constant precisely *because* it is one,
and converting would break ~28 sites to remove a hazard that only bites when
the environment changes mid-process.

## #1725 / #1726 — the stated cause was wrong

#1725 said the `organizer` mutation profile is blocked because
`core/organizer.py` imports the media extractors at module scope, loading
av/torch into every fork. I made them lazy and **the segfault count did not
move by one** — still exactly 432.

Two controlled experiments locate the real cause in the **test files**:

- Mutating the known-clean `batch_sizer.py` while merely adding
  `tests/core/test_organizer.py` to the selection produces **42 segfaults**,
  in a profile that is otherwise 129 killed / 65 survived / 0 crashed.
- `--max-children 1` changes nothing (42 either way), so it is the fork
  itself, not concurrency between children.

Those tests create threads and mutmut forks per mutant. That is the *same*
root cause as `parallel`'s hang — crash in one case, deadlock in the other —
so **#1725 and #1726 are one problem**, and neither is fixable by narrowing
imports or tuning workers. It needs a non-forking runner. Blocked reasons and
docs are corrected, including an explicit note that the av/torch explanation
was disproven, so nobody re-runs this experiment.

The lazy import is kept on its own merits: it takes the module's import from
2,839 to 1,665 modules, dropping av and torch from every CLI invocation
including ones that never touch media.

## Verification

- **Serial full suite** (`pytest tests -q --no-cov -p no:randomly`, #1677's
  exact acceptance command): **22,537 passed, 0 failed.** Before this branch
  the same command failed the two cluster-B tests.
- Both originally-failing cluster-B tests pass with the poisoner
  (`tests/history/test_db_migrations.py`) in the same session.
- Every fix mutation-checked: reverting each one makes its regression test
  fail. That covers the alembic `disable_existing_loggers` change and both
  import-time-capture conversions.
- 1,509 tests pass across the touched trees; 36 PDF tests on pypdf 6.15.0.

### One acceptance criterion is NOT met, and it is not this PR's doing

#1677 also asks that the suite pass under three `pytest-randomly` seeds.
It does not:

| Seed | Result |
| :--- | :--- |
| 99991 | 22,537 passed |
| 12345 | 2 failed |
| 20260808 | 1 failed |

The failures are **pre-existing and unrelated to order**:
`tests/pipeline/test_prefetch.py::test_prefetch_faster_than_sequential`
asserts a wall-clock speedup and loses the measurement to CPU contention under
`-n auto`. Reproduced **3/3 on a clean `origin/main` worktree**, so it is not
introduced here. Filed as #1729 with three options for fixing it properly.

I am flagging this rather than quietly relaxing the criterion: #1677 can close
on its named clusters, both of which are fixed and verified, but the suite is
not yet green under arbitrary seeds and that is worth knowing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved application logging during in-process database migrations.
  * Ensured feedback and rules directories reflect current configuration and environment settings.
  * Improved graceful handling of corrupt feedback files and storage errors.
  * Reduced migration-related issues when processing audio and video files.

* **Documentation**
  * Clarified mutation-testing failures involving forked, thread-creating tests.

* **Tests**
  * Added regression coverage for logging, configuration-based paths, and feedback persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->