### PR TITLE
fix(1729): make the suite deterministic under load, and close the launcher port race

### DIFF
--- a/src/file_organizer/desktop/app.py
+++ b/src/file_organizer/desktop/app.py
@@ -9,17 +9,22 @@ pywebview main loop exits (i.e. when the user closes the window).
 
 Design constraints
 ------------------
-- Port allocation uses ``socket`` to find a free port before handing it to
-  uvicorn, avoiding TOCTOU races on busy machines.
-- A blocking poll loop (50 ms intervals, 10 s timeout) waits for the HTTP
-  server to be ready before creating the webview window; this prevents the
-  window from displaying a blank/error page on slow cold starts.
+- Port allocation binds an ephemeral port and hands uvicorn the **still-open**
+  socket. Binding, reading the port and then releasing the socket would leave
+  a multi-second window -- spanning uvicorn's import and app construction --
+  in which another process can take the port; passing the bound socket removes
+  that window rather than narrowing it.
+- Readiness comes from uvicorn's own ``started`` flag, relayed through a
+  ``threading.Event``, not from probing the port. With a pre-bound socket a TCP
+  connect succeeds as soon as the socket listens, which is well before the ASGI
+  app can serve, so a connect probe would open the window on a blank page.
 - ``webview.start()`` **must** be called from the main thread (OS requirement
   on macOS and Windows). The server thread is therefore a background daemon.
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import socket
 import subprocess
@@ -206,58 +211,110 @@ _DEFAULT_WIDTH = 1280
 _DEFAULT_HEIGHT = 800
 _READY_POLL_INTERVAL = 0.05  # seconds
 _READY_TIMEOUT = 10.0  # seconds
+_SHUTDOWN_TIMEOUT = 5.0  # seconds to wait for uvicorn to stop
 
 
-def _find_free_port() -> int:
-    """Return an ephemeral port that is free at the time of the call."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+def _bind_free_socket() -> socket.socket:
+    """Bind an ephemeral port and return the still-open listening socket.
+
+    The socket is deliberately **not** closed. Binding, reading the port and
+    then releasing the socket leaves a window — several seconds wide, spanning
+    uvicorn's import and app construction — in which any other process can take
+    that port. Handing the bound socket to uvicorn removes the window rather
+    than narrowing it.
+
+    Callers own the returned socket and must close it if they do not pass it
+    to :func:`_run_server`.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(128)
+    return sock
 
 
-def _wait_for_server(port: int, timeout: float = _READY_TIMEOUT) -> bool:
-    """Poll until the server is accepting TCP connections or timeout expires.
+def _wait_for_server(
+    ready: threading.Event,
+    server_thread: threading.Thread,
+    timeout: float = _READY_TIMEOUT,
+) -> bool:
+    """Wait for uvicorn to report startup complete.
+
+    Waits on an event the server thread sets once uvicorn's own ``started``
+    flag flips, rather than probing the port. With a pre-bound socket a TCP
+    connect succeeds the instant the socket is listening — the kernel accepts
+    into the backlog long before the ASGI app can serve a request — so a
+    connect-based probe would report ready while the app was still importing.
+
+    Returns ``False`` promptly if the server thread dies. uvicorn calls
+    ``sys.exit()`` on a startup failure, and a ``SystemExit`` raised inside a
+    thread is swallowed by ``Thread._bootstrap_inner``; without this check a
+    dead thread would still burn the full timeout.
 
     Args:
-        port: Local port to poll.
+        ready: Set by the server thread once uvicorn has started.
+        server_thread: The thread running uvicorn, watched for early death.
         timeout: Maximum seconds to wait before giving up.
 
     Returns:
-        ``True`` if the server became ready within *timeout* seconds, ``False``
-        otherwise.
+        ``True`` if the server started within *timeout* seconds.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
-                return True
-        except OSError:
-            time.sleep(_READY_POLL_INTERVAL)
+        if ready.wait(timeout=_READY_POLL_INTERVAL):
+            return True
+        if not server_thread.is_alive():
+            return False
     return False
 
 
-def _run_server(port: int, **uvicorn_kwargs: Any) -> None:
-    """Start uvicorn with the File Organizer FastAPI app.
+def _run_server(
+    sock: socket.socket,
+    *,
+    ready: threading.Event | None = None,
+    server_box: dict[str, Any] | None = None,
+    **uvicorn_kwargs: Any,
+) -> None:
+    """Serve the File Organizer FastAPI app on an already-bound socket.
 
     Intended to be run in a daemon thread.
 
     Args:
-        port: Port to bind uvicorn to.
+        sock: Listening socket to serve on. Ownership transfers here.
+        ready: Set once uvicorn reports startup complete, so the caller does
+            not have to infer readiness from a TCP probe.
+        server_box: Optional dict receiving the ``uvicorn.Server`` under key
+            ``"server"``, so the caller can request shutdown.
         **uvicorn_kwargs: Additional keyword arguments forwarded to
-            ``uvicorn.run``.
+            ``uvicorn.Config``.
     """
+    import asyncio
+
     import uvicorn
 
     from file_organizer.api.main import create_app
 
     app = create_app()
-    uvicorn.run(
-        app,
-        host="127.0.0.1",
-        port=port,
-        log_level="warning",
-        **uvicorn_kwargs,
-    )
+    config = uvicorn.Config(app, log_level="warning", **uvicorn_kwargs)
+    server = uvicorn.Server(config)
+    if server_box is not None:
+        server_box["server"] = server
+
+    async def _serve() -> None:
+        serve_task = asyncio.ensure_future(server.serve(sockets=[sock]))
+        while not server.started and not serve_task.done():
+            await asyncio.sleep(_READY_POLL_INTERVAL)
+        # Only on a real start. Setting the event unconditionally here would
+        # report a failed boot as ready; a failure must instead reach the
+        # caller as the thread dying, which `_wait_for_server` watches for.
+        if server.started and ready is not None:
+            ready.set()
+        await serve_task
+
+    try:
+        asyncio.run(_serve())
+    finally:
+        with contextlib.suppress(OSError):
+            sock.close()
 
 
 def launch(
@@ -297,21 +354,30 @@ def launch(
             "Install it with: pip install 'file-organizer[desktop]'"
         ) from exc
 
-    port = _find_free_port()
+    sock = _bind_free_socket()
+    port = sock.getsockname()[1]
     url = f"http://127.0.0.1:{port}"
 
     logger.info("Starting File Organizer server on %s", url)
 
+    ready = threading.Event()
+    server_box: dict[str, Any] = {}
     server_thread = threading.Thread(
         target=_run_server,
-        args=(port,),
+        args=(sock,),
+        kwargs={"ready": ready, "server_box": server_box},
         daemon=True,
         name="fo-server",
     )
     server_thread.start()
 
-    if not _wait_for_server(port):
-        raise RuntimeError(f"File Organizer server did not become ready within {_READY_TIMEOUT}s")
+    if not _wait_for_server(ready, server_thread):
+        detail = (
+            "the server thread exited during startup"
+            if not server_thread.is_alive()
+            else f"it did not start within {_READY_TIMEOUT}s"
+        )
+        raise RuntimeError(f"File Organizer server failed to start: {detail}")
 
     logger.info("Server ready — opening window")
 
@@ -326,6 +392,15 @@ def launch(
         js_api=api,
     )
     # webview.start() blocks until the window is closed; MUST run on main thread.
-    webview.start(debug=False)
+    try:
+        webview.start(debug=False)
+    finally:
+        # Ask uvicorn to stop. Without this the daemon thread outlives the
+        # window, holding the port and its loguru sink for the life of the
+        # process -- which in a test session is the rest of the worker's run.
+        server = server_box.get("server")
+        if server is not None:
+            server.should_exit = True
+        server_thread.join(timeout=_SHUTDOWN_TIMEOUT)
     logger.info("Window closed — exiting")
     _ = window  # suppress "window created but never used" linters

--- a/src/file_organizer/desktop/app.py
+++ b/src/file_organizer/desktop/app.py
@@ -293,13 +293,7 @@ def _run_server(
 
     from file_organizer.api.main import create_app
 
-    app = create_app()
-    config = uvicorn.Config(app, log_level="warning", **uvicorn_kwargs)
-    server = uvicorn.Server(config)
-    if server_box is not None:
-        server_box["server"] = server
-
-    async def _serve() -> None:
+    async def _serve(server: Any) -> None:
         serve_task = asyncio.ensure_future(server.serve(sockets=[sock]))
         while not server.started and not serve_task.done():
             await asyncio.sleep(_READY_POLL_INTERVAL)
@@ -311,7 +305,17 @@ def _run_server(
         await serve_task
 
     try:
-        asyncio.run(_serve())
+        # Inside the guard: `create_app()` builds 15 routers and can raise, as
+        # can Config/Server construction. Outside it, such a failure killed the
+        # thread with the socket still bound — leaking the port for the life of
+        # the process, which is the very failure mode this function exists to
+        # make survivable.
+        app = create_app()
+        config = uvicorn.Config(app, log_level="warning", **uvicorn_kwargs)
+        server = uvicorn.Server(config)
+        if server_box is not None:
+            server_box["server"] = server
+        asyncio.run(_serve(server))
     finally:
         with contextlib.suppress(OSError):
             sock.close()

--- a/tests/ci/test_review_regressions.py
+++ b/tests/ci/test_review_regressions.py
@@ -45,6 +45,10 @@ def _imports_loguru(source: str) -> bool:
             ):
                 return True
         elif isinstance(node, ast.ImportFrom):
+            # level > 0 is a relative import: `from .loguru import x` refers to
+            # a sibling module that merely shares the name.
+            if node.level:
+                continue
             module = node.module or ""
             if module == "loguru" or module.startswith("loguru."):
                 return True

--- a/tests/ci/test_review_regressions.py
+++ b/tests/ci/test_review_regressions.py
@@ -26,7 +26,29 @@ _LOGURU_METHODS = {
 
 
 def _imports_loguru(source: str) -> bool:
-    return "loguru" in source and "logger" in source
+    """True when the module actually imports loguru.
+
+    Checked against the parsed import statements, not by substring. A plain
+    ``"loguru" in source`` also matches the word appearing in a comment or
+    docstring, which made this rail flag ``desktop/app.py`` — a module using
+    **stdlib** ``logging``, where ``%s`` lazy formatting is correct and
+    rewriting it to ``{}`` would emit literal braces.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(
+                alias.name == "loguru" or alias.name.startswith("loguru.") for alias in node.names
+            ):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "loguru" or module.startswith("loguru."):
+                return True
+    return False
 
 
 def _find_loguru_percent_formatting(path: Path) -> list[str]:
@@ -60,6 +82,25 @@ def _find_loguru_percent_formatting(path: Path) -> list[str]:
             if re.search(r"%[sd]\b", message):
                 violations.append(f"{path}: {message}")
     return violations
+
+
+def test_loguru_detection_ignores_prose_mentions() -> None:
+    """A module that only *mentions* loguru must not be treated as using it.
+
+    Regression: the check was ``"loguru" in source``, so a comment explaining
+    loguru behaviour turned a stdlib-``logging`` module into a false positive
+    and demanded ``{}`` placeholders that would print literally.
+    """
+    stdlib_module = (
+        "import logging\n"
+        "# The API server installs a loguru sink; this module does not.\n"
+        "logger = logging.getLogger(__name__)\n"
+        "logger.info('started on %s', url)\n"
+    )
+    assert not _imports_loguru(stdlib_module)
+
+    real_loguru = "from loguru import logger\nlogger.info('started on %s', url)\n"
+    assert _imports_loguru(real_loguru)
 
 
 def test_loguru_formatting_uses_braces() -> None:

--- a/tests/desktop/test_pywebview_app.py
+++ b/tests/desktop/test_pywebview_app.py
@@ -306,6 +306,22 @@ class TestRunServer:
 
         assert not ready.is_set()
 
+    def test_publishes_the_server_so_the_caller_can_stop_it(self) -> None:
+        """`launch()` needs a handle to shut uvicorn down when the window closes."""
+        from file_organizer.desktop.app import _run_server
+
+        mock_uvicorn, server = self._uvicorn_double()
+        mock_api_main = MagicMock()
+        mock_api_main.create_app.return_value = MagicMock()
+        box: dict[str, object] = {}
+
+        with patch.dict(
+            sys.modules, {"uvicorn": mock_uvicorn, "file_organizer.api.main": mock_api_main}
+        ):
+            _run_server(_FakeSocket(54324), server_box=box)
+
+        assert box["server"] is server
+
     def test_forwards_extra_kwargs_to_uvicorn_config(self) -> None:
         from file_organizer.desktop.app import _run_server
 
@@ -320,6 +336,40 @@ class TestRunServer:
             _run_server(_FakeSocket(9999), workers=2)
 
         mock_uvicorn.Config.assert_called_once_with(mock_app, log_level="warning", workers=2)
+
+
+class TestLaunchShutdown:
+    """The window closing must stop the server, not leak the thread."""
+
+    def test_window_close_requests_uvicorn_shutdown(self) -> None:
+        """Previously the daemon thread outlived the window.
+
+        It kept the port bound and its loguru sink installed for the life of
+        the process — which in a test session is the rest of the worker's run.
+        """
+        mock_webview = MagicMock()
+        fake_server = MagicMock()
+
+        from file_organizer.desktop import app as desktop_app
+
+        def _fake_run_server(sock, *, ready=None, server_box=None, **kw):
+            if server_box is not None:
+                server_box["server"] = fake_server
+            if ready is not None:
+                ready.set()
+
+        with (
+            patch.dict(sys.modules, {"webview": mock_webview}),
+            patch(
+                "file_organizer.desktop.app._bind_free_socket",
+                return_value=_FakeSocket(43999),
+            ),
+            patch("file_organizer.desktop.app._run_server", _fake_run_server),
+            patch("file_organizer.desktop.app._wait_for_server", return_value=True),
+        ):
+            desktop_app.launch()
+
+        assert fake_server.should_exit is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/desktop/test_pywebview_app.py
+++ b/tests/desktop/test_pywebview_app.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import runpy
 import socket
 import sys
+import threading
+import time
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -22,54 +24,96 @@ pytestmark = [pytest.mark.unit, pytest.mark.ci]
 # ---------------------------------------------------------------------------
 
 
-class TestFindFreePort:
-    def test_returns_integer(self) -> None:
-        from file_organizer.desktop.app import _find_free_port
+class _FakeSocket:
+    """Stands in for a bound listening socket in launch/_run_server tests."""
 
-        port = _find_free_port()
-        assert isinstance(port, int)
-        assert 1024 <= port <= 65535
+    def __init__(self, port: int) -> None:
+        self._port = port
+        self.closed = False
 
-    def test_port_in_valid_range(self) -> None:
-        from file_organizer.desktop.app import _find_free_port
+    def getsockname(self) -> tuple[str, int]:
+        return ("127.0.0.1", self._port)
 
-        port = _find_free_port()
-        assert 1024 <= port <= 65535
+    def close(self) -> None:
+        self.closed = True
 
-    def test_port_is_free(self) -> None:
-        """The returned port should be bindable immediately after the call."""
-        from file_organizer.desktop.app import _find_free_port
 
-        port = _find_free_port()
-        # Re-binding to the port should succeed (it is free).
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(("127.0.0.1", port))  # raises OSError if port in use
+class TestBindFreeSocket:
+    def test_returns_a_listening_socket_on_a_valid_port(self) -> None:
+        from file_organizer.desktop.app import _bind_free_socket
+
+        sock = _bind_free_socket()
+        try:
+            port = sock.getsockname()[1]
+            assert isinstance(port, int)
+            assert 1024 <= port <= 65535
+        finally:
+            sock.close()
+
+    def test_port_is_held_not_released(self) -> None:
+        """The anti-TOCTOU property, and the inverse of the old contract.
+
+        This previously asserted the port was re-bindable immediately after
+        the call — which is exactly the race: the helper bound port 0, read
+        the number, closed the socket, and uvicorn re-bound seconds later.
+        Anything could take it in between. The socket is now held open and
+        handed to uvicorn, so a second bind must FAIL.
+        """
+        from file_organizer.desktop.app import _bind_free_socket
+
+        sock = _bind_free_socket()
+        try:
+            port = sock.getsockname()[1]
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as other:
+                with pytest.raises(OSError, match="Address already in use"):
+                    other.bind(("127.0.0.1", port))
+        finally:
+            sock.close()
+
+
+class TestWaitForServer:
+    def test_returns_true_once_the_server_signals_ready(self) -> None:
+        from file_organizer.desktop.app import _wait_for_server
+
+        ready = threading.Event()
+        ready.set()
+        stop = threading.Event()
+        alive = threading.Thread(target=stop.wait, daemon=True)
+        alive.start()
+
+        assert _wait_for_server(ready, alive, timeout=2.0) is True
+
+    def test_returns_false_when_the_server_never_signals(self) -> None:
+        from file_organizer.desktop.app import _wait_for_server
+
+        ready = threading.Event()  # never set
+        stop = threading.Event()
+        alive = threading.Thread(target=stop.wait, daemon=True)
+        alive.start()
+
+        assert _wait_for_server(ready, alive, timeout=0.15) is False
+
+    def test_returns_false_promptly_when_the_server_thread_dies(self) -> None:
+        """uvicorn calls sys.exit() on a bind failure, and a SystemExit raised
+        inside a thread is swallowed by ``Thread._bootstrap_inner``. Without
+        watching liveness, a dead server would still burn the whole timeout and
+        report "did not become ready" rather than "it crashed".
+        """
+        from file_organizer.desktop.app import _wait_for_server
+
+        ready = threading.Event()  # never set
+        dead = threading.Thread(target=lambda: None, daemon=True)
+        dead.start()
+        dead.join()
+
+        started = time.monotonic()
+        assert _wait_for_server(ready, dead, timeout=10.0) is False
+        assert time.monotonic() - started < 2.0, "should not wait out the full timeout"
 
 
 # ---------------------------------------------------------------------------
 # _wait_for_server
 # ---------------------------------------------------------------------------
-
-
-class TestWaitForServer:
-    def test_returns_true_when_port_open(self) -> None:
-        from file_organizer.desktop.app import _find_free_port, _wait_for_server
-
-        # Open a real listening socket so _wait_for_server can connect.
-        port = _find_free_port()
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
-            srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            srv.bind(("127.0.0.1", port))
-            srv.listen(1)
-            assert _wait_for_server(port, timeout=2.0) is True
-
-    def test_returns_false_when_nothing_listening(self) -> None:
-        from file_organizer.desktop.app import _find_free_port, _wait_for_server
-
-        port = _find_free_port()
-        # Nothing is bound — should time out quickly.
-        assert _wait_for_server(port, timeout=0.15) is False
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +143,7 @@ class TestLaunch:
             patch("file_organizer.desktop.app._wait_for_server", return_value=False),
             patch("file_organizer.desktop.app._run_server"),
         ):
-            with pytest.raises(RuntimeError, match="did not become ready"):
+            with pytest.raises(RuntimeError, match="failed to start"):
                 launch()
 
         _ = sys  # keep import for clarity
@@ -160,7 +204,10 @@ class TestLaunch:
 
         with (
             patch.dict(sys.modules, {"webview": mock_webview}),
-            patch("file_organizer.desktop.app._find_free_port", return_value=43123),
+            patch(
+                "file_organizer.desktop.app._bind_free_socket",
+                return_value=_FakeSocket(43123),
+            ),
             patch("file_organizer.desktop.app._wait_for_server", return_value=True),
             patch("file_organizer.desktop.app.threading") as mock_threading,
         ):
@@ -179,51 +226,100 @@ class TestLaunch:
 
 
 class TestRunServer:
-    def test_calls_uvicorn_run_with_correct_args(self) -> None:
-        """_run_server() should call uvicorn.run with host/port/log_level."""
-        import sys
+    """`_run_server` serves on the socket it is handed, and signals readiness."""
 
+    @staticmethod
+    def _uvicorn_double() -> tuple[MagicMock, MagicMock]:
+        """Return (uvicorn_module, server) doubles wired for one clean serve."""
+        server = MagicMock()
+        server.started = True
+
+        async def _serve(sockets=None):
+            server.serve_sockets = sockets
+
+        server.serve = _serve
+        mock_uvicorn = MagicMock()
+        mock_uvicorn.Server.return_value = server
+        return mock_uvicorn, server
+
+    def test_serves_on_the_socket_it_was_given(self) -> None:
+        """The whole point of the change: uvicorn must not re-bind a port."""
         from file_organizer.desktop.app import _run_server
 
-        mock_uvicorn = MagicMock()
-        mock_app = MagicMock()
+        mock_uvicorn, server = self._uvicorn_double()
         mock_api_main = MagicMock()
+        mock_app = MagicMock()
+        mock_api_main.create_app.return_value = mock_app
+        sock = _FakeSocket(54321)
+
+        with patch.dict(
+            sys.modules, {"uvicorn": mock_uvicorn, "file_organizer.api.main": mock_api_main}
+        ):
+            _run_server(sock)
+
+        assert server.serve_sockets == [sock], "uvicorn was not handed the bound socket"
+        mock_uvicorn.Config.assert_called_once_with(mock_app, log_level="warning")
+        assert sock.closed, "the socket must be released when serving stops"
+
+    def test_sets_the_ready_event_once_uvicorn_reports_started(self) -> None:
+        from file_organizer.desktop.app import _run_server
+
+        mock_uvicorn, _ = self._uvicorn_double()
+        mock_api_main = MagicMock()
+        mock_api_main.create_app.return_value = MagicMock()
+        ready = threading.Event()
+
+        with patch.dict(
+            sys.modules, {"uvicorn": mock_uvicorn, "file_organizer.api.main": mock_api_main}
+        ):
+            _run_server(_FakeSocket(54322), ready=ready)
+
+        assert ready.is_set()
+
+    def test_does_not_signal_ready_when_startup_fails(self) -> None:
+        """A crashed boot must not look like a successful one.
+
+        uvicorn exits the process on a bind failure; inside a thread that
+        `SystemExit` is swallowed. If `_run_server` set the event regardless,
+        `launch()` would open a window onto a server that never started.
+        """
+        from file_organizer.desktop.app import _run_server
+
+        server = MagicMock()
+        server.started = False  # never starts
+
+        async def _serve(sockets=None):
+            raise SystemExit(3)
+
+        server.serve = _serve
+        mock_uvicorn = MagicMock()
+        mock_uvicorn.Server.return_value = server
+        mock_api_main = MagicMock()
+        mock_api_main.create_app.return_value = MagicMock()
+        ready = threading.Event()
+
+        with patch.dict(
+            sys.modules, {"uvicorn": mock_uvicorn, "file_organizer.api.main": mock_api_main}
+        ):
+            with pytest.raises(SystemExit):
+                _run_server(_FakeSocket(54323), ready=ready)
+
+        assert not ready.is_set()
+
+    def test_forwards_extra_kwargs_to_uvicorn_config(self) -> None:
+        from file_organizer.desktop.app import _run_server
+
+        mock_uvicorn, _ = self._uvicorn_double()
+        mock_api_main = MagicMock()
+        mock_app = MagicMock()
         mock_api_main.create_app.return_value = mock_app
 
         with patch.dict(
             sys.modules, {"uvicorn": mock_uvicorn, "file_organizer.api.main": mock_api_main}
         ):
-            _run_server(54321)
+            _run_server(_FakeSocket(9999), workers=2)
 
-        mock_uvicorn.run.assert_called_once_with(
-            mock_app,
-            host="127.0.0.1",
-            port=54321,
-            log_level="warning",
-        )
-
-    def test_forwards_extra_kwargs_to_uvicorn(self) -> None:
-        """_run_server() should forward **uvicorn_kwargs to uvicorn.run."""
-        from file_organizer.desktop.app import _run_server
-
-        mock_uvicorn = MagicMock()
-        mock_api_main = MagicMock()
-        mock_api_main.create_app.return_value = MagicMock()
-
-        with patch.dict(
-            sys.modules, {"uvicorn": mock_uvicorn, "file_organizer.api.main": mock_api_main}
-        ):
-            _run_server(9999, workers=2)
-
-        assert mock_uvicorn.run.call_count == 1
-        args, kwargs = mock_uvicorn.run.call_args
-        assert args == (mock_api_main.create_app.return_value,)
-        assert kwargs == {
-            "host": "127.0.0.1",
-            "port": 9999,
-            "log_level": "warning",
-            "workers": 2,
-        }
+        mock_uvicorn.Config.assert_called_once_with(mock_app, log_level="warning", workers=2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/desktop/test_pywebview_app.py
+++ b/tests/desktop/test_pywebview_app.py
@@ -7,6 +7,7 @@ launch() without requiring pywebview to be installed.
 
 from __future__ import annotations
 
+import errno
 import runpy
 import socket
 import sys
@@ -65,8 +66,11 @@ class TestBindFreeSocket:
         try:
             port = sock.getsockname()[1]
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as other:
-                with pytest.raises(OSError, match="Address already in use"):
+                # errno, not message text: Windows reports WSAEADDRINUSE
+                # with different wording.
+                with pytest.raises(OSError) as excinfo:  # noqa: pytest-raises-hygiene
                     other.bind(("127.0.0.1", port))
+            assert excinfo.value.errno == errno.EADDRINUSE
         finally:
             sock.close()
 

--- a/tests/integration/test_desktop_launcher_integration.py
+++ b/tests/integration/test_desktop_launcher_integration.py
@@ -10,6 +10,7 @@ serves HTTP — only ``webview`` (absent in this env) is faked so its
 
 from __future__ import annotations
 
+import errno
 import os
 import socket
 import sys
@@ -78,11 +79,30 @@ def test_launch_boots_real_server_and_opens_window(monkeypatch: pytest.MonkeyPat
     assert fake_webview.captured["kwargs"]["width"] == 900  # type: ignore[attr-defined]
 
 
+class _FakeLauncherSocket:
+    """Stands in for a bound socket so launch() does not hold a real port."""
+
+    def __init__(self, port: int) -> None:
+        self._port = port
+        self.closed = False
+
+    def getsockname(self) -> tuple[str, int]:
+        return ("127.0.0.1", self._port)
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def test_launch_raises_when_server_never_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     """If the server never starts, launch() raises rather than opening a window."""
     fake_webview = _make_fake_webview(lambda captured: None)
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
 
+    # Patch the binder too. Unpatched, launch() binds a real socket that the
+    # stub _run_server never takes ownership of, and launch() raises before its
+    # shutdown block — leaking a bound loopback port per run.
+    fake_sock = _FakeLauncherSocket(43998)
+    monkeypatch.setattr(desktop_app, "_bind_free_socket", lambda: fake_sock)
     monkeypatch.setattr(desktop_app, "_run_server", lambda sock, **kw: None)
     monkeypatch.setattr(desktop_app, "_wait_for_server", lambda ready, thread, timeout=0.0: False)
 
@@ -102,8 +122,11 @@ def test_bind_free_socket_holds_the_port() -> None:
         port = sock.getsockname()[1]
         assert 1024 < port < 65536
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as other:
-            with pytest.raises(OSError, match="Address already in use"):
+            # errno, not message text: Windows reports WSAEADDRINUSE
+            # with different wording.
+            with pytest.raises(OSError) as excinfo:  # noqa: pytest-raises-hygiene
                 other.bind(("127.0.0.1", port))
+        assert excinfo.value.errno == errno.EADDRINUSE
     finally:
         sock.close()
 

--- a/tests/integration/test_desktop_launcher_integration.py
+++ b/tests/integration/test_desktop_launcher_integration.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import os
 import socket
 import sys
+import threading
+import time
 import types
 from pathlib import Path
 from typing import Any
@@ -77,41 +79,65 @@ def test_launch_boots_real_server_and_opens_window(monkeypatch: pytest.MonkeyPat
 
 
 def test_launch_raises_when_server_never_ready(monkeypatch: pytest.MonkeyPatch) -> None:
-    """If the server never binds, launch() times out with a RuntimeError."""
+    """If the server never starts, launch() raises rather than opening a window."""
     fake_webview = _make_fake_webview(lambda captured: None)
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
 
-    # Force readiness to fail fast instead of booting a real server.
-    monkeypatch.setattr(desktop_app, "_run_server", lambda port, **kw: None)
-    monkeypatch.setattr(desktop_app, "_wait_for_server", lambda port, timeout=0.0: False)
+    monkeypatch.setattr(desktop_app, "_run_server", lambda sock, **kw: None)
+    monkeypatch.setattr(desktop_app, "_wait_for_server", lambda ready, thread, timeout=0.0: False)
 
-    with pytest.raises(RuntimeError, match="did not become ready"):
+    with pytest.raises(RuntimeError, match="failed to start"):
         desktop_app.launch()
 
 
-def test_find_free_port_returns_bindable_port() -> None:
-    """_find_free_port returns a port that is actually free to bind."""
-    port = desktop_app._find_free_port()
-    assert isinstance(port, int)
-    assert 1024 < port < 65536
-    # It is free right now: we can bind it ourselves.
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", port))
+def test_bind_free_socket_holds_the_port() -> None:
+    """The port must NOT be re-bindable — that is the anti-TOCTOU property.
+
+    The previous helper returned a bare int and released the socket, so the
+    port was free for anything else to claim during uvicorn's multi-second
+    boot. This asserts the inverse of that old contract.
+    """
+    sock = desktop_app._bind_free_socket()
+    try:
+        port = sock.getsockname()[1]
+        assert 1024 < port < 65536
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as other:
+            with pytest.raises(OSError, match="Address already in use"):
+                other.bind(("127.0.0.1", port))
+    finally:
+        sock.close()
 
 
-def test_wait_for_server_times_out_on_dead_port() -> None:
-    """_wait_for_server returns False when nothing is listening."""
-    dead_port = desktop_app._find_free_port()  # free => nothing is listening
-    assert desktop_app._wait_for_server(dead_port, timeout=0.3) is False
+def test_wait_for_server_times_out_when_never_signalled() -> None:
+    """Readiness comes from an event, not from a TCP probe."""
+    ready = threading.Event()
+    stop = threading.Event()
+    alive = threading.Thread(target=stop.wait, daemon=True)
+    alive.start()
+
+    assert desktop_app._wait_for_server(ready, alive, timeout=0.3) is False
 
 
-def test_wait_for_server_detects_live_socket() -> None:
-    """_wait_for_server returns True once a socket is accepting connections."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
-        server.bind(("127.0.0.1", 0))
-        server.listen(1)
-        port = server.getsockname()[1]
-        assert desktop_app._wait_for_server(port, timeout=2.0) is True
+def test_wait_for_server_returns_true_once_signalled() -> None:
+    ready = threading.Event()
+    stop = threading.Event()
+    alive = threading.Thread(target=stop.wait, daemon=True)
+    alive.start()
+    threading.Timer(0.05, ready.set).start()
+
+    assert desktop_app._wait_for_server(ready, alive, timeout=2.0) is True
+
+
+def test_wait_for_server_gives_up_immediately_if_the_thread_died() -> None:
+    """A dead server must not cost the full timeout before being noticed."""
+    ready = threading.Event()  # never set
+    dead = threading.Thread(target=lambda: None, daemon=True)
+    dead.start()
+    dead.join()
+
+    started = time.monotonic()
+    assert desktop_app._wait_for_server(ready, dead, timeout=10.0) is False
+    assert time.monotonic() - started < 2.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_executable_plan_review_regressions.py
+++ b/tests/integration/test_executable_plan_review_regressions.py
@@ -299,7 +299,19 @@ def test_execute_plan_cleans_destination_when_history_logging_fails(
 
 
 @requires_safedir
-def test_file_organizer_plan_helpers_execute_and_restore_state(tmp_path: Path) -> None:
+def test_file_organizer_plan_helpers_execute_and_restore_state(
+    tmp_path: Path, stub_all_models: None
+) -> None:
+    """`build_plan` must restore `dry_run` after flipping it internally.
+
+    Takes ``stub_all_models`` because without it this test is not hermetic:
+    ``build_plan`` runs the real ``organize()`` pipeline, which initialises
+    ``TextModel`` and opens a live connection to whatever Ollama daemon
+    happens to be listening on the machine. Measured: 0.10 s with
+    ``OLLAMA_HOST`` pointed at a dead port versus 0.92 s with a daemon up —
+    the test was quietly doing real network work, and its runtime therefore
+    depended on the developer's environment and on load (#1729).
+    """
     input_dir = tmp_path / "input"
     input_dir.mkdir()
     source = input_dir / "notes.txt"
@@ -309,6 +321,8 @@ def test_file_organizer_plan_helpers_execute_and_restore_state(tmp_path: Path) -
     plan = organizer.build_plan(input_dir, tmp_path / "preview-output")
     result = organizer.execute_plan(plan)
 
+    # The regression this guards: build_plan sets dry_run=True internally and
+    # must put it back, or every later execute_plan silently does nothing.
     assert organizer.dry_run is False
     assert result.processed_files == 1
     assert any((tmp_path / "preview-output").rglob("*.txt"))

--- a/tests/optimization/test_warmup.py
+++ b/tests/optimization/test_warmup.py
@@ -240,27 +240,37 @@ class TestModelWarmupAsync:
         assert "model-a" in result.loaded
 
     def test_warmup_async_runs_in_background(self) -> None:
-        """Test that warmup_async returns immediately."""
+        """`warmup_async` must hand back a future without waiting for the load.
+
+        Asserts that by holding the loader open rather than by timing the
+        call. The previous version measured wall-clock and required
+        ``call_duration < 50`` ms, which is not a property of the code under
+        test when 18 xdist workers are competing for 18 cores — merely
+        submitting to an executor can exceed that budget under load (#1729).
+
+        Gating the loader on an event proves the same thing and cannot be
+        perturbed by scheduling: if `warmup_async` were synchronous, the call
+        could not return while the loader is still parked.
+        """
         cache = ModelCache(max_models=5)
 
         loader_started = threading.Event()
+        release_loader = threading.Event()
 
         def loader_factory(name: str):
             def loader():
                 loader_started.set()
-                threading.Event().wait(0.1)
+                release_loader.wait(timeout=10)
                 return _make_mock_model(name)
 
             return loader
 
         warmup = ModelWarmup(cache=cache, loader_factory=loader_factory)
-        start = time.monotonic()
         future = warmup.warmup_async(["model-a"])
-        call_duration = (time.monotonic() - start) * 1000
 
-        # The call should return almost immediately
-        assert call_duration < 50  # ms
+        assert loader_started.wait(timeout=10), "loader never ran in the background"
+        assert not future.done(), "warmup_async blocked until the load finished"
 
-        # But the result takes longer
+        release_loader.set()
         result = future.result(timeout=10)
         assert "model-a" in result.loaded

--- a/tests/optimization/test_warmup.py
+++ b/tests/optimization/test_warmup.py
@@ -259,7 +259,12 @@ class TestModelWarmupAsync:
         def loader_factory(name: str):
             def loader():
                 loader_started.set()
-                release_loader.wait(timeout=10)
+                # No timeout: a self-releasing wait would let the loader finish
+                # on its own if this thread were descheduled, and `future` could
+                # then be done before the assertion below — reintroducing the
+                # very scheduling flake this test exists to remove. Release is
+                # the test's job, and the `finally` guarantees it.
+                release_loader.wait()
                 return _make_mock_model(name)
 
             return loader
@@ -267,9 +272,11 @@ class TestModelWarmupAsync:
         warmup = ModelWarmup(cache=cache, loader_factory=loader_factory)
         future = warmup.warmup_async(["model-a"])
 
-        assert loader_started.wait(timeout=10), "loader never ran in the background"
-        assert not future.done(), "warmup_async blocked until the load finished"
+        try:
+            assert loader_started.wait(timeout=30), "loader never ran in the background"
+            assert not future.done(), "warmup_async blocked until the load finished"
+        finally:
+            release_loader.set()
 
-        release_loader.set()
-        result = future.result(timeout=10)
+        result = future.result(timeout=30)
         assert "model-a" in result.loaded

--- a/tests/optimization/test_warmup.py
+++ b/tests/optimization/test_warmup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-import time
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/parallel/test_processor.py
+++ b/tests/parallel/test_processor.py
@@ -253,6 +253,14 @@ class TestProcessBatch(unittest.TestCase):
         self.assertEqual(result.total, 50)
         self.assertEqual(result.succeeded, 50)
 
+    # Spawns real interpreters. Each child re-imports the package, and with
+    # `concurrency = ["multiprocessing", "thread"]` coverage traces that import
+    # too, so the work genuinely takes longer than the global --timeout=30 when
+    # 18 xdist workers are already saturating the CPU. Raised deliberately: the
+    # work is slower, not racing. Where a timeout hides a race (see the desktop
+    # launcher port handoff) widening it makes things worse, and there the fix
+    # was structural instead (#1729).
+    @pytest.mark.timeout(120)
     def test_process_pool_executor(self) -> None:
         """Test processing with ProcessPoolExecutor."""
         config = ParallelConfig(

--- a/tests/pipeline/test_prefetch.py
+++ b/tests/pipeline/test_prefetch.py
@@ -219,10 +219,14 @@ class TestPrefetchOverlap:
         Asserts the *mechanism*, not the clock. The previous version of this
         test required a >= 20% wall-clock speedup, which is unmeasurable when
         the suite runs under ``-n auto``: 18 workers contend for 18 cores, and
-        the ratio drowns in scheduling noise. It failed roughly one run in
-        three on unmodified main (#1729) while passing in isolation, and no
-        amount of median-taking fixed it — the previous author had already
-        added interleaved pairing and alternating order.
+        the ratio drowns in scheduling noise.
+
+        Measured on unmodified main (#1729): 3 of 3 full-suite runs failed,
+        and 2 of 3 runs of the smaller ``pipeline + parallel + integration``
+        subset. It passed in isolation every time. No amount of median-taking
+        fixed it — the previous author had already added interleaved pairing,
+        alternating order to cancel page-cache bias, and medians over eight
+        iterations.
 
         Overlap is what prefetch actually promises, it is binary, and one
         observation across ten files is enough. Speed belongs in the benchmark

--- a/tests/pipeline/test_prefetch.py
+++ b/tests/pipeline/test_prefetch.py
@@ -6,10 +6,10 @@ error handling in PipelineOrchestrator._process_batch_prefetch.
 
 from __future__ import annotations
 
+import contextlib
 import random
-import statistics
 import threading
-import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -91,6 +91,72 @@ class _SlowComputeStage:
         return context
 
 
+class _OverlapProbe:
+    """Records whether an I/O stage ever ran while a compute stage was running.
+
+    This is what prefetch actually promises: the I/O stage for file N+1 runs
+    on the executor's thread pool while the compute stages for file N run on
+    the calling thread. That overlap either happens or it does not, which
+    makes it a *structural* observation rather than a timing measurement.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._io_in_flight = 0
+        self._compute_in_flight = 0
+        self.overlap_count = 0
+
+    @contextlib.contextmanager
+    def io(self) -> Iterator[None]:
+        """Mark an I/O stage as in flight for the duration of the block."""
+        with self._lock:
+            self._io_in_flight += 1
+            if self._compute_in_flight:
+                self.overlap_count += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._io_in_flight -= 1
+
+    @contextlib.contextmanager
+    def compute(self) -> Iterator[None]:
+        """Mark a compute stage as in flight for the duration of the block."""
+        with self._lock:
+            self._compute_in_flight += 1
+            if self._io_in_flight:
+                self.overlap_count += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._compute_in_flight -= 1
+
+
+class _ProbedIOStage(_SlowIOStage):
+    """``_SlowIOStage`` that reports its in-flight window to a probe."""
+
+    def __init__(self, probe: _OverlapProbe, delay_s: float) -> None:
+        super().__init__(delay_s=delay_s)
+        self._probe = probe
+
+    def process(self, context: StageContext) -> StageContext:
+        with self._probe.io():
+            return super().process(context)
+
+
+class _ProbedComputeStage(_SlowComputeStage):
+    """``_SlowComputeStage`` that reports its in-flight window to a probe."""
+
+    def __init__(self, probe: _OverlapProbe, delay_s: float) -> None:
+        super().__init__(delay_s=delay_s)
+        self._probe = probe
+
+    def process(self, context: StageContext) -> StageContext:
+        with self._probe.compute():
+            return super().process(context)
+
+
 class _ErrorIOStage:
     """I/O stage that raises on files matching a predicate."""
 
@@ -120,75 +186,71 @@ def _make_files(tmp_path: Path, count: int, size_bytes: int, seed: int = 42) -> 
 
 
 # ---------------------------------------------------------------------------
-# Performance test
+# I/O-compute overlap
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.slow
 @pytest.mark.unit
-class TestPrefetchPerformance:
-    """Verify prefetch gives >= 20% wall-clock speedup on a 10-file batch."""
+class TestPrefetchOverlap:
+    """Verify prefetch overlaps I/O with compute, and that depth=0 does not.
 
-    def _paired_medians(
-        self,
-        files: list[Path],
-        io_delay: float,
-        compute_delay: float,
-        iterations: int = 8,
-    ) -> tuple[float, float]:
-        """Median time for depth=0 and depth=2, sampled interleaved.
+    Deliberately asserts structure rather than elapsed time. See #1729 for why
+    the wall-clock version could not survive ``-n auto``.
+    """
 
-        Two biases to remove, not one:
+    def _run_with_probe(self, files: list[Path], depth: int) -> _OverlapProbe:
+        """Process *files* at ``prefetch_depth=depth``, returning the probe."""
+        probe = _OverlapProbe()
+        orchestrator = PipelineOrchestrator(
+            stages=[
+                _ProbedIOStage(probe, delay_s=0.015),
+                _ProbedComputeStage(probe, delay_s=0.04),
+            ],
+            prefetch_depth=depth,
+            prefetch_stages=1,
+        )
+        orchestrator.process_batch(files)
+        return probe
 
-        - Timing all baseline runs and then all prefetch runs lets drift
-          between the two blocks drive the ratio — a runner that gets busier
-          mid-test makes prefetch look slower than it is. Hence pairing.
-        - Within a pair, always running depth=0 first hands depth=2 a warm
-          page cache every single time, which flatters prefetch. Seven
-          medians do not cancel a systematic order bias. Hence alternating,
-          over an even iteration count so each order runs equally often.
-        """
-        baseline: list[float] = []
-        prefetched: list[float] = []
-        for iteration in range(iterations):
-            runs = ((0, baseline), (2, prefetched))
-            if iteration % 2:
-                runs = ((2, prefetched), (0, baseline))
-            for depth, bucket in runs:
-                orchestrator = PipelineOrchestrator(
-                    stages=[
-                        _SlowIOStage(delay_s=io_delay),
-                        _SlowComputeStage(delay_s=compute_delay),
-                    ],
-                    prefetch_depth=depth,
-                    prefetch_stages=1,
-                )
-                t0 = time.monotonic()
-                orchestrator.process_batch(files)
-                bucket.append(time.monotonic() - t0)
-        return statistics.median(baseline), statistics.median(prefetched)
+    def test_prefetch_overlaps_io_with_compute(self, tmp_path: Path) -> None:
+        """Prefetch must run a file's I/O stage while another file computes.
 
-    def test_prefetch_faster_than_sequential(self, tmp_path: Path) -> None:
-        """Prefetch depth=2 must be >= 20% faster than no-prefetch baseline.
+        Asserts the *mechanism*, not the clock. The previous version of this
+        test required a >= 20% wall-clock speedup, which is unmeasurable when
+        the suite runs under ``-n auto``: 18 workers contend for 18 cores, and
+        the ratio drowns in scheduling noise. It failed roughly one run in
+        three on unmodified main (#1729) while passing in isolation, and no
+        amount of median-taking fixed it — the previous author had already
+        added interleaved pairing and alternating order.
 
-        Uses 10 x 1 MB files (seed=42), controlled sleep values to make
-        the I/O-compute overlap measurable in CI without flakiness.
+        Overlap is what prefetch actually promises, it is binary, and one
+        observation across ten files is enough. Speed belongs in the benchmark
+        suite, where nothing else is competing for the CPU.
         """
         files = _make_files(tmp_path, count=10, size_bytes=1024 * 1024, seed=42)
 
-        # Keep delays large enough that overlap is clearly measurable and
-        # small enough that the test finishes within the 30 s CI timeout.
-        io_delay = 0.015  # 15 ms  — simulates file-read latency
-        compute_delay = 0.04  # 40 ms  — simulates LLM inference
+        probe = self._run_with_probe(files, depth=2)
 
-        baseline, with_prefetch = self._paired_medians(
-            files, io_delay=io_delay, compute_delay=compute_delay
+        assert probe.overlap_count > 0, (
+            "prefetch_depth=2 never ran an I/O stage concurrently with a "
+            "compute stage; the double-buffering is not happening"
         )
 
-        speedup = (baseline - with_prefetch) / baseline
-        assert speedup >= 0.20, (
-            f"Expected >= 20% speedup, got {speedup:.1%} "
-            f"(baseline={baseline:.3f}s, prefetch={with_prefetch:.3f}s)"
+    def test_without_prefetch_io_and_compute_never_overlap(self, tmp_path: Path) -> None:
+        """The counterfactual, without which the overlap assertion proves nothing.
+
+        If the probe reported overlap here too, it would be measuring its own
+        bookkeeping rather than prefetch. depth=0 runs strictly sequentially on
+        the calling thread, so the two stages can never be in flight together.
+        """
+        files = _make_files(tmp_path, count=10, size_bytes=1024 * 1024, seed=42)
+
+        probe = self._run_with_probe(files, depth=0)
+
+        assert probe.overlap_count == 0, (
+            f"depth=0 must run sequentially, but observed "
+            f"{probe.overlap_count} overlapping stage windows"
         )
 
     def test_no_prefetch_flag_produces_sequential_timing(self, tmp_path: Path) -> None:

--- a/tests/plugins/test_sandbox_isolation.py
+++ b/tests/plugins/test_sandbox_isolation.py
@@ -275,6 +275,14 @@ class TestExecutorInterface:
     ``@pytest.mark.skip`` decorator when the executor is ready.
     """
 
+    # Spawns real interpreters. Each child re-imports the package, and with
+    # `concurrency = ["multiprocessing", "thread"]` coverage traces that import
+    # too, so the work genuinely takes longer than the global --timeout=30 when
+    # 18 xdist workers are already saturating the CPU. Raised deliberately: the
+    # work is slower, not racing. Where a timeout hides a race (see the desktop
+    # launcher port handoff) widening it makes things worse, and there the fix
+    # was structural instead (#1729).
+    @pytest.mark.timeout(120)
     def test_executor_starts_and_stops(self, tmp_path: Path) -> None:
         """PluginExecutor starts a child process, accepts a call, stops cleanly.
 

--- a/tests/tui/test_settings_view.py
+++ b/tests/tui/test_settings_view.py
@@ -66,6 +66,14 @@ def test_load_parallel_runtime_settings_caps_workers_to_cpu_count() -> None:
     assert settings.prefetch_depth == 1
 
 
+# Spawns real interpreters. Each child re-imports the package, and with
+# `concurrency = ["multiprocessing", "thread"]` coverage traces that import
+# too, so the work genuinely takes longer than the global --timeout=30 when
+# 18 xdist workers are already saturating the CPU. Raised deliberately: the
+# work is slower, not racing. Where a timeout hides a race (see the desktop
+# launcher port handoff) widening it makes things worse, and there the fix
+# was structural instead (#1729).
+@pytest.mark.timeout(120)
 def test_load_parallel_runtime_settings_uses_cpu_count_fallback_when_unavailable() -> None:
     """Module-level worker cap should fall back to 1 when ``os.cpu_count()`` is unavailable."""
     code = """

--- a/tests/web/test_web_organize_routes.py
+++ b/tests/web/test_web_organize_routes.py
@@ -379,8 +379,17 @@ class TestOrganizeInputValidation:
             },
             headers=csrf_headers,
         )
-        # Should accept valid sort/filter combinations
-        assert response.status_code in (200, 400)
+        # Should accept valid sort/filter combinations. 200 or 400 only: a 5xx
+        # or a CSRF rejection is a real failure.
+        #
+        # Reported with the body attached because this test has been seen to
+        # fail intermittently in full-suite runs under `-n auto` (#1729) and a
+        # bare status code gives whoever hits it nothing to work with. It could
+        # not be reproduced in six runs of `tests/web tests/api -n auto`, so the
+        # cause is still unknown — this is a diagnostic aid, not a fix.
+        assert response.status_code in (200, 400), (
+            f"unexpected status {response.status_code}; body={response.text[:500]!r}"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #1729 and #1731. Everything found along the way is fixed here rather than filed.

## Result

| | before | after |
| :--- | :--- | :--- |
| `pipeline + parallel + integration + desktop + web`, `-n auto` | 2/3 runs failed, 99–215 s | **3/3 green, ~72–86 s** |
| serial full suite (`-p no:randomly`) | 2 failures | **22,544 passed, 0 failed** |
| `tests/pipeline/test_prefetch.py` alone | ~11 s | **1.6 s** |

The speedup matters as much as the green: the prefetch test wasn't only *suffering* from contention, it was *generating* it — 16 full pipeline runs over 10×1 MB files purely to take a timing median, and under xdist the total is bounded by the slowest worker.

## 1. Prefetch: assert the mechanism, not the clock

It required a **≥ 20% wall-clock speedup**, unmeasurable when 18 workers contend for 18 cores. Not fixable with better statistics — the previous author had already added interleaved pairing, alternating order to cancel page-cache bias, and medians over 8 iterations. Measured on unmodified `main`: **3/3 full-suite runs failed, 2/3 subset runs**, while passing in isolation every time.

**My first two reproduction attempts were wrong**, which is worth recording: steady CPU load (0/5) and bursty jittered load (0/6) both failed to reproduce it, because a paired median is robust to uniform slowdown. Only real concurrent tests did it.

Replaced with the actual promise — file N+1's I/O runs while file N computes — plus a depth=0 counterfactual. The counterfactual is load-bearing: without it the first assertion could be measuring its own bookkeeping, which is exactly the trap I hit in #1728. **Mutation-checked**: disabling prefetch fails the overlap test while the sequential one still passes.

## 2. A test was dialling Ollama

`build_plan` runs the real `organize()` pipeline, which initialises `TextModel` and connects to whatever daemon is listening. **0.10 s with `OLLAMA_HOST` at a dead port, 0.92 s with a daemon up.** Now takes the existing `stub_all_models` fixture: 0.10 s either way.

## 3. The launcher port race (#1731) — fixed, not filed

`_find_free_port()` bound port 0, read the number, **closed the socket**, and returned a bare int; uvicorn re-bound seconds later. The module docstring claimed this design *"avoid[s] TOCTOU races on busy machines"* — releasing the socket **is** the TOCTOU.

Three changes, none correct alone:

- `_bind_free_socket()` keeps the socket and hands it to `uvicorn.Server.serve(sockets=[...])` — window eliminated, not narrowed.
- Readiness from uvicorn's own `started` flag via an Event. **Mandatory, not cosmetic**: a pre-bound socket accepts TCP the instant it listens, so the old connect-probe would report ready mid-import — turning a timeout bug into a blank-window bug.
- `_wait_for_server` watches thread liveness: uvicorn `sys.exit()`s on bind failure and `Thread._bootstrap_inner` swallows it, so a crash previously burned 10 s and reported "did not become ready".

Also gives `launch()` a shutdown path; the daemon thread previously outlived the window holding the port and a loguru sink.

13 tests encoded the old contract — including one asserting the port was re-bindable immediately after allocation, which **was** the race. Rewritten to assert the inverse, plus crash-detection and no-ready-on-failure cases.

## 4. Three guardrails fired on this work

Two were mine and correct:
- `time.sleep()` added to tests — while fixing timing flakiness. Replaced with threads parked on an Event.
- `pytest.raises(OSError)` without `match`.

One was the **rail's own bug**, so it is fixed rather than worked around: `_imports_loguru` tested `"loguru" in source`, a substring match that fires on the word in a comment. My comment mentioning a loguru sink turned `desktop/app.py` — stdlib `logging`, where `%s` is correct — into a false positive demanding `{}` that would print literally. Now an AST import check, with a regression test.

## Docs vs implementation

Audited against code, not eyeballed:

| Claim | Result |
| :--- | :--- |
| triage README: 979 rows, all allowlisted, 0 open | exactly 979, all allowlisted |
| table: 26 retarget / 953 untracked | matches worklist |
| mutation floors 63/76/77 | match `PROFILES` |
| "three small modules" | 3 runnable of 5 (2 blocked) |
| install line, nightly cron, "never on a PR" | match the workflow |

One mismatch was mine: the new prefetch docstring said "roughly one run in three" when I had measured 3-of-3 and 2-of-3. Corrected to the measured figures.

## Still open, deliberately

#1726 (mutmut's fork model blocks 2 mutation profiles). I tested the one hypothesis that would have made it cheap — leaked threads in the parent poisoning forks — and measured **zero leaked threads** in all three implicated files. So the tractable fix does not exist; what remains is a runner migration, which I am not starting without a mechanism. The harness already refuses to report a score for those profiles rather than reporting a fake one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop application startup reliability by preserving the server socket, detecting startup failures promptly, and distinguishing failures from readiness timeouts.
  - Improved shutdown behavior so closing the desktop window cleanly stops the embedded server.
  - Ensured execution planning restores its expected dry-run state before running.

- **Performance**
  - Verified that prefetching overlaps data loading with computation when enabled, while preserving sequential behavior when disabled.

- **Tests**
  - Strengthened coverage for desktop startup, shutdown, concurrency, warmup behavior, import detection, and long-running subprocess operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->