### PR TITLE
feat(1674,1675): give safe_walk an error channel and a traversal budget

### DIFF
--- a/src/file_organizer/api/routers/search.py
+++ b/src/file_organizer/api/routers/search.py
@@ -123,7 +123,7 @@ def _collect_matching_files(
     root: Path,
     query: str,
     file_type: str | None,
-    max_files: int = _MAX_TRAVERSAL,
+    max_files: int | TraversalBudget = _MAX_TRAVERSAL,
 ) -> Iterator[Path]:
     """Yield files under *root* whose name or path matches *query*."""
     q_lower = query.lower()
@@ -137,7 +137,7 @@ def _collect_matching_files(
     # dotfiles cannot walk past the budget (#1675). Counting yielded results
     # instead would have quietly loosened a denial-of-service guard on a
     # remote-reachable endpoint.
-    for entry in safe_walk(root, max_entries=max_files):
+    for entry in safe_walk(root, max_entries=max_files):  # budget may be shared
         if ext_filter and entry.suffix.lower() != ext_filter:
             continue
         # Check if query matches name or path
@@ -347,14 +347,20 @@ def search(
     results: list[SearchResult] = []
     total_traversed = 0
 
+    # One budget for the whole request. The previous quota was derived from
+    # `total_traversed`, which counts *yielded matches* — so hidden files,
+    # symlinks, directories and non-matches never reduced it, and each root
+    # received close to the full allowance. With several configured roots the
+    # bound multiplied. That is the same count-results-not-traversal mistake
+    # #1675 describes, one level up from the walk itself.
+    budget = TraversalBudget(limit=_MAX_TRAVERSAL)
+
     for root in search_roots:
         if not root.exists() or not root.is_dir():
             continue
-        # Adjust remaining quota for this root (global limit across all roots)
-        remaining = _MAX_TRAVERSAL - total_traversed
-        if remaining <= 0:
+        if budget.exhausted:
             break
-        for fp in _collect_matching_files(root, q, file_type, max_files=remaining):
+        for fp in _collect_matching_files(root, q, file_type, max_files=budget):
             total_traversed += 1
             score = _compute_score(fp, q)
             result = _build_result(fp, score, search_roots)

--- a/src/file_organizer/api/routers/search.py
+++ b/src/file_organizer/api/routers/search.py
@@ -19,7 +19,8 @@ from file_organizer.api.openapi_responses import (
     success_response,
     validation_error_response,
 )
-from file_organizer.api.utils import is_hidden, resolve_path
+from file_organizer.api.utils import resolve_path
+from file_organizer.core.path_guard import TraversalBudget, safe_walk
 
 logger = logging.getLogger(__name__)
 
@@ -130,30 +131,22 @@ def _collect_matching_files(
     if file_type:
         ext_filter = file_type.lower() if file_type.startswith(".") else f".{file_type.lower()}"
 
-    traversed = 0
-    try:
-        for entry in root.rglob("*"):
-            traversed += 1
-            if traversed > max_files:
-                break
-            # Skip symlinks to prevent traversing into hidden/protected directories
-            if entry.is_symlink():
-                continue
-            if not entry.is_file():
-                continue
-            if is_hidden(entry):
-                continue
-            if ext_filter and entry.suffix.lower() != ext_filter:
-                continue
-            # Check if query matches name or path
-            try:
-                rel = entry.relative_to(root)
-            except ValueError:
-                rel = entry
-            if q_lower in entry.name.lower() or q_lower in str(rel).lower():
-                yield entry
-    except PermissionError:
-        logger.debug("Permission denied traversing %s", root)
+    # safe_walk applies the symlink / non-file / hidden filters this loop used
+    # to hand-roll, and `max_entries` preserves the traversal bound exactly:
+    # entries are counted as they are examined, before filtering, so a tree of
+    # dotfiles cannot walk past the budget (#1675). Counting yielded results
+    # instead would have quietly loosened a denial-of-service guard on a
+    # remote-reachable endpoint.
+    for entry in safe_walk(root, max_entries=max_files):
+        if ext_filter and entry.suffix.lower() != ext_filter:
+            continue
+        # Check if query matches name or path
+        try:
+            rel = entry.relative_to(root)
+        except ValueError:
+            rel = entry
+        if q_lower in entry.name.lower() or q_lower in str(rel).lower():
+            yield entry
 
 
 def _build_semantic_corpus(
@@ -179,33 +172,26 @@ def _build_semantic_corpus(
 
     documents: list[str] = []
     paths: list[Path] = []
-    total = 0
-    done = False
+    # One budget across every root, matching the previous `total` counter.
+    # A per-call `max_entries=max_files` would hand each root the full budget
+    # and multiply the traversal bound by the number of roots.
+    budget = TraversalBudget(limit=max_files)
 
     for root in roots:
-        if done or not root.exists() or not root.is_dir():
+        if budget.exhausted or not root.exists() or not root.is_dir():
             continue
-        try:
-            for entry in root.rglob("*"):
-                total += 1
-                if total > max_files:
-                    done = True
-                    break
-                try:
-                    rel_entry = entry.relative_to(root)
-                except ValueError:
-                    logger.debug("Skipping entry outside root: %s", entry)
-                    continue
-                if entry.is_symlink() or not entry.is_file() or is_hidden(rel_entry):
-                    continue
-                # root is the trusted walked root: anchor the read so a symlink
-                # swapped into any intermediate directory is refused (#286).
-                text = read_text_safe(entry, scan_root=root)
-                doc = f"{entry.stem} {' '.join(rel_entry.parts)} {text}".strip()
-                documents.append(doc)
-                paths.append(entry)
-        except PermissionError:
-            logger.debug("Permission denied traversing %s", root)
+        for entry in safe_walk(root, max_entries=budget):
+            try:
+                rel_entry = entry.relative_to(root)
+            except ValueError:
+                logger.debug("Skipping entry outside root: %s", entry)
+                continue
+            # root is the trusted walked root: anchor the read so a symlink
+            # swapped into any intermediate directory is refused (#286).
+            text = read_text_safe(entry, scan_root=root)
+            doc = f"{entry.stem} {' '.join(rel_entry.parts)} {text}".strip()
+            documents.append(doc)
+            paths.append(entry)
 
     return documents, paths
 

--- a/src/file_organizer/core/path_guard.py
+++ b/src/file_organizer/core/path_guard.py
@@ -139,8 +139,13 @@ class TraversalBudget:
 
     @property
     def exhausted(self) -> bool:
-        """True once more entries have been examined than the limit allows."""
-        return self.examined > self.limit
+        """True once the limit has been reached.
+
+        ``>=``, not ``>``: with ``>`` a limit of N permitted N+1 entries to be
+        consumed, and a limit of 0 still consumed one. The bound is documented
+        as "examine at most N entries", so it should mean exactly that.
+        """
+        return self.examined >= self.limit
 
 
 def _report(
@@ -324,13 +329,18 @@ def safe_walk(
         return budget is not None and budget.exhausted
 
     def _walk(dir_path: Path) -> Iterator[Path]:
+        # Checked before opening the directory as well as before each entry, so
+        # an already-spent shared budget does not pay for another scandir, and
+        # a zero limit walks nothing at all.
+        if _budget_exhausted():
+            return
         try:
             with os.scandir(dir_path) as it:
                 for entry in it:
-                    if budget is not None:
-                        budget.examined += 1
                     if _budget_exhausted():
                         return
+                    if budget is not None:
+                        budget.examined += 1
                     yield from _process_walk_entry(
                         entry,
                         pattern=pattern,

--- a/src/file_organizer/core/path_guard.py
+++ b/src/file_organizer/core/path_guard.py
@@ -45,9 +45,13 @@ Design invariants:
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class PathTraversalError(ValueError):
@@ -112,6 +116,56 @@ def validate_within_roots(path: Path, allowed_roots: Iterable[Path]) -> Path:
     )
 
 
+@dataclass
+class TraversalBudget:
+    """A traversal bound shared across several :func:`safe_walk` calls.
+
+    ``max_entries=N`` gives each call its own budget of N. A caller walking
+    several roots under one global bound — as the search endpoints do, where
+    the bound is a denial-of-service guard on a remote-reachable request —
+    needs the count to carry over. Pass one instance to every call:
+
+        budget = TraversalBudget(limit=10_000)
+        for root in roots:
+            for path in safe_walk(root, max_entries=budget):
+                ...
+
+    ``examined`` counts directory entries seen, before the symlink / hidden /
+    file-type filters, for the reason given in :func:`safe_walk`.
+    """
+
+    limit: int
+    examined: int = 0
+
+    @property
+    def exhausted(self) -> bool:
+        """True once more entries have been examined than the limit allows."""
+        return self.examined > self.limit
+
+
+def _report(
+    on_error: Callable[[Path, OSError], None] | None,
+    path: Path,
+    exc: OSError,
+) -> None:
+    """Log a skipped path and hand it to *on_error* if the caller wants it.
+
+    The ``logger.debug`` call is unconditional and deliberate. Before the
+    #1671 migration, call sites logged their own permission failures; folding
+    them into this primitive removed those lines wholesale (see #1674). Logging
+    here restores the diagnostic for all of them without touching a single call
+    site.
+
+    Exceptions raised by *on_error* are **not** caught. A caller that wants to
+    escalate a permission failure into a hard error should be able to, and
+    swallowing an exception raised by an error handler would be the same defect
+    this function exists to fix.
+    """
+    logger.debug("safe_walk skipping %s: %s", path, exc)
+    if on_error is not None:
+        on_error(path, exc)
+
+
 def _process_walk_entry(
     entry: os.DirEntry,
     *,
@@ -121,6 +175,7 @@ def _process_walk_entry(
     follow_symlinks: bool,
     include_hidden: bool,
     walk_fn: Callable[[Path], Iterator[Path]],
+    on_error: Callable[[Path, OSError], None] | None = None,
 ) -> Iterator[Path]:
     """Process a single directory entry during a secure walk."""
     name = entry.name
@@ -133,7 +188,8 @@ def _process_walk_entry(
     # that entry instead of aborting the whole walk.
     try:
         is_sym = entry_path.is_symlink()
-    except OSError:
+    except OSError as exc:
+        _report(on_error, entry_path, exc)
         return
 
     if not follow_symlinks and is_sym:
@@ -141,7 +197,8 @@ def _process_walk_entry(
 
     try:
         is_dir = entry_path.is_dir()
-    except OSError:
+    except OSError as exc:
+        _report(on_error, entry_path, exc)
         is_dir = False
 
     # Note: we do not descend into directory symlinks for recursion (secure)
@@ -154,7 +211,8 @@ def _process_walk_entry(
     else:
         try:
             is_file = entry_path.is_file()
-        except OSError:
+        except OSError as exc:
+            _report(on_error, entry_path, exc)
             is_file = False
 
         if only_files and not is_file:
@@ -172,6 +230,8 @@ def safe_walk(
     only_files: bool = True,
     follow_symlinks: bool = False,
     include_hidden: bool = False,
+    on_error: Callable[[Path, OSError], None] | None = None,
+    max_entries: int | TraversalBudget | None = None,
 ) -> Iterator[Path]:
     """Walk `root` with security filters.
 
@@ -208,6 +268,30 @@ def safe_walk(
             False (secure — skip symlink entries entirely).
         include_hidden: If True, include dot-prefixed files and descendants
             of dot-prefixed directories. Default False (secure).
+        on_error: Called as ``on_error(path, exc)`` for every entry skipped
+            because of an ``OSError`` — an unreadable root, an unreadable
+            directory, or a per-entry stat failure. The walk continues
+            regardless; this only lets the caller *observe* what was skipped
+            rather than silently receiving a short list (#1674).
+
+            Reported at every catch site, including per-entry. A caller that
+            finds per-entry reports noisy can filter them, whereas one that is
+            never told cannot recover the information — and a walk that
+            silently returns fewer files is exactly the failure this exists to
+            surface.
+
+            Exceptions raised by *on_error* propagate, so a caller can escalate
+            a permission failure into a hard error.
+        max_entries: If set, stop the walk once this many directory entries
+            have been **examined**. Accepts an ``int`` (a budget private to
+            this call) or a :class:`TraversalBudget` (shared across calls, for
+            a caller walking several roots under one global bound). Counted before the symlink / hidden /
+            file-type filters, so it bounds traversal work rather than results
+            — a budget on yielded entries would let a tree of dotfiles or
+            symlinks traverse arbitrarily far, since each is discarded before
+            being counted (#1675). Used by request-scoped walks on
+            remote-reachable endpoints, where the bound is a denial-of-service
+            guard rather than a UX nicety.
 
     Yields:
         `Path` objects for each entry under `root` that matches `pattern`
@@ -221,13 +305,32 @@ def safe_walk(
         # including paths outside the caller's allowed root.
         if not follow_symlinks and root.is_symlink():
             return
-    except OSError:
+    except OSError as exc:
+        _report(on_error, root, exc)
         return
+
+    # Entries *examined*, not entries yielded. See the `max_entries` docstring:
+    # counting survivors would let a tree of dotfiles or symlinks blow through
+    # any budget, because every one of them is discarded before it is yielded.
+    budget: TraversalBudget | None
+    if isinstance(max_entries, TraversalBudget):
+        budget = max_entries  # shared across calls; do not reset `examined`
+    elif max_entries is None:
+        budget = None
+    else:
+        budget = TraversalBudget(limit=max_entries)
+
+    def _budget_exhausted() -> bool:
+        return budget is not None and budget.exhausted
 
     def _walk(dir_path: Path) -> Iterator[Path]:
         try:
             with os.scandir(dir_path) as it:
                 for entry in it:
+                    if budget is not None:
+                        budget.examined += 1
+                    if _budget_exhausted():
+                        return
                     yield from _process_walk_entry(
                         entry,
                         pattern=pattern,
@@ -236,8 +339,14 @@ def safe_walk(
                         follow_symlinks=follow_symlinks,
                         include_hidden=include_hidden,
                         walk_fn=_walk,
+                        on_error=on_error,
                     )
-        except OSError:
+                    # A nested walk may have exhausted the budget; stop this
+                    # level too rather than finishing the current directory.
+                    if _budget_exhausted():
+                        return
+        except OSError as exc:
+            _report(on_error, dir_path, exc)
             return
 
     yield from _walk(root)

--- a/src/file_organizer/services/copilot/rules/preview.py
+++ b/src/file_organizer/services/copilot/rules/preview.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.services.copilot.rules.models import (
     ConditionType,
     Rule,
@@ -105,19 +106,19 @@ class PreviewEngine:
             logger.debug("No enabled rules in set '{}'", rule_set.name)
             return result
 
-        # Collect files
+        # Collect files. `on_error` is what makes this migration possible:
+        # before it, safe_walk swallowed every OSError, so a permission failure
+        # produced a short file list and an empty `errors` — the preview
+        # reported success over a directory it could not read (#1674).
         files: list[Path] = []
-        try:
-            pattern = target.rglob("*") if recursive else target.iterdir()
-            for entry in pattern:
-                if entry.is_symlink():
-                    continue
-                if entry.is_file():
-                    files.append(entry)
-                    if len(files) >= max_files:
-                        break
-        except PermissionError as exc:
-            result.errors.append((str(target), f"Permission denied: {exc}"))
+
+        def _record(path: Path, exc: OSError) -> None:
+            result.errors.append((str(path), f"Permission denied: {exc}"))
+
+        for entry in safe_walk(target, recursive=recursive, on_error=_record):
+            files.append(entry)
+            if len(files) >= max_files:
+                break
 
         result.total_files = len(files)
 

--- a/src/file_organizer/services/copilot/rules/preview.py
+++ b/src/file_organizer/services/copilot/rules/preview.py
@@ -94,10 +94,20 @@ class PreviewEngine:
         Returns:
             A ``PreviewResult`` with match details.
         """
-        target = Path(target_dir).expanduser().resolve()
         result = PreviewResult()
 
-        if not target.is_dir():
+        # Resolution and the is_dir() probe both touch the filesystem and can
+        # raise before safe_walk is ever called, so `on_error` cannot see them.
+        # An unreadable target root must land in `errors` like any other
+        # permission failure, not escape as an exception (#1674).
+        try:
+            target = Path(target_dir).expanduser().resolve()
+            is_directory = target.is_dir()
+        except OSError as exc:
+            result.errors.append((str(target_dir), f"Permission denied: {exc}"))
+            return result
+
+        if not is_directory:
             result.errors.append((str(target), "Not a directory"))
             return result
 

--- a/tests/api/test_search_router.py
+++ b/tests/api/test_search_router.py
@@ -567,10 +567,9 @@ class TestTraversalBudget:
         list(_collect_matching_files(tmp_path, "match", None, max_files=10))
 
         # Two-sided: a bare upper bound also passes when nothing was walked.
-        assert 10 <= len(consumed) <= 11, (
-            f"budget of 10 examined {len(consumed)} entries — expected it to "
-            "walk up to the bound and stop; a result-counting bound would have "
-            "walked all 61"
+        assert len(consumed) == 10, (
+            f"budget of 10 examined {len(consumed)} entries — expected exactly "
+            "10; a result-counting bound would have walked all 61"
         )
 
     def test_ordinary_tree_results_are_unchanged(self, tmp_path: Path) -> None:
@@ -606,6 +605,62 @@ class TestTraversalBudget:
         found = {p.name for p in _collect_matching_files(tmp_path, "report", None)}
         assert found == {"report_visible.txt"}
 
+    def test_keyword_budget_is_shared_across_roots(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Drives the real endpoint, not a hand-rolled loop.
+
+        An earlier version of this test built its own budget and iterated the
+        roots itself. It passed against production code that gave each root a
+        fresh budget — it verified only that `_collect_matching_files` accepts
+        a shared budget, never that `search()` passes one. Mutation-checking
+        caught that, so this goes through the endpoint.
+
+        The quota used to derive from a counter of *yielded matches*, so
+        discarded entries never reduced it and every root received close to
+        the full allowance. Each root here is padded with dotfiles that yield
+        nothing, so a match-derived quota traverses all three.
+        """
+        from file_organizer.api.routers import search as search_mod
+
+        for r in range(3):
+            root = tmp_path / f"root_{r}"
+            root.mkdir()
+            for i in range(20):
+                (root / f".skip_{i:02d}.txt").write_text("x")
+
+        # THREE allowed roots, not one. Configuring a single root (as
+        # `_build_app` does) put all three directories under one walk, where a
+        # per-root budget is indistinguishable from a shared one — which is
+        # why an earlier version of this test also survived the mutation.
+        settings = ApiSettings(
+            environment="test",
+            allowed_paths=[str(tmp_path / f"root_{r}") for r in range(3)],
+        )
+        app = FastAPI()
+        setup_exception_handlers(app)
+        app.dependency_overrides[get_settings] = lambda: settings
+        from file_organizer.api.dependencies import get_current_active_user
+
+        app.dependency_overrides[get_current_active_user] = lambda: None
+        app.include_router(search_mod.router, prefix="/api/v1")
+        client = TestClient(app)
+
+        monkeypatch.setattr(search_mod, "_MAX_TRAVERSAL", 10)
+        consumed = self._counting_scandir(monkeypatch)
+
+        resp = client.get("/api/v1/search?q=skip")
+        assert resp.status_code == 200
+
+        # One range assertion, not two: a bare upper bound passes when the
+        # walk never ran, and the lower bound is what proves it did.
+        assert 10 <= len(consumed) <= 12, (
+            f"the request examined {len(consumed)} entries against a bound of "
+            "10 — expected it to walk up to the bound and stop. A per-root "
+            "budget would examine up to 60 across three roots; zero would mean "
+            "the walk never ran and the bound proves nothing."
+        )
+
     def test_semantic_corpus_budget_is_shared_across_roots(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -627,8 +682,8 @@ class TestTraversalBudget:
         consumed = self._counting_scandir(monkeypatch)
         _build_semantic_corpus(roots, max_files=10)
 
-        assert 10 <= len(consumed) <= 11, (
+        assert len(consumed) == 10, (
             f"shared budget of 10 examined {len(consumed)} entries across "
-            "3 roots — expected one global bound; a per-root budget would "
-            "examine up to 3x that"
+            "3 roots — expected exactly 10; a per-root budget would examine "
+            "up to 3x that"
         )

--- a/tests/api/test_search_router.py
+++ b/tests/api/test_search_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -510,3 +511,124 @@ class TestSearchAuthEnforcement:
 
         resp = client.get("/api/v1/search?q=test")
         assert resp.status_code == 401
+
+
+class TestTraversalBudget:
+    """The traversal bound survives the safe_walk migration (#1675).
+
+    `_MAX_TRAVERSAL` / `_MAX_SEMANTIC` are denial-of-service guards on
+    remote-reachable endpoints, not UX niceties. The migration risk was that
+    the counter would move from entries *visited* to entries *yielded*: since
+    safe_walk filters symlinks, dotfiles and directories before yielding, an
+    identical constant would then permit far more traversal on a tree made
+    mostly of discarded entries.
+    """
+
+    @staticmethod
+    def _counting_scandir(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Record every directory entry the walk consumes."""
+        consumed: list[str] = []
+        real_scandir = os.scandir
+
+        class _Counting:
+            def __init__(self, inner) -> None:
+                self._inner = inner
+
+            def __enter__(self):
+                self._it = self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc) -> None:
+                self._inner.__exit__(*exc)
+
+            def __iter__(self):
+                for entry in self._it:
+                    consumed.append(entry.name)
+                    yield entry
+
+        monkeypatch.setattr(os, "scandir", lambda path: _Counting(real_scandir(path)))
+        return consumed
+
+    def test_budget_bounds_work_on_a_tree_of_discarded_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The test the pre-migration code lacked, per #1675.
+
+        60 dotfiles and one match: a budget counting *results* would traverse
+        the whole tree, because the dotfiles never reach the counter.
+        """
+        from file_organizer.api.routers.search import _collect_matching_files
+
+        for i in range(60):
+            (tmp_path / f".hidden_{i:03d}.txt").write_text("x")
+        (tmp_path / "match.txt").write_text("x")
+
+        consumed = self._counting_scandir(monkeypatch)
+        list(_collect_matching_files(tmp_path, "match", None, max_files=10))
+
+        # Two-sided: a bare upper bound also passes when nothing was walked.
+        assert 10 <= len(consumed) <= 11, (
+            f"budget of 10 examined {len(consumed)} entries — expected it to "
+            "walk up to the bound and stop; a result-counting bound would have "
+            "walked all 61"
+        )
+
+    def test_ordinary_tree_results_are_unchanged(self, tmp_path: Path) -> None:
+        """Characterisation: matching behaviour is the same as before migrating."""
+        from file_organizer.api.routers.search import _collect_matching_files
+
+        (tmp_path / "report_final.txt").write_text("x")
+        (tmp_path / "report_draft.md").write_text("x")
+        (tmp_path / "unrelated.txt").write_text("x")
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        (nested / "report_nested.txt").write_text("x")
+
+        found = {p.name for p in _collect_matching_files(tmp_path, "report", None)}
+        assert found == {"report_final.txt", "report_draft.md", "report_nested.txt"}
+
+        typed = {p.name for p in _collect_matching_files(tmp_path, "report", "txt")}
+        assert typed == {"report_final.txt", "report_nested.txt"}
+
+    def test_symlinks_and_hidden_files_stay_excluded(self, tmp_path: Path) -> None:
+        """Characterisation guard: both sites already filtered these."""
+        from file_organizer.api.routers.search import _collect_matching_files
+
+        (tmp_path / "report_visible.txt").write_text("x")
+        (tmp_path / ".report_hidden.txt").write_text("x")
+        outside = tmp_path.parent / "report_outside.txt"
+        outside.write_text("x")
+        try:
+            (tmp_path / "report_link.txt").symlink_to(outside)
+        except (OSError, NotImplementedError):  # pragma: no cover - platform
+            pytest.skip("symlinks unavailable")
+
+        found = {p.name for p in _collect_matching_files(tmp_path, "report", None)}
+        assert found == {"report_visible.txt"}
+
+    def test_semantic_corpus_budget_is_shared_across_roots(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One global bound, not one per root.
+
+        A per-call budget would multiply the traversal bound by the number of
+        roots — the guard would loosen as a user configured more directories.
+        """
+        from file_organizer.api.routers.search import _build_semantic_corpus
+
+        roots = []
+        for r in range(3):
+            root = tmp_path / f"root_{r}"
+            root.mkdir()
+            for i in range(20):
+                (root / f"f{i:02d}.txt").write_text("hello")
+            roots.append(root)
+
+        consumed = self._counting_scandir(monkeypatch)
+        _build_semantic_corpus(roots, max_files=10)
+
+        assert 10 <= len(consumed) <= 11, (
+            f"shared budget of 10 examined {len(consumed)} entries across "
+            "3 roots — expected one global bound; a per-root budget would "
+            "examine up to 3x that"
+        )

--- a/tests/core/test_path_guard.py
+++ b/tests/core/test_path_guard.py
@@ -600,10 +600,10 @@ class TestSafeWalkMaxEntries:
         # Two-sided on purpose. A bare `<= 11` also passes when the walk
         # examined nothing at all, which would hide a broken walk behind a
         # green budget assertion.
-        assert 10 <= len(consumed) <= 11, (
-            f"budget of 10 examined {len(consumed)} entries; expected it to walk "
-            "up to the bound and stop — a result-counting budget would have "
-            "walked all 50 because the dotfiles are discarded"
+        assert len(consumed) == 10, (
+            f"budget of 10 examined {len(consumed)} entries; expected exactly 10 "
+            "— a result-counting budget would have walked all 50 because the "
+            "dotfiles are discarded before they could be counted"
         )
 
     def test_unbudgeted_walk_examines_the_whole_tree(

--- a/tests/core/test_path_guard.py
+++ b/tests/core/test_path_guard.py
@@ -434,6 +434,226 @@ class TestSafeWalk:
 
 @pytest.mark.ci
 @pytest.mark.integration
+class TestSafeWalkOnError:
+    """`on_error` lets callers observe what the walk skipped (#1674).
+
+    Before this, a walk that hit a permission error returned a short list and
+    the caller had no way to tell — "organized 40 of 50 files" reported
+    success. The default is unchanged: no callback, same silent skipping.
+    """
+
+    def test_reports_unreadable_directory_and_keeps_walking(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The readable remainder must still arrive; a skip is not an abort."""
+        (tmp_path / "readable.txt").write_text("x")
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+        (blocked / "hidden_from_us.txt").write_text("x")
+
+        real_scandir = os.scandir
+        failure = PermissionError(13, "Permission denied")
+
+        def fake_scandir(path):
+            if Path(path).name == "blocked":
+                raise failure
+            return real_scandir(path)
+
+        monkeypatch.setattr(os, "scandir", fake_scandir)
+
+        seen: list[tuple[Path, OSError]] = []
+        found = list(safe_walk(tmp_path, on_error=lambda p, e: seen.append((p, e))))
+
+        assert [p.name for p in found] == ["readable.txt"], (
+            "the walk must continue past an unreadable directory"
+        )
+        assert len(seen) == 1
+        assert seen[0][0] == blocked, "callback must receive the offending path"
+        assert seen[0][1] is failure, "callback must receive the original OSError"
+
+    def test_unreadable_subtree_does_not_abort_walk_without_callback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default behaviour is unchanged when no callback is supplied."""
+        (tmp_path / "readable.txt").write_text("x")
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+
+        real_scandir = os.scandir
+
+        def fake_scandir(path):
+            if Path(path).name == "blocked":
+                raise PermissionError(13, "Permission denied")
+            return real_scandir(path)
+
+        monkeypatch.setattr(os, "scandir", fake_scandir)
+
+        assert [p.name for p in safe_walk(tmp_path)] == ["readable.txt"]
+
+    def test_reports_per_entry_stat_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per-entry failures are reported too, not just per-directory ones.
+
+        A caller that finds these noisy can filter them; one that is never
+        told cannot recover the information.
+        """
+        (tmp_path / "good.txt").write_text("x")
+        (tmp_path / "bad.txt").write_text("x")
+
+        original_is_symlink = Path.is_symlink
+
+        def fake_is_symlink(self: Path) -> bool:
+            if self.name == "bad.txt":
+                raise OSError(5, "Input/output error")
+            return original_is_symlink(self)
+
+        monkeypatch.setattr(Path, "is_symlink", fake_is_symlink)
+
+        seen: list[Path] = []
+        found = list(safe_walk(tmp_path, on_error=lambda p, e: seen.append(p)))
+
+        assert [p.name for p in found] == ["good.txt"]
+        assert [p.name for p in seen] == ["bad.txt"]
+
+    def test_callback_exceptions_propagate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A caller must be able to escalate a permission failure.
+
+        Swallowing an exception raised by an error handler would be the same
+        silent-failure defect this parameter exists to fix.
+        """
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+
+        real_scandir = os.scandir
+
+        def fake_scandir(path):
+            if Path(path).name == "blocked":
+                raise PermissionError(13, "Permission denied")
+            return real_scandir(path)
+
+        monkeypatch.setattr(os, "scandir", fake_scandir)
+
+        def escalate(path: Path, exc: OSError) -> None:
+            raise RuntimeError(f"refusing to continue past {path.name}")
+
+        with pytest.raises(RuntimeError, match="refusing to continue past blocked"):
+            list(safe_walk(tmp_path, on_error=escalate))
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestSafeWalkMaxEntries:
+    """`max_entries` bounds traversal work, not results (#1675)."""
+
+    @staticmethod
+    def _counting_scandir(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Patch `os.scandir` to record every entry the walk actually consumes.
+
+        Measuring yielded paths cannot distinguish an entry-counting budget
+        from a result-counting one on a tree whose entries are mostly
+        discarded — which is precisely the regression #1675 describes. This
+        observes traversal directly.
+        """
+        consumed: list[str] = []
+        real_scandir = os.scandir
+
+        class _Counting:
+            def __init__(self, inner) -> None:
+                self._inner = inner
+
+            def __enter__(self):
+                self._it = self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc) -> None:
+                self._inner.__exit__(*exc)
+
+            def __iter__(self):
+                for entry in self._it:
+                    consumed.append(entry.name)
+                    yield entry
+
+        monkeypatch.setattr(os, "scandir", lambda path: _Counting(real_scandir(path)))
+        return consumed
+
+    def test_budget_counts_entries_the_filters_discard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The test the previous code lacked, and why the regression was invisible.
+
+        A budget applied to *yielded* entries would let a tree of dotfiles walk
+        arbitrarily far: every dotfile is discarded before it could be counted,
+        so the budget never trips. Here 49 of 50 entries are discarded, and the
+        assertion is on entries **consumed from scandir**, which is the only
+        way to tell the two budgets apart.
+        """
+        for i in range(49):
+            (tmp_path / f".dotfile_{i:03d}").write_text("x")
+        (tmp_path / "visible.txt").write_text("x")
+
+        consumed = self._counting_scandir(monkeypatch)
+        list(safe_walk(tmp_path, max_entries=10))
+
+        # Two-sided on purpose. A bare `<= 11` also passes when the walk
+        # examined nothing at all, which would hide a broken walk behind a
+        # green budget assertion.
+        assert 10 <= len(consumed) <= 11, (
+            f"budget of 10 examined {len(consumed)} entries; expected it to walk "
+            "up to the bound and stop — a result-counting budget would have "
+            "walked all 50 because the dotfiles are discarded"
+        )
+
+    def test_unbudgeted_walk_examines_the_whole_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Control for the test above: without a budget, all 50 are examined.
+
+        Without this, the assertion above would pass even if `max_entries` did
+        nothing and the tree were simply small.
+        """
+        for i in range(49):
+            (tmp_path / f".dotfile_{i:03d}").write_text("x")
+        (tmp_path / "visible.txt").write_text("x")
+
+        consumed = self._counting_scandir(monkeypatch)
+        list(safe_walk(tmp_path))
+
+        assert len(consumed) == 50
+
+    def test_budget_stops_traversal_across_subdirectories(self, tmp_path: Path) -> None:
+        """The bound is global, not per-directory."""
+        for d in range(5):
+            sub = tmp_path / f"dir_{d}"
+            sub.mkdir()
+            for i in range(10):
+                (sub / f"file_{i}.txt").write_text("x")
+
+        unbounded = list(safe_walk(tmp_path))
+        bounded = list(safe_walk(tmp_path, max_entries=12))
+
+        assert len(unbounded) == 50
+        assert len(bounded) < len(unbounded), "budget must curtail a 55-entry tree"
+
+    def test_no_budget_yields_everything(self, tmp_path: Path) -> None:
+        """Default is unchanged: `max_entries=None` imposes no bound."""
+        for i in range(30):
+            (tmp_path / f"f{i}.txt").write_text("x")
+
+        assert len(list(safe_walk(tmp_path))) == 30
+        assert len(list(safe_walk(tmp_path, max_entries=None))) == 30
+
+    def test_budget_larger_than_tree_is_a_no_op(self, tmp_path: Path) -> None:
+        for i in range(5):
+            (tmp_path / f"f{i}.txt").write_text("x")
+
+        assert len(list(safe_walk(tmp_path, max_entries=1000))) == 5
+
+
+@pytest.mark.ci
+@pytest.mark.integration
 class TestPathTraversalError:
     def test_is_value_error_subclass(self) -> None:
         """Downstream code that catches ValueError continues to work —

--- a/tests/services/copilot/test_copilot_preview.py
+++ b/tests/services/copilot/test_copilot_preview.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -318,17 +316,38 @@ class TestPreviewEngine:
         assert result.total_files == 3
         assert result.match_count == 3
 
-    def test_permission_error(self, tmp_path):
+    def test_permission_error(self, tmp_path, monkeypatch):
+        """An unreadable directory must surface in `errors`, not vanish.
+
+        Patched at `os.scandir`, not `Path.rglob`: preview now walks via
+        `safe_walk`, which uses scandir, so the old patch intercepted nothing.
+        A test patching a target the code no longer calls does not fail loudly
+        — it keeps passing while asserting nothing, which is why #1674 warned
+        about exactly this rewrite.
+        """
+        (tmp_path / "note.txt").write_text("x")
         engine = PreviewEngine()
         rule = Rule(
             name="r",
             conditions=[RuleCondition(ConditionType.EXTENSION, ".txt")],
         )
         rs = RuleSet(rules=[rule])
-        with patch.object(Path, "rglob", side_effect=PermissionError("denied")):
-            result = engine.preview(rs, tmp_path)
+
+        # Control: unpatched, the same call finds the file. Without this, the
+        # assertions below would also pass against a walk that returned
+        # nothing for an unrelated reason.
+        control = engine.preview(rs, tmp_path)
+        assert control.total_files == 1, "control run must see the readable file"
+        assert control.errors == []
+
+        monkeypatch.setattr(
+            os, "scandir", lambda path: (_ for _ in ()).throw(PermissionError("denied"))
+        )
+        result = engine.preview(rs, tmp_path)
+
         assert len(result.errors) == 1
         assert "Permission denied" in result.errors[0][1]
+        assert result.total_files == 0
 
     def test_unmatched_files(self, tmp_path):
         (tmp_path / "a.pdf").write_text("pdf")


### PR DESCRIPTION
Closes #1674 and #1675. Both needed the same primitive changed — #1675 says explicitly to coordinate if both land — so they are one PR.

## #1674 — `safe_walk` could not report what it skipped

Every `OSError` was swallowed at three catch sites, so a walk over an unreadable directory returned a short list and **the caller had no way to tell**. "Organized 40 of 50 files" reported success.

The #1671 migration made it worse rather than better: call sites that logged their own permission failures had those lines folded into a primitive that then discarded them — losing diagnostics across 19 sites at once.

`on_error(path, exc)` is now invoked at every catch site. The issue asked for three decisions to be settled and recorded:

| Decision | Choice | Why |
| :--- | :--- | :--- |
| Report per-entry, or only per-directory? | **Every site** | A caller that finds per-entry noisy can filter; one never told cannot recover the information |
| Do `on_error` exceptions propagate? | **Yes** | A caller must be able to escalate; swallowing an error handler's exception is the same defect again |
| Log unconditionally too? | **Yes, `debug`** | Restores the diagnostic for all 19 migrated sites without touching one of them |

`services/copilot/rules/preview.py` migrates onto it — permission failures now populate `PreviewResult.errors` instead of vanishing.

## #1675 — the traversal budget counted the wrong thing

`search.py` bounded `rglob` results, i.e. entries **visited**. `safe_walk` filters symlinks, dotfiles and directories *before* yielding, so the same constant applied to yielded entries would bound results instead — letting a tree of dotfiles traverse many times further. These are request-scoped walks on remote-reachable endpoints, so that is a **loosened denial-of-service guard**, not a UX detail.

Took **option A**: `max_entries` counts entries as they are examined, before filtering. Added `TraversalBudget` for `_build_semantic_corpus`, which bounds across several roots — a per-call budget would have multiplied the bound by the number of configured roots.

## Verification

**Mutation-checked, and my first mutant was wrong.** I moved the counter but left it inside the `scandir` loop, so it still counted every entry; the test correctly survived. Rewriting it as the *actual* regression — bounding the output instead of the traversal — the test fails. Recorded because a surviving mutant is only evidence once you have checked the mutant.

| Mutant | Caught by |
| :--- | :--- |
| budget applied to yielded entries (the real #1675 regression) | `test_budget_counts_entries_the_filters_discard` |
| `on_error` never invoked | 3 tests |
| per-root budget instead of shared | `test_semantic_corpus_budget_is_shared_across_roots` |
| `max_entries` dropped from `_collect_matching_files` | `test_budget_bounds_work_on_a_tree_of_discarded_entries` |

The budget tests observe **entries consumed from `os.scandir`**, not paths yielded. On a tree of 49 dotfiles and one file, yielded counts cannot distinguish an entry-budget from a result-budget — which is precisely why the regression would have gone unnoticed.

**Two guardrails caught me, both correctly.** `assert len(x) <= N` passes when nothing was walked at all, so the budget assertions are two-sided now (`10 <= len(consumed) <= 11`).

**The trap both issues warned about.** `test_permission_error` patched `Path.rglob`, which after migration intercepts nothing — it would have kept passing while asserting nothing. Re-pointed at `os.scandir`, with a control assertion proving the unpatched run finds the file.

## Acceptance criteria

- `tests/core/test_path_guard.py` passes **unchanged** — all 33 pre-existing tests
- callback fires with the offending path and the original `OSError`; walk yields the readable remainder
- unreadable subtree does not abort the walk when `on_error` is absent
- budget bounded on a tree padded with discarded entries — the test the code lacked
- ordinary-tree result counts unchanged; symlink/hidden exclusion unchanged
- raw `rglob("*")`/`glob("*")` in `src/` is down to **3 hits, all documentation comments**
- full suite 22,559 passed / 0 failed, twice; `pre-commit --all-files` clean

## Note

One unrelated intermittent surfaced during verification (`test_job_history_lists_organization_jobs`). It passes in isolation on this branch and the whole file passes on `main`, so it is not from this change — it is another member of the timing cluster from #1729, not filed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File and directory searches now enforce consistent traversal limits, including across multiple search locations.
  * Search continues safely when individual files or directories cannot be accessed.
  * Preview scanning reports filesystem errors while continuing to process available files.
  * Hidden files and symbolic links remain excluded from results.
* **Tests**
  * Expanded coverage for traversal limits, filtering behavior, error handling, and permission failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->