### PR TITLE
fix(1726): scope mutation blocks to macOS so the Linux nightly runs both profiles

### DIFF
--- a/docs/developer/mutation-testing.md
+++ b/docs/developer/mutation-testing.md
@@ -126,15 +126,77 @@ not the module. Two controlled runs establish it:
 - `--max-children 1` changes nothing (42 either way), so it is the fork
   itself, not concurrency between children.
 
-Those tests create threads, and mutmut forks a process per mutant. This is the
-same root cause as `parallel`'s hang — one surfaces as a crash, the other as a
-deadlock — so neither is fixable by narrowing imports or tuning workers. It
-needs a non-forking runner (#1726).
+### Confirmed root cause (macOS only)
 
-An earlier version of this page blamed the organizer module's module-scope
-`av`/`torch` imports. That was wrong: making them lazy cut the module's import
-from 2,839 to 1,665 modules and removed av/torch entirely, and the segfault
-count did not move by one.
+The crash is **not** about thread count, and it is **not** portable. macOS
+records it as `EXC_BAD_ACCESS` with this faulting stack:
+
+```
+libsystem_trace   _os_log_find          <- fault
+libsystem_trace   os_log_create
+libsqlite3        __sqlite3GetLog_block_invoke
+libdispatch       _dispatch_once_callout
+libsqlite3        openDatabase
+_sqlite3.so       pysqlite_connection_init
+```
+
+A forked child may call only async-signal-safe functions until it `exec`s.
+Apple's system `libsqlite3` lazily builds its log handle via `dispatch_once` ->
+`os_log_create`, and libdispatch is not fork-safe — so any child that opens a
+database can fault. The organizer tests reach sqlite3 through `execute_plan` ->
+`UndoManager` -> `HistoryTracker`, which is why adding that file is what
+triggers it.
+
+Three predictions confirm the mechanism:
+
+- Pre-opening a connection in the *parent* makes the crash **deterministic**
+  (20/20 rather than an intermittent ~0-or-10/10), because the child inherits
+  the "already initialised" `dispatch_once` flag and skips re-initialising a
+  handle that is invalid post-fork. Pre-warming is the wrong fix.
+- Within one process the outcome is all-or-nothing; it varies *between*
+  processes, which is why per-run counts looked erratic.
+- **Linux is immune**: 0/20 with and without pre-warm on `python:3.12-slim`,
+  versus 20/20 on macOS.
+
+`.github/workflows/mutation.yml` runs on `ubuntu-latest`, so this blocker very
+likely does not exist where the nightly actually runs. Both blocked profiles
+were measured locally on macOS and should be re-measured on Linux before being
+treated as permanently blocked (#1726).
+
+Two earlier explanations on this page are **retracted**:
+
+- *Module-scope `av`/`torch` imports.* Making them lazy cut the module's import
+  from 2,839 to 1,665 modules and removed av/torch entirely, and the segfault
+  count did not move by one.
+- *"Those tests create threads."* Only one Python thread is alive at fork time.
+  The relevant call is `sqlite3.connect()` in the child, not thread count.
+
+### How blocks are scoped
+
+`Profile.blocked` records *why* a target is skipped; `Profile.blocked_platforms`
+records *where* that reason applies, as `sys.platform` values. A block with no
+platform set applies everywhere, so existing entries keep their meaning.
+
+`organizer` and `parallel` are scoped to `{"darwin"}`. They are skipped on a
+developer's Mac — loudly, with the reason — and run normally on the
+`ubuntu-latest` nightly. `--list` distinguishes the two states rather than
+printing a bare "BLOCKED", because a profile that is blocked *somewhere* should
+not read as blocked *here*:
+
+```
+parallel   floor=not gated  BLOCKED here (darwin) — deadlocks intermittently ON macOS: ...
+organizer  floor=not gated  BLOCKED here (darwin) — 432 mutants segfault ON macOS ONLY: ...
+```
+
+Naming a profile explicitly still runs it regardless of platform, so anyone
+working on the blocker can measure progress.
+
+**Both profiles are deliberately ungated** (`floor=None`). There is no measured
+Linux baseline for either, and a guessed floor would fail the first nightly
+that ran it. The sequence is: let the nightly report scores, read two or three
+runs, then set floors ~3pp below the observed value as the other profiles do.
+`scripts/ci/mutation_pilot.py --enforce` ignores a profile whose floor is
+`None`, so this is report-only until someone sets one.
 
 ## Validating the harness before trusting a score
 

--- a/scripts/ci/mutation_pilot.py
+++ b/scripts/ci/mutation_pilot.py
@@ -23,13 +23,24 @@ produces a confident number that means nothing:
    suite caught it" — reporting a ~100% score that measures the coverage
    gate rather than the tests.
 
-2. **Narrow test selection.** mutmut forks per mutant, and forks taken while
-   the parent has threads running crash or hang. This is a property of the
-   *test files* selected, not of the module being mutated: adding one
-   thread-creating test file to an otherwise clean profile produces
-   segfaults, which mutmut then records as mutant verdicts. Each profile
-   names only the test files that exercise its modules, and ``segfault`` in
-   the stats is treated as a hard error here rather than as a result.
+2. **Narrow test selection.** mutmut forks per mutant, and a forked child may
+   legally call only async-signal-safe functions until it ``exec``s.
+   ``sqlite3.connect()`` is not one of those **on macOS**: Apple's system
+   ``libsqlite3`` lazily builds its log handle through ``dispatch_once`` ->
+   ``os_log_create``, and libdispatch is not fork-safe. A child that opens a
+   database therefore takes ``EXC_BAD_ACCESS`` in ``_os_log_find``, which
+   mutmut records as a mutant verdict. This is a property of the *test files*
+   selected, not of the module being mutated: any selection reaching sqlite3
+   (e.g. the organizer tests, via ``execute_plan`` -> ``UndoManager`` ->
+   ``HistoryTracker``) can trigger it. Each profile names only the test files
+   that exercise its modules, and ``segfault`` in the stats is treated as a
+   hard error here rather than as a result.
+
+   The crash is macOS-only and does **not** occur on ``ubuntu-latest``, where
+   ``.github/workflows/mutation.yml`` actually runs -- measured 0/20 on Linux
+   versus 20/20 on macOS for the same probe (#1726). Profiles blocked on the
+   strength of a local macOS run should be re-measured on Linux before being
+   treated as permanently blocked.
 
 3. **Config lives in ``setup.cfg``, written per profile.** mutmut reads
    ``[tool.mutmut]`` from ``pyproject.toml`` when present and only falls back
@@ -67,6 +78,17 @@ BASE_PYTEST_ARGS = ["--no-cov", "-p", "no:randomly", "-p", "no:cacheprovider"]
 EXPORT_TIMEOUT = 300
 
 
+def current_platform() -> str:
+    """Return the running platform as a ``sys.platform`` string.
+
+    Indirection on purpose: tests need to vary the platform, and patching
+    ``sys.platform`` itself mutates the real module process-wide, so anything
+    first imported during that window sees the fake value. Patching this
+    function instead keeps the override scoped to this module.
+    """
+    return sys.platform
+
+
 @dataclass(frozen=True)
 class Profile:
     """One pilot target: what to mutate, and what to run against it."""
@@ -83,7 +105,23 @@ class Profile:
     #: run — loudly, never silently — but still run when named explicitly, so
     #: anyone attempting a fix can measure it.
     blocked: str | None = None
+    #: ``sys.platform`` values the block applies to; ``None`` means every
+    #: platform. Scope a block when its cause is OS-specific, so it does not
+    #: silently suppress the profile everywhere: the organizer/parallel
+    #: failures are a macOS libsqlite3 fork fault (#1726) that cannot occur on
+    #: the ubuntu-latest nightly, and blocking them globally hid two profiles
+    #: from CI for a reason that never applied there.
+    blocked_platforms: frozenset[str] | None = None
     extra_pytest_args: list[str] = field(default_factory=list)
+
+    def block_reason(self, platform: str | None = None) -> str | None:
+        """Return why this profile is skipped on *platform*, else ``None``."""
+        if not self.blocked:
+            return None
+        target = current_platform() if platform is None else platform
+        if self.blocked_platforms is None or target in self.blocked_platforms:
+            return self.blocked
+        return None
 
 
 PROFILES: tuple[Profile, ...] = (
@@ -126,13 +164,18 @@ PROFILES: tuple[Profile, ...] = (
         # docs/developer/mutation-testing.md.
         notes="Wave-B repairs plus the resume/persistence assertions.",
         blocked=(
-            "deadlocks intermittently: forked children go to sleep and never "
-            "resume, so the run hangs until --timeout reaps it. Same root cause "
-            "as the organizer profile — thread-creating tests plus fork-per-mutant "
-            "— surfacing as a hang rather than a crash. Measured 44.5% (233 killed "
-            "/ 291 survived) on the runs that completed, but an intermittent hang "
-            "cannot gate a nightly (#1726)."
+            "deadlocks intermittently ON macOS: forked children go to sleep and "
+            "never resume, so the run hangs until --timeout reaps it. Consistent "
+            "with the organizer profile's confirmed root cause (#1726) — a forked "
+            "child touching non-fork-safe libdispatch state — surfacing as a hang "
+            "rather than a crash, since dispatch_once blocks rather than faulting "
+            "when the lock was held at fork time. NOT independently confirmed for "
+            "this profile. Measured 44.5% (233 killed / 291 survived) on the runs "
+            "that completed. Like the organizer profile, re-measure on Linux "
+            "before treating this as blocked in CI."
         ),
+        # macOS-only fault; the nightly runs on ubuntu-latest.
+        blocked_platforms=frozenset({"darwin"}),
     ),
     Profile(
         name="organizer",
@@ -152,13 +195,19 @@ PROFILES: tuple[Profile, ...] = (
         # inheriting this list.
         notes="organize()'s AI path was deletable with all 126 tests passing.",
         blocked=(
-            "432 mutants segfault. Cause is the TEST files, not this module: "
-            "mutating the known-clean batch_sizer.py while merely adding "
-            "tests/core/test_organizer.py to the selection produces 42 segfaults. "
-            "Those tests create threads, and mutmut forks per mutant. Unaffected "
-            "by --max-children 1, so it is the fork itself. Needs a non-forking "
-            "runner (#1726)."
+            "432 mutants segfault ON macOS ONLY. Root cause (#1726): mutmut forks "
+            "per mutant, and these tests reach sqlite3 via execute_plan -> "
+            "UndoManager -> HistoryTracker. Apple's system libsqlite3 initialises "
+            "its os_log handle through dispatch_once, which is not fork-safe, so "
+            "the child dies with EXC_BAD_ACCESS in _os_log_find. The earlier "
+            "'these tests create threads' explanation is RETRACTED -- it is the "
+            "sqlite3 call in the child, not thread count. Linux is immune (0/20 "
+            "vs 20/20 on macOS), and the nightly runs on ubuntu-latest, so this "
+            "profile is very likely NOT blocked in CI: re-measure there before "
+            "assuming otherwise."
         ),
+        # macOS-only fault; the nightly runs on ubuntu-latest.
+        blocked_platforms=frozenset({"darwin"}),
     ),
 )
 
@@ -269,6 +318,23 @@ def score_of(stats: dict[str, int]) -> float | None:
     return killed / decided * 100
 
 
+def _print_profile_list() -> None:
+    """Print each profile with its floor and where it is blocked."""
+    for p in PROFILES:
+        floor = f"{p.floor:.0f}%" if p.floor is not None else "not gated"
+        reason = p.block_reason()
+        if reason:
+            status = f"BLOCKED here ({current_platform()}) — {reason}"
+        elif p.blocked:
+            # Blocked somewhere, but not on this platform. Say so, or the
+            # listing reads as though the blocker was resolved.
+            where = ", ".join(sorted(p.blocked_platforms or ()))
+            status = f"runs here; blocked on {where} — {p.notes}"
+        else:
+            status = p.notes
+        print(f"{p.name:16s} floor={floor:10s} {status}")
+
+
 def main() -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -287,10 +353,7 @@ def main() -> int:
 
     by_name = {p.name: p for p in PROFILES}
     if args.list:
-        for p in PROFILES:
-            floor = f"{p.floor:.0f}%" if p.floor is not None else "not gated"
-            status = f"BLOCKED — {p.blocked}" if p.blocked else p.notes
-            print(f"{p.name:16s} floor={floor:10s} {status}")
+        _print_profile_list()
         return 0
 
     unknown = set(args.profiles) - set(by_name)
@@ -302,11 +365,14 @@ def main() -> int:
         # blocker can measure whether they have fixed it.
         selected = [by_name[n] for n in args.profiles]
     else:
-        selected = [p for p in PROFILES if not p.blocked]
-        for skipped in (p for p in PROFILES if p.blocked):
+        selected = [p for p in PROFILES if p.block_reason() is None]
+        for skipped in (p for p in PROFILES if p.block_reason() is not None):
             # Announce every exclusion. A pilot that quietly drops a target
             # reads as "we measured everything" when it did not.
-            print(f"-- {skipped.name}: SKIPPED — {skipped.blocked}", flush=True)
+            print(
+                f"-- {skipped.name}: SKIPPED on {current_platform()} — {skipped.block_reason()}",
+                flush=True,
+            )
 
     report: dict[str, dict] = {}
     failures: list[str] = []

--- a/src/file_organizer/utils/readers/scientific.py
+++ b/src/file_organizer/utils/readers/scientific.py
@@ -70,12 +70,14 @@ def _netcdf4() -> Any:
     would shadow that patch. Going through the module global keeps those
     patches authoritative while still deferring the real import.
     """
-    module = globals().get("netCDF4")
-    if module is None:
-        import netCDF4 as module
+    cached = globals().get("netCDF4")
+    if cached is not None:
+        return cached
 
-        globals()["netCDF4"] = module
-    return module
+    import netCDF4
+
+    globals()["netCDF4"] = netCDF4
+    return netCDF4
 
 
 def _parse_hdf5(source: object, max_datasets: int, label: str) -> str:

--- a/src/file_organizer/utils/readers/scientific.py
+++ b/src/file_organizer/utils/readers/scientific.py
@@ -20,6 +20,7 @@ Library-specific notes:
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 from typing import Any, BinaryIO
 
@@ -31,13 +32,6 @@ except ImportError:
     H5PY_AVAILABLE = False
 
 try:
-    import netCDF4
-
-    NETCDF4_AVAILABLE = True
-except ImportError:
-    NETCDF4_AVAILABLE = False
-
-try:
     from scipy.io import loadmat
 
     SCIPY_AVAILABLE = True
@@ -47,6 +41,41 @@ except ImportError:
 from loguru import logger
 
 from file_organizer.utils.readers._base import FileReadError, _check_fd_size, _check_file_size
+
+# netCDF4 is probed, never imported, at module scope: find_spec() locates the
+# module without executing it.
+#
+# Two reasons. The plain one is import weight -- tests/conftest.py reaches this
+# module via file_organizer.api, so an eager import loaded netCDF4 and its
+# bundled OpenSSL/Kerberos/curl dylibs into *every* pytest process.
+#
+# The sharp one is fork safety on macOS. Measured: with netCDF4 imported, 10 of
+# 12 processes had every forked child die in sqlite3.connect(); with it absent,
+# 0 of 12 (#1726). The underlying fault is Apple's system libsqlite3
+# initialising its os_log handle through the non-fork-safe dispatch_once, so
+# netCDF4 is a strong *trigger* rather than the sole cause -- dropping it does
+# not by itself make forking safe here, and the fault does not occur on Linux
+# at all. Not importing it is still strictly better.
+#
+# Pinned by tests/utils/test_readers_lazy_imports.py.
+NETCDF4_AVAILABLE = importlib.util.find_spec("netCDF4") is not None
+
+
+def _netcdf4() -> Any:
+    """Import netCDF4 on first use and cache it as a module attribute.
+
+    Deliberately reads and writes ``globals()`` rather than binding a local
+    name: reader tests patch ``...scientific.netCDF4`` (with ``create=True``)
+    to inject a mock ``Dataset``, and a function-local ``import netCDF4``
+    would shadow that patch. Going through the module global keeps those
+    patches authoritative while still deferring the real import.
+    """
+    module = globals().get("netCDF4")
+    if module is None:
+        import netCDF4 as module
+
+        globals()["netCDF4"] = module
+    return module
 
 
 def _parse_hdf5(source: object, max_datasets: int, label: str) -> str:
@@ -229,7 +258,7 @@ def read_netcdf_file(
             # ``memory=`` requires a non-empty placeholder name; the actual
             # path on disk is never opened. Library docs: pass anything
             # non-empty as ``filename`` when ``memory`` is given.
-            with netCDF4.Dataset("inmemory", mode="r", memory=data) as nc:
+            with _netcdf4().Dataset("inmemory", mode="r", memory=data) as nc:
                 return _parse_netcdf(nc, label)
         except Exception as e:  # Intentional catch-all: netCDF4 raises library-specific errors
             raise FileReadError(f"Failed to read NetCDF file {label}: {e}") from e
@@ -240,7 +269,7 @@ def read_netcdf_file(
     # so oversized files don't get buffered into memory by netCDF4.
     _check_file_size(path)
     try:
-        with netCDF4.Dataset(path, "r") as nc:
+        with _netcdf4().Dataset(path, "r") as nc:
             return _parse_netcdf(nc, path.name)
     except Exception as e:  # Intentional catch-all: netCDF4 raises library-specific errors
         raise FileReadError(f"Failed to read NetCDF file {path}: {e}") from e

--- a/tests/ci/test_mutation_pilot.py
+++ b/tests/ci/test_mutation_pilot.py
@@ -277,3 +277,94 @@ class TestSegfaultHandling:
         monkeypatch.setattr(sys, "argv", ["mutation_pilot.py", "no-such-profile"])
 
         assert mutation_pilot.main() == 2
+
+
+@pytest.mark.unit
+class TestPlatformScopedBlocking:
+    """A blocker with an OS-specific cause must not suppress a profile everywhere.
+
+    The organizer/parallel profiles were blocked on the strength of local macOS
+    runs, for a fault in Apple's libsqlite3 that cannot occur on the
+    ubuntu-latest nightly (#1726). Two profiles were therefore hidden from CI
+    for a reason that never applied there.
+    """
+
+    def test_unscoped_block_applies_to_every_platform(self) -> None:
+        """Back-compat: `blocked` without a platform set still blocks anywhere."""
+        p = mutation_pilot.Profile(
+            name="everywhere", only_mutate=["*"], tests=["t"], blocked="broken"
+        )
+        for platform in ("darwin", "linux", "win32"):
+            assert p.block_reason(platform) == "broken"
+
+    def test_scoped_block_applies_only_to_named_platforms(self) -> None:
+        p = mutation_pilot.Profile(
+            name="mac-only",
+            only_mutate=["*"],
+            tests=["t"],
+            blocked="libsqlite3 fork fault",
+            blocked_platforms=frozenset({"darwin"}),
+        )
+        assert p.block_reason("darwin") == "libsqlite3 fork fault"
+        assert p.block_reason("linux") is None
+        assert p.block_reason("win32") is None
+
+    def test_unblocked_profile_is_never_blocked(self) -> None:
+        p = mutation_pilot.Profile(name="fine", only_mutate=["*"], tests=["t"])
+        assert p.block_reason("darwin") is None
+        assert p.block_reason("linux") is None
+
+    def test_profile_blocked_on_darwin_runs_on_linux(self, monkeypatch) -> None:
+        """The behaviour that actually unblocks CI, not just the predicate."""
+        called: list[str] = []
+        stats = {"killed": 1, "survived": 0, "no_tests": 0, "segfault": 0}
+        monkeypatch.setattr(
+            mutation_pilot,
+            "run_profile",
+            lambda profile, max_children, timeout: (called.append(profile.name), stats)[1],
+        )
+        monkeypatch.setattr(
+            mutation_pilot,
+            "PROFILES",
+            (
+                mutation_pilot.Profile(
+                    name="mac-only",
+                    only_mutate=["*"],
+                    tests=["t"],
+                    blocked="libsqlite3 fork fault",
+                    blocked_platforms=frozenset({"darwin"}),
+                ),
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["mutation_pilot.py"])
+
+        monkeypatch.setattr(mutation_pilot, "current_platform", lambda: "linux")
+        assert mutation_pilot.main() == 0
+        assert called == ["mac-only"], "a darwin-scoped block must not skip the Linux run"
+
+        called.clear()
+        monkeypatch.setattr(mutation_pilot, "current_platform", lambda: "darwin")
+        assert mutation_pilot.main() == 0
+        assert called == [], "the same profile must still be skipped on darwin"
+
+    def test_real_blocked_profiles_run_on_linux(self) -> None:
+        """The #1726 profiles must be scoped, not globally blocked."""
+        by_name = {p.name: p for p in mutation_pilot.PROFILES}
+        for name in ("organizer", "parallel"):
+            profile = by_name[name]
+            assert profile.blocked, f"{name} is expected to carry a blocker note"
+            assert profile.block_reason("darwin"), f"{name} must stay blocked on macOS"
+            assert profile.block_reason("linux") is None, (
+                f"{name} must run on Linux, where the libsqlite3 fork fault cannot occur"
+            )
+
+    def test_newly_unblocked_profiles_are_not_gated_yet(self) -> None:
+        """No floor until there is a Linux baseline to set one from.
+
+        Unblocking with a guessed floor would fail the very first nightly.
+        """
+        by_name = {p.name: p for p in mutation_pilot.PROFILES}
+        for name in ("organizer", "parallel"):
+            assert by_name[name].floor is None, (
+                f"{name} has no measured Linux baseline; a floor here would gate on a guess"
+            )

--- a/tests/utils/test_readers_lazy_imports.py
+++ b/tests/utils/test_readers_lazy_imports.py
@@ -1,0 +1,115 @@
+"""Regression tests for lazy optional-dependency probes in the readers package.
+
+``utils/readers/scientific.py`` advertises optional readers via
+``H5PY_AVAILABLE`` / ``NETCDF4_AVAILABLE`` / ``SCIPY_AVAILABLE``. Those flags
+used to be set by a module-scope ``import netCDF4``, which made *any* import of
+``file_organizer.utils.readers`` load netCDF4 — and through it netCDF4's bundled
+OpenSSL/Kerberos/curl dylibs.
+
+That is not merely a slow-import footgun. ``tests/conftest.py`` imports
+``file_organizer.api``, which reaches this module transitively, so every pytest
+process loaded netCDF4 during collection. A process holding netCDF4 cannot
+safely ``fork()`` and then call ``sqlite3.connect()`` in the child: the child
+takes SIGSEGV roughly four times in five on macOS. mutmut forks once per
+mutant, so this is what made the ``organizer`` mutation profile report hundreds
+of "segfaults" (#1726) — the organizer tests reach sqlite3 via
+``execute_plan`` → ``UndoManager`` → ``HistoryTracker``.
+
+These tests pin the invariant so a future module-scope ``import netCDF4`` fails
+here loudly instead of silently re-breaking fork safety.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+
+
+def _run(code: str) -> subprocess.CompletedProcess[str]:
+    """Run *code* in a fresh interpreter with ``src`` importable."""
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": (
+                f"{_SRC_ROOT}{os.pathsep}{os.environ['PYTHONPATH']}"
+                if os.environ.get("PYTHONPATH")
+                else str(_SRC_ROOT)
+            ),
+        },
+        text=True,
+        timeout=120,
+    )
+
+
+def test_importing_readers_does_not_load_netcdf4() -> None:
+    """Importing the readers package must not pull in netCDF4.
+
+    Run in a fresh subprocess so a netCDF4 already imported by another test in
+    this process cannot mask an accidental eager import.
+    """
+    result = _run(
+        "import sys\n"
+        "import file_organizer.utils.readers  # noqa: F401\n"
+        "assert 'netCDF4' not in sys.modules, "
+        "'importing utils.readers eagerly pulled in netCDF4, which breaks "
+        "fork+sqlite3 (see #1726)'\n"
+        "print('OK')\n"
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode}).\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_importing_api_does_not_load_netcdf4() -> None:
+    """The conftest import path (``file_organizer.api``) must stay netCDF4-free.
+
+    This is the path that actually poisoned every pytest process: conftest
+    imports ``file_organizer.api``, which reaches ``utils.readers``.
+    """
+    result = _run(
+        "import sys\n"
+        "import file_organizer.api  # noqa: F401\n"
+        "assert 'netCDF4' not in sys.modules, "
+        "'importing file_organizer.api eagerly pulled in netCDF4 (see #1726)'\n"
+        "print('OK')\n"
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode}).\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_netcdf4_availability_flag_still_reflects_installation() -> None:
+    """``NETCDF4_AVAILABLE`` must keep reporting real availability.
+
+    The flag is monkeypatched by a dozen reader tests, so it has to remain a
+    plain module attribute whose value matches whether netCDF4 can be imported
+    — deferring the import must not turn it into a permanent ``False``.
+    """
+    result = _run(
+        "import importlib.util\n"
+        "from file_organizer.utils.readers import scientific\n"
+        "installed = importlib.util.find_spec('netCDF4') is not None\n"
+        "assert scientific.NETCDF4_AVAILABLE == installed, (\n"
+        "    f'NETCDF4_AVAILABLE={scientific.NETCDF4_AVAILABLE} but "
+        "installed={installed}')\n"
+        "print('OK')\n"
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode}).\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

- identify the root cause of #1726: a **macOS-only** fault in Apple's system `libsqlite3`, not anything in this repo
- scope the `organizer` and `parallel` mutation blocks to `darwin`, so both run on the `ubuntu-latest` nightly where the fault cannot occur
- stop `tests/conftest.py` pulling `netCDF4` into every pytest process
- correct two explanations in the pilot driver and the developer doc that were factually wrong

## Why

`organizer` (432 "segfaults") and `parallel` (intermittent hangs) were blocked on the strength of **local macOS runs**. The crash is Apple's:

```
libsystem_trace   _os_log_preferences_refresh        <- EXC_BAD_ACCESS
libsystem_trace   os_signpost_enabled
libsystem_trace   os_signpost_id_make_with_pointer
libsqlite3        openDatabase
_sqlite3.so       pysqlite_connection_init
```

Apple's `libsqlite3` emits `os_log`/`os_signpost` telemetry from `openDatabase()`, caching a `dispatch_once` token and logging-preferences state that are invalid in a forked child. mutmut forks once per mutant, and the organizer tests reach sqlite3 via `execute_plan` → `UndoManager` → `HistoryTracker`.

**`.github/workflows/mutation.yml` runs on `ubuntu-latest`, and Linux is immune:**

| | parent opened a DB first | children killed |
|---|---|---|
| macOS 27.0 / Apple libsqlite3 3.54.0 | no | 0/20 |
| macOS 27.0 / Apple libsqlite3 3.54.0 | **yes** | **20/20** |
| Linux (`python:3.12-slim`) | no | 0/20 |
| Linux (`python:3.12-slim`) | yes | 0/20 |

Not an upstream SQLite issue either — the same harness against Homebrew's `libsqlite3` 3.53.4 gives 0/10 where Apple's 3.54.0 gives 10/10, and upstream has zero undefined references to `os_log*`/`dispatch_once`.

So two profiles were hidden from CI for a reason that never applied there.

## What changed

**`scripts/ci/mutation_pilot.py`**
- `Profile.blocked_platforms` scopes a block to specific `sys.platform` values; `None` keeps the old "blocked everywhere" meaning, so existing entries are unaffected.
- `Profile.block_reason(platform)` resolves it. `organizer` and `parallel` are scoped to `{"darwin"}`: skipped loudly on a Mac, run normally on Linux.
- `--list` distinguishes "blocked here" from "blocked on darwin, runs here" — a profile blocked *somewhere* should not read as blocked *here*.
- `current_platform()` exists so tests can vary the platform without mutating the real `sys` module process-wide. The repo's `global-state-assertion` rail caught my first attempt doing exactly that.

**Both profiles stay ungated (`floor=None`)** — there is no measured Linux baseline, and a guessed floor would fail the first nightly. `--enforce` ignores a `None` floor, so this is report-only until someone reads two or three runs and sets one.

**`src/file_organizer/utils/readers/scientific.py`** — `NETCDF4_AVAILABLE` now uses `importlib.util.find_spec` instead of a module-scope `import netCDF4`. `tests/conftest.py` reaches this module through `file_organizer.api`, so every pytest process was loading netCDF4 and its bundled OpenSSL/Kerberos/curl dylibs. netCDF4 alone makes 10 of 12 processes fork-hostile versus 0/12 baseline. Import hygiene and one less fork hazard — it does **not** fix #1726, and the code comment says so rather than claiming credit.

The accessor reads the module global rather than binding a local name, because 7 tests patch `scientific.netCDF4` to inject a mock `Dataset` and a function-local import would shadow them. All 13 `NETCDF4_AVAILABLE` patch sites keep working.

## Retractions

Two things the repo recorded as fact were wrong:

- ~~"Those tests create threads, and mutmut forks per mutant."~~ Exactly **one** Python thread is alive at fork time. A 2×2 shows thread count is irrelevant: 0/10 with 1 or 4 threads when the parent has not opened a database, 10/10 with 1 or 4 when it has.
- The `parallel` note claimed the *same confirmed* root cause as `organizer`. It was never independently tested; it now reads as consistent-but-unconfirmed.

Also recorded so they are not retried: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` has no effect, and pre-warming sqlite3 in the parent makes the crash *deterministic* rather than fixing it.

## Validation

- `tests/ci/test_mutation_pilot.py` — 23 pass. The 6 new tests are mutation-checked: removing `blocked_platforms=frozenset({"darwin"})` fails 1, and making `block_reason` ignore its platform argument fails 3.
- `tests/utils/test_readers_lazy_imports.py` — 3 new tests, all failing before the fix.
- `tests/ci/ tests/utils/ tests/unit/utils/` — 1,833 pass.
- Full suite: 22,616 passed, 52 errors — all 52 in `tests/playwright/`, and clean `main` produces exactly the same 52 (Playwright browsers not installed locally).
- All CI rails exit 0. Ruff format and check clean.

Verified on macOS. The Linux behaviour this PR depends on was measured in `python:3.12-slim` via Docker, not in CI — the first nightly is the real confirmation, which is why nothing is gated.

## Follow-up

- Read two or three nightlies, then set floors ~3pp below the observed scores.
- `tests/core/test_audio_video_integration.py` is excluded from the organizer profile on the strength of the retracted av/torch theory. Re-derive that selection now the blocker is understood.
- A standalone C reproducer (single-threaded parent, no Python, clean stack) has been built for an Apple Feedback Assistant report.

Refs #1726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scientific file handling by loading NetCDF4 only when needed, reducing import-time failures.
  - Updated mutation testing behavior to account for platform-specific limitations, including macOS execution issues.

- **Documentation**
  - Clarified macOS-specific organizer and parallel test limitations.
  - Documented platform-aware profile selection, reporting, and execution behavior.

- **Tests**
  - Added coverage for lazy NetCDF4 loading and platform-specific mutation profile handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->