### PR TITLE
Enforce safe filesystem traversal scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,7 @@ are **enforced**; rails with pre-existing violation backlogs remain
 | Rail | What it flags | Status |
 |---|---|---|
 | `safedir-required` | Raw `open()`/`Path.open()`/`shutil.copy*`/`shutil.move` outside the `SafeDir` primitives themselves | enforced |
+| `raw-filesystem-traversal` | Raw `iterdir`/`glob`/`rglob`/`walk`/`scandir`/`listdir` calls outside the exact reviewed `safe_walk` exemption inventory | enforced |
 | `atomic-write` | Raw file-write operations bypassing `atomic_write()` | enforced |
 | `cli-path-validation` | A CLI command's `Path` parameter not wrapped in `resolve_cli_path()` | enforced |
 | `cli-file-kind-validation` | A CLI path resolved with `must_be_dir=False` without a subsequent file/directory kind check | advisory |

--- a/scripts/ci/guardrails/check_raw_filesystem_traversal.py
+++ b/scripts/ci/guardrails/check_raw_filesystem_traversal.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""CI rail: keep raw filesystem traversal behind an executable scope note.
+
+Issue #1736 found that prose describing ``safe_walk`` coverage had drifted
+from the source.  This rail recognizes the raw traversal APIs used by the
+package, rejects new call sites, and verifies that every retained call still
+matches one reviewed exemption with a reason.
+
+The distinction between ``ast.walk`` and filesystem traversal is deliberate:
+review-regression detectors walk syntax trees heavily, but that must not hide
+the real ``os.walk`` and ``Path.rglob`` calls in the same package.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+RAIL_NAME = "raw-filesystem-traversal"
+PACKAGE_ROOT = Path("src/file_organizer")
+_PRIMITIVE_PATH = "core/path_guard.py"
+
+TraversalKey = tuple[str, str, str]
+
+
+@dataclass(frozen=True)
+class TraversalSite:
+    """One raw traversal call found in package source."""
+
+    path: str
+    function: str
+    api: str
+    line: int
+
+    @property
+    def key(self) -> TraversalKey:
+        """Return the stable allowlist key for this call."""
+        return (self.path, self.function, self.api)
+
+
+@dataclass(frozen=True)
+class TraversalExemption:
+    """Reviewed reason and exact call count for an allowed raw traversal."""
+
+    count: int
+    reason: str
+
+
+# The executable safe_walk scope note.  Counts make duplicate calls visible:
+# deleting one or adding another both fail until this reviewed inventory is
+# deliberately updated.  Keep reasons specific to the contract safe_walk
+# cannot or need not provide.
+_EXEMPTIONS: dict[TraversalKey, TraversalExemption] = {
+    (
+        "cli/completion.py",
+        "complete_directory",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level shell completion must expose symlinked directory candidates",
+    ),
+    (
+        "cli/completion.py",
+        "complete_file",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level shell completion must expose symlinked file candidates",
+    ),
+    (
+        "config/path_migration.py",
+        "resolve_legacy_path",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=2,
+        reason="one-time emptiness checks over app-owned current and legacy XDG directories",
+    ),
+    (
+        "methodologies/para/migration_manager.py",
+        "PARAMigrationManager.analyze_source",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="internal migration inventory preserves caller-selected glob semantics",
+    ),
+    (
+        "methodologies/para/migration_manager.py",
+        "PARAMigrationManager.list_backups",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level listing of the app-owned migration backup directory",
+    ),
+    (
+        "parallel/persistence.py",
+        "JobPersistence.list_jobs",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level listing of app-owned job-queue JSON state",
+    ),
+    (
+        "plugins/config.py",
+        "PluginConfigManager.list_configured_plugins",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level listing of app-owned plugin configuration JSON files",
+    ),
+    (
+        "review_regressions/framework.py",
+        "iter_python_files",
+        "os.walk",
+    ): TraversalExemption(
+        count=1,
+        reason="repository audit must prune excluded directories before descending",
+    ),
+    (
+        "review_regressions/template_js.py",
+        "_iter_template_files",
+        "Path.rglob",
+    ): TraversalExemption(
+        count=1,
+        reason="static audit reads only the repository-owned web template tree",
+    ),
+    (
+        "services/analytics/storage_analyzer.py",
+        "StorageAnalyzer._walk_directory",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=1,
+        reason="recursive analyzer requires a caller-selected maximum depth",
+    ),
+    (
+        "services/copilot/rules/rule_manager.py",
+        "RuleManager.list_rule_sets",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level listing of app-shipped rule YAML files",
+    ),
+    (
+        "services/intelligence/profile_manager.py",
+        "ProfileManager.list_profiles",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level listing of the app-owned profile directory",
+    ),
+    (
+        "services/intelligence/profile_manager.py",
+        "ProfileManager.get_profile_count",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level count of the app-owned profile directory",
+    ),
+    (
+        "services/intelligence/profile_migrator.py",
+        "ProfileMigrator.list_backups",
+        "Path.glob",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level listing of app-owned profile backups",
+    ),
+    (
+        "services/misplacement_detector.py",
+        "MisplacementDetector._list_directory_files",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level cache funnel deliberately lists one directory once",
+    ),
+    (
+        "tui/file_preview.py",
+        "FilePreviewPanel._preview_directory",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=2,
+        reason="bounded single-level UI preview preserves hidden and symlink visibility",
+    ),
+    (
+        "undo/trash_gc.py",
+        "TrashGC._recover_orphans",
+        "Path.iterdir",
+    ): TraversalExemption(
+        count=1,
+        reason="single-level recovery scan of the app-owned trash directory",
+    ),
+    (
+        "undo/validator.py",
+        "OperationValidator._get_trash_path",
+        "Path.rglob",
+    ): TraversalExemption(
+        count=1,
+        reason="recovery lookup is confined to the app-owned trash directory",
+    ),
+    (
+        "utils/safedir.py",
+        "SafeDir.scandir",
+        "os.scandir",
+    ): TraversalExemption(
+        count=1,
+        reason="fd-anchored secure enumeration primitive underlying SafeDir",
+    ),
+}
+
+_PATH_METHODS = frozenset({"glob", "iterdir", "rglob"})
+_OS_APIS = frozenset({"os.fwalk", "os.listdir", "os.scandir", "os.walk"})
+_GLOB_APIS = frozenset({"glob.glob", "glob.iglob"})
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    """Return a dotted name for a simple Name/Attribute expression."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        if prefix is not None:
+            return f"{prefix}.{node.attr}"
+    return None
+
+
+def _import_aliases(tree: ast.AST) -> dict[str, str]:
+    """Map import-local names to their qualified module/API names."""
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".", 1)[0]
+                aliases[local] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _resolve_alias(name: str, aliases: dict[str, str]) -> str:
+    """Resolve the first component of *name* through imports."""
+    first, dot, rest = name.partition(".")
+    resolved = aliases.get(first, first)
+    return f"{resolved}.{rest}" if dot else resolved
+
+
+def _filesystem_api(node: ast.Call, aliases: dict[str, str]) -> str | None:
+    """Return a normalized raw traversal API, excluding syntax-tree walks."""
+    name = _dotted_name(node.func)
+    if name is None:
+        return None
+    resolved = _resolve_alias(name, aliases)
+    if resolved == "ast.walk":
+        return None
+    if resolved in _OS_APIS or resolved in _GLOB_APIS:
+        return resolved
+
+    # pathlib traversal is normally called on a variable, so the receiver's
+    # type is not statically named.  Attribute shape is the reliable signal.
+    if isinstance(node.func, ast.Attribute) and node.func.attr in _PATH_METHODS:
+        return f"Path.{node.func.attr}"
+
+    # Path.walk() is available on newer supported Python versions.  Treat any
+    # non-ast attribute walk as review-required; a custom walk can be exempted
+    # with an exact function-level reason if one is ever introduced.
+    if isinstance(node.func, ast.Attribute) and node.func.attr == "walk":
+        return "Path.walk"
+    return None
+
+
+class _TraversalVisitor(ast.NodeVisitor):
+    """Collect raw traversal calls with their enclosing qualified function."""
+
+    def __init__(self, path: str, aliases: dict[str, str]) -> None:
+        self.path = path
+        self.aliases = aliases
+        self.scope: list[str] = []
+        self.sites: list[TraversalSite] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        api = _filesystem_api(node, self.aliases)
+        if api is not None:
+            self.sites.append(
+                TraversalSite(
+                    path=self.path,
+                    function=".".join(self.scope) or "<module>",
+                    api=api,
+                    line=node.lineno,
+                )
+            )
+        self.generic_visit(node)
+
+
+def find_traversals(source: str, *, path: str) -> list[TraversalSite]:
+    """Parse *source* and return its raw filesystem traversal sites."""
+    tree = ast.parse(source, filename=path)
+    visitor = _TraversalVisitor(path, _import_aliases(tree))
+    visitor.visit(tree)
+    return sorted(visitor.sites, key=lambda site: (site.path, site.line, site.api))
+
+
+def audit_sites(
+    sites: list[TraversalSite],
+    exemptions: dict[TraversalKey, TraversalExemption],
+) -> tuple[list[TraversalSite], list[tuple[TraversalKey, int, int]]]:
+    """Return unexpected sites and stale/mismatched exemption counts."""
+    counts = Counter(site.key for site in sites)
+    unexpected = [site for site in sites if site.key not in exemptions]
+    stale = [
+        (key, exemption.count, counts.get(key, 0))
+        for key, exemption in exemptions.items()
+        if counts.get(key, 0) != exemption.count
+    ]
+    return unexpected, sorted(stale)
+
+
+def scan_package(package_root: Path = PACKAGE_ROOT) -> list[TraversalSite]:
+    """Return every non-primitive raw traversal under *package_root*."""
+    sites: list[TraversalSite] = []
+    for file_path in sorted(package_root.rglob("*.py")):
+        relative = file_path.relative_to(package_root).as_posix()
+        if relative == _PRIMITIVE_PATH:
+            continue
+        source = file_path.read_text(encoding="utf-8")
+        sites.extend(find_traversals(source, path=relative))
+    return sorted(sites, key=lambda site: (site.path, site.line, site.api))
+
+
+def main() -> int:
+    """Audit package traversal sites against the executable scope note."""
+    if not PACKAGE_ROOT.exists():
+        print(f"[{RAIL_NAME}] {PACKAGE_ROOT} not found; run from repository root.", file=sys.stderr)
+        return 1
+
+    try:
+        sites = scan_package()
+    except (OSError, SyntaxError) as exc:
+        print(f"[{RAIL_NAME}] could not scan package: {exc}", file=sys.stderr)
+        return 1
+
+    unexpected, stale = audit_sites(sites, _EXEMPTIONS)
+    if unexpected or stale:
+        print(f"[{RAIL_NAME}] traversal scope drift found:", file=sys.stderr)
+        for site in unexpected:
+            print(
+                f"  {site.path}:{site.line}: {site.function} calls {site.api} without an exemption",
+                file=sys.stderr,
+            )
+        for key, expected, actual in stale:
+            path, function, api = key
+            reason = _EXEMPTIONS[key].reason
+            print(
+                f"  stale exemption {path}:{function}:{api}: expected {expected}, found {actual} ({reason})",
+                file=sys.stderr,
+            )
+        print(
+            "Fix: migrate user-root traversal to core.path_guard.safe_walk, or add/update "
+            "one exact _EXEMPTIONS entry with a reviewed reason.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[{RAIL_NAME}] {len(sites)} reviewed raw call(s); "
+        f"{len(_EXEMPTIONS)} exact exemption key(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/guardrails/check_raw_filesystem_traversal.py
+++ b/scripts/ci/guardrails/check_raw_filesystem_traversal.py
@@ -322,6 +322,17 @@ def audit_sites(
     exemptions: dict[TraversalKey, TraversalExemption],
 ) -> tuple[list[TraversalSite], list[tuple[TraversalKey, int, int]]]:
     """Return unexpected sites and stale/mismatched exemption counts."""
+    invalid: list[str] = []
+    for key, exemption in sorted(exemptions.items()):
+        label = "::".join(key)
+        if exemption.count < 1:
+            invalid.append(f"{label} has count {exemption.count}; count must be at least 1")
+        if not exemption.reason.strip():
+            invalid.append(f"{label} has a blank reason")
+
+    if invalid:
+        raise ValueError("invalid traversal exemptions: " + "; ".join(invalid))
+
     counts = Counter(site.key for site in sites)
     unexpected = [site for site in sites if site.key not in exemptions]
     stale = [
@@ -356,7 +367,11 @@ def main() -> int:
         print(f"[{RAIL_NAME}] could not scan package: {exc}", file=sys.stderr)
         return 1
 
-    unexpected, stale = audit_sites(sites, _EXEMPTIONS)
+    try:
+        unexpected, stale = audit_sites(sites, _EXEMPTIONS)
+    except ValueError as exc:
+        print(f"[{RAIL_NAME}] invalid executable scope note: {exc}", file=sys.stderr)
+        return 1
     if unexpected or stale:
         print(f"[{RAIL_NAME}] traversal scope drift found:", file=sys.stderr)
         for site in unexpected:

--- a/scripts/ci/rails.toml
+++ b/scripts/ci/rails.toml
@@ -19,6 +19,12 @@ mode = "enforce"
 description = "Flags raw open(), Path.open(), and shutil copy/move functions on caller-supplied paths (WP-6.1)."
 
 [[rail]]
+name = "raw-filesystem-traversal"
+command = ["python", "scripts/ci/guardrails/check_raw_filesystem_traversal.py"]
+mode = "enforce"
+description = "Flags raw filesystem enumeration outside the exact reviewed safe_walk exemption inventory (issue #1736)."
+
+[[rail]]
 name = "atomic-write"
 command = ["python", "scripts/ci/guardrails/check_atomic_write.py"]
 mode = "enforce"

--- a/src/file_organizer/cli/autotag.py
+++ b/src/file_organizer/cli/autotag.py
@@ -10,6 +10,8 @@ import json
 import sys
 from pathlib import Path
 
+from file_organizer.core.path_guard import safe_walk
+
 from ..services.auto_tagging import AutoTaggingService
 
 
@@ -238,14 +240,10 @@ def handle_batch(service: AutoTaggingService, args: argparse.Namespace) -> None:
         print(f"Error: Not a directory: {directory}", file=sys.stderr)
         sys.exit(1)
 
-    # Find files
-    if args.recursive:
-        pattern = f"**/{args.pattern}"
-    else:
-        pattern = args.pattern
-
-    files = list(directory.glob(pattern))
-    files = [f for f in files if f.is_file()]
+    # Find files under the guarded hidden/symlink policy used by other
+    # user-supplied CLI traversal roots.
+    pattern = args.pattern
+    files = list(safe_walk(directory, pattern=pattern, recursive=args.recursive))
 
     if not files:
         print(f"No files found matching pattern: {pattern}")

--- a/src/file_organizer/cli/autotag_v2.py
+++ b/src/file_organizer/cli/autotag_v2.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from rich.table import Table
 
 from file_organizer.cli.path_validation import resolve_cli_path
+from file_organizer.core.path_guard import safe_walk
 
 autotag_app = typer.Typer(
     name="autotag",
@@ -54,7 +55,7 @@ def suggest(
         console.print(f"[red]Error initializing service: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
-    files = [f for f in resolved.iterdir() if f.is_file()]
+    files = list(safe_walk(resolved, recursive=False))
     if not files:
         console.print("[dim]No files found in directory.[/dim]")
         raise typer.Exit(code=0)
@@ -212,8 +213,7 @@ def batch(
         console.print(f"[red]Error initializing service: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
-    glob_pattern = f"**/{pattern}" if recursive else pattern
-    files = [f for f in resolved.glob(glob_pattern) if f.is_file()]
+    files = list(safe_walk(resolved, pattern=pattern, recursive=recursive))
 
     if not files:
         console.print(f"[dim]No files found matching pattern: {pattern}[/dim]")

--- a/src/file_organizer/cli/autotag_v2.py
+++ b/src/file_organizer/cli/autotag_v2.py
@@ -29,6 +29,12 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
+def _abort_on_walk_error(path: Path, exc: OSError) -> None:
+    """Report an incomplete traversal and fail the current CLI command."""
+    console.print("[red]Filesystem traversal failed:[/red]", path, exc)
+    raise typer.Exit(code=1) from exc
+
+
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
@@ -55,7 +61,7 @@ def suggest(
         console.print(f"[red]Error initializing service: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
-    files = list(safe_walk(resolved, recursive=False))
+    files = list(safe_walk(resolved, recursive=False, on_error=_abort_on_walk_error))
     if not files:
         console.print("[dim]No files found in directory.[/dim]")
         raise typer.Exit(code=0)
@@ -213,7 +219,14 @@ def batch(
         console.print(f"[red]Error initializing service: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
-    files = list(safe_walk(resolved, pattern=pattern, recursive=recursive))
+    files = list(
+        safe_walk(
+            resolved,
+            pattern=pattern,
+            recursive=recursive,
+            on_error=_abort_on_walk_error,
+        )
+    )
 
     if not files:
         console.print(f"[dim]No files found matching pattern: {pattern}[/dim]")

--- a/src/file_organizer/cli/autotag_v2.py
+++ b/src/file_organizer/cli/autotag_v2.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -29,10 +30,16 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
-def _abort_on_walk_error(path: Path, exc: OSError) -> None:
-    """Report an incomplete traversal and fail the current CLI command."""
-    console.print("[red]Filesystem traversal failed:[/red]", path, exc)
-    raise typer.Exit(code=1) from exc
+def _walk_error_handler(root: Path) -> Callable[[Path, OSError], None]:
+    """Fail for an unreadable root while skipping unreadable descendants."""
+
+    def handle(path: Path, exc: OSError) -> None:
+        if path == root:
+            console.print("[red]Filesystem traversal failed:[/red]", path, exc)
+            raise typer.Exit(code=1) from exc
+        console.print("[yellow]Skipping unreadable path:[/yellow]", path, exc)
+
+    return handle
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +68,7 @@ def suggest(
         console.print(f"[red]Error initializing service: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
-    files = list(safe_walk(resolved, recursive=False, on_error=_abort_on_walk_error))
+    files = list(safe_walk(resolved, recursive=False, on_error=_walk_error_handler(resolved)))
     if not files:
         console.print("[dim]No files found in directory.[/dim]")
         raise typer.Exit(code=0)
@@ -224,7 +231,7 @@ def batch(
             resolved,
             pattern=pattern,
             recursive=recursive,
-            on_error=_abort_on_walk_error,
+            on_error=_walk_error_handler(resolved),
         )
     )
 

--- a/src/file_organizer/core/path_guard.py
+++ b/src/file_organizer/core/path_guard.py
@@ -17,16 +17,16 @@ Epic A.foundation (hardening roadmap #154). Provides two primitives:
   out of scope (see *Scope note* below) and continue to use `glob`/`rglob`
   until they cross a user-input boundary.
 
-Scope note — system-managed paths that *don't* need `safe_walk`:
+Scope note — reviewed paths that *don't* use `safe_walk`:
 
-- `undo/validator.py` (trash directory, system-managed)
-- `services/copilot/rules/rule_manager.py` (app-shipped rule yamls)
-- `services/intelligence/profile_{manager,migrator}.py` (profile/backup dir)
-- `config/path_migration.py` (legacy XDG migration, run once)
-- `parallel/persistence.py` (job-queue state, internal only)
-- `methodologies/para/migration_manager.py` (internal migration helper)
-- `core/file_ops.py::collect_files` (called on a pre-validated organize
-  root; safe_walk adoption here tracked as a follow-up)
+The executable, reason-bearing inventory lives in
+`scripts/ci/guardrails/check_raw_filesystem_traversal.py::_EXEMPTIONS` and is
+enforced by the `raw-filesystem-traversal` rail. It covers only these contract
+classes: app-owned state and shipped assets; bounded single-level UI or shell
+completion listings that intentionally expose symlinks; depth-pruned or
+directory-pruned walkers whose semantics `safe_walk` does not provide; static
+repository audits; and the fd-anchored `SafeDir.scandir` primitive. Adding or
+removing a raw traversal without updating that exact inventory fails CI.
 
 Design invariants:
 

--- a/src/file_organizer/methodologies/johnny_decimal/compatibility.py
+++ b/src/file_organizer/methodologies/johnny_decimal/compatibility.py
@@ -12,6 +12,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
+
 from .categories import JohnnyDecimalNumber, NumberLevel
 from .config import JohnnyDecimalConfig, PARAIntegrationConfig
 
@@ -198,7 +200,7 @@ class CompatibilityAnalyzer:
             return detected
 
         # Look for PARA folders
-        for item in root_path.iterdir():
+        for item in safe_walk(root_path, recursive=False, only_files=False):
             if not item.is_dir():
                 continue
 
@@ -229,7 +231,7 @@ class CompatibilityAnalyzer:
 
         # Check for JD numbers
         has_jd = False
-        for item in root_path.iterdir():
+        for item in safe_walk(root_path, recursive=False, only_files=False):
             if item.is_dir() and self._looks_like_jd(item.name):
                 has_jd = True
                 break

--- a/src/file_organizer/methodologies/johnny_decimal/scanner.py
+++ b/src/file_organizer/methodologies/johnny_decimal/scanner.py
@@ -151,10 +151,6 @@ class FolderScanner:
         )
 
         for item in items:
-            # Skip hidden files/folders if configured
-            if self.skip_hidden and item.name.startswith("."):
-                continue
-
             if item.is_dir():
                 # Scan subdirectory
                 folder_info = self._create_folder_info(item, depth)

--- a/src/file_organizer/methodologies/johnny_decimal/scanner.py
+++ b/src/file_organizer/methodologies/johnny_decimal/scanner.py
@@ -10,6 +10,8 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from file_organizer.core.path_guard import safe_walk
+
 from .categories import JohnnyDecimalNumber, NumberingScheme
 
 logger = logging.getLogger(__name__)
@@ -139,11 +141,14 @@ class FolderScanner:
 
         folders: list[FolderInfo] = []
 
-        try:
-            items = sorted(path.iterdir())
-        except PermissionError:
-            logger.warning(f"Permission denied: {path}")
-            return folders
+        items = sorted(
+            safe_walk(
+                path,
+                recursive=False,
+                only_files=False,
+                include_hidden=not self.skip_hidden,
+            )
+        )
 
         for item in items:
             # Skip hidden files/folders if configured
@@ -178,17 +183,18 @@ class FolderScanner:
         file_count = 0
         total_size = 0
 
-        try:
-            # Count immediate files
-            for item in path.iterdir():
-                if item.is_file():
-                    file_count += 1
-                    try:
-                        total_size += item.stat().st_size
-                    except OSError:
-                        pass
-        except PermissionError:
-            pass
+        # Count immediate files through the same hidden/symlink policy as the
+        # recursive scan that discovered this folder.
+        for item in safe_walk(
+            path,
+            recursive=False,
+            include_hidden=not self.skip_hidden,
+        ):
+            file_count += 1
+            try:
+                total_size += item.stat().st_size
+            except OSError:
+                pass
 
         folder_info = FolderInfo(
             path=path,

--- a/src/file_organizer/methodologies/para/ai/feature_extractor.py
+++ b/src/file_organizer/methodologies/para/ai/feature_extractor.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.utils.file_times import creation_timestamp
 
 logger = logging.getLogger(__name__)
@@ -368,7 +369,7 @@ class FeatureExtractor:
         parent_dir = file_path.parent
         if parent_dir.exists() and parent_dir.is_dir():
             try:
-                sibling_count = sum(1 for f in parent_dir.iterdir() if f.is_file()) - 1
+                sibling_count = sum(1 for _ in safe_walk(parent_dir, recursive=False)) - 1
             except OSError:
                 sibling_count = 0
 
@@ -490,7 +491,15 @@ class FeatureExtractor:
         }
 
         try:
-            entries = {entry.name.lower() for entry in directory.iterdir()}
+            entries = {
+                entry.name.lower()
+                for entry in safe_walk(
+                    directory,
+                    recursive=False,
+                    only_files=False,
+                    include_hidden=True,
+                )
+            }
             return bool(entries & project_indicators)
         except OSError:
             return False

--- a/src/file_organizer/methodologies/para/ai/feature_extractor.py
+++ b/src/file_organizer/methodologies/para/ai/feature_extractor.py
@@ -369,7 +369,9 @@ class FeatureExtractor:
         parent_dir = file_path.parent
         if parent_dir.exists() and parent_dir.is_dir():
             try:
-                sibling_count = sum(1 for _ in safe_walk(parent_dir, recursive=False)) - 1
+                sibling_count = sum(
+                    1 for sibling in safe_walk(parent_dir, recursive=False) if sibling != file_path
+                )
             except OSError:
                 sibling_count = 0
 
@@ -394,7 +396,7 @@ class FeatureExtractor:
 
         return StructuralFeatures(
             directory_depth=depth,
-            sibling_count=max(sibling_count, 0),
+            sibling_count=sibling_count,
             parent_category_hint=parent_category_hint,
             path_keywords=sorted(set(path_keywords)),
             has_project_structure=has_project_structure,

--- a/src/file_organizer/plugins/marketplace/installer.py
+++ b/src/file_organizer/plugins/marketplace/installer.py
@@ -10,6 +10,7 @@ import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.plugins.marketplace.errors import MarketplaceInstallError
 from file_organizer.plugins.marketplace.models import InstalledPlugin
 from file_organizer.plugins.marketplace.repository import PluginRepository
@@ -215,7 +216,16 @@ class PluginInstaller:
         if direct_plugin.exists():
             return extracted_dir
 
-        children = [path for path in extracted_dir.iterdir() if path.name != "__MACOSX"]
+        children = [
+            path
+            for path in safe_walk(
+                extracted_dir,
+                recursive=False,
+                only_files=False,
+                include_hidden=True,
+            )
+            if path.name != "__MACOSX"
+        ]
         directory_children = [path for path in children if path.is_dir()]
         if len(directory_children) == 1 and (directory_children[0] / "plugin.py").exists():
             return directory_children[0]

--- a/src/file_organizer/services/deduplication/image_dedup.py
+++ b/src/file_organizer/services/deduplication/image_dedup.py
@@ -31,6 +31,8 @@ except ImportError:  # pragma: no cover - numpy is optional ([dedup]/[search] ex
 
 from PIL.Image import DecompressionBombError
 
+from file_organizer.core.path_guard import safe_walk
+
 from .image_utils import SUPPORTED_FORMATS, safedir_image_open
 
 logger = logging.getLogger(__name__)
@@ -436,20 +438,8 @@ class ImageDeduplicator:
         """
         image_files: list[Path] = []
 
-        if recursive:
-            pattern = "**/*"
-        else:
-            pattern = "*"
-
-        for path in directory.glob(pattern):
-            # ``Path.is_file()`` follows symlinks. Filter symlinked entries here
-            # so SafeDir's per-component check inside the dedup hash flow remains
-            # the only place that decides whether a symlinked image is
-            # processed — never silently accepted by the walk.
-            if path.is_symlink():
-                logger.debug("Skipping symlinked image in walk: %s", path)
-                continue
-            if path.is_file() and path.suffix.lower() in SUPPORTED_FORMATS:
+        for path in safe_walk(directory, recursive=recursive, include_hidden=True):
+            if path.suffix.lower() in SUPPORTED_FORMATS:
                 image_files.append(path)
 
         return image_files

--- a/src/file_organizer/services/deduplication/image_utils.py
+++ b/src/file_organizer/services/deduplication/image_utils.py
@@ -35,6 +35,7 @@ from typing import Any
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.utils.safedir import SafeDir
 
 logger = logging.getLogger(__name__)
@@ -393,10 +394,10 @@ def find_images_in_directory(
 
     image_files: list[Path] = []
 
-    pattern = "**/*" if recursive else "*"
-
-    for path in directory.glob(pattern):
-        if path.is_file() and path.suffix.lower() in extensions:
+    # Hidden images are part of this public helper's established result set;
+    # safe_walk still supplies the required symlink and file-type filtering.
+    for path in safe_walk(directory, recursive=recursive, include_hidden=True):
+        if path.suffix.lower() in extensions:
             image_files.append(path)
 
     return image_files

--- a/src/file_organizer/services/smart_suggestions.py
+++ b/src/file_organizer/services/smart_suggestions.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from file_organizer.core.path_guard import safe_walk
+
 from ..models.suggestion_types import ConfidenceFactors, Suggestion, SuggestionType
 from ..models.text_model import TextModel
 from .pattern_analyzer import PatternAnalysis, PatternAnalyzer
@@ -108,7 +110,7 @@ class ConfidenceScorer:
 
         # Check if target directory has similar file types
         target_dir = target_path if target_path.is_dir() else target_path.parent
-        similar_files = list(target_dir.glob(f"*{file_path.suffix}"))
+        similar_files = list(safe_walk(target_dir, pattern=f"*{file_path.suffix}", recursive=False))
 
         if not similar_files:
             return 20.0
@@ -212,7 +214,7 @@ class ConfidenceScorer:
             target_dir = target_path if target_path.is_dir() else target_path.parent
 
             # Get sizes of existing files in target
-            existing_files = [f for f in target_dir.iterdir() if f.is_file()]
+            existing_files = list(safe_walk(target_dir, recursive=False))
             if not existing_files:
                 return 50.0
 

--- a/src/file_organizer/web/_helpers.py
+++ b/src/file_organizer/web/_helpers.py
@@ -17,7 +17,7 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.utils import is_hidden, resolve_path
 from file_organizer.core.organizer import FileOrganizer
-from file_organizer.core.path_guard import safe_walk
+from file_organizer.core.path_guard import TraversalBudget, safe_walk
 from file_organizer.web._forms import TRUE_FORM_VALUES, form_bool
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -207,15 +207,19 @@ def validate_depth(path: Path, roots: list[Path]) -> None:
 
 def has_children(path: Path) -> bool:
     """Check whether a directory contains visible subdirectories."""
+    budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
     for entry in safe_walk(
         path,
         recursive=False,
         only_files=False,
-        max_entries=MAX_DIRECTORY_ENTRIES,
+        max_entries=budget,
     ):
         if entry.is_dir() and not is_hidden(entry):
             return True
-    return False
+    # Once the cap is reached, preserve the expand control: a visible
+    # subdirectory may exist beyond the examined prefix. Expanding the node
+    # will show the explicit truncation notice from ``build_tree_context``.
+    return budget.exhausted
 
 
 def is_probably_text(path: Path) -> bool:

--- a/src/file_organizer/web/_helpers.py
+++ b/src/file_organizer/web/_helpers.py
@@ -17,6 +17,7 @@ from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.utils import is_hidden, resolve_path
 from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.web._forms import TRUE_FORM_VALUES, form_bool
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -49,6 +50,7 @@ PAGE_SIZE = 48
 THUMBNAIL_SIZE = (240, 160)
 MAX_LIMIT = 500
 MAX_NAV_DEPTH = 12
+MAX_DIRECTORY_ENTRIES = 10_000
 MAX_UPLOAD_BYTES = 25 * 1024 * 1024
 UPLOAD_CHUNK_SIZE = 1024 * 1024
 MAX_THUMBNAIL_BYTES = 15 * 1024 * 1024
@@ -205,12 +207,14 @@ def validate_depth(path: Path, roots: list[Path]) -> None:
 
 def has_children(path: Path) -> bool:
     """Check whether a directory contains visible subdirectories."""
-    try:
-        for entry in path.iterdir():
-            if entry.is_dir() and not is_hidden(entry):
-                return True
-    except OSError:
-        return False
+    for entry in safe_walk(
+        path,
+        recursive=False,
+        only_files=False,
+        max_entries=MAX_DIRECTORY_ENTRIES,
+    ):
+        if entry.is_dir() and not is_hidden(entry):
+            return True
     return False
 
 

--- a/src/file_organizer/web/_helpers.py
+++ b/src/file_organizer/web/_helpers.py
@@ -205,9 +205,10 @@ def validate_depth(path: Path, roots: list[Path]) -> None:
         )
 
 
-def has_children(path: Path) -> bool:
-    """Check whether a directory contains visible subdirectories."""
-    budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
+def has_children(path: Path, *, budget: TraversalBudget | None = None) -> bool:
+    """Check for visible subdirectories within an optional shared budget."""
+    if budget is None:
+        budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
     for entry in safe_walk(
         path,
         recursive=False,

--- a/src/file_organizer/web/file_listing.py
+++ b/src/file_organizer/web/file_listing.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import quote
 
 from file_organizer.api.utils import file_info_from_path, is_hidden
-from file_organizer.core.path_guard import safe_walk
+from file_organizer.core.path_guard import TraversalBudget, safe_walk
 from file_organizer.utils.file_times import creation_timestamp
 from file_organizer.web._helpers import (
     MAX_DIRECTORY_ENTRIES,
@@ -32,8 +32,15 @@ def normalized_extension(path: Path) -> str:
     return suffixes[-1] if suffixes else ""
 
 
-def list_tree_nodes(path: Path, include_hidden: bool) -> list[dict[str, Any]]:
+def list_tree_nodes(
+    path: Path,
+    include_hidden: bool,
+    *,
+    budget: TraversalBudget | None = None,
+) -> list[dict[str, Any]]:
     """List immediate child directories of *path* as sidebar tree nodes."""
+    if budget is None:
+        budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
     nodes: list[dict[str, Any]] = []
     entries = sorted(
         (
@@ -43,7 +50,7 @@ def list_tree_nodes(path: Path, include_hidden: bool) -> list[dict[str, Any]]:
                 recursive=False,
                 only_files=False,
                 include_hidden=include_hidden,
-                max_entries=MAX_DIRECTORY_ENTRIES,
+                max_entries=budget,
             )
             if p.is_dir()
         ),
@@ -73,15 +80,18 @@ def collect_entries(
     sort_order: str,
     include_hidden: bool,
     limit: int,
+    budget: TraversalBudget | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     """Collect, filter, and sort directory entries for the file browser."""
+    if budget is None:
+        budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
     children = list(
         safe_walk(
             path,
             recursive=False,
             only_files=False,
             include_hidden=include_hidden,
-            max_entries=MAX_DIRECTORY_ENTRIES,
+            max_entries=budget,
         )
     )
 

--- a/src/file_organizer/web/file_listing.py
+++ b/src/file_organizer/web/file_listing.py
@@ -9,8 +9,10 @@ from typing import Any
 from urllib.parse import quote
 
 from file_organizer.api.utils import file_info_from_path, is_hidden
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.utils.file_times import creation_timestamp
 from file_organizer.web._helpers import (
+    MAX_DIRECTORY_ENTRIES,
     detect_kind,
     format_bytes,
     format_timestamp,
@@ -33,13 +35,20 @@ def normalized_extension(path: Path) -> str:
 def list_tree_nodes(path: Path, include_hidden: bool) -> list[dict[str, Any]]:
     """List immediate child directories of *path* as sidebar tree nodes."""
     nodes: list[dict[str, Any]] = []
-    try:
-        entries = sorted(
-            [p for p in path.iterdir() if p.is_dir()],
-            key=lambda p: p.name.lower(),
-        )
-    except OSError:
-        return nodes
+    entries = sorted(
+        (
+            p
+            for p in safe_walk(
+                path,
+                recursive=False,
+                only_files=False,
+                include_hidden=include_hidden,
+                max_entries=MAX_DIRECTORY_ENTRIES,
+            )
+            if p.is_dir()
+        ),
+        key=lambda p: p.name.lower(),
+    )
     for entry in entries:
         if not include_hidden and is_hidden(entry):
             continue
@@ -66,10 +75,15 @@ def collect_entries(
     limit: int,
 ) -> tuple[list[dict[str, Any]], int]:
     """Collect, filter, and sort directory entries for the file browser."""
-    try:
-        children = list(path.iterdir())
-    except OSError:
-        return [], 0
+    children = list(
+        safe_walk(
+            path,
+            recursive=False,
+            only_files=False,
+            include_hidden=include_hidden,
+            max_entries=MAX_DIRECTORY_ENTRIES,
+        )
+    )
 
     query_token = query.lower() if query else None
     allowed_types = parse_file_type_filter(file_type)

--- a/src/file_organizer/web/file_listing.py
+++ b/src/file_organizer/web/file_listing.py
@@ -65,7 +65,7 @@ def list_tree_nodes(
                 "name": entry.name,
                 "path": str(entry),
                 "path_param": quote(str(entry)),
-                "has_children": has_children(entry),
+                "has_children": has_children(entry, budget=budget),
             }
         )
     return nodes

--- a/src/file_organizer/web/file_operations.py
+++ b/src/file_organizer/web/file_operations.py
@@ -17,7 +17,9 @@ from PIL import Image, UnidentifiedImageError
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
 from file_organizer.api.utils import file_info_from_path, resolve_path
+from file_organizer.core.path_guard import TraversalBudget
 from file_organizer.web._helpers import (
+    MAX_DIRECTORY_ENTRIES,
     MAX_THUMBNAIL_BYTES,
     TEXT_PREVIEW_CHARS,
     THUMBNAIL_SIZE,
@@ -152,6 +154,7 @@ def build_file_results_context(
     entries: list[dict[str, Any]] = []
     total = 0
     current_path: Path | None = None
+    listing_budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
 
     try:
         current_path = resolve_selected_path(path, settings)
@@ -172,6 +175,7 @@ def build_file_results_context(
                 sort_order=sort_order,
                 include_hidden=False,
                 limit=limit,
+                budget=listing_budget,
             )
         except ApiError as exc:
             error_message = exc.message
@@ -201,6 +205,8 @@ def build_file_results_context(
         "next_limit": next_limit,
         "has_more": next_limit > limit,
         "error_message": error_message,
+        "listing_truncated": listing_budget.exhausted,
+        "directory_entry_limit": f"{MAX_DIRECTORY_ENTRIES:,}",
         "roots": [str(root) for root in roots],
         "page_size": page_size,
         "request": request,
@@ -229,12 +235,13 @@ def build_tree_context(
     active_path_param = quote(active_path) if active_path else ""
     nodes: list[dict[str, Any]] = []
     error_message: str | None = None
+    tree_budget = TraversalBudget(limit=MAX_DIRECTORY_ENTRIES)
 
     if path:
         try:
             current = resolve_path(path, settings.allowed_paths)
             validate_depth(current, roots)
-            nodes = list_tree_nodes(current, include_hidden=False)
+            nodes = list_tree_nodes(current, include_hidden=False, budget=tree_budget)
         except ApiError as exc:
             error_message = exc.message
     else:
@@ -259,6 +266,8 @@ def build_tree_context(
         "active_path": active_path,
         "active_path_param": active_path_param,
         "error_message": error_message,
+        "tree_truncated": tree_budget.exhausted,
+        "directory_entry_limit": f"{MAX_DIRECTORY_ENTRIES:,}",
     }
 
 

--- a/src/file_organizer/web/file_operations.py
+++ b/src/file_organizer/web/file_operations.py
@@ -252,7 +252,7 @@ def build_tree_context(
                     "name": root.name or root.as_posix(),
                     "path": str(root),
                     "path_param": quote(str(root)),
-                    "has_children": has_children(root),
+                    "has_children": has_children(root, budget=tree_budget),
                     "is_root": True,
                 }
             )

--- a/src/file_organizer/web/templates/files/_results.html
+++ b/src/file_organizer/web/templates/files/_results.html
@@ -114,6 +114,11 @@
 {% if error_message %}
     <div class="banner banner-error">{{ error_message }}</div>
 {% endif %}
+{% if listing_truncated %}
+    <div class="banner banner-info" role="status">
+        Safety limit reached after examining {{ directory_entry_limit }} directory entries. This listing may be incomplete.
+    </div>
+{% endif %}
 
 <div class="bulk-toolbar">
     <span class="bulk-count" data-selection-count>0 selected</span>

--- a/src/file_organizer/web/templates/files/_tree.html
+++ b/src/file_organizer/web/templates/files/_tree.html
@@ -1,6 +1,11 @@
 {% if error_message %}
     <div class="tree-error">{{ error_message }}</div>
 {% endif %}
+{% if tree_truncated %}
+    <div class="tree-error" role="status">
+        Safety limit reached after examining {{ directory_entry_limit }} directory entries. Some folders may be omitted.
+    </div>
+{% endif %}
 
 <ul class="tree-list" data-depth="{{ depth }}">
     {% for node in nodes %}

--- a/tests/ci/test_check_raw_filesystem_traversal.py
+++ b/tests/ci/test_check_raw_filesystem_traversal.py
@@ -1,0 +1,121 @@
+"""Tests for the raw-filesystem-traversal CI rail (issue #1736)."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from scripts.ci.guardrails import check_raw_filesystem_traversal as checker
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def _find(source: str) -> list[checker.TraversalSite]:
+    return checker.find_traversals(dedent(source), path="sample.py")
+
+
+@pytest.mark.parametrize(
+    ("expression", "api"),
+    [
+        ("root.iterdir()", "Path.iterdir"),
+        ("root.glob('*.txt')", "Path.glob"),
+        ("root.rglob('*.txt')", "Path.rglob"),
+        ("os.walk(root)", "os.walk"),
+        ("os.scandir(root)", "os.scandir"),
+        ("os.listdir(root)", "os.listdir"),
+        ("os.fwalk(root)", "os.fwalk"),
+        ("glob.glob('*.txt')", "glob.glob"),
+        ("glob.iglob('*.txt')", "glob.iglob"),
+    ],
+)
+def test_detects_supported_raw_traversal_apis(expression: str, api: str) -> None:
+    sites = _find(
+        f"""
+        import glob
+        import os
+
+        def scan(root):
+            {expression}
+        """
+    )
+    assert [(site.function, site.api) for site in sites] == [("scan", api)]
+
+
+def test_distinguishes_ast_walk_from_filesystem_walk_in_same_module() -> None:
+    sites = _find(
+        """
+        import ast
+        import os
+
+        def inspect(tree, root):
+            ast.walk(tree)
+            os.walk(root)
+        """
+    )
+    assert [(site.line, site.api) for site in sites] == [(7, "os.walk")]
+
+
+def test_resolves_import_aliases_and_direct_imports() -> None:
+    sites = _find(
+        """
+        import os as operating_system
+        from glob import iglob as iter_matches
+        from os import scandir as scan_entries
+
+        def scan(root):
+            operating_system.walk(root)
+            iter_matches('*.py')
+            scan_entries(root)
+        """
+    )
+    assert [site.api for site in sites] == ["os.walk", "glob.iglob", "os.scandir"]
+
+
+def test_does_not_flag_safedir_scandir_method() -> None:
+    sites = _find(
+        """
+        def scan(safe_dir):
+            safe_dir.scandir()
+        """
+    )
+    assert sites == []
+
+
+def test_records_qualified_class_function() -> None:
+    sites = _find(
+        """
+        class Scanner:
+            def scan(self, root):
+                return list(root.iterdir())
+        """
+    )
+    assert sites[0].function == "Scanner.scan"
+
+
+def test_audit_rejects_unexpected_site() -> None:
+    site = checker.TraversalSite("new.py", "scan", "Path.rglob", 9)
+    unexpected, stale = checker.audit_sites([site], {})
+    assert unexpected == [site]
+    assert stale == []
+
+
+def test_audit_rejects_stale_or_changed_exemption_count() -> None:
+    key = ("legacy.py", "scan", "Path.glob")
+    exemption = checker.TraversalExemption(count=2, reason="app-owned directory")
+    site = checker.TraversalSite(*key, line=4)
+
+    unexpected, stale = checker.audit_sites([site], {key: exemption})
+
+    assert unexpected == []
+    assert stale == [(key, 2, 1)]
+
+
+def test_repository_inventory_matches_executable_scope_note() -> None:
+    sites = checker.scan_package()
+    unexpected, stale = checker.audit_sites(sites, checker._EXEMPTIONS)
+
+    assert unexpected == []
+    assert stale == []
+    assert len(sites) == 21
+    assert sum(exemption.count for exemption in checker._EXEMPTIONS.values()) == 21

--- a/tests/ci/test_check_raw_filesystem_traversal.py
+++ b/tests/ci/test_check_raw_filesystem_traversal.py
@@ -111,6 +111,26 @@ def test_audit_rejects_stale_or_changed_exemption_count() -> None:
     assert stale == [(key, 2, 1)]
 
 
+@pytest.mark.parametrize(
+    ("exemption", "message"),
+    [
+        (
+            checker.TraversalExemption(count=0, reason="app-owned directory"),
+            "count must be at least 1",
+        ),
+        (checker.TraversalExemption(count=1, reason="  \t"), "blank reason"),
+    ],
+)
+def test_audit_rejects_invalid_exemption_definition(
+    exemption: checker.TraversalExemption,
+    message: str,
+) -> None:
+    key = ("legacy.py", "scan", "Path.glob")
+
+    with pytest.raises(ValueError, match=message):
+        checker.audit_sites([], {key: exemption})
+
+
 def test_repository_inventory_matches_executable_scope_note() -> None:
     sites = checker.scan_package()
     unexpected, stale = checker.audit_sites(sites, checker._EXEMPTIONS)

--- a/tests/ci/test_ci_rails_framework.py
+++ b/tests/ci/test_ci_rails_framework.py
@@ -132,6 +132,7 @@ def test_repo_registry_loads_registered_rails() -> None:
     rails = ci_rails.load_rails(ci_rails.DEFAULT_REGISTRY)
     expected_modes = {
         "safedir-required": "enforce",
+        "raw-filesystem-traversal": "enforce",
         "atomic-write": "enforce",
         "cli-path-validation": "enforce",
         "cli-file-kind-validation": "advisory",

--- a/tests/cli/test_cli_autotag.py
+++ b/tests/cli/test_cli_autotag.py
@@ -136,6 +136,7 @@ class TestHandleAutotagCommand:
                 handle_autotag_command(args)
                 mock_handler.assert_called_once()
 
+    @pytest.mark.integration
     def test_route_batch(self, mock_service):
         args = Namespace(
             autotag_command="batch",

--- a/tests/cli/test_cli_autotag.py
+++ b/tests/cli/test_cli_autotag.py
@@ -491,6 +491,7 @@ class TestHandleBatch:
         captured = capsys.readouterr()
         assert "No files found" in captured.out
 
+    @pytest.mark.ci
     def test_batch_recursive(self, mock_service, tmp_path, capsys):
         sub = tmp_path / "sub"
         sub.mkdir()

--- a/tests/cli/test_cli_autotag_v2_coverage.py
+++ b/tests/cli/test_cli_autotag_v2_coverage.py
@@ -27,6 +27,29 @@ class _FakeRecommendation:
     suggestions: list = field(default_factory=list)
 
 
+@pytest.mark.ci
+@pytest.mark.parametrize("command", ["suggest", "batch"])
+def test_traversal_error_fails_command(command: str, tmp_path: Path) -> None:
+    from file_organizer.cli.autotag_v2 import autotag_app
+
+    def failed_walk(root: Path, **kwargs):
+        kwargs["on_error"](root, PermissionError("denied"))
+        return iter(())
+
+    with (
+        patch(
+            "file_organizer.services.auto_tagging.AutoTaggingService",
+            return_value=MagicMock(),
+        ),
+        patch("file_organizer.cli.autotag_v2.safe_walk", side_effect=failed_walk),
+    ):
+        result = runner.invoke(autotag_app, [command, str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert str(tmp_path) in result.output.replace("\n", "")
+    assert "denied" in result.output
+
+
 class TestAutotagSuggestErrors:
     """Covers error branches in suggest command (lines 47-49, 53-54, 61-62)."""
 

--- a/tests/cli/test_cli_autotag_v2_coverage.py
+++ b/tests/cli/test_cli_autotag_v2_coverage.py
@@ -28,6 +28,7 @@ class _FakeRecommendation:
 
 
 @pytest.mark.ci
+@pytest.mark.integration
 @pytest.mark.parametrize("command", ["suggest", "batch"])
 def test_traversal_error_fails_command(command: str, tmp_path: Path) -> None:
     from file_organizer.cli.autotag_v2 import autotag_app

--- a/tests/cli/test_cli_autotag_v2_coverage.py
+++ b/tests/cli/test_cli_autotag_v2_coverage.py
@@ -51,6 +51,36 @@ def test_traversal_error_fails_command(command: str, tmp_path: Path) -> None:
     assert "denied" in result.output
 
 
+@pytest.mark.ci
+@pytest.mark.integration
+def test_batch_skips_unreadable_descendant_and_processes_other_files(tmp_path: Path) -> None:
+    from file_organizer.cli.autotag_v2 import autotag_app
+
+    good_file = tmp_path / "good.txt"
+    good_file.write_text("good")
+    restricted = tmp_path / "restricted"
+    mock_service = MagicMock()
+    mock_service.recommender.batch_recommend.return_value = {}
+
+    def partial_walk(_root: Path, **kwargs):
+        kwargs["on_error"](restricted, PermissionError("denied"))
+        return iter([good_file])
+
+    with (
+        patch(
+            "file_organizer.services.auto_tagging.AutoTaggingService",
+            return_value=mock_service,
+        ),
+        patch("file_organizer.cli.autotag_v2.safe_walk", side_effect=partial_walk),
+    ):
+        result = runner.invoke(autotag_app, ["batch", str(tmp_path), "--recursive"])
+
+    assert result.exit_code == 0
+    assert "Skipping unreadable path" in result.output
+    assert str(restricted) in result.output.replace("\n", "")
+    mock_service.recommender.batch_recommend.assert_called_once_with([good_file], top_n=5)
+
+
 class TestAutotagSuggestErrors:
     """Covers error branches in suggest command (lines 47-49, 53-54, 61-62)."""
 

--- a/tests/methodologies/johnny_decimal/test_compatibility.py
+++ b/tests/methodologies/johnny_decimal/test_compatibility.py
@@ -179,6 +179,7 @@ class TestPARAJohnnyDecimalBridge:
 class TestCompatibilityAnalyzer:
     """Tests for CompatibilityAnalyzer."""
 
+    @pytest.mark.ci
     def test_detect_para_structure(self, analyzer, para_structure):
         """Test PARA structure detection."""
         detected = analyzer.detect_para_structure(para_structure)
@@ -207,6 +208,7 @@ class TestCompatibilityAnalyzer:
         assert detected[PARACategory.RESOURCES] is None
         assert detected[PARACategory.ARCHIVE] is None
 
+    @pytest.mark.ci
     def test_is_mixed_structure(self, analyzer, tmp_path):
         """Test mixed structure detection."""
         # Create both PARA and JD folders

--- a/tests/methodologies/johnny_decimal/test_jd_scanner.py
+++ b/tests/methodologies/johnny_decimal/test_jd_scanner.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from file_organizer.core.path_guard import safe_walk
 from file_organizer.methodologies.johnny_decimal.categories import get_default_scheme
 from file_organizer.methodologies.johnny_decimal.scanner import FolderInfo, FolderScanner
 from file_organizer.methodologies.johnny_decimal.system import JohnnyDecimalSystem
@@ -191,21 +193,24 @@ class TestScannerCoverage:
         assert result.folder_tree[0].name == "sub"
         assert result.folder_tree[0].children == []
 
-    # Lines 158->148: _scan_folder PermissionError in iterdir (branch)
+    # Unreadable child walks are represented by safe_walk's empty iterator.
     def test_scan_folder_permission_denied(self, scanner: FolderScanner, tmp_path: Path) -> None:
         restricted = tmp_path / "restricted"
         restricted.mkdir()
-        original_iterdir = Path.iterdir
 
-        def guarded_iterdir(path_self: Path) -> Iterator[Path]:
-            if path_self == restricted:
-                raise PermissionError("permission denied")
-            return original_iterdir(path_self)
+        def guarded_walk(root: Path, **kwargs: Any) -> Iterator[Path]:
+            if root == restricted:
+                return iter(())
+            return safe_walk(root, **kwargs)
 
-        with patch.object(Path, "iterdir", guarded_iterdir):
+        with patch(
+            "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
+            side_effect=guarded_walk,
+        ):
             result = scanner.scan_directory(tmp_path)
         assert result is not None
-        assert any(folder.path == restricted for folder in result.folder_tree)
+        restricted_info = next(folder for folder in result.folder_tree if folder.path == restricted)
+        assert restricted_info.children == []
 
     # Lines 163-164: _scan_folder counts files and handles OSError on stat
     def test_scan_counts_files(self, scanner: FolderScanner, tmp_path: Path) -> None:
@@ -213,7 +218,7 @@ class TestScannerCoverage:
         result = scanner.scan_directory(tmp_path)
         assert result.total_files >= 1
 
-    # Lines 188-191: _create_folder_info PermissionError
+    # An unreadable immediate listing is empty after safe_walk handles the error.
     def test_create_folder_info_permission_error(
         self, scanner: FolderScanner, tmp_path: Path
     ) -> None:
@@ -222,12 +227,10 @@ class TestScannerCoverage:
         inner_file = restricted / "data.txt"
         inner_file.write_text("data")
 
-        def denied_iterdir(path_self: Path) -> Iterator[Path]:
-            if path_self == restricted:
-                raise PermissionError("permission denied")
-            return iter(())
-
-        with patch.object(Path, "iterdir", denied_iterdir):
+        with patch(
+            "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
+            return_value=iter(()),
+        ):
             info = scanner._create_folder_info(restricted, depth=0)
         assert info.file_count == 0
 
@@ -245,7 +248,10 @@ class TestScannerCoverage:
             def stat(self) -> object:
                 raise OSError("bad stat")
 
-        with patch.object(Path, "iterdir", return_value=iter([BrokenSizeFile()])):
+        with patch(
+            "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
+            return_value=iter([BrokenSizeFile()]),
+        ):
             result = scanner.scan_directory(tmp_path)
         assert result is not None
         assert result.total_files == 1
@@ -267,7 +273,10 @@ class TestScannerCoverage:
             def stat(self) -> object:
                 raise OSError("bad stat")
 
-        with patch.object(Path, "iterdir", return_value=iter([BrokenSizeFile()])):
+        with patch(
+            "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
+            return_value=iter([BrokenSizeFile()]),
+        ):
             info = scanner._create_folder_info(sub, depth=0)
         assert info.file_count == 1
         assert info.total_size == 0
@@ -293,21 +302,23 @@ class TestScannerCoverage:
         result = scanner.scan_directory(tmp_path)
         assert result.total_files == 0
 
-    # PermissionError in _scan_folder during sorted(path.iterdir())
-    def test_scan_folder_iterdir_permission_error(
+    def test_scan_folder_delegates_each_level_to_safe_walk(
         self, scanner: FolderScanner, tmp_path: Path
     ) -> None:
         sub = tmp_path / "noperm"
         sub.mkdir()
         (sub / "inner").mkdir()
 
-        original_iterdir = Path.iterdir
-
-        def guarded_iterdir(path_self: Path) -> Iterator[Path]:
-            if path_self == sub:
-                raise PermissionError("permission denied")
-            return original_iterdir(path_self)
-
-        with patch.object(Path, "iterdir", guarded_iterdir):
+        with patch(
+            "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
+            wraps=safe_walk,
+        ) as mock_walk:
             result = scanner.scan_directory(tmp_path)
+
         assert result is not None
+        mock_walk.assert_any_call(
+            sub,
+            recursive=False,
+            only_files=False,
+            include_hidden=False,
+        )

--- a/tests/methodologies/johnny_decimal/test_jd_scanner.py
+++ b/tests/methodologies/johnny_decimal/test_jd_scanner.py
@@ -258,6 +258,7 @@ class TestScannerCoverage:
         assert result.total_size == 0
 
     # Lines 188-189: OSError on file stat in _create_folder_info
+    @pytest.mark.ci
     def test_create_folder_info_file_stat_oserror(
         self, scanner: FolderScanner, tmp_path: Path
     ) -> None:

--- a/tests/methodologies/johnny_decimal/test_jd_scanner.py
+++ b/tests/methodologies/johnny_decimal/test_jd_scanner.py
@@ -212,16 +212,14 @@ class TestScannerCoverage:
         restricted_info = next(folder for folder in result.folder_tree if folder.path == restricted)
         assert restricted_info.children == []
 
-    def test_scan_folder_defensively_skips_hidden_and_non_file_entries(
+    def test_scan_folder_skips_non_file_entries(
         self, scanner: FolderScanner, tmp_path: Path
     ) -> None:
-        hidden = tmp_path / ".hidden"
-        hidden.mkdir()
         missing = tmp_path / "missing"
 
         with patch(
             "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
-            return_value=iter([hidden, missing]),
+            return_value=iter([missing]),
         ):
             result = scanner.scan_directory(tmp_path)
 

--- a/tests/methodologies/johnny_decimal/test_jd_scanner.py
+++ b/tests/methodologies/johnny_decimal/test_jd_scanner.py
@@ -212,6 +212,22 @@ class TestScannerCoverage:
         restricted_info = next(folder for folder in result.folder_tree if folder.path == restricted)
         assert restricted_info.children == []
 
+    def test_scan_folder_defensively_skips_hidden_and_non_file_entries(
+        self, scanner: FolderScanner, tmp_path: Path
+    ) -> None:
+        hidden = tmp_path / ".hidden"
+        hidden.mkdir()
+        missing = tmp_path / "missing"
+
+        with patch(
+            "file_organizer.methodologies.johnny_decimal.scanner.safe_walk",
+            return_value=iter([hidden, missing]),
+        ):
+            result = scanner.scan_directory(tmp_path)
+
+        assert result.folder_tree == []
+        assert result.total_files == 0
+
     # Lines 163-164: _scan_folder counts files and handles OSError on stat
     def test_scan_counts_files(self, scanner: FolderScanner, tmp_path: Path) -> None:
         (tmp_path / "file.txt").write_text("hello")

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -252,6 +252,39 @@ class TestExtractStructuralFeatures:
         features = extractor.extract_structural_features(target)
         assert features.sibling_count == 4  # 5 files minus the target
 
+    def test_hidden_file_sibling_count_does_not_subtract_excluded_target(
+        self,
+        extractor: FeatureExtractor,
+        tmp_path: Path,
+    ) -> None:
+        """A hidden target is absent from safe_walk and must not be subtracted."""
+        target = tmp_path / ".target.txt"
+        target.write_text("hidden")
+        (tmp_path / "first.txt").write_text("first")
+        (tmp_path / "second.txt").write_text("second")
+
+        features = extractor.extract_structural_features(target)
+
+        assert features.sibling_count == 2
+
+    def test_symlink_file_sibling_count_does_not_subtract_excluded_target(
+        self,
+        extractor: FeatureExtractor,
+        tmp_path: Path,
+    ) -> None:
+        """A symlink target is absent from safe_walk and must not be subtracted."""
+        parent = tmp_path / "files"
+        parent.mkdir()
+        source = tmp_path / "source.txt"
+        source.write_text("source")
+        target = parent / "target.txt"
+        target.symlink_to(source)
+        (parent / "sibling.txt").write_text("sibling")
+
+        features = extractor.extract_structural_features(target)
+
+        assert features.sibling_count == 1
+
     def test_parent_category_hint_project(
         self,
         extractor: FeatureExtractor,

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -472,10 +472,13 @@ class TestEdgeCasesAndErrorHandling:
         test_file = test_dir / "file.txt"
         test_file.write_text("content")
 
-        def mock_iterdir(_self: Path) -> None:
+        def mock_safe_walk(*_args: object, **_kwargs: object) -> None:
             raise OSError("Permission denied")
 
-        monkeypatch.setattr(Path, "iterdir", mock_iterdir)
+        monkeypatch.setattr(
+            "file_organizer.methodologies.para.ai.feature_extractor.safe_walk",
+            mock_safe_walk,
+        )
         features = extractor.extract_structural_features(test_file)
         # Should handle error gracefully and return 0 siblings
         assert features.sibling_count == 0
@@ -499,7 +502,7 @@ class TestEdgeCasesAndErrorHandling:
         result = extractor._has_project_structure(test_file)
         assert result is False
 
-    def test_has_project_structure_with_iterdir_error(
+    def test_has_project_structure_with_walk_error(
         self,
         extractor: FeatureExtractor,
         tmp_path: Path,
@@ -509,10 +512,13 @@ class TestEdgeCasesAndErrorHandling:
         test_dir = tmp_path / "proj"
         test_dir.mkdir()
 
-        def mock_iterdir(_self: Path) -> None:
+        def mock_safe_walk(*_args: object, **_kwargs: object) -> None:
             raise OSError("Permission denied")
 
-        monkeypatch.setattr(Path, "iterdir", mock_iterdir)
+        monkeypatch.setattr(
+            "file_organizer.methodologies.para.ai.feature_extractor.safe_walk",
+            mock_safe_walk,
+        )
         result = extractor._has_project_structure(test_dir)
         # Should handle error and return False
         assert result is False

--- a/tests/plugins/test_installer_coverage.py
+++ b/tests/plugins/test_installer_coverage.py
@@ -242,6 +242,7 @@ class TestPluginInstallerLocateRoot:
         result = installer._locate_plugin_root(extracted)
         assert result == extracted
 
+    @pytest.mark.ci
     def test_nested_single_dir(self, tmp_path):
         extracted = tmp_path / "extract"
         nested = extracted / "my-plugin"

--- a/tests/web/test_file_operations_helpers.py
+++ b/tests/web/test_file_operations_helpers.py
@@ -11,6 +11,7 @@ import pytest
 
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
+from file_organizer.core.path_guard import TraversalBudget
 from file_organizer.web.file_operations import (
     build_preview_context,
     build_tree_context,
@@ -33,6 +34,27 @@ class TestBuildTreeContext:
 
         assert context["error_message"] is None
         assert context["nodes"][0]["is_root"] is True
+
+    def test_root_probes_share_request_budget(self, tmp_path: Path, settings: ApiSettings) -> None:
+        roots = [tmp_path / "first", tmp_path / "second"]
+        observed_budgets: list[TraversalBudget] = []
+
+        def observe_budget(_path: Path, *, budget: TraversalBudget) -> bool:
+            observed_budgets.append(budget)
+            return False
+
+        with (
+            patch("file_organizer.web.file_operations.allowed_roots", return_value=roots),
+            patch(
+                "file_organizer.web.file_operations.has_children",
+                side_effect=observe_budget,
+            ),
+        ):
+            context = build_tree_context(None, settings, depth=0, active=None)
+
+        assert len(context["nodes"]) == 2
+        assert len(observed_budgets) == 2
+        assert observed_budgets[0] is observed_budgets[1]
 
     def test_returns_error_when_resolve_fails(self, settings: ApiSettings) -> None:
         with patch(

--- a/tests/web/test_file_operations_helpers.py
+++ b/tests/web/test_file_operations_helpers.py
@@ -37,9 +37,11 @@ class TestBuildTreeContext:
 
     def test_root_probes_share_request_budget(self, tmp_path: Path, settings: ApiSettings) -> None:
         roots = [tmp_path / "first", tmp_path / "second"]
+        observed_paths: list[Path] = []
         observed_budgets: list[TraversalBudget] = []
 
-        def observe_budget(_path: Path, *, budget: TraversalBudget) -> bool:
+        def observe_budget(path: Path, *, budget: TraversalBudget) -> bool:
+            observed_paths.append(path)
             observed_budgets.append(budget)
             return False
 
@@ -53,6 +55,8 @@ class TestBuildTreeContext:
             context = build_tree_context(None, settings, depth=0, active=None)
 
         assert len(context["nodes"]) == 2
+        assert {node["path"] for node in context["nodes"]} == {str(root) for root in roots}
+        assert observed_paths == roots
         assert len(observed_budgets) == 2
         assert observed_budgets[0] is observed_budgets[1]
 

--- a/tests/web/test_files_routes.py
+++ b/tests/web/test_files_routes.py
@@ -96,6 +96,7 @@ class TestBuildBreadcrumbs:
 class TestListTreeNodes:
     """Test sidebar tree node listing."""
 
+    @pytest.mark.integration
     def test_excludes_hidden(self, tree):
         nodes = list_tree_nodes(tree, include_hidden=False)
         names = [n["name"] for n in nodes]
@@ -149,6 +150,7 @@ class TestListTreeNodes:
 class TestCollectEntries:
     """Test directory entry collection, filtering, and sorting."""
 
+    @pytest.mark.integration
     def test_basic_listing(self, tree):
         entries, total = collect_entries(
             tree,

--- a/tests/web/test_files_routes.py
+++ b/tests/web/test_files_routes.py
@@ -14,6 +14,7 @@ import pytest
 
 from file_organizer.api.config import ApiSettings
 from file_organizer.api.exceptions import ApiError
+from file_organizer.core.path_guard import TraversalBudget
 from file_organizer.web.file_operations import (
     build_breadcrumbs,
     build_file_results_context,
@@ -131,6 +132,13 @@ class TestListTreeNodes:
             assert "path_param" in node
             assert "has_children" in node
 
+    def test_marks_tree_budget_exhausted(self, tree):
+        budget = TraversalBudget(limit=1)
+
+        list_tree_nodes(tree, include_hidden=False, budget=budget)
+
+        assert budget.exhausted is True
+
 
 # ---------------------------------------------------------------------------
 # collect_entries
@@ -246,8 +254,26 @@ class TestCollectEntries:
                 limit=100,
             )
 
+        broken.stat.assert_called_once_with()
         assert entries == [{"name": "broken.txt"}]
         assert total == 1
+
+    def test_marks_listing_budget_exhausted(self, tree):
+        budget = TraversalBudget(limit=2)
+
+        entries, total = collect_entries(
+            tree,
+            query=None,
+            file_type=None,
+            sort_by="name",
+            sort_order="asc",
+            include_hidden=False,
+            limit=100,
+            budget=budget,
+        )
+
+        assert budget.exhausted is True
+        assert len(entries) == total == 2
 
     def test_sort_by_created(self, tree):
         entries, _ = collect_entries(

--- a/tests/web/test_files_routes.py
+++ b/tests/web/test_files_routes.py
@@ -273,7 +273,8 @@ class TestCollectEntries:
         )
 
         assert budget.exhausted is True
-        assert len(entries) == total == 2
+        assert len(entries) == total
+        assert 0 < total <= budget.limit
 
     def test_sort_by_created(self, tree):
         entries, _ = collect_entries(

--- a/tests/web/test_files_routes.py
+++ b/tests/web/test_files_routes.py
@@ -140,6 +140,22 @@ class TestListTreeNodes:
 
         assert budget.exhausted is True
 
+    def test_child_probes_share_tree_budget(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        for directory_name in ("first", "second"):
+            child = root / directory_name
+            child.mkdir()
+            for index in range(3):
+                (child / f"file-{index}.txt").write_text("data")
+        budget = TraversalBudget(limit=5)
+
+        nodes = list_tree_nodes(root, include_hidden=False, budget=budget)
+
+        assert len(nodes) == 2
+        assert budget.examined == budget.limit
+        assert budget.exhausted is True
+
 
 # ---------------------------------------------------------------------------
 # collect_entries

--- a/tests/web/test_files_routes.py
+++ b/tests/web/test_files_routes.py
@@ -7,6 +7,7 @@ using mocked templates/settings.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -220,6 +221,33 @@ class TestCollectEntries:
             limit=100,
         )
         assert len(entries) > 0
+
+    def test_sort_by_size_handles_stat_error(self, tmp_path):
+        broken = MagicMock(spec=Path)
+        broken.name = "broken.txt"
+        broken.is_dir.return_value = False
+        broken.is_file.return_value = True
+        broken.stat.side_effect = OSError("unreadable")
+
+        with (
+            patch("file_organizer.web.file_listing.safe_walk", return_value=[broken]),
+            patch(
+                "file_organizer.web.file_listing._file_entry",
+                return_value={"name": "broken.txt"},
+            ),
+        ):
+            entries, total = collect_entries(
+                tmp_path,
+                query=None,
+                file_type=None,
+                sort_by="size",
+                sort_order="asc",
+                include_hidden=False,
+                limit=100,
+            )
+
+        assert entries == [{"name": "broken.txt"}]
+        assert total == 1
 
     def test_sort_by_created(self, tree):
         entries, _ = collect_entries(

--- a/tests/web/test_helpers.py
+++ b/tests/web/test_helpers.py
@@ -509,6 +509,16 @@ class TestHasChildren:
         hidden.mkdir()
         assert has_children(visible) is False
 
+    def test_cap_keeps_directory_expandable(self, tmp_path, monkeypatch):
+        """A capped prefix must not imply that no later subdirectory exists."""
+        parent = tmp_path / "many"
+        parent.mkdir()
+        for name in ("one.txt", "two.txt", "three.txt"):
+            (parent / name).write_text(name)
+        monkeypatch.setattr("file_organizer.web._helpers.MAX_DIRECTORY_ENTRIES", 2)
+
+        assert has_children(parent) is True
+
 
 # ---------------------------------------------------------------------------
 # is_probably_text

--- a/tests/web/test_helpers.py
+++ b/tests/web/test_helpers.py
@@ -480,6 +480,7 @@ class TestValidateDepth:
 class TestHasChildren:
     """Test directory children detection."""
 
+    @pytest.mark.ci
     def test_directory_with_subdirs(self, file_tree):
         """Should detect subdirectories."""
         assert has_children(file_tree) is True

--- a/tests/web/test_web_ui.py
+++ b/tests/web/test_web_ui.py
@@ -273,6 +273,28 @@ def test_file_browser_endpoints(tmp_path: Path) -> None:
     assert (root / "upload.txt").exists()
 
 
+def test_file_browser_reports_directory_entry_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "large"
+    root.mkdir()
+    for name in ("alpha", "beta", "gamma"):
+        (root / name).mkdir()
+
+    monkeypatch.setattr("file_organizer.web.file_operations.MAX_DIRECTORY_ENTRIES", 2)
+    client = _build_client(tmp_path, allowed_root=root)
+
+    listing = client.get("/ui/files/list", params={"path": str(root)})
+    tree = client.get("/ui/files/tree", params={"path": str(root)})
+
+    assert listing.status_code == 200
+    assert "Safety limit reached after examining 2 directory entries" in listing.text
+    assert "This listing may be incomplete" in listing.text
+    assert tree.status_code == 200
+    assert "Safety limit reached after examining 2 directory entries" in tree.text
+    assert "Some folders may be omitted" in tree.text
+
+
 def test_upload_rejects_hidden_files(tmp_path: Path) -> None:
     root = tmp_path / "library"
     root.mkdir()


### PR DESCRIPTION
## Summary

- migrate 17 user-root and untrusted-root filesystem enumerations to `safe_walk`
- replace the prose-only scope note with an enforced AST rail and exact, reason-bearing exemptions
- bound remote web directory enumeration to 10,000 examined entries and visibly report incomplete results
- preserve established hidden-image discovery, sibling-count accuracy, and best-effort descendant scanning while rejecting symlink traversal

## Why

The #1680 follow-up audit reported 25 unresolved raw traversal sites, but its blanket exclusion of `review_regressions/**` also hid two real filesystem traversals alongside the intended `ast.walk()` exclusions. The verified baseline was therefore 38 raw filesystem traversal sites outside `path_guard`: 11 pre-existing exemptions and 27 sites requiring a decision.

This change migrates 17 sites and records 10 additional reviewed exemptions. The remaining 21 raw calls are represented by 19 exact function/API keys with expected counts, so additions, deletions, and duplicate calls all cause the rail to fail until the scope is deliberately reviewed.

## User impact

User-supplied recursive walks now consistently reject symlink escapes and apply the intended hidden-entry policy. `autotag suggest` and `autotag batch` fail when the selected root cannot be traversed, while unreadable descendants are reported and skipped so accessible files still process. Web file listings and directory trees stop after examining 10,000 entries and show an explicit warning that results may be incomplete. Johnny Decimal permission diagnostics now use the shared `safe_walk` debug-level reporting established by #1671 instead of call-site warnings. Intentional single-level UI, completion, app-owned-state, depth-pruned, and repository-audit traversals retain their existing behavior.

## Validation

- 14,585 non-integration tests passed in the exhaustive commit-hook run; its sole initial failure exposed the hidden-image contract and was fixed
- 7,644 CI-selected tests passed and 80 were skipped in the latest workflow-shaped local run
- 240 tests across the seven directly affected modules passed
- 12 focused regression cases passed for sibling counts, traversal errors, web caps, scanner cleanup, and stat-error coverage
- changed-module mypy checks passed
- Ruff, pre-commit, and all enforced CI rails passed
- diff coverage: 100% (63/63 executable changed lines)

Fixes #1736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Standardized filesystem discovery through guarded traversal for safer path access.
  * Added limits to web directory listings to prevent excessive enumeration.

* **Bug Fixes**
  * Improved handling of hidden files, symlinks, permissions, unreadable directories, and filesystem errors.
  * Added clear notices when web listings or directory trees are truncated.

* **Chores**
  * Added automated checks to identify unapproved filesystem traversal.
  * Expanded coverage for safe filesystem operations and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->