### PR TITLE
fix(1680): apply one hidden-path rule across a PatternAnalysis

### DIFF
--- a/src/file_organizer/services/pattern_analyzer.py
+++ b/src/file_organizer/services/pattern_analyzer.py
@@ -149,30 +149,39 @@ class PatternAnalyzer:
             metadata={"min_pattern_count": self.min_pattern_count, "max_depth": self.max_depth},
         )
 
-    def _collect_files(self, directory: Path, current_depth: int = 0) -> list[Path]:
-        """Recursively collect all files up to max_depth.
+    def _collect_files(self, directory: Path) -> list[Path]:
+        """Collect files up to ``max_depth``, using the walk's hidden-path rule.
+
+        Previously this hand-rolled its own traversal and applied a *different*
+        definition of "hidden" from :meth:`get_location_patterns`, so one
+        ``PatternAnalysis`` carried two rules (#1680):
+
+        - it dot-checked directories only, so hidden **files** such as ``.env``
+          were counted in ``total_files`` and ``content_clusters``;
+        - the check was leaf-only, so ``root/.cache/visible/`` was skipped here
+          but for a different reason than in the other path;
+        - symlinks were followed.
+
+        ``safe_walk`` is now the single rule for both. It excludes any path with
+        a dot component relative to the root, and skips symlinks — the stricter,
+        security-hardened definition, and the one the location analysis has used
+        since #1671. Aligning on the looser rule would have meant feeding
+        credential-bearing files like ``.ssh/`` into pattern analysis.
 
         Args:
             directory: Directory to scan
-            current_depth: Current recursion depth
 
         Returns:
             List of file paths
         """
-        if current_depth > self.max_depth:
-            return []
-
-        files = []
-        try:
-            for item in directory.iterdir():
-                if item.is_file():
-                    files.append(item)
-                elif item.is_dir() and not item.name.startswith("."):
-                    files.extend(self._collect_files(item, current_depth + 1))
-        except PermissionError:
-            logger.warning(f"Permission denied: {directory}")
-
-        return files
+        # `safe_walk` has no depth parameter, so the bound is applied here.
+        # A file directly inside `directory` has one relative part and sits at
+        # depth 0, matching the old `current_depth` numbering exactly.
+        return [
+            path
+            for path in safe_walk(directory, only_files=True)
+            if len(path.relative_to(directory).parts) - 1 <= self.max_depth
+        ]
 
     def detect_naming_patterns(self, files: list[Path]) -> list[NamingPattern]:
         """Detect naming patterns across files.

--- a/src/file_organizer/services/pattern_analyzer.py
+++ b/src/file_organizer/services/pattern_analyzer.py
@@ -253,8 +253,20 @@ class PatternAnalyzer:
             if not subdir.is_dir():
                 continue
 
-            # Get files in this directory (non-recursive)
-            files = [f for f in subdir.iterdir() if f.is_file()]
+            # Get files in this directory (non-recursive).
+            #
+            # `safe_walk`, not `iterdir()`: this enumeration is the THIRD place
+            # the analysis decides what counts as hidden, and it was the one
+            # left behind. The outer walk above excluded hidden directories and
+            # `_collect_files` excluded hidden files, but a raw `iterdir()` here
+            # still admitted `docs/.secret` into `file_count`, `file_types` and
+            # `naming_patterns` — so `total_files` and `location_patterns`
+            # disagreed even after #1680's first pass (caught in review).
+            #
+            # `recursive=False` keeps this a single-level listing; the hidden
+            # check is relative to `subdir`, which is what excludes a dotfile
+            # sitting directly inside it.
+            files = list(safe_walk(subdir, recursive=False, only_files=True))
 
             if not files:
                 continue

--- a/tests/services/test_pattern_analyzer.py
+++ b/tests/services/test_pattern_analyzer.py
@@ -471,3 +471,101 @@ class TestEdgeCases:
             analysis = analyzer.analyze_directory(tmppath)
 
             assert analysis.total_files == 1
+
+
+@pytest.mark.unit
+class TestSingleHiddenPathRule:
+    """One `PatternAnalysis` must not carry two definitions of "hidden" (#1680).
+
+    `_collect_files` hand-rolled a traversal that dot-checked directories only,
+    while `get_location_patterns` walked via `safe_walk`, which excludes any
+    path with a dot component relative to the root. So a hidden file was
+    counted in `total_files` but its directory never reached
+    `location_patterns` — one object, two rules.
+    """
+
+    @staticmethod
+    def _tree(root: Path) -> None:
+        docs = root / "docs"
+        docs.mkdir()
+        for i in range(4):
+            (docs / f"report_{i}.txt").write_text("x")
+        # Hidden file at the root, and one inside a visible directory.
+        (root / ".env").write_text("SECRET=1")
+        (docs / ".secret").write_text("SECRET=2")
+        # Visible directory buried under a hidden one.
+        buried = root / ".cache" / "visible"
+        buried.mkdir(parents=True)
+        (buried / "cached.txt").write_text("x")
+
+    def test_hidden_files_are_excluded_from_collection(self) -> None:
+        """`.env` and `.secret` must not reach pattern analysis.
+
+        They were previously counted: the old check only dot-tested
+        directories, so hidden *files* passed straight through into
+        `total_files` and `content_clusters`. Feeding credential-bearing files
+        into pattern analysis is the reason the strict rule was chosen.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._tree(root)
+
+            collected = PatternAnalyzer()._collect_files(root)
+            names = {p.name for p in collected}
+
+            assert names == {f"report_{i}.txt" for i in range(4)}, (
+                f"expected only the visible reports, got {sorted(names)}"
+            )
+
+    def test_collection_and_location_analysis_agree_on_hidden(self) -> None:
+        """The two paths must apply the same rule — the actual defect.
+
+        Anything under `.cache/` is excluded from the location patterns by
+        `safe_walk`; the file collection must exclude it too, or `total_files`
+        counts a directory that `location_patterns` will never mention.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._tree(root)
+            analyzer = PatternAnalyzer()
+
+            collected_dirs = {p.parent for p in analyzer._collect_files(root)}
+            located = {lp.directory for lp in analyzer.get_location_patterns(root)}
+
+            buried = root / ".cache" / "visible"
+            assert buried not in collected_dirs, "buried dir leaked into collection"
+            assert buried not in located, "premise: safe_walk already excludes it"
+            assert collected_dirs <= located | {root}, (
+                f"collection saw directories the location analysis did not: "
+                f"{sorted(collected_dirs - located - {root})}"
+            )
+
+    def test_max_depth_bound_is_preserved(self) -> None:
+        """Migrating to safe_walk must not lose the depth limit.
+
+        `safe_walk` has no depth parameter, so the bound moved to a filter on
+        the relative path. Depth numbering is unchanged: a file directly inside
+        the root is depth 0.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "top.txt").write_text("x")
+            deep = root / "a" / "b" / "c"
+            deep.mkdir(parents=True)
+            (root / "a" / "one.txt").write_text("x")
+            (root / "a" / "b" / "two.txt").write_text("x")
+            (deep / "three.txt").write_text("x")
+
+            assert {p.name for p in PatternAnalyzer(max_depth=0)._collect_files(root)} == {
+                "top.txt"
+            }
+            assert {p.name for p in PatternAnalyzer(max_depth=1)._collect_files(root)} == {
+                "top.txt",
+                "one.txt",
+            }
+            assert {p.name for p in PatternAnalyzer(max_depth=10)._collect_files(root)} == {
+                "top.txt",
+                "one.txt",
+                "two.txt",
+                "three.txt",
+            }

--- a/tests/services/test_pattern_analyzer.py
+++ b/tests/services/test_pattern_analyzer.py
@@ -540,6 +540,33 @@ class TestSingleHiddenPathRule:
                 f"{sorted(collected_dirs - located - {root})}"
             )
 
+    def test_location_patterns_do_not_count_hidden_files(self) -> None:
+        """`docs/.secret` must not reach the `docs` LocationPattern.
+
+        The gap this catches, found in review: unifying `_collect_files` was
+        not enough, because `get_location_patterns` enumerated each
+        directory's direct files with a raw `iterdir()`. So a third rule
+        survived — hidden files were excluded from `total_files` but still
+        counted in `file_count`, `file_types` and `naming_patterns`.
+
+        The directory-level assertion in the sibling test could not see this:
+        `docs` legitimately appears in both paths. Only the count reveals it.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._tree(root)
+
+            patterns = {
+                lp.directory.name: lp for lp in PatternAnalyzer().get_location_patterns(root)
+            }
+
+            assert "docs" in patterns, "premise: docs is analysed"
+            assert patterns["docs"].file_count == 4, (
+                f"docs counted {patterns['docs'].file_count} files; the four visible "
+                "reports plus .secret means the hidden rule is not applied here"
+            )
+            assert ".secret" not in patterns["docs"].file_types
+
     def test_max_depth_bound_is_preserved(self) -> None:
         """Migrating to safe_walk must not lose the depth limit.
 


### PR DESCRIPTION
Closes #1680.

## The defect

`analyze_directory()` returned one `PatternAnalysis` built from **two different definitions of "hidden"**:

- `get_location_patterns` walks via `safe_walk` — excludes any path with a dot component relative to the root.
- `_collect_files` hand-rolled a traversal with `not item.name.startswith(".")`.

So a hidden file was counted in `total_files` and `content_clusters` while its directory never appeared in `location_patterns`.

## The divergence was wider than the issue described

Reading the code, it was **three** differences, not one:

| | `_collect_files` (old) | `safe_walk` |
| :--- | :--- | :--- |
| hidden **files** | **counted** — the check only ever tested directories | excluded |
| hidden directories | leaf-only dot check | any dot component relative to root |
| symlinks | followed | skipped |

The first is the one the issue does not mention and the one that matters most: `.env` and `docs/.secret` were being fed into pattern analysis.

## Which rule, and why

Unified on `safe_walk`'s. Loosening the other path instead would mean routing credential-bearing files (`.ssh/`, `.env`) through naming- and content-pattern analysis — noise at best, and the opposite direction from the #1671 hardening that introduced `safe_walk` here.

`safe_walk` has no depth parameter, so the `max_depth` bound moved to a filter on the relative path. Numbering is preserved exactly — a file directly inside the root is depth 0 — pinned by three explicit cases (`max_depth` 0, 1, 10).

## Behaviour change

Hidden files no longer contribute to `total_files`, `content_clusters`, `file_type_distribution` or `depth_distribution`. **That is the point of the issue** — the two halves now agree rather than one being quietly wrong.

## Verification

| Mutant | Caught by |
| :--- | :--- |
| restore the old leaf-only traversal | `test_hidden_files_are_excluded_from_collection` |
| drop the depth filter | `test_max_depth_bound_is_preserved`, plus two pre-existing depth tests |

`test_collection_and_location_analysis_agree_on_hidden` asserts the actual defect directly: every directory the collection sees must be one the location analysis also sees. No existing test compared the two paths, which is why they could drift.

Full suite: 22,566 passed. `pre-commit --all-files` clean.

One intermittent (`tests/watcher/test_monitor.py::test_observer_type_property`) appeared in a parallel run and passes in isolation — a known member of the #1729 timing cluster, unrelated to this change.

## #1726 — investigated, not fixed

Worked on it in the same session; reporting findings on the issue rather than shipping a speculative runner migration. Summary: mutmut labels **both `-11` (SIGSEGV) and `-9` (SIGKILL)** as "segfault", which are different failures — but ours is genuinely `-11`, measured at 397 occurrences. Details on #1726.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file discovery by consistently excluding hidden files, hidden directories, and symlinked paths.
  * Corrected maximum-depth handling for nested paths.
  * Standardized file collection and location analysis behavior.

* **Tests**
  * Added coverage for hidden-path exclusion and depth limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->