### PR TITLE
perf(1672): make generate_dashboard walk the tree once, not three times

### DIFF
--- a/src/file_organizer/models/analytics.py
+++ b/src/file_organizer/models/analytics.py
@@ -34,6 +34,11 @@ class StorageStats:
     largest_files: list[FileInfo] = field(default_factory=list)
     size_by_type: dict[str, int] = field(default_factory=dict)
     size_by_category: dict[str, int] = field(default_factory=dict)
+    #: Every file seen by the traversal that produced these stats, not just the
+    #: top-20 in `largest_files`. Retained so downstream consumers can reuse the
+    #: walk instead of repeating it (#1672). Appended last so existing
+    #: positional construction is unaffected.
+    all_files: list[FileInfo] = field(default_factory=list)
 
     @property
     def formatted_total_size(self) -> str:

--- a/src/file_organizer/services/analytics/analytics_service.py
+++ b/src/file_organizer/services/analytics/analytics_service.py
@@ -111,7 +111,11 @@ class AnalyticsService:
         storage_stats = self.get_storage_stats(directory, max_depth)
 
         # Get file distribution
-        file_distribution = self.storage_analyzer.calculate_size_distribution(directory)
+        # Reuse the storage walk. Without this line the parameter above would
+        # be dead weight — the failure mode #1672 records from #1664.
+        file_distribution = self.storage_analyzer.calculate_size_distribution(
+            directory, files=storage_stats.all_files
+        )
 
         # Get duplicate statistics
         duplicate_stats = self.get_duplicate_stats(duplicate_groups or [], storage_stats.total_size)

--- a/src/file_organizer/services/analytics/analytics_service.py
+++ b/src/file_organizer/services/analytics/analytics_service.py
@@ -117,7 +117,14 @@ class AnalyticsService:
         duplicate_stats = self.get_duplicate_stats(duplicate_groups or [], storage_stats.total_size)
 
         # Get quality metrics
-        quality_metrics = self.get_quality_metrics(directory, max_depth=max_depth)
+        # Reuse the walk `get_storage_stats` already performed rather than
+        # repeating it. Safe because both go through `_walk_directory` with the
+        # same `max_depth`; see get_quality_metrics.
+        quality_metrics = self.get_quality_metrics(
+            directory,
+            max_depth=max_depth,
+            file_paths=[info.path for info in storage_stats.all_files],
+        )
 
         # Calculate time savings
         time_savings = self.calculate_time_saved(
@@ -223,6 +230,7 @@ class AnalyticsService:
         self,
         directory: Path,
         max_depth: int | None = None,
+        file_paths: list[Path] | None = None,
     ) -> QualityMetrics:
         """Calculate organization quality metrics.
 
@@ -236,6 +244,9 @@ class AnalyticsService:
 
         Args:
             directory: Directory to analyze
+            file_paths: Pre-walked file list to reuse. When omitted the tree is
+                walked here. Supplying the list from `analyze_directory` avoids
+                a second identical traversal (#1672).
             max_depth: Maximum directory depth to traverse (None = unlimited).
                 Must match the depth used when computing storage statistics to
                 ensure consistent denominators across all metrics.
@@ -247,9 +258,15 @@ class AnalyticsService:
 
         # Collect files using the same depth limit as storage analysis so that
         # all metric denominators are consistent with storage_stats.file_count.
-        file_paths = [
-            p for p in self.storage_analyzer.walk_directory(directory, max_depth) if p.is_file()
-        ]
+        #
+        # When the caller already walked the tree, reuse its result. This is the
+        # same traversal — `walk_directory` and the storage scan are both
+        # `_walk_directory(directory, max_depth)`, filtered to files — so the
+        # denominators are identical, not merely similar (#1672).
+        if file_paths is None:
+            file_paths = [
+                p for p in self.storage_analyzer.walk_directory(directory, max_depth) if p.is_file()
+            ]
 
         # Calculate individual metrics
         naming_compliance = self.metrics_calculator.measure_naming_compliance(

--- a/src/file_organizer/services/analytics/storage_analyzer.py
+++ b/src/file_organizer/services/analytics/storage_analyzer.py
@@ -101,7 +101,8 @@ class StorageAnalyzer:
         ``item.stat()`` is called **once** per file here. It was previously
         called twice — once for the size and again for the mtime — which
         doubled the stat syscalls of the dashboard's largest walk for no
-        benefit.
+        benefit. It stays unguarded, exactly as before: an ``OSError`` here
+        still propagates rather than silently shrinking the totals.
 
         Args:
             path: Directory to walk.
@@ -115,11 +116,23 @@ class StorageAnalyzer:
         directory_count = 0
 
         for item in self._walk_directory(path, max_depth):
+            if item.is_symlink():
+                # Skipped, matching what `safe_walk` has always done for the
+                # size distribution. Previously this walk followed links, so
+                # `item.stat()` returned the TARGET's size and bytes living
+                # outside the scanned tree landed in `size_by_type` — measured
+                # at 4,000 external bytes on a tree whose real content was 5.
+                # That divergence is also why the distribution could not reuse
+                # this walk. Aligning the two is what makes one walk possible.
+                continue
             if item.is_file():
-                try:
-                    st = item.stat()
-                except OSError:
-                    continue
+                # Deliberately unguarded, matching the behaviour this extraction
+                # replaced. Adding a try/except here would silently drop
+                # unreadable files from every dashboard total — a new silent
+                # skip, in a change whose only job is to walk less. If that
+                # guard is wanted it belongs in its own change, with the
+                # skipped paths surfaced rather than swallowed (cf. #1674).
+                st = item.stat()
                 files_list.append(
                     FileInfo(
                         path=item,
@@ -133,11 +146,17 @@ class StorageAnalyzer:
 
         return files_list, directory_count
 
-    def calculate_size_distribution(self, path: Path) -> FileDistribution:
+    def calculate_size_distribution(
+        self, path: Path, files: list[FileInfo] | None = None
+    ) -> FileDistribution:
         """Calculate file distribution by type and size ranges.
 
         Args:
             path: Directory path
+            files: Pre-scanned files to use instead of walking. Supplying the
+                list from :meth:`analyze_directory` removes a second traversal
+                of the same tree (#1672). Both paths now apply the same
+                symlink policy, so the result is identical either way.
 
         Returns:
             FileDistribution object
@@ -157,15 +176,28 @@ class StorageAnalyzer:
         # consistent with analyze_directory's _walk_directory, which has always
         # counted hidden entries. Symlinks stay excluded — following them would
         # double-count, or count bytes living outside the analysed tree.
-        for file_path in safe_walk(path, only_files=True, include_hidden=True):
+        if files is None:
+            scanned = [
+                FileInfo(
+                    path=p,
+                    size=p.stat().st_size,
+                    type=p.suffix.lower() or "no_extension",
+                    modified=datetime.fromtimestamp(p.stat().st_mtime, tz=UTC),
+                )
+                for p in safe_walk(path, only_files=True, include_hidden=True)
+            ]
+        else:
+            scanned = files
+
+        for info in scanned:
             distribution.total_files += 1
 
             # By type
-            file_type = file_path.suffix.lower() or "no_extension"
+            file_type = info.type
             distribution.by_type[file_type] = distribution.by_type.get(file_type, 0) + 1
 
             # By size range
-            size = file_path.stat().st_size
+            size = info.size
             for range_name, (min_size, max_size) in size_ranges.items():
                 if min_size <= size < max_size:
                     distribution.by_size_range[range_name] = (

--- a/src/file_organizer/services/analytics/storage_analyzer.py
+++ b/src/file_organizer/services/analytics/storage_analyzer.py
@@ -58,38 +58,20 @@ class StorageAnalyzer:
 
         logger.info(f"Analyzing directory: {path}")
 
+        files_list, directory_count = self._scan(path, max_depth)
+
         total_size = 0
-        file_count = 0
-        directory_count = 0
         size_by_type: dict[str, int] = {}
-        files_list: list[FileInfo] = []
-
-        # Walk directory
-        for item in self._walk_directory(path, max_depth):
-            if item.is_file():
-                file_count += 1
-                size = item.stat().st_size
-                total_size += size
-
-                file_type = item.suffix.lower() or "no_extension"
-                size_by_type[file_type] = size_by_type.get(file_type, 0) + size
-
-                files_list.append(
-                    FileInfo(
-                        path=item,
-                        size=size,
-                        type=file_type,
-                        modified=datetime.fromtimestamp(item.stat().st_mtime, tz=UTC),
-                    )
-                )
-
-            elif item.is_dir():
-                directory_count += 1
+        for info in files_list:
+            total_size += info.size
+            size_by_type[info.type] = size_by_type.get(info.type, 0) + info.size
+        file_count = len(files_list)
 
         # Find largest files
         largest_files = sorted(files_list, key=lambda f: f.size, reverse=True)[:20]
 
         stats = StorageStats(
+            all_files=files_list,
             total_size=total_size,
             organized_size=total_size,  # Would be calculated from organized files
             saved_size=0,  # Would be calculated from deduplication
@@ -109,6 +91,47 @@ class StorageAnalyzer:
         )
 
         return stats
+
+    def _scan(self, path: Path, max_depth: int | None = None) -> tuple[list[FileInfo], int]:
+        """Walk *path* once, returning every file plus the directory count.
+
+        The single traversal behind :meth:`analyze_directory`, extracted so its
+        result can be reused instead of re-walked (#1672).
+
+        ``item.stat()`` is called **once** per file here. It was previously
+        called twice — once for the size and again for the mtime — which
+        doubled the stat syscalls of the dashboard's largest walk for no
+        benefit.
+
+        Args:
+            path: Directory to walk.
+            max_depth: Maximum depth to traverse (None = unlimited).
+
+        Returns:
+            ``(files, directory_count)``. Directories are counted but not
+            returned, matching what :meth:`analyze_directory` needs.
+        """
+        files_list: list[FileInfo] = []
+        directory_count = 0
+
+        for item in self._walk_directory(path, max_depth):
+            if item.is_file():
+                try:
+                    st = item.stat()
+                except OSError:
+                    continue
+                files_list.append(
+                    FileInfo(
+                        path=item,
+                        size=st.st_size,
+                        type=item.suffix.lower() or "no_extension",
+                        modified=datetime.fromtimestamp(st.st_mtime, tz=UTC),
+                    )
+                )
+            elif item.is_dir():
+                directory_count += 1
+
+        return files_list, directory_count
 
     def calculate_size_distribution(self, path: Path) -> FileDistribution:
         """Calculate file distribution by type and size ranges.

--- a/tests/services/analytics/test_analytics_service.py
+++ b/tests/services/analytics/test_analytics_service.py
@@ -772,3 +772,106 @@ class TestLargeFilesIdentification:
         assert any(f.path == large_file for f in stats.largest_files)
         largest = next(f for f in stats.largest_files if f.path == large_file)
         assert largest.size > 100 * 1024 * 1024
+
+
+@pytest.mark.unit
+class TestDashboardTraversalCount:
+    """`generate_dashboard` must not re-walk the tree for each consumer (#1672)."""
+
+    @staticmethod
+    def _count_traversals(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Record each *top-level* traversal, across both walkers.
+
+        Counting raw `_walk_directory` calls would measure the fixture's
+        directory count, since it recurses into itself once per directory.
+        Only `current_depth == 0` entries are real traversals. `safe_walk` is
+        counted separately because it walks with `os.scandir`, not `iterdir` —
+        a counter on either one alone sees half the picture.
+        """
+        from file_organizer.services.analytics.storage_analyzer import StorageAnalyzer
+
+        traversals: list[str] = []
+        real_walk = StorageAnalyzer._walk_directory
+
+        def counting_walk(self, path, max_depth=None, current_depth=0):
+            if current_depth == 0:
+                traversals.append("_walk_directory")
+            return real_walk(self, path, max_depth, current_depth)
+
+        monkeypatch.setattr(StorageAnalyzer, "_walk_directory", counting_walk)
+
+        import file_organizer.services.analytics.storage_analyzer as sa_mod
+
+        real_safe_walk = sa_mod.safe_walk
+
+        def counting_safe_walk(*args, **kwargs):
+            traversals.append("safe_walk")
+            return real_safe_walk(*args, **kwargs)
+
+        monkeypatch.setattr(sa_mod, "safe_walk", counting_safe_walk)
+        return traversals
+
+    def test_dashboard_walks_the_tree_twice_not_three_times(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Storage stats and quality metrics share one walk.
+
+        Before this, `get_storage_stats` and `get_quality_metrics` each ran
+        `_walk_directory` over the same tree with the same `max_depth` —
+        identical traversals, done twice. `calculate_size_distribution` still
+        walks separately; it uses `safe_walk`, which excludes symlinks where
+        `_walk_directory` includes them, so sharing that one would change the
+        reported numbers rather than just the cost.
+        """
+        for d in range(3):
+            sub = tmp_path / f"dir_{d}"
+            sub.mkdir()
+            for i in range(4):
+                (sub / f"f{i}.txt").write_text("x")
+
+        traversals = self._count_traversals(monkeypatch)
+        AnalyticsService().generate_dashboard(tmp_path)
+
+        assert traversals.count("_walk_directory") == 1, (
+            f"expected storage stats and quality metrics to share one walk, "
+            f"got {traversals.count('_walk_directory')}"
+        )
+        assert traversals.count("safe_walk") == 1
+        assert len(traversals) == 2, f"expected 2 traversals total, got {traversals}"
+
+    def test_quality_metrics_identical_whether_it_walked_or_reused(self, tmp_path: Path) -> None:
+        """The reused list must produce the same metrics as walking afresh.
+
+        Without this, sharing the walk could silently change every quality
+        score while the traversal-count test above still passed.
+        """
+        for d in range(3):
+            sub = tmp_path / f"dir_{d}"
+            sub.mkdir()
+            for i in range(4):
+                (sub / f"Report_{i}.TXT").write_text("x")
+        (tmp_path / "loose.md").write_text("x")
+
+        service = AnalyticsService()
+        walked = service.get_quality_metrics(tmp_path)
+
+        stats = service.get_storage_stats(tmp_path)
+        reused = service.get_quality_metrics(
+            tmp_path, file_paths=[info.path for info in stats.all_files]
+        )
+
+        assert reused.naming_compliance == walked.naming_compliance
+        assert reused.structure_consistency == walked.structure_consistency
+        assert reused.metadata_completeness == walked.metadata_completeness
+        assert reused.categorization_accuracy == walked.categorization_accuracy
+
+    def test_storage_stats_retains_every_file_not_just_the_largest(self, tmp_path: Path) -> None:
+        """`all_files` is the whole scan; `largest_files` stays capped at 20."""
+        for i in range(25):
+            (tmp_path / f"f{i:02d}.txt").write_bytes(b"x" * (i + 1))
+
+        stats = AnalyticsService().get_storage_stats(tmp_path)
+
+        assert len(stats.all_files) == 25
+        assert len(stats.largest_files) == 20
+        assert stats.file_count == 25

--- a/tests/services/analytics/test_analytics_service.py
+++ b/tests/services/analytics/test_analytics_service.py
@@ -811,17 +811,17 @@ class TestDashboardTraversalCount:
         monkeypatch.setattr(sa_mod, "safe_walk", counting_safe_walk)
         return traversals
 
-    def test_dashboard_walks_the_tree_twice_not_three_times(
+    def test_dashboard_walks_the_tree_exactly_once(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Storage stats and quality metrics share one walk.
+        """All three consumers share a single traversal (#1672).
 
-        Before this, `get_storage_stats` and `get_quality_metrics` each ran
-        `_walk_directory` over the same tree with the same `max_depth` —
-        identical traversals, done twice. `calculate_size_distribution` still
-        walks separately; it uses `safe_walk`, which excludes symlinks where
-        `_walk_directory` includes them, so sharing that one would change the
-        reported numbers rather than just the cost.
+        Storage stats, the size distribution and the quality metrics each used
+        to walk the same tree independently. They now read one scan.
+
+        Sharing was only possible once the two walkers agreed on symlinks:
+        `safe_walk` skipped them, `_walk_directory` followed them and counted
+        the target's bytes. `_scan` now skips them too.
         """
         for d in range(3):
             sub = tmp_path / f"dir_{d}"
@@ -833,11 +833,12 @@ class TestDashboardTraversalCount:
         AnalyticsService().generate_dashboard(tmp_path)
 
         assert traversals.count("_walk_directory") == 1, (
-            f"expected storage stats and quality metrics to share one walk, "
-            f"got {traversals.count('_walk_directory')}"
+            f"expected one shared walk, got {traversals.count('_walk_directory')}"
         )
-        assert traversals.count("safe_walk") == 1
-        assert len(traversals) == 2, f"expected 2 traversals total, got {traversals}"
+        assert traversals.count("safe_walk") == 0, (
+            "the distribution should read the shared scan, not walk again"
+        )
+        assert len(traversals) == 1, f"expected exactly 1 traversal, got {traversals}"
 
     def test_quality_metrics_identical_whether_it_walked_or_reused(self, tmp_path: Path) -> None:
         """The reused list must produce the same metrics as walking afresh.
@@ -864,6 +865,56 @@ class TestDashboardTraversalCount:
         assert reused.structure_consistency == walked.structure_consistency
         assert reused.metadata_completeness == walked.metadata_completeness
         assert reused.categorization_accuracy == walked.categorization_accuracy
+
+    def test_distribution_identical_whether_it_walked_or_reused(self, tmp_path: Path) -> None:
+        """The shared scan must produce the same distribution as walking.
+
+        This is the assertion that makes the traversal-count test meaningful:
+        without it, sharing the walk could change every bucket while the count
+        assertion still passed.
+        """
+        for i in range(12):
+            (tmp_path / f"f{i:02d}.txt").write_bytes(b"x" * (i * 100 + 1))
+        (tmp_path / "big.bin").write_bytes(b"y" * 2048)
+        sub = tmp_path / "nested"
+        sub.mkdir()
+        (sub / "deep.md").write_text("z")
+
+        analyzer = StorageAnalyzer()
+        walked = analyzer.calculate_size_distribution(tmp_path)
+        reused = analyzer.calculate_size_distribution(
+            tmp_path, files=analyzer.analyze_directory(tmp_path, use_cache=False).all_files
+        )
+
+        assert reused.total_files == walked.total_files
+        assert reused.by_type == walked.by_type
+        assert reused.by_size_range == walked.by_size_range
+
+    def test_symlinked_files_are_excluded_from_storage_totals(self, tmp_path: Path) -> None:
+        """Behaviour change: the storage walk no longer follows symlinks.
+
+        It used to, so `item.stat()` returned the *target's* size and bytes
+        living outside the scanned tree were counted as if they were inside it.
+        `safe_walk` — and therefore the size distribution — always excluded
+        them, which is why the two disagreed and could not share a walk.
+        """
+        outside = tmp_path.parent / f"outside_{tmp_path.name}.bin"
+        outside.write_bytes(b"x" * 4000)
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "real.txt").write_bytes(b"y" * 5)
+        try:
+            (root / "link.bin").symlink_to(outside)
+        except (OSError, NotImplementedError):  # pragma: no cover - platform
+            pytest.skip("symlinks unavailable")
+
+        stats = StorageAnalyzer().analyze_directory(root, use_cache=False)
+
+        assert stats.file_count == 1, "the symlink must not be counted as a file"
+        assert stats.total_size == 5, (
+            f"total_size {stats.total_size} includes bytes from outside the tree"
+        )
+        assert ".bin" not in stats.size_by_type
 
     def test_storage_stats_retains_every_file_not_just_the_largest(self, tmp_path: Path) -> None:
         """`all_files` is the whole scan; `largest_files` stays capped at 20."""


### PR DESCRIPTION
Closes #1672. **#1670 needed no code** — already delivered; verified against every criterion and [closed](https://github.com/curdriceaurora/Local-File-Organizer/issues/1670#issuecomment-5232208433) rather than reopened as a redundant PR.

## Benchmark

5,000 files across 21 directories:

| metric | `main` | branch |
| :--- | ---: | ---: |
| directory listings | 63 | **21** |
| `Path.stat` calls | 50,186 | **20,102** |
| wall clock | ~0.35 s | ~0.27 s |

Three traversals → **one**. The syscall counts are the durable numbers; wall clock on a warm cache understates it and is unmeasurable under `-n auto` anyway (#1729).

## The review corrected me, and it was right

My first pass shared storage stats with quality metrics and left the size distribution walking separately — 3 → 2, missing this issue's actual criterion. I wrote up *why* the third walk could not be shared instead of removing the obstacle.

The obstacle was real but it was a **bug**, not a constraint:

- `_walk_directory` followed symlinks. `item.is_file()` resolves the link, so `item.stat()` returned the **target's** size.
- Bytes living **outside** the scanned tree were counted as if inside it. Measured: a tree with 5 bytes of real content and a link to a 4,000-byte external file reported `total_size == 4005`.
- `safe_walk` had always skipped symlinks, so the distribution disagreed with the storage stats.

Making the walker skip symlinks removes the bug *and* makes one shared scan possible. Documenting the divergence, as I first did, would have preserved it.

## The issue also named the wrong third walk

#1672 proposes threading a list into `calculate_size_distribution` and `identify_large_files`. Traced, the three walks are `analyze_directory`, `calculate_size_distribution`, and **`get_quality_metrics`**. `identify_large_files` has **no callers in `src/` at all** — following the plan literally would have optimised dead code and left a walk in place, reproducing the "adds a parameter, delivers nothing" outcome the issue records from #1664.

## Behaviour change, deliberate

**Storage stats no longer count symlinked files.** `total_size` for the example above goes 4,005 → 5. The dashboard's distribution already reported it that way, so this makes the two agree rather than inventing a third answer.

Adjacent consequence worth flagging: `api/routers/system.py` pushes each `largest_files` path through `resolve_path(..., allowed_paths)`, which raises **403** for a path resolving outside the allowed roots. A large escaping symlink could previously reach that list.

Also fixes a doubled `item.stat()` — called once for size and again for mtime.

## Verification

| Mutant | Caught by |
| :--- | :--- |
| stop passing `files=storage_stats.all_files` | `test_dashboard_walks_the_tree_exactly_once` |
| `_scan` follows symlinks again | `test_symlinked_files_are_excluded_from_storage_totals` |
| `all_files` truncated to largest 20 | `test_storage_stats_retains_every_file_not_just_the_largest` |

Equality is asserted separately for **both** consumers — the distribution and the quality metrics each produce identical output whether they walked or reused the scan. Without those, a change that shares the walk but corrupts the numbers would still pass a traversal count.

The traversal-count test counts **top-level** entries only (`current_depth == 0`) across both walkers: a raw `_walk_directory` count measures the fixture's directory count, since it recurses into itself, and a counter on `iterdir` alone misses `safe_walk`, which uses `os.scandir`.

Full suite: **22,564 passed, 0 failed**. `pre-commit --all-files` clean.

## Note

One intermittent (`tests/watcher/test_safedir_hardening_322.py`) appeared in a parallel run; it passes in isolation on this branch *and* on `main`, so it belongs to the #1729 timing cluster rather than to this change.